### PR TITLE
[16.0][ADD] budget_project: add project/activity budget management

### DIFF
--- a/budget/models/budget_move_line.py
+++ b/budget/models/budget_move_line.py
@@ -96,6 +96,7 @@ class BudgetMoveLine(models.Model):
         store=True,
         required=False,
         digits="Budget",
+        compute="_compute_unallocated_balance",
     )
     credit = fields.Float(
         readonly=False,
@@ -202,6 +203,10 @@ class BudgetMoveLine(models.Model):
     def _compute_hide_unallocated_balance(self):
         for line in self:
             line.hide_unallocated_balance = True
+
+    def _compute_unallocated_balance(self):
+        for rec in self:
+            rec.unallocated_balance = 0
 
     @api.onchange("balance")
     def _inverse_balance(self):

--- a/budget/models/budget_move_line.py
+++ b/budget/models/budget_move_line.py
@@ -200,7 +200,8 @@ class BudgetMoveLine(models.Model):
                 line.debit = 0
 
     def _compute_hide_unallocated_balance(self):
-        return True
+        for line in self:
+            line.hide_unallocated_balance = True
 
     @api.onchange("balance")
     def _inverse_balance(self):

--- a/budget/models/budget_move_line.py
+++ b/budget/models/budget_move_line.py
@@ -90,6 +90,13 @@ class BudgetMoveLine(models.Model):
         readonly=False,
         tracking=True,
     )
+    unallocated_balance = fields.Float(
+        string="ยังไม่ระบุรายการ",
+        help="จำนวนเงินที่ยังไม่มีการวางแผนการใช้งาน แต่ต้องการจองจำนวนเงินไว้ก่อน",
+        store=True,
+        required=False,
+        digits="Budget",
+    )
     credit = fields.Float(
         readonly=False,
         digits="Budget Precision",
@@ -141,6 +148,9 @@ class BudgetMoveLine(models.Model):
         default=False,
         help="Line created automatically for double-entry",
     )
+    hide_unallocated_balance = fields.Boolean(
+        compute="_compute_hide_unallocated_balance", readonly=True
+    )
     source_line_id = fields.Many2one(
         comodel_name="budget.move.line",
         string="Source Line",
@@ -152,10 +162,12 @@ class BudgetMoveLine(models.Model):
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
-        if 'default_activity_analytic_id' in self.env.context:
-            res['activity_analytic_id'] = self.env.context['default_activity_analytic_id']
-        if 'default_fund_analytic_id' in self.env.context:
-            res['fund_analytic_id'] = self.env.context['default_fund_analytic_id']
+        if "default_activity_analytic_id" in self.env.context:
+            res["activity_analytic_id"] = self.env.context[
+                "default_activity_analytic_id"
+            ]
+        if "default_fund_analytic_id" in self.env.context:
+            res["fund_analytic_id"] = self.env.context["default_fund_analytic_id"]
         return res
 
     @api.depends("move_id", "move_id.department_analytic_id", "move_id.move_type")
@@ -186,6 +198,9 @@ class BudgetMoveLine(models.Model):
             else:
                 line.credit = -line.balance
                 line.debit = 0
+
+    def _compute_hide_unallocated_balance(self):
+        return True
 
     @api.onchange("balance")
     def _inverse_balance(self):
@@ -243,9 +258,9 @@ class BudgetMoveLine(models.Model):
                     regular_line = lines[regular_idx]
                     virtual_line = lines[virtual_idx]
                     # Set the source_line_id relationship
-                    virtual_line.with_context(skip_virtual_update=True).write({
-                        'source_line_id': regular_line.id
-                    })
+                    virtual_line.with_context(skip_virtual_update=True).write(
+                        {"source_line_id": regular_line.id}
+                    )
 
             exit_stack.enter_context(
                 self.env.protecting(
@@ -376,21 +391,28 @@ class BudgetMoveLine(models.Model):
                 # using source_line_id to maintain 1-1 relationships
                 for line in appropriation_lines:
                     # Find the virtual line linked to this regular line
-                    virtual_line = self.search([
-                        ('source_line_id', '=', line.id),
-                        ('is_virtual_line', '=', True)
-                    ], limit=1)
+                    virtual_line = self.search(
+                        [
+                            ("source_line_id", "=", line.id),
+                            ("is_virtual_line", "=", True),
+                        ],
+                        limit=1,
+                    )
 
                     if virtual_line:
                         # Update existing virtual line
                         virtual_update_vals = {}
                         if balance_update:
-                            virtual_update_vals['balance'] = -line.balance
+                            virtual_update_vals["balance"] = -line.balance
                         if analytic_update:
-                            virtual_update_vals['analytic_distribution'] = line.analytic_distribution
+                            virtual_update_vals["analytic_distribution"] = (
+                                line.analytic_distribution
+                            )
 
                         if virtual_update_vals:
-                            virtual_line.with_context(skip_virtual_update=True).write(virtual_update_vals)
+                            virtual_line.with_context(skip_virtual_update=True).write(
+                                virtual_update_vals
+                            )
                     else:
                         # Create missing virtual line (shouldn't happen in normal flow)
                         virtual_vals = self._prepare_virtual_line_vals(
@@ -485,15 +507,15 @@ class BudgetMoveLine(models.Model):
         """
         # Technical Note: Cascade Deletion via source_line_id
         # Find virtual lines that should be deleted along with regular lines
-        virtual_lines_to_delete = self.env['budget.move.line']
+        virtual_lines_to_delete = self.env["budget.move.line"]
 
         for line in self:
             if line.move_id.move_type == "appropriation" and not line.is_virtual_line:
                 # Find virtual line linked to this regular line
-                virtual_line = self.search([
-                    ('source_line_id', '=', line.id),
-                    ('is_virtual_line', '=', True)
-                ], limit=1)
+                virtual_line = self.search(
+                    [("source_line_id", "=", line.id), ("is_virtual_line", "=", True)],
+                    limit=1,
+                )
                 if virtual_line:
                     virtual_lines_to_delete |= virtual_line
 

--- a/budget/views/budget_move_views.xml
+++ b/budget/views/budget_move_views.xml
@@ -231,6 +231,7 @@
                             domain="[('budget_type', '=', budget_type), ('budgetable', '=', True), '|', ('fund_analytic_ids', '=', False), ('fund_analytic_ids', 'in', [fund_analytic_id])]"
                         />
                         <field name="balance" />
+                        <field name="unallocated_balance" attrs="{'invisible': [('hide_unallocated_balance', '=', True)]}" />
                         <field name="debit" invisible="1" />
                         <field name="credit" invisible="1" />
                         <field name="note" />

--- a/budget/views/budget_move_views.xml
+++ b/budget/views/budget_move_views.xml
@@ -205,6 +205,7 @@
                         <field name="date_range_fy_id" readonly="1" invisible="1" />
                         <field name="move_id" readonly="1" invisible="1" />
                         <field name="source_analytic_id" readonly="1" invisible="1" />
+                        <field name="hide_unallocated_balance" readonly="1" invisible="1" />
                         <field name="budget_type" invisible="1" />
                         <field
                             name="department_analytic_id"

--- a/budget_procurement_plan/models/budget_move_line.py
+++ b/budget_procurement_plan/models/budget_move_line.py
@@ -42,3 +42,10 @@ class BudgetMoveLine(models.Model):
                 rec.unallocated_balance = rec.balance - total_price
             else:
                 rec.unallocated_balance = rec.balance + rec.unallocated_balance
+
+    @api.depends("account_id.procurement_plan")
+    def _compute_hide_unallocated_balance(self):
+        super()._compute_hide_unallocated_balance()
+        for line in self:
+            if line.account_id.procurement_plan:
+                line.hide_unallocated_balance = False

--- a/budget_procurement_plan/models/budget_move_line.py
+++ b/budget_procurement_plan/models/budget_move_line.py
@@ -10,13 +10,6 @@ _logger = logging.getLogger(__name__)
 class BudgetMoveLine(models.Model):
     _inherit = "budget.move.line"
 
-    unallocated_balance = fields.Float(
-        string="ยังไม่ระบุรายการ",
-        help="จำนวนเงินที่ยังไม่มีการวางแผนการใช้งาน แต่ต้องการจองจำนวนเงินไว้ก่อน",
-        store=True,
-        required=False,
-        compute="_compute_amount",
-    )
     procurement_plan_ids = fields.One2many(
         comodel_name="procurement.plan",
         inverse_name="budget_move_line_id",
@@ -35,13 +28,12 @@ class BudgetMoveLine(models.Model):
         "procurement_plan_ids.total_price",
         "balance",
     )
-    def _compute_amount(self):
+    def _compute_unallocated_balance(self):
+        super()._compute_unallocated_balance()
         for rec in self:
             if rec.procurement_plan:
                 total_price = sum(rec.procurement_plan_ids.mapped("total_price"))
                 rec.unallocated_balance = rec.balance - total_price
-            else:
-                rec.unallocated_balance = rec.balance + rec.unallocated_balance
 
     @api.depends("account_id.procurement_plan")
     def _compute_hide_unallocated_balance(self):

--- a/budget_procurement_plan/models/budget_move_line.py
+++ b/budget_procurement_plan/models/budget_move_line.py
@@ -27,6 +27,7 @@ class BudgetMoveLine(models.Model):
         "procurement_plan_ids.price_per_unit",
         "procurement_plan_ids.total_price",
         "balance",
+        "account_id.procurement_plan",
     )
     def _compute_unallocated_balance(self):
         super()._compute_unallocated_balance()

--- a/budget_procurement_plan/views/budget_move_line_views.xml
+++ b/budget_procurement_plan/views/budget_move_line_views.xml
@@ -10,7 +10,7 @@
             <xpath expr="//field[@name='balance']" position="before">
                 <field name="procurement_plan" invisible="1" />
             </xpath>
-            <xpath expr="//field[@name='balance']" position="before">
+            <xpath expr="//field[@name='balance']" position="after">
                 <field name="procurement_plan_ids" attrs="{'invisible': [('procurement_plan', '=', False)]}" context="{
                     'from_budget_line': True,
                     'default_date_range_fy_id': date_range_fy_id,

--- a/budget_procurement_plan/views/budget_move_line_views.xml
+++ b/budget_procurement_plan/views/budget_move_line_views.xml
@@ -32,9 +32,6 @@
                     </tree>
                 </field>
             </xpath>
-            <xpath expr="//field[@name='procurement_plan_ids']" position="after">
-                <field name="unallocated_balance" attrs="{'invisible': [('procurement_plan', '=', False)], 'readonly': True}" />
-            </xpath>
         </field>
     </record>
 

--- a/budget_project/README.rst
+++ b/budget_project/README.rst
@@ -1,0 +1,60 @@
+===============
+Budget Project
+===============
+
+This module adds project/activity budgeting capabilities to the KMITL budget system.
+
+Features
+========
+
+* Create and manage budget projects/activities
+* Link projects to specific budget accounts  
+* Track project budgets with 4-dimensional financial dimensions
+* Integrate with budget move lines for project allocation
+* State workflow: draft → confirmed → done
+
+Configuration
+=============
+
+1. Go to Budgeting → Configuration → Budget Accounts
+2. Enable "Enable Project/Activity" checkbox on budget accounts that should support project management
+3. Only budget accounts with this flag enabled will be available for project creation
+
+Usage
+=====
+
+**Creating Projects/Activities:**
+
+1. Go to Budgeting → Projects/Activities
+2. Create a new project with name, budget amount, and budget account
+3. Set financial dimensions (department, activity, fund, source)
+4. Assign responsible user and set project dates
+
+**Managing Projects from Budget Moves:**
+
+1. When creating a budget appropriation, select a budget move line
+2. If the budget account has project enabled, a "Projects/Activities" tab will appear
+3. Create and manage projects directly from the budget move line form
+4. Projects will automatically inherit financial dimensions from the budget line
+
+**Project States:**
+
+* Draft: Initial state for new projects
+* Confirmed: Project is approved and active
+* Done: Project is completed
+* Cancelled: Project is cancelled
+
+Known Issues / Roadmap
+======================
+
+* Future: Add project budget consumption tracking
+* Future: Integration with procurement and accounting
+* Future: Project reporting and analytics
+
+Credits
+=======
+
+Contributors
+------------
+
+* KMITL Development Team

--- a/budget_project/__init__.py
+++ b/budget_project/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/budget_project/__manifest__.py
+++ b/budget_project/__manifest__.py
@@ -1,0 +1,36 @@
+{
+    "name": "Budget Project",
+    "version": "16.0.1.0.0",
+    "category": "KMITL/Budget",
+    "summary": "Budget management for projects and activities",
+    "description": """
+Budget Project Management
+=========================
+
+This module adds project/activity budgeting capabilities to the budget system.
+
+Features:
+---------
+* Create and manage budget projects/activities
+* Link projects to specific budget accounts
+* Track project budgets with financial dimensions
+* Integrate with budget move lines for project allocation
+    """,
+    "author": "KMITL",
+    "website": "https://www.kmitl.ac.th",
+    "depends": [
+        "budget",
+        "account_analytic_kmitl",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/budget_account_views.xml",
+        "views/budget_project_views.xml",
+        "views/budget_move_views.xml",
+        "views/menu_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+    "license": "LGPL-3",
+}

--- a/budget_project/i18n/th.po
+++ b/budget_project/i18n/th.po
@@ -1,0 +1,531 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* budget_project
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-06 08:40+0000\n"
+"PO-Revision-Date: 2025-08-06 15:44+0700\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.6\n"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Activity"
+msgstr "กิจกรรม"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Additional notes..."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__analytic_distribution
+msgid "Analytic"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__analytic_distribution_search
+msgid "Analytic Distribution Search"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__analytic_precision
+msgid "Analytic Precision"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model,name:budget_project.model_budget_account
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__budget_account_id
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Budget Account"
+msgstr "รหัสงบประมาณ"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__budget_amount
+msgid "Budget Amount"
+msgstr "งบประมาณ"
+
+#. module: budget_project
+#: model:ir.model,name:budget_project.model_budget_move
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__budget_move_id
+msgid "Budget Move"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model,name:budget_project.model_budget_move_line
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__budget_move_line_id
+msgid "Budget Move Line"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model,name:budget_project.model_budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Budget Project/Activity"
+msgstr "โครงการ/กิจกรรม"
+
+#. module: budget_project
+#: model:ir.actions.act_window,name:budget_project.action_budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_tree
+msgid "Budget Projects/Activities"
+msgstr "โครงการ/กิจกรรม"
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Budget amount cannot be negative."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields.selection,name:budget_project.selection__budget_project__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Cannot cancel a completed project."
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Cannot create projects on virtual budget lines."
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Cannot delete a completed project."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_account__project_enabled
+#: model:ir.model.fields,help:budget_project.field_budget_move_line__project_enabled
+msgid "Check this to allow project/activity management for this budget account"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__company_id
+msgid "Company"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields.selection,name:budget_project.selection__budget_project__state__confirmed
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Confirmed"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.actions.act_window,help:budget_project.action_budget_project
+msgid "Create a new budget project/activity"
+msgstr "สร้างโครงการ/กิจกรรมใหม่"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Current Year"
+msgstr "ปีปัจจุบัน"
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Department"
+msgstr "ส่วนงาน"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__description
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Description"
+msgstr "รายละเอียด"
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Dimensions"
+msgstr "มิติ"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__display_name
+msgid "Display Name"
+msgstr "ชื่อรายการ"
+
+#. module: budget_project
+#: model:ir.model.fields.selection,name:budget_project.selection__budget_project__state__done
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Done"
+msgstr "เสร็จสิ้น"
+
+#. module: budget_project
+#: model:ir.model.fields.selection,name:budget_project.selection__budget_project__state__draft
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Draft"
+msgstr "แบบร่าง"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_account__project_enabled
+msgid "Enable Project/Activity"
+msgstr "โครงการ/กิจกรรม"
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Financial Dimensions"
+msgstr "มิติทางบัญชี"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__date_range_fy_id
+msgid "Fiscal Year"
+msgstr "ปีงบประมาณ"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Fund"
+msgstr "กองทุน"
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Group By"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__id
+msgid "ID"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__message_has_error
+#: model:ir.model.fields,help:budget_project.field_budget_project__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_main_attachment_id
+msgid "Main Attachment"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.actions.act_window,help:budget_project.action_budget_project
+msgid "Manage budget projects and activities linked to specific budget accounts."
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Mark as Done"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_calendar_event_id
+msgid "Next Activity Calendar Event"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__note
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Notes"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Only cancelled projects can be reset to draft."
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Only confirmed projects can be marked as done."
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_project.py:0
+#, python-format
+msgid "Only draft projects can be confirmed."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_move_line__project_enabled
+msgid "Project Enabled"
+msgstr "โครงการ/กิจกรรม"
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Project/Activity Description..."
+msgstr "รายละเอียด"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__name
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_form
+msgid "Project/Activity Name"
+msgstr "ชื่อรายการ"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_move__budget_project_ids
+#: model:ir.model.fields,field_description:budget_project.field_budget_move_line__budget_project_ids
+#: model:ir.ui.menu,name:budget_project.menu_budget_project
+msgid "Projects/Activities"
+msgstr "โครงการ/กิจกรรม"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Search Budget Projects"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "Source"
+msgstr "แหล่งเงิน"
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_search
+msgid "State"
+msgstr "สถานะ"
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__state
+msgid "Status"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_app_form_inherit_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_move_line_form_inherit_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_project_tree
+msgid "Total Budget"
+msgstr ""
+
+#. module: budget_project
+#. odoo-python
+#: code:addons/budget_project/models/budget_move_line.py:0
+#, python-format
+msgid "Total project amounts cannot exceed the allocated budget amount."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_project__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__fund_analytic_id
+msgid "กองทุน"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,help:budget_project.field_budget_move_line__unallocated_balance
+msgid "จำนวนเงินที่ยังไม่มีการวางแผนการใช้งาน แต่ต้องการจองจำนวนเงินไว้ก่อน"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__activity_analytic_id
+msgid "ด้าน/แผนงาน/กิจกรรม"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_move_line__unallocated_balance
+msgid "ยังไม่ระบุรายการ"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__department_analytic_id
+msgid "ส่วนงาน"
+msgstr ""
+
+#. module: budget_project
+#: model:ir.model.fields,field_description:budget_project.field_budget_project__source_analytic_id
+msgid "แหล่งเงิน"
+msgstr ""
+
+#. module: budget_project
+#: model_terms:ir.ui.view,arch_db:budget_project.view_budget_app_form_inherit_project
+msgid "โครงการ/กิจกรรม"
+msgstr ""

--- a/budget_project/models/__init__.py
+++ b/budget_project/models/__init__.py
@@ -1,0 +1,3 @@
+from . import budget_account
+from . import budget_project
+from . import budget_move_line

--- a/budget_project/models/__init__.py
+++ b/budget_project/models/__init__.py
@@ -1,3 +1,4 @@
 from . import budget_account
 from . import budget_project
 from . import budget_move_line
+from . import budget_move

--- a/budget_project/models/budget_account.py
+++ b/budget_project/models/budget_account.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class BudgetAccount(models.Model):
+    _inherit = "budget.account"
+
+    project_enabled = fields.Boolean(
+        string="Enable Project/Activity",
+        help="Check this to allow project/activity management for this budget account",
+        tracking=True,
+    )

--- a/budget_project/models/budget_move.py
+++ b/budget_project/models/budget_move.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class BudgetMove(models.Model):
+    _inherit = 'budget.move'
+
+    budget_project_ids = fields.One2many(
+        "budget.project",
+        "budget_move_line_id",
+        compute='_compute_budget_project_ids',
+        string="Projects/Activities",
+        domain=[("budget_move_line_id.is_virtual_line", "=", False)],
+    )
+
+    def _compute_budget_project_ids(self):
+        for record in self:
+            record.budget_project_ids = record.line_ids.mapped('budget_project_ids')

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -17,30 +17,25 @@ class BudgetMoveLine(models.Model):
         readonly=True,
         store=True,
     )
-    total_project_amount = fields.Float(
-        string="Total Project Amount",
-        compute="_compute_project_amounts",
+    unallocated_balance = fields.Float(
+        string="ยังไม่ระบุรายการ",
+        help="จำนวนเงินที่ยังไม่มีการวางแผนการใช้งาน แต่ต้องการจองจำนวนเงินไว้ก่อน",
         store=True,
-        digits="Budget",
-    )
-    unallocated_project_amount = fields.Float(
-        string="Unallocated Project Amount",
-        compute="_compute_project_amounts",
-        store=True,
+        required=False,
+        compute="_compute_unallocated_balance",
         digits="Budget",
     )
 
     @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "balance")
-    def _compute_project_amounts(self):
+    def _compute_unallocated_balance(self):
         for line in self:
             total = sum(line.budget_project_ids.mapped("budget_amount"))
-            line.total_project_amount = total
-            line.unallocated_project_amount = line.balance - total
+            line.unallocated_balance = line.balance - total
 
     @api.constrains("budget_project_ids", "balance")
     def _check_project_amounts(self):
         for line in self:
-            if line.project_enabled and line.unallocated_project_amount < 0:
+            if line.project_enabled and line.unallocated_balance < 0:
                 raise ValidationError(
                     _("Total project amounts cannot exceed the allocated budget amount.")
                 )

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -24,7 +24,12 @@ class BudgetMoveLine(models.Model):
         digits="Budget",
     )
 
-    @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "balance")
+    @api.depends(
+        "budget_project_ids",
+        "budget_project_ids.budget_amount",
+        "balance",
+        "account_id.project_enabled",
+    )
     def _compute_unallocated_balance(self):
         super()._compute_unallocated_balance()
         for rec in self:
@@ -37,11 +42,15 @@ class BudgetMoveLine(models.Model):
         for line in self:
             if line.project_enabled and line.unallocated_balance < 0:
                 raise ValidationError(
-                    _("Total project amounts cannot exceed the allocated budget amount.")
+                    _(
+                        "Total project amounts cannot exceed the allocated budget amount."
+                    )
                 )
 
     def _prepare_virtual_line_vals(self, original_vals, move, source_line_id=None):
-        vals = super()._prepare_virtual_line_vals(original_vals, move, source_line_id=source_line_id)
+        vals = super()._prepare_virtual_line_vals(
+            original_vals, move, source_line_id=source_line_id
+        )
         if "budget_project_ids" in vals:
             del vals["budget_project_ids"]
         return vals

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -26,12 +26,11 @@ class BudgetMoveLine(models.Model):
 
     @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "balance")
     def _compute_unallocated_balance(self):
+        super()._compute_unallocated_balance()
         for rec in self:
             if rec.project_enabled:
                 total = sum(rec.budget_project_ids.mapped("budget_amount"))
                 rec.unallocated_balance = rec.balance - total
-            else:
-                rec.unallocated_balance = rec.balance + rec.unallocated_balance
 
     @api.constrains("budget_project_ids", "balance")
     def _check_project_amounts(self):

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -29,14 +29,14 @@ class BudgetMoveLine(models.Model):
         digits="Budget",
     )
 
-    @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "allocated")
+    @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "balance")
     def _compute_project_amounts(self):
         for line in self:
             total = sum(line.budget_project_ids.mapped("budget_amount"))
             line.total_project_amount = total
-            line.unallocated_project_amount = line.allocated - total
+            line.unallocated_project_amount = line.balance - total
 
-    @api.constrains("budget_project_ids", "allocated")
+    @api.constrains("budget_project_ids", "balance")
     def _check_project_amounts(self):
         for line in self:
             if line.project_enabled and line.unallocated_project_amount < 0:

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -45,3 +45,10 @@ class BudgetMoveLine(models.Model):
         if "budget_project_ids" in vals:
             del vals["budget_project_ids"]
         return vals
+
+    @api.depends("account_id.project_enabled")
+    def _compute_hide_unallocated_balance(self):
+        super()._compute_hide_unallocated_balance()
+        for line in self:
+            if line.account_id.project_enabled:
+                line.hide_unallocated_balance = False

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -47,5 +47,6 @@ class BudgetMoveLine(models.Model):
 
     def _prepare_virtual_line_vals(self, original_vals, move, source_line_id=None):
         vals = super()._prepare_virtual_line_vals(original_vals, move, source_line_id=source_line_id)
-        del vals["budget_project_ids"]
+        if "budget_project_ids" in vals:
+            del vals["budget_project_ids"]
         return vals

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -1,0 +1,45 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class BudgetMoveLine(models.Model):
+    _inherit = "budget.move.line"
+
+    budget_project_ids = fields.One2many(
+        "budget.project",
+        "budget_move_line_id",
+        string="Projects/Activities",
+    )
+    project_enabled = fields.Boolean(
+        string="Project Enabled",
+        related="account_id.project_enabled",
+        readonly=True,
+        store=True,
+    )
+    total_project_amount = fields.Float(
+        string="Total Project Amount",
+        compute="_compute_project_amounts",
+        store=True,
+        digits="Budget",
+    )
+    unallocated_project_amount = fields.Float(
+        string="Unallocated Project Amount",
+        compute="_compute_project_amounts",
+        store=True,
+        digits="Budget",
+    )
+
+    @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "allocated")
+    def _compute_project_amounts(self):
+        for line in self:
+            total = sum(line.budget_project_ids.mapped("budget_amount"))
+            line.total_project_amount = total
+            line.unallocated_project_amount = line.allocated - total
+
+    @api.constrains("budget_project_ids", "allocated")
+    def _check_project_amounts(self):
+        for line in self:
+            if line.project_enabled and line.unallocated_project_amount < 0:
+                raise ValidationError(
+                    _("Total project amounts cannot exceed the allocated budget amount.")
+                )

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -18,8 +18,6 @@ class BudgetMoveLine(models.Model):
         store=True,
     )
     unallocated_balance = fields.Float(
-        string="ยังไม่ระบุรายการ",
-        help="จำนวนเงินที่ยังไม่มีการวางแผนการใช้งาน แต่ต้องการจองจำนวนเงินไว้ก่อน",
         store=True,
         required=False,
         compute="_compute_unallocated_balance",
@@ -28,9 +26,12 @@ class BudgetMoveLine(models.Model):
 
     @api.depends("budget_project_ids", "budget_project_ids.budget_amount", "balance")
     def _compute_unallocated_balance(self):
-        for line in self:
-            total = sum(line.budget_project_ids.mapped("budget_amount"))
-            line.unallocated_balance = line.balance - total
+        for rec in self:
+            if rec.project_enabled:
+                total = sum(rec.budget_project_ids.mapped("budget_amount"))
+                rec.unallocated_balance = rec.balance - total
+            else:
+                rec.unallocated_balance = rec.balance + rec.unallocated_balance
 
     @api.constrains("budget_project_ids", "balance")
     def _check_project_amounts(self):

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -44,3 +44,8 @@ class BudgetMoveLine(models.Model):
                 raise ValidationError(
                     _("Total project amounts cannot exceed the allocated budget amount.")
                 )
+
+    def _prepare_virtual_line_vals(self, original_vals, move, source_line_id=None):
+        vals = super()._prepare_virtual_line_vals(original_vals, move, source_line_id=source_line_id)
+        del vals["budget_project_ids"]
+        return vals

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -9,6 +9,7 @@ class BudgetMoveLine(models.Model):
         "budget.project",
         "budget_move_line_id",
         string="Projects/Activities",
+        domain=[("budget_move_line_id.is_virtual_line", "=", False)],
     )
     project_enabled = fields.Boolean(
         string="Project Enabled",

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -5,7 +5,7 @@ from odoo.exceptions import ValidationError
 class BudgetProject(models.Model):
     _name = "budget.project"
     _description = "Budget Project/Activity"
-    _inherit = ["mail.thread", "mail.activity.mixin", "account.analytic.distribution.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "analytic.distribution.mixin"]
     _order = "create_date desc, id desc"
     _rec_name = "name"
 

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -75,14 +75,6 @@ class BudgetProject(models.Model):
         required=True,
         tracking=True,
     )
-    date_from = fields.Date(
-        string="Start Date",
-        tracking=True,
-    )
-    date_to = fields.Date(
-        string="End Date",
-        tracking=True,
-    )
     responsible_user_id = fields.Many2one(
         "res.users",
         string="Responsible",

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -36,7 +36,7 @@ class BudgetProject(models.Model):
         store=True,
         digits="Budget",
     )
-    
+
     # Budget integration
     budget_move_line_id = fields.Many2one(
         "budget.move.line",
@@ -58,10 +58,10 @@ class BudgetProject(models.Model):
         domain="[('project_enabled', '=', True)]",
         tracking=True,
     )
-    
+
     # Financial dimensions - inherited from AnalyticDistributionMixin
     # department_analytic_id, activity_analytic_id, fund_analytic_id, source_analytic_id
-    
+
     # Additional fields
     state = fields.Selection(
         [
@@ -104,7 +104,7 @@ class BudgetProject(models.Model):
     note = fields.Text(
         string="Notes",
     )
-    
+
     # Related fields for reporting
     date_range_fy_id = fields.Many2one(
         "account.fiscal.year",
@@ -114,12 +114,12 @@ class BudgetProject(models.Model):
         readonly=True,
     )
 
-    @api.depends("budget_move_line_id", "budget_move_line_id.allocated")
+    @api.depends("budget_move_line_id", "budget_move_line_id.balance")
     def _compute_allocated_amount(self):
         for project in self:
             if project.budget_move_line_id:
                 # Get allocated amount from related budget move line
-                project.allocated_amount = project.budget_move_line_id.allocated
+                project.allocated_amount = project.budget_move_line_id.balance
             else:
                 project.allocated_amount = 0.0
 

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -120,12 +120,11 @@ class BudgetProject(models.Model):
             if project.budget_amount < 0:
                 raise ValidationError(_("Budget amount cannot be negative."))
 
-    @api.constrains("date_from", "date_to")
-    def _check_dates(self):
+    @api.constrains("budget_move_line_id")
+    def _check_virtual_line(self):
         for project in self:
-            if project.date_from and project.date_to:
-                if project.date_from > project.date_to:
-                    raise ValidationError(_("Start date must be before end date."))
+            if project.budget_move_line_id and project.budget_move_line_id.is_virtual_line:
+                raise ValidationError(_("Cannot create projects on virtual budget lines."))
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -133,6 +132,9 @@ class BudgetProject(models.Model):
         for vals in vals_list:
             if vals.get("budget_move_line_id"):
                 line = self.env["budget.move.line"].browse(vals["budget_move_line_id"])
+                # Check if line is virtual
+                if line.is_virtual_line:
+                    raise ValidationError(_("Cannot create projects on virtual budget lines."))
                 # Set default analytic dimensions from budget move line
                 if not vals.get("department_analytic_id") and line.department_analytic_id:
                     vals["department_analytic_id"] = line.department_analytic_id.id

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -1,0 +1,196 @@
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class BudgetProject(models.Model):
+    _name = "budget.project"
+    _description = "Budget Project/Activity"
+    _inherit = ["mail.thread", "mail.activity.mixin", "account.analytic.distribution.mixin"]
+    _order = "create_date desc, id desc"
+    _rec_name = "name"
+
+    name = fields.Char(
+        string="Project/Activity Name",
+        required=True,
+        tracking=True,
+    )
+    description = fields.Text(
+        string="Description",
+        tracking=True,
+    )
+    budget_amount = fields.Float(
+        string="Budget Amount",
+        required=True,
+        tracking=True,
+        digits="Budget",
+    )
+    allocated_amount = fields.Float(
+        string="Allocated Amount",
+        compute="_compute_allocated_amount",
+        store=True,
+        digits="Budget",
+    )
+    remaining_amount = fields.Float(
+        string="Remaining Amount",
+        compute="_compute_remaining_amount",
+        store=True,
+        digits="Budget",
+    )
+    
+    # Budget integration
+    budget_move_line_id = fields.Many2one(
+        "budget.move.line",
+        string="Budget Move Line",
+        ondelete="cascade",
+        index=True,
+    )
+    budget_move_id = fields.Many2one(
+        "budget.move",
+        string="Budget Move",
+        related="budget_move_line_id.move_id",
+        store=True,
+        readonly=True,
+    )
+    budget_account_id = fields.Many2one(
+        "budget.account",
+        string="Budget Account",
+        required=True,
+        domain="[('project_enabled', '=', True)]",
+        tracking=True,
+    )
+    
+    # Financial dimensions - inherited from AnalyticDistributionMixin
+    # department_analytic_id, activity_analytic_id, fund_analytic_id, source_analytic_id
+    
+    # Additional fields
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("confirmed", "Confirmed"),
+            ("done", "Done"),
+            ("cancel", "Cancelled"),
+        ],
+        string="Status",
+        default="draft",
+        required=True,
+        tracking=True,
+    )
+    date_from = fields.Date(
+        string="Start Date",
+        tracking=True,
+    )
+    date_to = fields.Date(
+        string="End Date",
+        tracking=True,
+    )
+    responsible_user_id = fields.Many2one(
+        "res.users",
+        string="Responsible",
+        default=lambda self: self.env.user,
+        tracking=True,
+    )
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        related="company_id.currency_id",
+        readonly=True,
+    )
+    note = fields.Text(
+        string="Notes",
+    )
+    
+    # Related fields for reporting
+    date_range_fy_id = fields.Many2one(
+        "date.range",
+        string="Fiscal Year",
+        related="budget_move_line_id.date_range_fy_id",
+        store=True,
+        readonly=True,
+    )
+
+    @api.depends("budget_move_line_id", "budget_move_line_id.allocated")
+    def _compute_allocated_amount(self):
+        for project in self:
+            if project.budget_move_line_id:
+                # Get allocated amount from related budget move line
+                project.allocated_amount = project.budget_move_line_id.allocated
+            else:
+                project.allocated_amount = 0.0
+
+    @api.depends("budget_amount", "allocated_amount")
+    def _compute_remaining_amount(self):
+        for project in self:
+            project.remaining_amount = project.budget_amount - project.allocated_amount
+
+    @api.constrains("budget_amount")
+    def _check_budget_amount(self):
+        for project in self:
+            if project.budget_amount < 0:
+                raise ValidationError(_("Budget amount cannot be negative."))
+
+    @api.constrains("date_from", "date_to")
+    def _check_dates(self):
+        for project in self:
+            if project.date_from and project.date_to:
+                if project.date_from > project.date_to:
+                    raise ValidationError(_("Start date must be before end date."))
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Override to set default analytic values from budget move line if created from there"""
+        for vals in vals_list:
+            if vals.get("budget_move_line_id"):
+                line = self.env["budget.move.line"].browse(vals["budget_move_line_id"])
+                # Set default analytic dimensions from budget move line
+                if not vals.get("department_analytic_id") and line.department_analytic_id:
+                    vals["department_analytic_id"] = line.department_analytic_id.id
+                if not vals.get("activity_analytic_id") and line.activity_analytic_id:
+                    vals["activity_analytic_id"] = line.activity_analytic_id.id
+                if not vals.get("fund_analytic_id") and line.fund_analytic_id:
+                    vals["fund_analytic_id"] = line.fund_analytic_id.id
+                if not vals.get("source_analytic_id") and line.source_analytic_id:
+                    vals["source_analytic_id"] = line.source_analytic_id.id
+                # Set budget account from line if not provided
+                if not vals.get("budget_account_id") and line.account_id:
+                    vals["budget_account_id"] = line.account_id.id
+        return super().create(vals_list)
+
+    def action_confirm(self):
+        """Confirm the project"""
+        self.ensure_one()
+        if self.state != "draft":
+            raise ValidationError(_("Only draft projects can be confirmed."))
+        self.state = "confirmed"
+
+    def action_done(self):
+        """Mark project as done"""
+        self.ensure_one()
+        if self.state != "confirmed":
+            raise ValidationError(_("Only confirmed projects can be marked as done."))
+        self.state = "done"
+
+    def action_cancel(self):
+        """Cancel the project"""
+        self.ensure_one()
+        if self.state == "done":
+            raise ValidationError(_("Cannot cancel a completed project."))
+        self.state = "cancel"
+
+    def action_draft(self):
+        """Reset to draft"""
+        self.ensure_one()
+        if self.state != "cancel":
+            raise ValidationError(_("Only cancelled projects can be reset to draft."))
+        self.state = "draft"
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_done(self):
+        for project in self:
+            if project.state == "done":
+                raise ValidationError(_("Cannot delete a completed project."))

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -107,7 +107,7 @@ class BudgetProject(models.Model):
     
     # Related fields for reporting
     date_range_fy_id = fields.Many2one(
-        "date.range",
+        "account.fiscal.year",
         string="Fiscal Year",
         related="budget_move_line_id.date_range_fy_id",
         store=True,

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -24,18 +24,6 @@ class BudgetProject(models.Model):
         tracking=True,
         digits="Budget",
     )
-    allocated_amount = fields.Float(
-        string="Allocated Amount",
-        compute="_compute_allocated_amount",
-        store=True,
-        digits="Budget",
-    )
-    remaining_amount = fields.Float(
-        string="Remaining Amount",
-        compute="_compute_remaining_amount",
-        store=True,
-        digits="Budget",
-    )
 
     # Budget integration
     budget_move_line_id = fields.Many2one(
@@ -100,20 +88,6 @@ class BudgetProject(models.Model):
         readonly=True,
     )
 
-    @api.depends("budget_move_line_id", "budget_move_line_id.balance")
-    def _compute_allocated_amount(self):
-        for project in self:
-            if project.budget_move_line_id:
-                # Get allocated amount from related budget move line
-                project.allocated_amount = project.budget_move_line_id.balance
-            else:
-                project.allocated_amount = 0.0
-
-    @api.depends("budget_amount", "allocated_amount")
-    def _compute_remaining_amount(self):
-        for project in self:
-            project.remaining_amount = project.budget_amount - project.allocated_amount
-
     @api.constrains("budget_amount")
     def _check_budget_amount(self):
         for project in self:
@@ -123,8 +97,13 @@ class BudgetProject(models.Model):
     @api.constrains("budget_move_line_id")
     def _check_virtual_line(self):
         for project in self:
-            if project.budget_move_line_id and project.budget_move_line_id.is_virtual_line:
-                raise ValidationError(_("Cannot create projects on virtual budget lines."))
+            if (
+                project.budget_move_line_id
+                and project.budget_move_line_id.is_virtual_line
+            ):
+                raise ValidationError(
+                    _("Cannot create projects on virtual budget lines.")
+                )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -134,9 +113,14 @@ class BudgetProject(models.Model):
                 line = self.env["budget.move.line"].browse(vals["budget_move_line_id"])
                 # Check if line is virtual
                 if line.is_virtual_line:
-                    raise ValidationError(_("Cannot create projects on virtual budget lines."))
+                    raise ValidationError(
+                        _("Cannot create projects on virtual budget lines.")
+                    )
                 # Set default analytic dimensions from budget move line
-                if not vals.get("department_analytic_id") and line.department_analytic_id:
+                if (
+                    not vals.get("department_analytic_id")
+                    and line.department_analytic_id
+                ):
                     vals["department_analytic_id"] = line.department_analytic_id.id
                 if not vals.get("activity_analytic_id") and line.activity_analytic_id:
                     vals["activity_analytic_id"] = line.activity_analytic_id.id

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -75,12 +75,6 @@ class BudgetProject(models.Model):
         required=True,
         tracking=True,
     )
-    responsible_user_id = fields.Many2one(
-        "res.users",
-        string="Responsible",
-        default=lambda self: self.env.user,
-        tracking=True,
-    )
     company_id = fields.Many2one(
         "res.company",
         string="Company",

--- a/budget_project/security/ir.model.access.csv
+++ b/budget_project/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_budget_project_user,budget.project.user,model_budget_project,budget.group_budget_user,1,1,1,1
+access_budget_project_manager,budget.project.manager,model_budget_project,budget.group_budget_manager,1,1,1,1
+access_budget_project_viewer,budget.project.viewer,model_budget_project,budget.group_budget_viewer,1,0,0,0

--- a/budget_project/security/ir.model.access.csv
+++ b/budget_project/security/ir.model.access.csv
@@ -1,4 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_budget_project_user,budget.project.user,model_budget_project,budget.group_budget_user,1,1,1,1
-access_budget_project_manager,budget.project.manager,model_budget_project,budget.group_budget_manager,1,1,1,1
-access_budget_project_viewer,budget.project.viewer,model_budget_project,budget.group_budget_viewer,1,0,0,0
+access_budget_project_user,budget_project_user,model_budget_project,,1,1,1,1

--- a/budget_project/views/budget_account_views.xml
+++ b/budget_project/views/budget_account_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Inherit budget account form view to add project_enabled field -->
+    <record id="view_budget_account_form_inherit_project" model="ir.ui.view">
+        <field name="name">budget.account.form.inherit.project</field>
+        <field name="model">budget.account</field>
+        <field name="inherit_id" ref="budget.view_budget_account_form"/>
+        <field name="arch" type="xml">
+            <field name="deprecated" position="after">
+                <field name="project_enabled"/>
+            </field>
+        </field>
+    </record>
+
+    <!-- Inherit budget account tree view to add project_enabled field -->
+    <record id="view_budget_account_tree_inherit_project" model="ir.ui.view">
+        <field name="name">budget.account.tree.inherit.project</field>
+        <field name="model">budget.account</field>
+        <field name="inherit_id" ref="budget.view_budget_account_tree"/>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="project_enabled" optional="show"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_project/views/budget_account_views.xml
+++ b/budget_project/views/budget_account_views.xml
@@ -19,7 +19,7 @@
         <field name="model">budget.account</field>
         <field name="inherit_id" ref="budget.view_budget_account_tree"/>
         <field name="arch" type="xml">
-            <field name="type" position="after">
+            <field name="deprecated" position="after">
                 <field name="project_enabled" optional="show"/>
             </field>
         </field>

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -48,6 +48,22 @@
                 <field name="total_project_amount" optional="hide"/>
                 <field name="unallocated_project_amount" optional="hide"/>
             </xpath>
+
+            <xpath expr="//notebook" position="inside">
+                <page name="procurement_plan" string="แผนการจัดซื้อจัดจ้าง" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="procurement_plan_ids">
+                        <tree>
+                            <field name="budget_account_id"/>
+                            <field name="name"/>
+                            <field name="amount" />
+                            <field name="unit" />
+                            <field name="price_per_unit" />
+                            <field name="total_price"/>
+                            <field name="procurement_method_id" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
         </field>
     </record>
 

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -50,16 +50,16 @@
             </xpath>
 
             <xpath expr="//notebook" position="inside">
-                <page name="procurement_plan" string="แผนการจัดซื้อจัดจ้าง" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
-                    <field name="procurement_plan_ids">
+                <page name="budget_project" string="โครงการ/กิจกรรม" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="budget_project_ids">
                         <tree>
                             <field name="budget_account_id"/>
                             <field name="name"/>
-                            <field name="amount" />
-                            <field name="unit" />
-                            <field name="price_per_unit" />
-                            <field name="total_price"/>
-                            <field name="procurement_method_id" />
+                            <field name="budget_amount" sum="Total Budget"/>
+                            <field name="department_analytic_id" options="{'no_create': True}" domain="[('root_plan_id.code', '=', 'departments')]"/>
+                            <field name="activity_analytic_id" options="{'no_create': True}" domain="[('root_plan_id.code', '=', 'activities')]"/>
+                            <field name="fund_analytic_id" options="{'no_create': True}" domain="[('root_plan_id.code', '=', 'funds')]"/>
+                            <field name="source_analytic_id" options="{'no_create': True}" domain="[('root_plan_id.code', '=', 'sources')]"/>
                         </tree>
                     </field>
                 </page>

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -28,8 +28,6 @@
                     <tree editable="bottom">
                         <field name="name"/>
                         <field name="budget_amount" sum="Total Budget"/>
-                        <field name="date_from" optional="show"/>
-                        <field name="date_to" optional="show"/>
                         <field name="responsible_user_id"/>
                         <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
                         <field name="description" optional="hide"/>

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -37,9 +37,6 @@
                     </tree>
                 </field>
             </xpath>
-            <xpath expr="//field[@name='procurement_plan_ids']" position="after">
-                <field name="unallocated_balance" attrs="{'invisible': [('procurement_plan', '=', False)], 'readonly': True}" />
-            </xpath>
         </field>
     </record>
 

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -30,7 +30,6 @@
                         <field name="note" optional="hide"/>
                     </tree>
                 </field>
-                <field name="unallocated_balance" readonly="1"/>
             </xpath>
         </field>
     </record>
@@ -44,7 +43,6 @@
             <!-- Add project fields to appropriation lines tree -->
             <xpath expr="//field[@name='appropriation_line_ids']/tree" position="inside">
                 <field name="project_enabled" invisible="1"/>
-                <field name="unallocated_balance" optional="hide"/>
             </xpath>
 
             <xpath expr="//notebook" position="inside">

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -28,8 +28,6 @@
                     <tree editable="bottom">
                         <field name="name"/>
                         <field name="budget_amount" sum="Total Budget"/>
-                        <field name="responsible_user_id"/>
-                        <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
                         <field name="description" optional="hide"/>
                         <field name="note" optional="hide"/>
                     </tree>

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Inherit budget move line form view to add project tree -->
+    <record id="view_budget_move_line_form_inherit_project" model="ir.ui.view">
+        <field name="name">budget.move.line.form.inherit.project</field>
+        <field name="model">budget.move.line</field>
+        <field name="inherit_id" ref="budget.view_budget_move_line_form"/>
+        <field name="arch" type="xml">
+            <!-- Add project fields to tree view for visibility -->
+            <xpath expr="//form/sheet/notebook" position="inside">
+                <page string="Projects/Activities" name="projects" attrs="{'invisible': [('project_enabled', '=', False)]}">
+                    <group>
+                        <field name="project_enabled" invisible="1"/>
+                        <field name="total_project_amount" readonly="1"/>
+                        <field name="unallocated_project_amount" readonly="1"/>
+                    </group>
+                    <field name="budget_project_ids" context="{
+                        'from_budget_line': True,
+                        'default_date_range_fy_id': date_range_fy_id,
+                        'default_source_analytic_id': source_analytic_id,
+                        'default_activity_analytic_id': activity_analytic_id,
+                        'default_department_analytic_id': department_analytic_id,
+                        'default_fund_analytic_id': fund_analytic_id,
+                        'default_budget_account_id': account_id,
+                        'default_budget_move_line_id': id,
+                        'default_budget_move_id': move_id
+                    }">
+                        <tree editable="bottom">
+                            <field name="name"/>
+                            <field name="budget_amount" sum="Total Budget"/>
+                            <field name="date_from" optional="show"/>
+                            <field name="date_to" optional="show"/>
+                            <field name="responsible_user_id"/>
+                            <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
+                            <field name="description" optional="hide"/>
+                            <field name="note" optional="hide"/>
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Inherit budget appropriation form view to show projects in move lines -->
+    <record id="view_budget_app_inherit_form_project" model="ir.ui.view">
+        <field name="name">budget.app.form.inherit.project</field>
+        <field name="model">budget.move</field>
+        <field name="inherit_id" ref="budget.view_budget_app_inherit_form"/>
+        <field name="arch" type="xml">
+            <!-- Add project fields to appropriation lines tree -->
+            <xpath expr="//field[@name='appropriation_line_ids']/tree" position="inside">
+                <field name="project_enabled" invisible="1"/>
+                <field name="total_project_amount" optional="hide"/>
+                <field name="unallocated_project_amount" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -10,10 +10,8 @@
             <!-- Add project fields to tree view for visibility -->
             <xpath expr="//field[@name='balance']" position="before">
                 <field name="project_enabled" invisible="1" />
-                <field name="total_project_amount" readonly="1"/>
-                <field name="unallocated_project_amount" readonly="1"/>
             </xpath>
-            <xpath expr="//field[@name='balance']" position="before">
+            <xpath expr="//field[@name='balance']" position="after">
                 <field name="budget_project_ids" attrs="{'invisible': [('project_enabled', '=', False)]}" context="{
                     'from_budget_line': True,
                     'default_date_range_fy_id': date_range_fy_id,
@@ -32,6 +30,7 @@
                         <field name="note" optional="hide"/>
                     </tree>
                 </field>
+                <field name="unallocated_balance" readonly="1"/>
             </xpath>
         </field>
     </record>
@@ -45,8 +44,7 @@
             <!-- Add project fields to appropriation lines tree -->
             <xpath expr="//field[@name='appropriation_line_ids']/tree" position="inside">
                 <field name="project_enabled" invisible="1"/>
-                <field name="total_project_amount" optional="hide"/>
-                <field name="unallocated_project_amount" optional="hide"/>
+                <field name="unallocated_balance" optional="hide"/>
             </xpath>
 
             <xpath expr="//notebook" position="inside">

--- a/budget_project/views/budget_move_views.xml
+++ b/budget_project/views/budget_move_views.xml
@@ -8,45 +8,46 @@
         <field name="inherit_id" ref="budget.view_budget_move_line_form"/>
         <field name="arch" type="xml">
             <!-- Add project fields to tree view for visibility -->
-            <xpath expr="//form/sheet/notebook" position="inside">
-                <page string="Projects/Activities" name="projects" attrs="{'invisible': [('project_enabled', '=', False)]}">
-                    <group>
-                        <field name="project_enabled" invisible="1"/>
-                        <field name="total_project_amount" readonly="1"/>
-                        <field name="unallocated_project_amount" readonly="1"/>
-                    </group>
-                    <field name="budget_project_ids" context="{
-                        'from_budget_line': True,
-                        'default_date_range_fy_id': date_range_fy_id,
-                        'default_source_analytic_id': source_analytic_id,
-                        'default_activity_analytic_id': activity_analytic_id,
-                        'default_department_analytic_id': department_analytic_id,
-                        'default_fund_analytic_id': fund_analytic_id,
-                        'default_budget_account_id': account_id,
-                        'default_budget_move_line_id': id,
-                        'default_budget_move_id': move_id
+            <xpath expr="//field[@name='balance']" position="before">
+                <field name="project_enabled" invisible="1" />
+                <field name="total_project_amount" readonly="1"/>
+                <field name="unallocated_project_amount" readonly="1"/>
+            </xpath>
+            <xpath expr="//field[@name='balance']" position="before">
+                <field name="budget_project_ids" attrs="{'invisible': [('project_enabled', '=', False)]}" context="{
+                    'from_budget_line': True,
+                    'default_date_range_fy_id': date_range_fy_id,
+                    'default_source_analytic_id': source_analytic_id,
+                    'default_activity_analytic_id': activity_analytic_id,
+                    'default_department_analytic_id': department_analytic_id,
+                    'default_fund_analytic_id': fund_analytic_id,
+                    'default_budget_account_id': account_id,
+                    'default_budget_move_line_id': id,
+                    'default_budget_move_id': move_id
                     }">
-                        <tree editable="bottom">
-                            <field name="name"/>
-                            <field name="budget_amount" sum="Total Budget"/>
-                            <field name="date_from" optional="show"/>
-                            <field name="date_to" optional="show"/>
-                            <field name="responsible_user_id"/>
-                            <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
-                            <field name="description" optional="hide"/>
-                            <field name="note" optional="hide"/>
-                        </tree>
-                    </field>
-                </page>
+                    <tree editable="bottom">
+                        <field name="name"/>
+                        <field name="budget_amount" sum="Total Budget"/>
+                        <field name="date_from" optional="show"/>
+                        <field name="date_to" optional="show"/>
+                        <field name="responsible_user_id"/>
+                        <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
+                        <field name="description" optional="hide"/>
+                        <field name="note" optional="hide"/>
+                    </tree>
+                </field>
+            </xpath>
+            <xpath expr="//field[@name='procurement_plan_ids']" position="after">
+                <field name="unallocated_balance" attrs="{'invisible': [('procurement_plan', '=', False)], 'readonly': True}" />
             </xpath>
         </field>
     </record>
 
     <!-- Inherit budget appropriation form view to show projects in move lines -->
-    <record id="view_budget_app_inherit_form_project" model="ir.ui.view">
+    <record id="view_budget_app_form_inherit_project" model="ir.ui.view">
         <field name="name">budget.app.form.inherit.project</field>
         <field name="model">budget.move</field>
-        <field name="inherit_id" ref="budget.view_budget_app_inherit_form"/>
+        <field name="inherit_id" ref="budget.view_budget_app_form"/>
         <field name="arch" type="xml">
             <!-- Add project fields to appropriation lines tree -->
             <xpath expr="//field[@name='appropriation_line_ids']/tree" position="inside">

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -32,7 +32,6 @@
                             <field name="budget_amount"/>
                             <field name="allocated_amount" readonly="1"/>
                             <field name="remaining_amount" readonly="1"/>
-                            <field name="responsible_user_id"/>
                         </group>
                         <group>
                             <field name="budget_move_line_id" invisible="1"/>
@@ -85,7 +84,6 @@
                 <field name="budget_amount" sum="Total Budget"/>
                 <field name="allocated_amount" sum="Total Allocated"/>
                 <field name="remaining_amount" sum="Total Remaining"/>
-                <field name="responsible_user_id"/>
                 <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
                 <field name="department_analytic_id" optional="hide"/>
                 <field name="activity_analytic_id" optional="hide"/>
@@ -103,7 +101,6 @@
             <search string="Search Budget Projects">
                 <field name="name"/>
                 <field name="budget_account_id"/>
-                <field name="responsible_user_id"/>
                 <field name="department_analytic_id"/>
                 <field name="activity_analytic_id"/>
                 <field name="fund_analytic_id"/>
@@ -113,12 +110,9 @@
                 <filter string="Confirmed" name="confirmed" domain="[('state', '=', 'confirmed')]"/>
                 <filter string="Done" name="done" domain="[('state', '=', 'done')]"/>
                 <separator/>
-                <filter string="My Projects" name="my_projects" domain="[('responsible_user_id', '=', uid)]"/>
-                <separator/>
                 <filter string="Current Year" name="current_year" domain="[('date_range_fy_id.name', 'ilike', time.strftime('%%Y'))]"/>
                 <group expand="0" string="Group By">
                     <filter string="Budget Account" name="group_account" context="{'group_by': 'budget_account_id'}"/>
-                    <filter string="Responsible" name="group_responsible" context="{'group_by': 'responsible_user_id'}"/>
                     <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
                     <filter string="Department" name="group_department" context="{'group_by': 'department_analytic_id'}"/>
                     <filter string="Activity" name="group_activity" context="{'group_by': 'activity_analytic_id'}"/>

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -35,8 +35,6 @@
                             <field name="responsible_user_id"/>
                         </group>
                         <group>
-                            <field name="date_from"/>
-                            <field name="date_to"/>
                             <field name="budget_move_line_id" invisible="1"/>
                             <field name="budget_move_id" readonly="1" attrs="{'invisible': [('budget_move_id', '=', False)]}"/>
                             <field name="date_range_fy_id" readonly="1" attrs="{'invisible': [('date_range_fy_id', '=', False)]}"/>
@@ -48,7 +46,7 @@
                         <page string="Financial Dimensions" name="financial_dimensions">
                             <group>
                                 <group string="Dimensions">
-                                    <field name="department_analytic_id" options="{'no_create': True}" 
+                                    <field name="department_analytic_id" options="{'no_create': True}"
                                            domain="[('root_plan_id.code', '=', 'departments')]"/>
                                     <field name="activity_analytic_id" options="{'no_create': True}"
                                            domain="[('root_plan_id.code', '=', 'activities')]"/>
@@ -88,8 +86,6 @@
                 <field name="allocated_amount" sum="Total Allocated"/>
                 <field name="remaining_amount" sum="Total Remaining"/>
                 <field name="responsible_user_id"/>
-                <field name="date_from" optional="show"/>
-                <field name="date_to" optional="show"/>
                 <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
                 <field name="department_analytic_id" optional="hide"/>
                 <field name="activity_analytic_id" optional="hide"/>

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Budget Project Form View -->
+    <record id="view_budget_project_form" model="ir.ui.view">
+        <field name="name">budget.project.form</field>
+        <field name="model">budget.project</field>
+        <field name="arch" type="xml">
+            <form string="Budget Project/Activity">
+                <header>
+                    <button name="action_confirm" string="Confirm" type="object" class="btn-primary"
+                            attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                    <button name="action_done" string="Mark as Done" type="object" class="btn-primary"
+                            attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
+                    <button name="action_cancel" string="Cancel" type="object"
+                            attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"/>
+                    <button name="action_draft" string="Set to Draft" type="object"
+                            attrs="{'invisible': [('state', '!=', 'cancel')]}"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                    </div>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Project/Activity Name"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="budget_account_id"/>
+                            <field name="budget_amount"/>
+                            <field name="allocated_amount" readonly="1"/>
+                            <field name="remaining_amount" readonly="1"/>
+                            <field name="responsible_user_id"/>
+                        </group>
+                        <group>
+                            <field name="date_from"/>
+                            <field name="date_to"/>
+                            <field name="budget_move_line_id" invisible="1"/>
+                            <field name="budget_move_id" readonly="1" attrs="{'invisible': [('budget_move_id', '=', False)]}"/>
+                            <field name="date_range_fy_id" readonly="1" attrs="{'invisible': [('date_range_fy_id', '=', False)]}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="currency_id" invisible="1"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Financial Dimensions" name="financial_dimensions">
+                            <group>
+                                <group string="Dimensions">
+                                    <field name="department_analytic_id" options="{'no_create': True}" 
+                                           domain="[('root_plan_id.code', '=', 'departments')]"/>
+                                    <field name="activity_analytic_id" options="{'no_create': True}"
+                                           domain="[('root_plan_id.code', '=', 'activities')]"/>
+                                    <field name="fund_analytic_id" options="{'no_create': True}"
+                                           domain="[('root_plan_id.code', '=', 'funds')]"/>
+                                    <field name="source_analytic_id" options="{'no_create': True}"
+                                           domain="[('root_plan_id.code', '=', 'sources')]"/>
+                                </group>
+                            </group>
+                        </page>
+                        <page string="Description" name="description">
+                            <field name="description" placeholder="Project/Activity Description..."/>
+                        </page>
+                        <page string="Notes" name="notes">
+                            <field name="note" placeholder="Additional notes..."/>
+                        </page>
+                    </notebook>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids"/>
+                    <field name="activity_ids"/>
+                    <field name="message_ids"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <!-- Budget Project Tree View -->
+    <record id="view_budget_project_tree" model="ir.ui.view">
+        <field name="name">budget.project.tree</field>
+        <field name="model">budget.project</field>
+        <field name="arch" type="xml">
+            <tree string="Budget Projects/Activities" decoration-muted="state == 'cancel'">
+                <field name="name"/>
+                <field name="budget_account_id"/>
+                <field name="budget_amount" sum="Total Budget"/>
+                <field name="allocated_amount" sum="Total Allocated"/>
+                <field name="remaining_amount" sum="Total Remaining"/>
+                <field name="responsible_user_id"/>
+                <field name="date_from" optional="show"/>
+                <field name="date_to" optional="show"/>
+                <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
+                <field name="department_analytic_id" optional="hide"/>
+                <field name="activity_analytic_id" optional="hide"/>
+                <field name="fund_analytic_id" optional="hide"/>
+                <field name="source_analytic_id" optional="hide"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Budget Project Search View -->
+    <record id="view_budget_project_search" model="ir.ui.view">
+        <field name="name">budget.project.search</field>
+        <field name="model">budget.project</field>
+        <field name="arch" type="xml">
+            <search string="Search Budget Projects">
+                <field name="name"/>
+                <field name="budget_account_id"/>
+                <field name="responsible_user_id"/>
+                <field name="department_analytic_id"/>
+                <field name="activity_analytic_id"/>
+                <field name="fund_analytic_id"/>
+                <field name="source_analytic_id"/>
+                <separator/>
+                <filter string="Draft" name="draft" domain="[('state', '=', 'draft')]"/>
+                <filter string="Confirmed" name="confirmed" domain="[('state', '=', 'confirmed')]"/>
+                <filter string="Done" name="done" domain="[('state', '=', 'done')]"/>
+                <separator/>
+                <filter string="My Projects" name="my_projects" domain="[('responsible_user_id', '=', uid)]"/>
+                <separator/>
+                <filter string="Current Year" name="current_year" domain="[('date_range_fy_id.name', 'ilike', time.strftime('%%Y'))]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Budget Account" name="group_account" context="{'group_by': 'budget_account_id'}"/>
+                    <filter string="Responsible" name="group_responsible" context="{'group_by': 'responsible_user_id'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Department" name="group_department" context="{'group_by': 'department_analytic_id'}"/>
+                    <filter string="Activity" name="group_activity" context="{'group_by': 'activity_analytic_id'}"/>
+                    <filter string="Fund" name="group_fund" context="{'group_by': 'fund_analytic_id'}"/>
+                    <filter string="Source" name="group_source" context="{'group_by': 'source_analytic_id'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Budget Project Action -->
+    <record id="action_budget_project" model="ir.actions.act_window">
+        <field name="name">Budget Projects/Activities</field>
+        <field name="res_model">budget.project</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_budget_project_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new budget project/activity
+            </p>
+            <p>
+                Manage budget projects and activities linked to specific budget accounts.
+            </p>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -8,14 +8,14 @@
         <field name="arch" type="xml">
             <form string="Budget Project/Activity">
                 <header>
-                    <button name="action_confirm" string="Confirm" type="object" class="btn-primary"
-                            attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                    <!-- <button name="action_confirm" string="Confirm" type="object" class="btn-primary"
+                            attrs="{'invisible': [('state', '!=', 'draft')]}"/> -->
                     <button name="action_done" string="Mark as Done" type="object" class="btn-primary"
                             attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
-                    <button name="action_cancel" string="Cancel" type="object"
+                    <!-- <button name="action_cancel" string="Cancel" type="object"
                             attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"/>
                     <button name="action_draft" string="Set to Draft" type="object"
-                            attrs="{'invisible': [('state', '!=', 'cancel')]}"/>
+                            attrs="{'invisible': [('state', '!=', 'cancel')]}"/> -->
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done"/>
                 </header>
                 <sheet>
@@ -76,7 +76,7 @@
         <field name="name">budget.project.tree</field>
         <field name="model">budget.project</field>
         <field name="arch" type="xml">
-            <tree string="Budget Projects/Activities" decoration-muted="state == 'cancel'">
+            <tree string="Budget Projects/Activities" decoration-muted="state == 'cancel'" create="false" edit="false">
                 <field name="name"/>
                 <field name="budget_account_id"/>
                 <field name="budget_amount" sum="Total Budget"/>

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -30,8 +30,6 @@
                         <group>
                             <field name="budget_account_id"/>
                             <field name="budget_amount"/>
-                            <field name="allocated_amount" readonly="1"/>
-                            <field name="remaining_amount" readonly="1"/>
                         </group>
                         <group>
                             <field name="budget_move_line_id" invisible="1"/>
@@ -82,8 +80,6 @@
                 <field name="name"/>
                 <field name="budget_account_id"/>
                 <field name="budget_amount" sum="Total Budget"/>
-                <field name="allocated_amount" sum="Total Allocated"/>
-                <field name="remaining_amount" sum="Total Remaining"/>
                 <field name="state" widget="badge" decoration-success="state == 'done'" decoration-warning="state == 'confirmed'" decoration-info="state == 'draft'"/>
                 <field name="department_analytic_id" optional="hide"/>
                 <field name="activity_analytic_id" optional="hide"/>

--- a/budget_project/views/menu_views.xml
+++ b/budget_project/views/menu_views.xml
@@ -4,7 +4,7 @@
     <!-- Menu item for Budget Projects -->
     <menuitem id="menu_budget_project"
               name="Projects/Activities"
-              parent="budget.budget_menu_main"
+              parent="budget.budget_root_menu"
               action="action_budget_project"
               sequence="50"/>
 

--- a/budget_project/views/menu_views.xml
+++ b/budget_project/views/menu_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Menu item for Budget Projects -->
+    <menuitem id="menu_budget_project"
+              name="Projects/Activities"
+              parent="budget.budget_menu_main"
+              action="action_budget_project"
+              sequence="50"/>
+
+</odoo>


### PR DESCRIPTION
## Summary
- Add new `budget.project` model for managing projects/activities linked to budget accounts
- Enable project management only for specific budget accounts via `project_enabled` flag
- Integrate seamlessly with budget move lines for easy project allocation

## Features
- **Project Management**: Create and track budget projects/activities with dedicated amounts
- **4D Financial Dimensions**: Full integration with KMITL's financial dimension framework (department, activity, fund, source)
- **Budget Account Configuration**: Enable project management selectively via checkbox on budget accounts
- **Budget Move Line Integration**: Manage projects directly from budget appropriation forms
- **State Workflow**: Track project lifecycle (draft → confirmed → done)
- **Validation**: Ensure project amounts don't exceed allocated budget

## Test plan
- [ ] Install the `budget_project` module
- [ ] Go to Budgeting → Configuration → Budget Accounts and enable "Enable Project/Activity" on some accounts
- [ ] Create a budget appropriation and add budget lines with project-enabled accounts
- [ ] In the budget move line form, verify the "Projects/Activities" tab appears
- [ ] Create projects from the budget line and verify financial dimensions are inherited
- [ ] Test project state transitions and validations
- [ ] Verify project amounts cannot exceed allocated budget amounts

🤖 Generated with [Claude Code](https://claude.ai/code)