### PR TITLE
[16.0][ADD] budget: add company_id field to budget account

### DIFF
--- a/budget/models/budget_account.py
+++ b/budget/models/budget_account.py
@@ -107,6 +107,14 @@ class BudgetAccount(models.Model):
         help="Set active to false to hide the Budget Account without removing it.",
     )
 
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        required=True,
+        default=lambda self: self.env.company,
+        tracking=True,
+    )
+
     _sql_constraints = [
         (
             "unique_budget_account_line",


### PR DESCRIPTION
## Summary
• Add company_id field to budget.account model to support multi-company operations
• Field is required with default set to current company
• Includes tracking for audit trail

## Test plan
- [ ] Verify budget accounts are created with correct company context
- [ ] Test multi-company scenarios to ensure proper data isolation
- [ ] Check that existing budget accounts maintain functionality

🤖 Generated with [Claude Code](https://claude.ai/code)