### PR TITLE
[16.0][IMP] budget: add obligated state to budget commitments

### DIFF
--- a/budget/models/budget_commitment.py
+++ b/budget/models/budget_commitment.py
@@ -42,11 +42,12 @@ class BudgetCommitment(models.Model):
         • Color-coded visual feedback in the user interface
 
     State Lifecycle:
-        draft → reserved → done
-        │       │         │
-        │       │         └── Fully processed, budget released or consumed
-        │       └──────────── Budget reserved, prevents over-commitment
-        └─────────────────── Editable, no budget impact
+        draft → reserved → obligated → done
+        │       │         │           │
+        │       │         │           └── Fully processed, budget released or consumed
+        │       │         └──────────── Budget obligated, firm commitment
+        │       └─────────────────────── Budget reserved, prevents over-commitment
+        └────────────────────────────── Editable, no budget impact
 
     Key Features:
         • Real-time budget availability checking with hierarchical matching
@@ -86,6 +87,7 @@ class BudgetCommitment(models.Model):
 
     READONLY_STATES = {
         "reserved": [("readonly", True)],
+        "obligated": [("readonly", True)],
         "done": [("readonly", True)],
         "cancel": [("readonly", True)],
     }
@@ -123,6 +125,7 @@ class BudgetCommitment(models.Model):
         selection=[
             ("draft", "Draft"),
             ("reserved", "Reserved"),
+            ("obligated", "Obligated"),
             ("done", "Done"),
             ("cancel", "Cancelled"),
         ],
@@ -384,8 +387,8 @@ class BudgetCommitment(models.Model):
                     record.company_id.id
                 )
 
-                # If commitment is already reserved, add back its own amount to available
-                if record.state == 'reserved' and record.amount:
+                # If commitment is already reserved or obligated, add back its own amount to available
+                if record.state in ['reserved', 'obligated'] and record.amount:
                     available += record.amount
 
                 record.available_budget_amount = available
@@ -565,11 +568,18 @@ class BudgetCommitment(models.Model):
 
             record.state = 'reserved'
 
+    def action_obligate(self):
+        """Obligate budget for this commitment - mark as firm commitment"""
+        for record in self:
+            if record.state != 'reserved':
+                raise UserError(_('Only reserved commitments can be obligated.'))
+            record.state = 'obligated'
+
     def action_done(self):
         """Mark commitment as done - closes the commitment and releases any remaining budget"""
         for record in self:
-            if record.state not in ['reserved']:
-                raise UserError(_('Only reserved commitments can be marked as done.'))
+            if record.state not in ['obligated']:
+                raise UserError(_('Only obligated commitments can be marked as done.'))
             record.state = 'done'
 
     def action_cancel(self):

--- a/budget/models/budget_commitment_mixin.py
+++ b/budget/models/budget_commitment_mixin.py
@@ -331,6 +331,43 @@ class BudgetCommitmentMixin(models.AbstractModel):
 
         return True
 
+    def _obligate_budget_commitment(self, commitment=None):
+        """
+        Obligate a budget commitment (mark as obligated).
+        This transitions from reserved to obligated state for firm commitments.
+        If no commitment is provided, uses the record's dynamic commitment field.
+
+        Args:
+            commitment (budget.commitment, optional): Commitment to obligate
+                                                     If None, uses record's commitment field
+
+        Returns:
+            bool: True if successful
+
+        Raises:
+            UserError: If commitment cannot be obligated
+        """
+        self.ensure_one()
+
+        if commitment is None:
+            commitment = self._get_commitment_field_value('commitment_id')
+
+        if not commitment:
+            return True
+
+        if commitment.state == 'obligated':
+            return True  # Already obligated
+
+        if commitment.state != 'reserved':
+            raise UserError(_(
+                "Cannot obligate commitment %s - it must be in reserved state"
+            ) % commitment.name)
+
+        commitment.action_obligate()
+        _logger.info("Obligated budget commitment %s", commitment.name)
+
+        return True
+
     def _close_budget_commitment(self, commitment=None):
         """
         Close a budget commitment (mark as done).
@@ -358,9 +395,9 @@ class BudgetCommitmentMixin(models.AbstractModel):
         if commitment.state == 'done':
             return True  # Already done
 
-        if commitment.state != 'reserved':
+        if commitment.state != 'obligated':
             raise UserError(_(
-                "Cannot close commitment %s - it must be in reserved state"
+                "Cannot close commitment %s - it must be in obligated state"
             ) % commitment.name)
 
         commitment.action_done()
@@ -397,9 +434,9 @@ class BudgetCommitmentMixin(models.AbstractModel):
         if not commitment:
             raise ValidationError(_("No commitment to update"))
 
-        if commitment.state != 'reserved':
+        if commitment.state not in ['reserved', 'obligated']:
             raise UserError(_(
-                "Can only update amount for reserved commitments"
+                "Can only update amount for reserved or obligated commitments"
             ))
 
         if new_amount <= 0:
@@ -473,9 +510,9 @@ class BudgetCommitmentMixin(models.AbstractModel):
         if not commitment:
             raise ValidationError(_("No commitment to consume"))
 
-        if commitment.state != 'reserved':
+        if commitment.state not in ['reserved', 'obligated']:
             raise UserError(_(
-                "Can only consume from reserved commitments"
+                "Can only consume from reserved or obligated commitments"
             ))
 
         if amount > commitment.remaining_amount:

--- a/budget/models/budget_controller.py
+++ b/budget/models/budget_controller.py
@@ -303,10 +303,10 @@ class BudgetController(models.AbstractModel):
                         'amount': -abs(line.balance),
                     })
 
-        # Get reserved commitments
+        # Get reserved and obligated commitments
         BudgetCommitment = self.env['budget.commitment']
         domain = [
-            ('state', '=', 'reserved'),
+            ('state', 'in', ['reserved', 'obligated']),
             ('date_range_fy_id', '=', fiscal_year_id),
             ('company_id', '=', company_id),
         ]
@@ -346,8 +346,8 @@ class BudgetController(models.AbstractModel):
         if not commitment.exists():
             raise UserError(_('Budget commitment not found.'))
 
-        if commitment.state != 'reserved':
-            raise UserError(_('Budget commitment must be in reserved state to consume.'))
+        if commitment.state not in ['reserved', 'obligated']:
+            raise UserError(_('Budget commitment must be in reserved or obligated state to consume.'))
 
         consumption_move = commitment.create_consumption_move(amount)
 
@@ -414,9 +414,9 @@ class BudgetController(models.AbstractModel):
 
     @api.model
     def _calculate_reserved_amount(self, analytic_data, fiscal_year_id, company_id):
-        """Calculate total reserved amount from commitments"""
+        """Calculate total reserved amount from commitments (reserved + obligated)"""
         domain = [
-            ('state', '=', 'reserved'),
+            ('state', 'in', ['reserved', 'obligated']),
             ('date_range_fy_id', '=', fiscal_year_id),
             ('company_id', '=', company_id),
         ]

--- a/budget/models/budget_execution_status_report.py
+++ b/budget/models/budget_execution_status_report.py
@@ -336,7 +336,7 @@ class BudgetExecutionStatusReport(models.TransientModel):
             ('date', '>=', self.date_from),
             ('date', '<=', self.date_to),
             ('company_id', '=', self.company_id.id),
-            ('state', '=', 'reserved'),
+            ('state', 'in', ['reserved', 'obligated']),
         ]
 
         # Add analytic filters

--- a/budget/views/budget_commitment_views.xml
+++ b/budget/views/budget_commitment_views.xml
@@ -22,6 +22,7 @@
                 <field name="state" widget="badge"
                        decoration-success="state == 'done'"
                        decoration-info="state == 'reserved'"
+                       decoration-muted="state == 'obligated'"
                        decoration-warning="state == 'draft'"
                        decoration-danger="state == 'cancel'"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="show" />
@@ -41,14 +42,17 @@
                             help="Check budget availability for this commitment"/>
                     <button name="action_reserve" string="Reserve Budget" type="object"
                             class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                    <button name="action_obligate" string="Obligate Budget" type="object"
+                            class="btn-primary" attrs="{'invisible': [('state', '!=', 'reserved')]}"
+                            help="Mark this commitment as obligated - firm commitment"/>
                     <button name="action_done" string="Mark as Done" type="object"
-                            attrs="{'invisible': [('state', '!=', 'reserved')]}"
+                            attrs="{'invisible': [('state', '!=', 'obligated')]}"
                             help="Close this commitment and release any remaining budget"/>
                     <button name="action_cancel" string="Cancel" type="object"
                             attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"/>
                     <button name="action_reset_to_draft" string="Reset to Draft" type="object"
                             attrs="{'invisible': [('state', 'not in', ['cancel'])]}"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,reserved,done"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,reserved,obligated,done"/>
                 </header>
 
                 <sheet>


### PR DESCRIPTION
## Summary
This enhancement adds a new 'obligated' state to the budget commitment workflow, creating a more structured approval process for budget management.

## Changes Made

### State Workflow
- **Before**: `draft → reserved → done`
- **After**: `draft → reserved → obligated → done`

The new `obligated` state represents a firm commitment after initial budget reservation, providing better control over the budget approval process.

### Key Components Updated

#### 1. budget.commitment Model
- Added `obligated` state to selection field
- Added `action_obligate()` method for state transitions
- Updated `action_done()` to only accept obligated commitments
- Updated READONLY_STATES to include obligated state
- Updated budget availability calculations

#### 2. budget.commitment.mixin 
- Added `_obligate_budget_commitment()` method
- Updated state validation in all mixin methods
- Allow consumption and amount updates for both reserved and obligated states

#### 3. budget.controller Service
- Updated reserved amount calculations to include obligated commitments
- Updated consumption methods to accept obligated commitments
- Updated transaction detail queries

#### 4. Views & UI
- Added "Obligate Budget" button in form view
- Updated statusbar to show all states
- Updated tree view decorations for obligated state
- Updated button visibility logic

#### 5. Reporting
- Updated execution status report to include obligated amounts

## Business Logic
- **Reserved**: Budget is reserved to prevent over-allocation
- **Obligated**: Budget is formally committed/obligated (firm commitment)  
- **Done**: Budget commitment is completed (only from obligated state)
- **Consumption**: Can consume from both reserved and obligated states
- **Budget Calculations**: Both reserved and obligated count toward used budget

## Test plan
- [ ] Create draft commitment and reserve budget
- [ ] Obligate reserved commitment 
- [ ] Verify only obligated commitments can be marked done
- [ ] Test consumption from both reserved and obligated states
- [ ] Verify budget availability calculations include obligated amounts
- [ ] Check execution reports show obligated commitments

🤖 Generated with [Claude Code](https://claude.ai/code)