### PR TITLE
[16.0][IMP] account_analytic_seq: improve default ordering for analytic accounts

### DIFF
--- a/account_analytic_seq/models/account_analytic.py
+++ b/account_analytic_seq/models/account_analytic.py
@@ -1,12 +1,33 @@
 import logging
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
 
 class AccountAnalyticAccount(models.Model):
     _inherit = "account.analytic.account"
-    _order = "code, name"
 
     line_seq = fields.Integer(default=50)
+
+    @api.model
+    def _search(
+        self,
+        domain,
+        offset=0,
+        limit=None,
+        order=None,
+        count=False,
+        access_rights_uid=None,
+    ):
+        # ใช้ _order แล้วไม่ได้ผล จึงแก้ไขด้วยวิธีนี้แทน
+        if not order:
+            order = "code asc"
+        return super()._search(
+            domain,
+            offset=offset,
+            limit=limit,
+            order=order,
+            count=count,
+            access_rights_uid=access_rights_uid,
+        )


### PR DESCRIPTION
## Summary
- Replace `_order` class attribute with dynamic `_search` override to ensure consistent 'code asc' ordering
- The `_order` attribute was not working reliably in all contexts
- This implementation forces the default order when none is specified in search operations

## Test plan
- [ ] Verify analytic accounts are ordered by code in list views
- [ ] Test that custom ordering still works when explicitly specified
- [ ] Check that the ordering is consistent across different views and contexts

🤖 Generated with [Claude Code](https://claude.ai/code)