### PR TITLE
[16.0][FIX] budget_report: fix expand/collapse OWL lifecycle issues

### DIFF
--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -125,11 +125,14 @@ export class BudgetReportSummary extends Component {
         const rowKey = event.currentTarget.getAttribute('data-row-key');
         if (!rowKey) return;
         
-        if (this.state.expandedRows.has(rowKey)) {
-            this.state.expandedRows.delete(rowKey);
+        // Create a new Set to ensure OWL detects the state change properly
+        const newExpandedRows = new Set(this.state.expandedRows);
+        if (newExpandedRows.has(rowKey)) {
+            newExpandedRows.delete(rowKey);
         } else {
-            this.state.expandedRows.add(rowKey);
+            newExpandedRows.add(rowKey);
         }
+        this.state.expandedRows = newExpandedRows;
     }
 
     isRowExpanded(rowKey) {
@@ -137,7 +140,7 @@ export class BudgetReportSummary extends Component {
     }
 
     isRowVisible(row) {
-        if (!row || !this.state.rows) {
+        if (!row || !this.state.rows || !row.row_key) {
             return false;
         }
         
@@ -147,8 +150,8 @@ export class BudgetReportSummary extends Component {
         
         // Find parent row
         const parentRow = this.state.rows.find(r => r && r.row_key === row.parent_row_id);
-        if (!parentRow) {
-            return true;
+        if (!parentRow || !parentRow.row_key) {
+            return true; // Show row if parent not found (defensive)
         }
         
         // Row is visible if parent is expanded and parent is visible (recursive)
@@ -159,7 +162,7 @@ export class BudgetReportSummary extends Component {
         if (!this.state.rows || !Array.isArray(this.state.rows)) {
             return [];
         }
-        return this.state.rows.filter(row => this.isRowVisible(row));
+        return this.state.rows.filter(row => row && row.row_key && this.isRowVisible(row));
     }
 
     expandAll() {
@@ -167,16 +170,19 @@ export class BudgetReportSummary extends Component {
             return;
         }
         
-        this.state.expandedRows.clear();
+        // Create a new Set with all rows that have children
+        const newExpandedRows = new Set();
         this.state.rows.forEach(row => {
             if (row && row.has_children && row.row_key) {
-                this.state.expandedRows.add(row.row_key);
+                newExpandedRows.add(row.row_key);
             }
         });
+        this.state.expandedRows = newExpandedRows;
     }
 
     collapseAll() {
-        this.state.expandedRows.clear();
+        // Create a new empty Set to ensure OWL detects the change
+        this.state.expandedRows = new Set();
     }
 
     // Get expand toggle icon class

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
@@ -150,9 +150,9 @@
                                             <t
                                                 t-foreach="visibleRows"
                                                 t-as="row"
-                                                t-key="row.row_key"
+                                                t-key="row.row_key || 'empty-' + row_index"
                                             >
-                                                <tr t-att-class="{'expandable-row': row.has_children}">
+                                                <tr t-if="row and row.row_key" t-att-class="{'expandable-row': row.has_children}">
                                                     <th
                                                         style="
                                                             width: 25%;

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
@@ -150,7 +150,7 @@
                                             <t
                                                 t-foreach="visibleRows"
                                                 t-as="row"
-                                                t-key="row.row_key || 'empty-' + row_index"
+                                                t-key="(row.row_key || 'empty') + '-' + row_index"
                                             >
                                                 <tr t-if="row and row.row_key" t-att-class="{'expandable-row': row.has_children}">
                                                     <th


### PR DESCRIPTION
## Summary
Fix critical OWL lifecycle errors in budget_report_summary component expand/collapse functionality.

- Fix parentEl null reference error during DOM updates
- Fix duplicate key error in t-foreach loops  
- Improve state management and template safety

## Changes Made

### 1. OWL Lifecycle Error Fix (`a377eb5`)
- **Issue**: `Cannot read properties of null (reading 'parentEl')` error during expand/collapse
- **Solution**: 
  - Replace direct Set mutations with new Set instances for proper OWL reactivity
  - Add defensive null checks in `isRowVisible` and `visibleRows` methods
  - Enhance template safety with conditional rendering and fallback keys
  - Prevent DOM update race conditions during expand/collapse operations

### 2. Duplicate Key Error Fix (`495d2a5`)
- **Issue**: `Got duplicate key in t-foreach: fund_0100_2` error
- **Solution**: 
  - Combine `row_key` with `row_index` to guarantee unique keys: `(row.row_key || 'empty') + '-' + row_index`
  - Prevents template rendering errors when backend generates duplicate row keys
  - Maintains proper DOM tracking for expand/collapse functionality

## Files Changed
- `budget_report/static/src/components/budget_report_summary/budget_report_summary.js`
- `budget_report/static/src/components/budget_report_summary/budget_report_summary.xml`

## Test Plan
- [x] Expand/collapse functionality works without errors
- [x] No OWL lifecycle errors in browser console
- [x] No duplicate key errors during template rendering
- [x] Report data displays correctly with proper hierarchy

## Impact
- Resolves critical runtime errors preventing users from using expand/collapse features
- Improves overall stability of budget report summary interface
- Ensures proper OWL framework compliance

🤖 Generated with [Claude Code](https://claude.ai/code)