### PR TITLE
[16.0][ADD] budget_report: add drill-down functionality for interactive reporting

### DIFF
--- a/budget/models/budget_move_line.py
+++ b/budget/models/budget_move_line.py
@@ -125,6 +125,7 @@ class BudgetMoveLine(models.Model):
     )
     date_range_fy_id = fields.Many2one(related="move_id.date_range_fy_id", store=True)
     parent_state = fields.Selection(related="move_id.state", store=True)
+    move_type = fields.Selection(related="move_id.move_type", store=True)
     journal_id = fields.Many2one(
         related="move_id.journal_id",
         store=True,

--- a/budget_report/models/budget_report_summary.py
+++ b/budget_report/models/budget_report_summary.py
@@ -173,24 +173,29 @@ class BudgetReportSummary(models.AbstractModel):
             if node.node_type == "activity":
                 parent_contexts["activity"] = {
                     "id": node.value["id"],
+                    "code": node.value.get("code", ""),
                     "path": node.value.get("parent_path", ""),
                 }
             elif node.node_type == "fund":
                 parent_contexts["fund"] = {
                     "id": node.value["id"],
+                    "code": node.value.get("code", ""),
                     "path": node.value.get("parent_path", ""),
                 }
                 # Include parent activity context
                 if "activity" in parent_contexts:
                     row_data["parent_activity_id"] = parent_contexts["activity"]["id"]
+                    row_data["parent_activity_code"] = parent_contexts["activity"]["code"]
                     row_data["parent_activity_path"] = parent_contexts["activity"]["path"]
             elif node.node_type == "account":
                 # Include all parent contexts
                 if "activity" in parent_contexts:
                     row_data["parent_activity_id"] = parent_contexts["activity"]["id"]
+                    row_data["parent_activity_code"] = parent_contexts["activity"]["code"]
                     row_data["parent_activity_path"] = parent_contexts["activity"]["path"]
                 if "fund" in parent_contexts:
                     row_data["parent_fund_id"] = parent_contexts["fund"]["id"]
+                    row_data["parent_fund_code"] = parent_contexts["fund"]["code"]
                     row_data["parent_fund_path"] = parent_contexts["fund"]["path"]
             
             # Add to parent tracking
@@ -392,3 +397,41 @@ class BudgetReportSummary(models.AbstractModel):
         account_ids.update(commitments.mapped('account_id').ids)
         
         return list(account_ids)
+
+    @api.model
+    def get_analytic_ids_by_code_prefix(self, code_prefix, field_name):
+        """Get analytic account IDs that start with the given code prefix"""
+        # Map field names to dimensions
+        dimension_map = {
+            'activity_analytic_id': 'activities',
+            'fund_analytic_id': 'funds', 
+            'source_analytic_id': 'sources',
+            'department_analytic_id': 'departments',
+        }
+        
+        dimension = dimension_map.get(field_name)
+        if not dimension:
+            _logger.warning(f"Unknown analytic field: {field_name}")
+            return []
+        
+        # Search analytic accounts by code prefix
+        analytics = self.env["account.analytic.account"].search([
+            ("root_plan_id.code", "=", dimension),
+            ("code", "=ilike", f"{code_prefix}%"),
+        ])
+        
+        _logger.info(f"Found {len(analytics)} analytic accounts for {field_name} with code prefix {code_prefix}")
+        return analytics.ids
+
+    @api.model 
+    def get_budget_account_ids_by_code_prefix(self, code_prefix, parent_code_prefix=None):
+        """Get budget account IDs that start with the given code prefix"""
+        domain = [("code", "=ilike", f"{code_prefix}%")]
+        
+        # If parent code is provided, also filter by parent context
+        # This can be used for more specific filtering if needed
+        
+        accounts = self.env["budget.account"].search(domain)
+        
+        _logger.info(f"Found {len(accounts)} budget accounts with code prefix {code_prefix}")
+        return accounts.ids

--- a/budget_report/models/budget_report_summary.py
+++ b/budget_report/models/budget_report_summary.py
@@ -156,7 +156,10 @@ class BudgetReportSummary(models.AbstractModel):
         rows = []
         parent_map = {}  # Track parent-child relationships
 
-        def traverse(node, level=0, parent_id=None):
+        def traverse(node, level=0, parent_id=None, parent_contexts=None):
+            if parent_contexts is None:
+                parent_contexts = {}
+                
             row_data = node.to_dict()
             row_data["margin_level"] = str(level * 20) + "px"
             row_data["level"] = level
@@ -165,6 +168,30 @@ class BudgetReportSummary(models.AbstractModel):
             
             # Generate unique row key for expand/collapse tracking
             row_data["row_key"] = f"{node.node_type}_{node.value['code']}_{node.value['id']}"
+            
+            # Add parent context for multi-dimensional filtering
+            if node.node_type == "activity":
+                parent_contexts["activity"] = {
+                    "id": node.value["id"],
+                    "path": node.value.get("parent_path", ""),
+                }
+            elif node.node_type == "fund":
+                parent_contexts["fund"] = {
+                    "id": node.value["id"],
+                    "path": node.value.get("parent_path", ""),
+                }
+                # Include parent activity context
+                if "activity" in parent_contexts:
+                    row_data["parent_activity_id"] = parent_contexts["activity"]["id"]
+                    row_data["parent_activity_path"] = parent_contexts["activity"]["path"]
+            elif node.node_type == "account":
+                # Include all parent contexts
+                if "activity" in parent_contexts:
+                    row_data["parent_activity_id"] = parent_contexts["activity"]["id"]
+                    row_data["parent_activity_path"] = parent_contexts["activity"]["path"]
+                if "fund" in parent_contexts:
+                    row_data["parent_fund_id"] = parent_contexts["fund"]["id"]
+                    row_data["parent_fund_path"] = parent_contexts["fund"]["path"]
             
             # Add to parent tracking
             if parent_id:
@@ -175,10 +202,10 @@ class BudgetReportSummary(models.AbstractModel):
             rows.append(row_data)
             current_row_id = row_data["row_key"]
 
-            # Process children - sort them at each level
+            # Process children with updated context
             sorted_children = self._sort(node.children, level + 1)
             for child in sorted_children:
-                traverse(child, level + 1, current_row_id)
+                traverse(child, level + 1, current_row_id, parent_contexts.copy())
 
         # Start from root's children (skip root itself)
         sorted_roots = self._sort(roots, 0)
@@ -283,3 +310,18 @@ class BudgetReportSummary(models.AbstractModel):
             "source_analytics": self._get_source_analytics_options(),
             "departments": self._get_department_hierarchy(),
         }
+
+    @api.model
+    def get_analytic_children(self, analytic_id, dimension):
+        """Get all child analytic account IDs for hierarchical filtering"""
+        analytic = self.env["account.analytic.account"].browse(analytic_id)
+        if not analytic.exists():
+            return [analytic_id]
+        
+        # Use parent_path for efficient child retrieval
+        children = self.env["account.analytic.account"].search([
+            ("parent_path", "=like", f"{analytic.parent_path}%"),
+            ("root_plan_id.code", "=", dimension),
+        ])
+        
+        return children.ids

--- a/budget_report/models/budget_report_summary.py
+++ b/budget_report/models/budget_report_summary.py
@@ -339,3 +339,56 @@ class BudgetReportSummary(models.AbstractModel):
         ])
         
         return children.ids
+
+    @api.model
+    def get_budget_accounts_for_activity(self, activity_id):
+        """Get all budget account IDs that are used with this activity"""
+        # Get all child activities under this activity
+        activity_children = self.get_analytic_children(activity_id, 'activities')
+        
+        # Find all budget accounts that have data under these activities
+        move_lines = self.env["budget.move.line"].search([
+            ('activity_analytic_id', 'in', activity_children),
+            ('parent_state', '=', 'posted'),
+        ])
+        commitments = self.env["budget.commitment"].search([
+            ('activity_analytic_id', 'in', activity_children),
+            ('state', 'in', ['reserved', 'obligated']),
+        ])
+        
+        account_ids = set()
+        account_ids.update(move_lines.mapped('account_id').ids)
+        account_ids.update(commitments.mapped('account_id').ids)
+        
+        return list(account_ids)
+
+    @api.model
+    def get_budget_accounts_for_fund(self, fund_id, parent_activity_id=None):
+        """Get all budget account IDs that are used with this fund (and optionally parent activity)"""
+        # Get all child funds under this fund
+        fund_children = self.get_analytic_children(fund_id, 'funds')
+        
+        domain_move = [
+            ('fund_analytic_id', 'in', fund_children),
+            ('parent_state', '=', 'posted'),
+        ]
+        domain_commitment = [
+            ('fund_analytic_id', 'in', fund_children),
+            ('state', 'in', ['reserved', 'obligated']),
+        ]
+        
+        # If parent activity is specified, also filter by activity
+        if parent_activity_id:
+            activity_children = self.get_analytic_children(parent_activity_id, 'activities')
+            domain_move.append(('activity_analytic_id', 'in', activity_children))
+            domain_commitment.append(('activity_analytic_id', 'in', activity_children))
+        
+        # Find all budget accounts that have data under these funds
+        move_lines = self.env["budget.move.line"].search(domain_move)
+        commitments = self.env["budget.commitment"].search(domain_commitment)
+        
+        account_ids = set()
+        account_ids.update(move_lines.mapped('account_id').ids)
+        account_ids.update(commitments.mapped('account_id').ids)
+        
+        return list(account_ids)

--- a/budget_report/models/budget_report_summary.py
+++ b/budget_report/models/budget_report_summary.py
@@ -325,3 +325,17 @@ class BudgetReportSummary(models.AbstractModel):
         ])
         
         return children.ids
+
+    @api.model
+    def get_budget_account_children(self, account_id):
+        """Get all child budget account IDs for hierarchical filtering"""
+        account = self.env["budget.account"].browse(account_id)
+        if not account.exists():
+            return [account_id]
+        
+        # Use parent_path for efficient child retrieval
+        children = self.env["budget.account"].search([
+            ("parent_path", "=like", f"{account.parent_path}%"),
+        ])
+        
+        return children.ids

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -355,106 +355,44 @@ export class BudgetReportSummary extends Component {
         return domain;
     }
 
-    // Add analytic filters based on row context
+    // Add analytic filters based on row context using code-based filtering
     async _addRowAnalyticFilters(domain, row) {
-        // Determine which dimension we're filtering on based on row type
+        console.log('Adding analytic filters for row:', row);
+        
+        // Use code-based filtering with ilike for simpler and more reliable filtering
         if (row.type === 'activity') {
-            // For activity rows, filter by activity and its children
-            const activityIds = await this._getAnalyticWithChildren(row.id, 'activities');
-            console.log('Activity IDs for filtering:', activityIds, 'Row:', row);
-            
-            if (activityIds && activityIds.length > 0) {
-                // Filter out any null/false values
-                const validActivityIds = activityIds.filter(id => id);
-                if (validActivityIds.length > 0) {
-                    domain.push(['activity_analytic_id', 'in', validActivityIds]);
-                }
-            }
-            
-            // Also get all budget accounts under this activity
-            const accountIds = await this._getBudgetAccountsForActivity(row.id);
-            console.log('Account IDs for activity filtering:', accountIds);
-            
-            if (accountIds && accountIds.length > 0) {
-                const validAccountIds = accountIds.filter(id => id);
-                if (validAccountIds.length > 0) {
-                    domain.push(['account_id', 'in', validAccountIds]);
-                }
+            // For activity rows, filter by activity code and its children using prefix
+            if (row.code) {
+                // Use analytic account code prefix matching
+                await this._addAnalyticCodeFilter(domain, 'activity_analytic_id', row.code);
+                
+                // Also get budget accounts that start with this activity code
+                await this._addBudgetAccountCodeFilter(domain, row.code);
             }
         } else if (row.type === 'fund') {
-            // For fund rows, need to filter by parent activity AND fund
-            if (row.parent_activity_id) {
-                const activityIds = await this._getAnalyticWithChildren(
-                    row.parent_activity_id, 
-                    'activities'
-                );
-                console.log('Activity IDs for fund filtering:', activityIds);
+            // For fund rows, filter by fund code and parent activity if exists
+            if (row.parent_activity_code) {
+                await this._addAnalyticCodeFilter(domain, 'activity_analytic_id', row.parent_activity_code);
+            }
+            if (row.code) {
+                await this._addAnalyticCodeFilter(domain, 'fund_analytic_id', row.code);
                 
-                if (activityIds && activityIds.length > 0) {
-                    const validActivityIds = activityIds.filter(id => id);
-                    if (validActivityIds.length > 0) {
-                        domain.push(['activity_analytic_id', 'in', validActivityIds]);
-                    }
-                }
-            }
-            const fundIds = await this._getAnalyticWithChildren(row.id, 'funds');
-            console.log('Fund IDs for filtering:', fundIds);
-            
-            if (fundIds && fundIds.length > 0) {
-                const validFundIds = fundIds.filter(id => id);
-                if (validFundIds.length > 0) {
-                    domain.push(['fund_analytic_id', 'in', validFundIds]);
-                }
-            }
-            
-            // Also get all budget accounts under this fund (and parent activity if exists)
-            const accountIds = await this._getBudgetAccountsForFund(row.id, row.parent_activity_id);
-            console.log('Account IDs for fund filtering:', accountIds);
-            
-            if (accountIds && accountIds.length > 0) {
-                const validAccountIds = accountIds.filter(id => id);
-                if (validAccountIds.length > 0) {
-                    domain.push(['account_id', 'in', validAccountIds]);
-                }
+                // Also get budget accounts for this fund
+                await this._addBudgetAccountCodeFilter(domain, row.code, row.parent_activity_code);
             }
         } else if (row.type === 'account') {
-            // For account rows, filter by all parent dimensions
-            if (row.parent_activity_id) {
-                const activityIds = await this._getAnalyticWithChildren(
-                    row.parent_activity_id,
-                    'activities'
-                );
-                console.log('Activity IDs for account filtering:', activityIds);
-                
-                if (activityIds && activityIds.length > 0) {
-                    const validActivityIds = activityIds.filter(id => id);
-                    if (validActivityIds.length > 0) {
-                        domain.push(['activity_analytic_id', 'in', validActivityIds]);
-                    }
-                }
+            // For account rows, filter by parent analytic codes and account code
+            if (row.parent_activity_code) {
+                await this._addAnalyticCodeFilter(domain, 'activity_analytic_id', row.parent_activity_code);
             }
-            if (row.parent_fund_id) {
-                const fundIds = await this._getAnalyticWithChildren(
-                    row.parent_fund_id,
-                    'funds'
-                );
-                console.log('Fund IDs for account filtering:', fundIds);
-                
-                if (fundIds && fundIds.length > 0) {
-                    const validFundIds = fundIds.filter(id => id);
-                    if (validFundIds.length > 0) {
-                        domain.push(['fund_analytic_id', 'in', validFundIds]);
-                    }
-                }
+            if (row.parent_fund_code) {
+                await this._addAnalyticCodeFilter(domain, 'fund_analytic_id', row.parent_fund_code);
             }
-            // For budget account rows, get all child accounts too
-            const accountIds = await this._getBudgetAccountWithChildren(row.id);
-            console.log('Account IDs for account filtering:', accountIds);
-            
-            if (accountIds && accountIds.length > 0) {
-                const validAccountIds = accountIds.filter(id => id);
-                if (validAccountIds.length > 0) {
-                    domain.push(['account_id', 'in', validAccountIds]);
+            if (row.code) {
+                // Filter budget accounts by code prefix
+                const accountIds = await this._getBudgetAccountsByCode(row.code);
+                if (accountIds && accountIds.length > 0) {
+                    domain.push(['account_id', 'in', accountIds]);
                 }
             }
         }
@@ -517,6 +455,57 @@ export class BudgetReportSummary extends Component {
         } catch (error) {
             console.warn("Failed to get budget accounts for fund:", error);
             return [];
+        }
+    }
+
+    // Add analytic filter using code prefix matching
+    async _addAnalyticCodeFilter(domain, field_name, code) {
+        try {
+            const analyticIds = await this.orm.call(
+                "budget.report.summary", 
+                "get_analytic_ids_by_code_prefix", 
+                [code, field_name]
+            );
+            console.log(`${field_name} IDs for code ${code}:`, analyticIds);
+            
+            if (analyticIds && analyticIds.length > 0) {
+                domain.push([field_name, 'in', analyticIds]);
+            }
+        } catch (error) {
+            console.warn(`Failed to get analytic IDs for ${field_name} with code ${code}:`, error);
+        }
+    }
+
+    // Add budget account filter using code prefix
+    async _addBudgetAccountCodeFilter(domain, code, parentCode = null) {
+        try {
+            const accountIds = await this.orm.call(
+                "budget.report.summary", 
+                "get_budget_account_ids_by_code_prefix", 
+                [code, parentCode]
+            );
+            console.log(`Account IDs for code ${code}:`, accountIds);
+            
+            if (accountIds && accountIds.length > 0) {
+                domain.push(['account_id', 'in', accountIds]);
+            }
+        } catch (error) {
+            console.warn(`Failed to get account IDs for code ${code}:`, error);
+        }
+    }
+
+    // Get budget account IDs by code prefix
+    async _getBudgetAccountsByCode(code) {
+        try {
+            const accountIds = await this.orm.call(
+                "budget.report.summary", 
+                "get_budget_account_ids_by_code_prefix", 
+                [code]
+            );
+            return accountIds;
+        } catch (error) {
+            console.warn(`Failed to get budget accounts by code ${code}:`, error);
+            return []; 
         }
     }
 

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -199,10 +199,11 @@ export class BudgetReportSummary extends Component {
     }
 
     // Handler for งบประมาณ (Appropriation) column
-    async onAppropriationClick(event, row) {
+    async onAppropriationClick(event) {
         event.stopPropagation();
         event.preventDefault();
         
+        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
         const domain = this._buildMoveLineDomain(row, ['appropriation', 'entry']);
         
         await this.actionService.doAction({
@@ -220,10 +221,11 @@ export class BudgetReportSummary extends Component {
     }
 
     // Handler for เงินจอง (Commitment) column  
-    async onCommitmentClick(event, row) {
+    async onCommitmentClick(event) {
         event.stopPropagation();
         event.preventDefault();
         
+        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
         const domain = this._buildCommitmentDomain(row, 'reserved');
         
         await this.actionService.doAction({
@@ -240,10 +242,11 @@ export class BudgetReportSummary extends Component {
     }
 
     // Handler for ผูกพัน (Obligation) column
-    async onObligationClick(event, row) {
+    async onObligationClick(event) {
         event.stopPropagation();
         event.preventDefault();
         
+        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
         const domain = this._buildCommitmentDomain(row, 'obligated');
         
         await this.actionService.doAction({
@@ -260,10 +263,11 @@ export class BudgetReportSummary extends Component {
     }
 
     // Handler for เบิกจ่ายแล้ว (Expenditure) column
-    async onExpenditureClick(event, row) {
+    async onExpenditureClick(event) {
         event.stopPropagation();
         event.preventDefault();
         
+        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
         const domain = this._buildMoveLineDomain(row, ['consume']);
         
         await this.actionService.doAction({

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -198,12 +198,20 @@ export class BudgetReportSummary extends Component {
         return value && value !== 0;
     }
 
+    // Helper to find row by row_key
+    _findRowByKey(rowKey) {
+        return this.state.rows.find(row => row.row_key === rowKey);
+    }
+
     // Handler for งบประมาณ (Appropriation) column
     async onAppropriationClick(event) {
         event.stopPropagation();
         event.preventDefault();
         
-        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
+        const rowKey = event.currentTarget.getAttribute('data-row-key');
+        const row = this._findRowByKey(rowKey);
+        if (!row) return;
+        
         const domain = this._buildMoveLineDomain(row, ['appropriation', 'entry']);
         
         await this.actionService.doAction({
@@ -225,7 +233,10 @@ export class BudgetReportSummary extends Component {
         event.stopPropagation();
         event.preventDefault();
         
-        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
+        const rowKey = event.currentTarget.getAttribute('data-row-key');
+        const row = this._findRowByKey(rowKey);
+        if (!row) return;
+        
         const domain = this._buildCommitmentDomain(row, 'reserved');
         
         await this.actionService.doAction({
@@ -246,7 +257,10 @@ export class BudgetReportSummary extends Component {
         event.stopPropagation();
         event.preventDefault();
         
-        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
+        const rowKey = event.currentTarget.getAttribute('data-row-key');
+        const row = this._findRowByKey(rowKey);
+        if (!row) return;
+        
         const domain = this._buildCommitmentDomain(row, 'obligated');
         
         await this.actionService.doAction({
@@ -267,7 +281,10 @@ export class BudgetReportSummary extends Component {
         event.stopPropagation();
         event.preventDefault();
         
-        const row = JSON.parse(event.currentTarget.getAttribute('data-row'));
+        const rowKey = event.currentTarget.getAttribute('data-row-key');
+        const row = this._findRowByKey(rowKey);
+        if (!row) return;
+        
         const domain = this._buildMoveLineDomain(row, ['consume']);
         
         await this.actionService.doAction({

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -16,6 +16,7 @@ export class BudgetReportSummary extends Component {
 
         this.orm = useService("orm");
         this.notification = useService("notification");
+        this.actionService = useService("action");
 
         this.state = useState({
             filters: {
@@ -189,6 +190,204 @@ export class BudgetReportSummary extends Component {
     getExpandIcon(row) {
         if (!row || !row.has_children || !row.row_key) return '';
         return this.isRowExpanded(row.row_key) ? 'fa fa-caret-down' : 'fa fa-caret-right';
+    }
+
+    // Drill-down functionality
+    // Helper to check if a cell value is clickable (not zero)
+    isClickable(value) {
+        return value && value !== 0;
+    }
+
+    // Handler for งบประมาณ (Appropriation) column
+    async onAppropriationClick(event, row) {
+        event.stopPropagation();
+        event.preventDefault();
+        
+        const domain = this._buildMoveLineDomain(row, ['appropriation', 'entry']);
+        
+        await this.actionService.doAction({
+            type: 'ir.actions.act_window',
+            name: `งบประมาณ - ${row.code} ${row.name}`,
+            res_model: 'budget.move.line',
+            views: [[false, 'tree'], [false, 'form'], [false, 'pivot']],
+            domain: domain,
+            context: {
+                search_default_group_by_account: 1,
+                search_default_group_by_move: 1,
+            },
+            target: 'current',
+        });
+    }
+
+    // Handler for เงินจอง (Commitment) column  
+    async onCommitmentClick(event, row) {
+        event.stopPropagation();
+        event.preventDefault();
+        
+        const domain = this._buildCommitmentDomain(row, 'reserved');
+        
+        await this.actionService.doAction({
+            type: 'ir.actions.act_window',
+            name: `เงินจอง - ${row.code} ${row.name}`,
+            res_model: 'budget.commitment',
+            views: [[false, 'tree'], [false, 'form'], [false, 'pivot']],
+            domain: domain,
+            context: {
+                search_default_state_reserved: 1,
+            },
+            target: 'current',
+        });
+    }
+
+    // Handler for ผูกพัน (Obligation) column
+    async onObligationClick(event, row) {
+        event.stopPropagation();
+        event.preventDefault();
+        
+        const domain = this._buildCommitmentDomain(row, 'obligated');
+        
+        await this.actionService.doAction({
+            type: 'ir.actions.act_window',
+            name: `ผูกพัน - ${row.code} ${row.name}`,
+            res_model: 'budget.commitment',
+            views: [[false, 'tree'], [false, 'form'], [false, 'pivot']],
+            domain: domain,
+            context: {
+                search_default_state_obligated: 1,
+            },
+            target: 'current',
+        });
+    }
+
+    // Handler for เบิกจ่ายแล้ว (Expenditure) column
+    async onExpenditureClick(event, row) {
+        event.stopPropagation();
+        event.preventDefault();
+        
+        const domain = this._buildMoveLineDomain(row, ['consume']);
+        
+        await this.actionService.doAction({
+            type: 'ir.actions.act_window',
+            name: `เบิกจ่ายแล้ว - ${row.code} ${row.name}`,
+            res_model: 'budget.move.line',
+            views: [[false, 'tree'], [false, 'form'], [false, 'pivot']],
+            domain: domain,
+            context: {
+                search_default_group_by_move: 1,
+            },
+            target: 'current',
+        });
+    }
+
+    // Build domain for budget.move.line queries
+    _buildMoveLineDomain(row, moveTypes) {
+        const domain = [
+            ['parent_state', '=', 'posted'],
+            ['date_range_fy_id', '=', this.state.filters.fiscal_year_id],
+        ];
+        
+        // Add source analytic filter
+        if (this.state.filters.source_analytic_id) {
+            domain.push(['source_analytic_id', '=', this.state.filters.source_analytic_id]);
+        }
+        
+        // Add department filter from report filters
+        if (this.state.filters.department_ids && this.state.filters.department_ids.length > 0) {
+            const deptIds = this._getDepartmentWithChildren(this.state.filters.department_ids);
+            domain.push(['department_analytic_id', 'in', deptIds]);
+        }
+        
+        // Add move type filter
+        if (moveTypes && moveTypes.length > 0) {
+            domain.push(['move_type', 'in', moveTypes]);
+        }
+        
+        // Add row-specific analytic filters based on row type
+        this._addRowAnalyticFilters(domain, row);
+        
+        return domain;
+    }
+
+    // Build domain for budget.commitment queries
+    _buildCommitmentDomain(row, state) {
+        const domain = [
+            ['state', '=', state],
+            ['date_range_fy_id', '=', this.state.filters.fiscal_year_id],
+        ];
+        
+        // Add source analytic filter
+        if (this.state.filters.source_analytic_id) {
+            domain.push(['source_analytic_id', '=', this.state.filters.source_analytic_id]);
+        }
+        
+        // Add department filter from report filters
+        if (this.state.filters.department_ids && this.state.filters.department_ids.length > 0) {
+            const deptIds = this._getDepartmentWithChildren(this.state.filters.department_ids);
+            domain.push(['department_analytic_id', 'in', deptIds]);
+        }
+        
+        // Add row-specific analytic filters
+        this._addRowAnalyticFilters(domain, row);
+        
+        return domain;
+    }
+
+    // Add analytic filters based on row context
+    _addRowAnalyticFilters(domain, row) {
+        // Determine which dimension we're filtering on based on row type
+        if (row.type === 'activity') {
+            // For activity rows, filter by activity and its children
+            const activityIds = this._getAnalyticWithChildren(row.id, row.parent_path);
+            domain.push(['activity_analytic_id', 'in', activityIds]);
+        } else if (row.type === 'fund') {
+            // For fund rows, need to filter by parent activity AND fund
+            if (row.parent_activity_id) {
+                const activityIds = this._getAnalyticWithChildren(
+                    row.parent_activity_id, 
+                    row.parent_activity_path
+                );
+                domain.push(['activity_analytic_id', 'in', activityIds]);
+            }
+            const fundIds = this._getAnalyticWithChildren(row.id, row.parent_path);
+            domain.push(['fund_analytic_id', 'in', fundIds]);
+        } else if (row.type === 'account') {
+            // For account rows, filter by all parent dimensions
+            if (row.parent_activity_id) {
+                const activityIds = this._getAnalyticWithChildren(
+                    row.parent_activity_id,
+                    row.parent_activity_path
+                );
+                domain.push(['activity_analytic_id', 'in', activityIds]);
+            }
+            if (row.parent_fund_id) {
+                const fundIds = this._getAnalyticWithChildren(
+                    row.parent_fund_id,
+                    row.parent_fund_path
+                );
+                domain.push(['fund_analytic_id', 'in', fundIds]);
+            }
+            // Filter by specific budget account
+            domain.push(['account_id', '=', row.id]);
+        }
+    }
+
+    // Get analytic IDs including children (for hierarchical filtering)
+    _getAnalyticWithChildren(analyticId, parentPath) {
+        // For now, return just the ID
+        // Future enhancement: call server method for hierarchical expansion
+        // const children = await this.orm.call(
+        //     "budget.report.summary", 
+        //     "get_analytic_children", 
+        //     [analyticId, dimension]
+        // );
+        return [analyticId];
+    }
+
+    // Get department IDs including children
+    _getDepartmentWithChildren(departmentIds) {
+        // For now, return the original list
+        // This could be enhanced to expand to include child departments
+        return departmentIds;
     }
 }
 

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -360,6 +360,12 @@ export class BudgetReportSummary extends Component {
             // For activity rows, filter by activity and its children
             const activityIds = await this._getAnalyticWithChildren(row.id, 'activities');
             domain.push(['activity_analytic_id', 'in', activityIds]);
+            
+            // Also get all budget accounts under this activity
+            const accountIds = await this._getBudgetAccountsForActivity(row.id);
+            if (accountIds.length > 0) {
+                domain.push(['account_id', 'in', accountIds]);
+            }
         } else if (row.type === 'fund') {
             // For fund rows, need to filter by parent activity AND fund
             if (row.parent_activity_id) {
@@ -371,6 +377,12 @@ export class BudgetReportSummary extends Component {
             }
             const fundIds = await this._getAnalyticWithChildren(row.id, 'funds');
             domain.push(['fund_analytic_id', 'in', fundIds]);
+            
+            // Also get all budget accounts under this fund (and parent activity if exists)
+            const accountIds = await this._getBudgetAccountsForFund(row.id, row.parent_activity_id);
+            if (accountIds.length > 0) {
+                domain.push(['account_id', 'in', accountIds]);
+            }
         } else if (row.type === 'account') {
             // For account rows, filter by all parent dimensions
             if (row.parent_activity_id) {
@@ -420,6 +432,36 @@ export class BudgetReportSummary extends Component {
         } catch (error) {
             console.warn("Failed to get budget account children, using single ID:", error);
             return [accountId];
+        }
+    }
+
+    // Get budget account IDs for a specific activity
+    async _getBudgetAccountsForActivity(activityId) {
+        try {
+            const accountIds = await this.orm.call(
+                "budget.report.summary", 
+                "get_budget_accounts_for_activity", 
+                [activityId]
+            );
+            return accountIds;
+        } catch (error) {
+            console.warn("Failed to get budget accounts for activity:", error);
+            return [];
+        }
+    }
+
+    // Get budget account IDs for a specific fund and optional parent activity
+    async _getBudgetAccountsForFund(fundId, parentActivityId = null) {
+        try {
+            const accountIds = await this.orm.call(
+                "budget.report.summary", 
+                "get_budget_accounts_for_fund", 
+                [fundId, parentActivityId]
+            );
+            return accountIds;
+        } catch (error) {
+            console.warn("Failed to get budget accounts for fund:", error);
+            return [];
         }
     }
 

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -326,6 +326,7 @@ export class BudgetReportSummary extends Component {
         // Add row-specific analytic filters based on row type
         await this._addRowAnalyticFilters(domain, row);
         
+        console.log('Final move line domain:', domain, 'Row:', row);
         return domain;
     }
 
@@ -350,6 +351,7 @@ export class BudgetReportSummary extends Component {
         // Add row-specific analytic filters
         await this._addRowAnalyticFilters(domain, row);
         
+        console.log('Final commitment domain:', domain, 'Row:', row);
         return domain;
     }
 
@@ -359,12 +361,25 @@ export class BudgetReportSummary extends Component {
         if (row.type === 'activity') {
             // For activity rows, filter by activity and its children
             const activityIds = await this._getAnalyticWithChildren(row.id, 'activities');
-            domain.push(['activity_analytic_id', 'in', activityIds]);
+            console.log('Activity IDs for filtering:', activityIds, 'Row:', row);
+            
+            if (activityIds && activityIds.length > 0) {
+                // Filter out any null/false values
+                const validActivityIds = activityIds.filter(id => id);
+                if (validActivityIds.length > 0) {
+                    domain.push(['activity_analytic_id', 'in', validActivityIds]);
+                }
+            }
             
             // Also get all budget accounts under this activity
             const accountIds = await this._getBudgetAccountsForActivity(row.id);
-            if (accountIds.length > 0) {
-                domain.push(['account_id', 'in', accountIds]);
+            console.log('Account IDs for activity filtering:', accountIds);
+            
+            if (accountIds && accountIds.length > 0) {
+                const validAccountIds = accountIds.filter(id => id);
+                if (validAccountIds.length > 0) {
+                    domain.push(['account_id', 'in', validAccountIds]);
+                }
             }
         } else if (row.type === 'fund') {
             // For fund rows, need to filter by parent activity AND fund
@@ -373,15 +388,34 @@ export class BudgetReportSummary extends Component {
                     row.parent_activity_id, 
                     'activities'
                 );
-                domain.push(['activity_analytic_id', 'in', activityIds]);
+                console.log('Activity IDs for fund filtering:', activityIds);
+                
+                if (activityIds && activityIds.length > 0) {
+                    const validActivityIds = activityIds.filter(id => id);
+                    if (validActivityIds.length > 0) {
+                        domain.push(['activity_analytic_id', 'in', validActivityIds]);
+                    }
+                }
             }
             const fundIds = await this._getAnalyticWithChildren(row.id, 'funds');
-            domain.push(['fund_analytic_id', 'in', fundIds]);
+            console.log('Fund IDs for filtering:', fundIds);
+            
+            if (fundIds && fundIds.length > 0) {
+                const validFundIds = fundIds.filter(id => id);
+                if (validFundIds.length > 0) {
+                    domain.push(['fund_analytic_id', 'in', validFundIds]);
+                }
+            }
             
             // Also get all budget accounts under this fund (and parent activity if exists)
             const accountIds = await this._getBudgetAccountsForFund(row.id, row.parent_activity_id);
-            if (accountIds.length > 0) {
-                domain.push(['account_id', 'in', accountIds]);
+            console.log('Account IDs for fund filtering:', accountIds);
+            
+            if (accountIds && accountIds.length > 0) {
+                const validAccountIds = accountIds.filter(id => id);
+                if (validAccountIds.length > 0) {
+                    domain.push(['account_id', 'in', validAccountIds]);
+                }
             }
         } else if (row.type === 'account') {
             // For account rows, filter by all parent dimensions
@@ -390,18 +424,39 @@ export class BudgetReportSummary extends Component {
                     row.parent_activity_id,
                     'activities'
                 );
-                domain.push(['activity_analytic_id', 'in', activityIds]);
+                console.log('Activity IDs for account filtering:', activityIds);
+                
+                if (activityIds && activityIds.length > 0) {
+                    const validActivityIds = activityIds.filter(id => id);
+                    if (validActivityIds.length > 0) {
+                        domain.push(['activity_analytic_id', 'in', validActivityIds]);
+                    }
+                }
             }
             if (row.parent_fund_id) {
                 const fundIds = await this._getAnalyticWithChildren(
                     row.parent_fund_id,
                     'funds'
                 );
-                domain.push(['fund_analytic_id', 'in', fundIds]);
+                console.log('Fund IDs for account filtering:', fundIds);
+                
+                if (fundIds && fundIds.length > 0) {
+                    const validFundIds = fundIds.filter(id => id);
+                    if (validFundIds.length > 0) {
+                        domain.push(['fund_analytic_id', 'in', validFundIds]);
+                    }
+                }
             }
             // For budget account rows, get all child accounts too
             const accountIds = await this._getBudgetAccountWithChildren(row.id);
-            domain.push(['account_id', 'in', accountIds]);
+            console.log('Account IDs for account filtering:', accountIds);
+            
+            if (accountIds && accountIds.length > 0) {
+                const validAccountIds = accountIds.filter(id => id);
+                if (validAccountIds.length > 0) {
+                    domain.push(['account_id', 'in', validAccountIds]);
+                }
+            }
         }
     }
 

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -212,7 +212,7 @@ export class BudgetReportSummary extends Component {
         const row = this._findRowByKey(rowKey);
         if (!row) return;
         
-        const domain = this._buildMoveLineDomain(row, ['appropriation', 'entry']);
+        const domain = await this._buildMoveLineDomain(row, ['appropriation', 'entry']);
         
         await this.actionService.doAction({
             type: 'ir.actions.act_window',
@@ -237,7 +237,7 @@ export class BudgetReportSummary extends Component {
         const row = this._findRowByKey(rowKey);
         if (!row) return;
         
-        const domain = this._buildCommitmentDomain(row, 'reserved');
+        const domain = await this._buildCommitmentDomain(row, 'reserved');
         
         await this.actionService.doAction({
             type: 'ir.actions.act_window',
@@ -261,7 +261,7 @@ export class BudgetReportSummary extends Component {
         const row = this._findRowByKey(rowKey);
         if (!row) return;
         
-        const domain = this._buildCommitmentDomain(row, 'obligated');
+        const domain = await this._buildCommitmentDomain(row, 'obligated');
         
         await this.actionService.doAction({
             type: 'ir.actions.act_window',
@@ -285,7 +285,7 @@ export class BudgetReportSummary extends Component {
         const row = this._findRowByKey(rowKey);
         if (!row) return;
         
-        const domain = this._buildMoveLineDomain(row, ['consume']);
+        const domain = await this._buildMoveLineDomain(row, ['consume']);
         
         await this.actionService.doAction({
             type: 'ir.actions.act_window',
@@ -301,7 +301,7 @@ export class BudgetReportSummary extends Component {
     }
 
     // Build domain for budget.move.line queries
-    _buildMoveLineDomain(row, moveTypes) {
+    async _buildMoveLineDomain(row, moveTypes) {
         const domain = [
             ['parent_state', '=', 'posted'],
             ['date_range_fy_id', '=', this.state.filters.fiscal_year_id],
@@ -314,7 +314,7 @@ export class BudgetReportSummary extends Component {
         
         // Add department filter from report filters
         if (this.state.filters.department_ids && this.state.filters.department_ids.length > 0) {
-            const deptIds = this._getDepartmentWithChildren(this.state.filters.department_ids);
+            const deptIds = await this._getDepartmentWithChildren(this.state.filters.department_ids);
             domain.push(['department_analytic_id', 'in', deptIds]);
         }
         
@@ -324,13 +324,13 @@ export class BudgetReportSummary extends Component {
         }
         
         // Add row-specific analytic filters based on row type
-        this._addRowAnalyticFilters(domain, row);
+        await this._addRowAnalyticFilters(domain, row);
         
         return domain;
     }
 
     // Build domain for budget.commitment queries
-    _buildCommitmentDomain(row, state) {
+    async _buildCommitmentDomain(row, state) {
         const domain = [
             ['state', '=', state],
             ['date_range_fy_id', '=', this.state.filters.fiscal_year_id],
@@ -343,72 +343,99 @@ export class BudgetReportSummary extends Component {
         
         // Add department filter from report filters
         if (this.state.filters.department_ids && this.state.filters.department_ids.length > 0) {
-            const deptIds = this._getDepartmentWithChildren(this.state.filters.department_ids);
+            const deptIds = await this._getDepartmentWithChildren(this.state.filters.department_ids);
             domain.push(['department_analytic_id', 'in', deptIds]);
         }
         
         // Add row-specific analytic filters
-        this._addRowAnalyticFilters(domain, row);
+        await this._addRowAnalyticFilters(domain, row);
         
         return domain;
     }
 
     // Add analytic filters based on row context
-    _addRowAnalyticFilters(domain, row) {
+    async _addRowAnalyticFilters(domain, row) {
         // Determine which dimension we're filtering on based on row type
         if (row.type === 'activity') {
             // For activity rows, filter by activity and its children
-            const activityIds = this._getAnalyticWithChildren(row.id, row.parent_path);
+            const activityIds = await this._getAnalyticWithChildren(row.id, 'activities');
             domain.push(['activity_analytic_id', 'in', activityIds]);
         } else if (row.type === 'fund') {
             // For fund rows, need to filter by parent activity AND fund
             if (row.parent_activity_id) {
-                const activityIds = this._getAnalyticWithChildren(
+                const activityIds = await this._getAnalyticWithChildren(
                     row.parent_activity_id, 
-                    row.parent_activity_path
+                    'activities'
                 );
                 domain.push(['activity_analytic_id', 'in', activityIds]);
             }
-            const fundIds = this._getAnalyticWithChildren(row.id, row.parent_path);
+            const fundIds = await this._getAnalyticWithChildren(row.id, 'funds');
             domain.push(['fund_analytic_id', 'in', fundIds]);
         } else if (row.type === 'account') {
             // For account rows, filter by all parent dimensions
             if (row.parent_activity_id) {
-                const activityIds = this._getAnalyticWithChildren(
+                const activityIds = await this._getAnalyticWithChildren(
                     row.parent_activity_id,
-                    row.parent_activity_path
+                    'activities'
                 );
                 domain.push(['activity_analytic_id', 'in', activityIds]);
             }
             if (row.parent_fund_id) {
-                const fundIds = this._getAnalyticWithChildren(
+                const fundIds = await this._getAnalyticWithChildren(
                     row.parent_fund_id,
-                    row.parent_fund_path
+                    'funds'
                 );
                 domain.push(['fund_analytic_id', 'in', fundIds]);
             }
-            // Filter by specific budget account
-            domain.push(['account_id', '=', row.id]);
+            // For budget account rows, get all child accounts too
+            const accountIds = await this._getBudgetAccountWithChildren(row.id);
+            domain.push(['account_id', 'in', accountIds]);
         }
     }
 
     // Get analytic IDs including children (for hierarchical filtering)
-    _getAnalyticWithChildren(analyticId, parentPath) {
-        // For now, return just the ID
-        // Future enhancement: call server method for hierarchical expansion
-        // const children = await this.orm.call(
-        //     "budget.report.summary", 
-        //     "get_analytic_children", 
-        //     [analyticId, dimension]
-        // );
-        return [analyticId];
+    async _getAnalyticWithChildren(analyticId, dimension) {
+        try {
+            const children = await this.orm.call(
+                "budget.report.summary", 
+                "get_analytic_children", 
+                [analyticId, dimension]
+            );
+            return children;
+        } catch (error) {
+            console.warn("Failed to get analytic children, using single ID:", error);
+            return [analyticId];
+        }
+    }
+
+    // Get budget account IDs including children
+    async _getBudgetAccountWithChildren(accountId) {
+        try {
+            const children = await this.orm.call(
+                "budget.report.summary", 
+                "get_budget_account_children", 
+                [accountId]
+            );
+            return children;
+        } catch (error) {
+            console.warn("Failed to get budget account children, using single ID:", error);
+            return [accountId];
+        }
     }
 
     // Get department IDs including children
-    _getDepartmentWithChildren(departmentIds) {
-        // For now, return the original list
-        // This could be enhanced to expand to include child departments
-        return departmentIds;
+    async _getDepartmentWithChildren(departmentIds) {
+        try {
+            const allDeptIds = [];
+            for (const deptId of departmentIds) {
+                const children = await this._getAnalyticWithChildren(deptId, 'departments');
+                allDeptIds.push(...children);
+            }
+            return [...new Set(allDeptIds)]; // Remove duplicates
+        } catch (error) {
+            console.warn("Failed to get department children, using original IDs:", error);
+            return departmentIds;
+        }
     }
 }
 

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.scss
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.scss
@@ -120,6 +120,39 @@
             text-align: right;
             font-family: 'Courier New', monospace;
         }
+
+        // Clickable cell styles for drill-down
+        &.clickable-cell {
+            cursor: pointer;
+            position: relative;
+            transition: all 0.2s ease;
+            
+            &:hover {
+                background-color: rgba(0, 123, 255, 0.1) !important;
+                color: #007bff;
+                text-decoration: underline;
+                font-weight: 500;
+            }
+            
+            &:active {
+                background-color: rgba(0, 123, 255, 0.2) !important;
+            }
+            
+            // Add a subtle icon indicator
+            &::after {
+                content: "\f08e"; // External link icon
+                font-family: FontAwesome;
+                font-size: 0.7em;
+                margin-left: 4px;
+                opacity: 0;
+                transition: opacity 0.2s ease;
+                color: #007bff;
+            }
+            
+            &:hover::after {
+                opacity: 0.8;
+            }
+        }
     }
 
     // Animation for row expand/collapse

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
@@ -190,7 +190,7 @@
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.appropriation)}"
                                                         t-on-click="row.appropriation ? onAppropriationClick.bind(this) : null"
-                                                        t-att-data-row='JSON.stringify(row)'>
+                                                        t-att-data-row-key="row.row_key">
                                                         <t
                                                             t-esc="formatCurrency(row.appropriation)"
                                                         />
@@ -199,7 +199,7 @@
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.commitment)}"
                                                         t-on-click="row.commitment ? onCommitmentClick.bind(this) : null"
-                                                        t-att-data-row='JSON.stringify(row)'>
+                                                        t-att-data-row-key="row.row_key">
                                                         <t
                                                             t-esc="formatCurrency(row.commitment)"
                                                         />
@@ -207,7 +207,7 @@
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.obligation)}"
                                                         t-on-click="row.obligation ? onObligationClick.bind(this) : null"
-                                                        t-att-data-row='JSON.stringify(row)'>
+                                                        t-att-data-row-key="row.row_key">
                                                         <t
                                                             t-esc="formatCurrency(row.obligation)"
                                                         />
@@ -215,7 +215,7 @@
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.expenditure)}"
                                                         t-on-click="row.expenditure ? onExpenditureClick.bind(this) : null"
-                                                        t-att-data-row='JSON.stringify(row)'>
+                                                        t-att-data-row-key="row.row_key">
                                                         <t
                                                             t-esc="formatCurrency(row.expenditure)"
                                                         />

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
@@ -187,23 +187,31 @@
                                                         </div>
                                                     </th>
                                                     <td class="amount-cell">0</td>
-                                                    <td class="amount-cell">
+                                                    <td class="amount-cell"
+                                                        t-att-class="{'clickable-cell': isClickable(row.appropriation)}"
+                                                        t-on-click="(event) => row.appropriation ? onAppropriationClick(event, row) : null">
                                                         <t
                                                             t-esc="formatCurrency(row.appropriation)"
                                                         />
                                                     </td>
                                                     <td class="amount-cell">0</td>
-                                                    <td class="amount-cell">
+                                                    <td class="amount-cell"
+                                                        t-att-class="{'clickable-cell': isClickable(row.commitment)}"
+                                                        t-on-click="(event) => row.commitment ? onCommitmentClick(event, row) : null">
                                                         <t
                                                             t-esc="formatCurrency(row.commitment)"
                                                         />
                                                     </td>
-                                                    <td class="amount-cell">
+                                                    <td class="amount-cell"
+                                                        t-att-class="{'clickable-cell': isClickable(row.obligation)}"
+                                                        t-on-click="(event) => row.obligation ? onObligationClick(event, row) : null">
                                                         <t
                                                             t-esc="formatCurrency(row.obligation)"
                                                         />
                                                     </td>
-                                                    <td class="amount-cell">
+                                                    <td class="amount-cell"
+                                                        t-att-class="{'clickable-cell': isClickable(row.expenditure)}"
+                                                        t-on-click="(event) => row.expenditure ? onExpenditureClick(event, row) : null">
                                                         <t
                                                             t-esc="formatCurrency(row.expenditure)"
                                                         />

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
@@ -189,7 +189,8 @@
                                                     <td class="amount-cell">0</td>
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.appropriation)}"
-                                                        t-on-click="(event) => row.appropriation ? onAppropriationClick(event, row) : null">
+                                                        t-on-click="row.appropriation ? onAppropriationClick.bind(this) : null"
+                                                        t-att-data-row='JSON.stringify(row)'>
                                                         <t
                                                             t-esc="formatCurrency(row.appropriation)"
                                                         />
@@ -197,21 +198,24 @@
                                                     <td class="amount-cell">0</td>
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.commitment)}"
-                                                        t-on-click="(event) => row.commitment ? onCommitmentClick(event, row) : null">
+                                                        t-on-click="row.commitment ? onCommitmentClick.bind(this) : null"
+                                                        t-att-data-row='JSON.stringify(row)'>
                                                         <t
                                                             t-esc="formatCurrency(row.commitment)"
                                                         />
                                                     </td>
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.obligation)}"
-                                                        t-on-click="(event) => row.obligation ? onObligationClick(event, row) : null">
+                                                        t-on-click="row.obligation ? onObligationClick.bind(this) : null"
+                                                        t-att-data-row='JSON.stringify(row)'>
                                                         <t
                                                             t-esc="formatCurrency(row.obligation)"
                                                         />
                                                     </td>
                                                     <td class="amount-cell"
                                                         t-att-class="{'clickable-cell': isClickable(row.expenditure)}"
-                                                        t-on-click="(event) => row.expenditure ? onExpenditureClick(event, row) : null">
+                                                        t-on-click="row.expenditure ? onExpenditureClick.bind(this) : null"
+                                                        t-att-data-row='JSON.stringify(row)'>
                                                         <t
                                                             t-esc="formatCurrency(row.expenditure)"
                                                         />


### PR DESCRIPTION
## Summary
- Add clickable cells for budget report amounts enabling drill-down navigation
- Implement contextual filtering to related budget.move.line and budget.commitment records
- Add visual indicators with hover effects and external link icons for better UX
- Support multi-dimensional filtering across activity/fund/account hierarchy

## Features Added
1. **Interactive Budget Cells**
   - งบประมาณ (Appropriation) → Opens budget.move.line with appropriation/entry moves
   - เงินจอง (Commitment) → Opens budget.commitment with reserved state
   - ผูกพัน (Obligation) → Opens budget.commitment with obligated state
   - เบิกจ่ายแล้ว (Expenditure) → Opens budget.move.line with consume moves

2. **Smart Filtering**
   - Maintains all current report filters (fiscal year, source, departments)
   - Applies row-specific analytic dimensions (activity, fund, account)
   - Hierarchical parent-child context tracking

3. **Enhanced UX**
   - Visual hover effects on clickable cells
   - External link icons for clear interaction feedback
   - Zero-value cells remain non-clickable for better usability

## Technical Implementation
- **Frontend**: OWL component with action service integration
- **Backend**: Enhanced data structure with parent context tracking
- **Styling**: SCSS with smooth transitions and FontAwesome icons
- **Filtering**: Multi-dimensional domain building for accurate drill-down

## Test plan
- [ ] Test drill-down from different budget report rows (activity, fund, account levels)
- [ ] Verify filtering accuracy in opened views matches report context
- [ ] Check visual indicators work properly on hover
- [ ] Test with different fiscal years and department filters
- [ ] Ensure zero-value cells are non-clickable

🤖 Generated with [Claude Code](https://claude.ai/code)