### PR TITLE
[16.0][ADD] iframe_viewer_widget: add iframe viewer widget for Odoo backend

### DIFF
--- a/iframe_viewer_widget/__init__.py
+++ b/iframe_viewer_widget/__init__.py
@@ -1,0 +1,1 @@
+# IFrame Widget Module

--- a/iframe_viewer_widget/__manifest__.py
+++ b/iframe_viewer_widget/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'IFrame Viewer Widget',
+    'version': '16.0.1.0.0',
+    'category': 'Web',
+    'summary': 'IFrame viewer widget for Odoo backend',
+    'description': """
+        This module adds an iframe_viewer widget that allows displaying URLs
+        in an embedded iframe within Odoo backend forms and views.
+        
+        Usage:
+        <field name="preview_url" widget="iframe_viewer" />
+    """,
+    'author': 'KMITL',
+    'website': 'https://www.kmitl.ac.th',
+    'depends': ['web'],
+    'data': [],
+    'assets': {
+        'web.assets_backend': [
+            'iframe_viewer_widget/static/src/js/iframe_viewer_widget.js',
+        ],
+    },
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/iframe_viewer_widget/static/src/js/iframe_viewer_widget.js
+++ b/iframe_viewer_widget/static/src/js/iframe_viewer_widget.js
@@ -1,0 +1,83 @@
+/** @odoo-module **/
+
+import { Component, onMounted, useRef, useState } from "@odoo/owl";
+
+import { CharField } from "@web/views/fields/char/char_field";
+import { registry } from "@web/core/registry";
+
+class IFrameViewerWidget extends CharField {
+    setup() {
+        super.setup();
+        this.iframeRef = useRef("iframe");
+        this.state = useState({
+            url: this.props.value || '',
+            loading: true,
+            error: false
+        });
+    }
+
+    get displayName() {
+        return this.props.value || '';
+    }
+
+    onIframeLoad() {
+        this.state.loading = false;
+        this.state.error = false;
+    }
+
+    onIframeError() {
+        this.state.loading = false;
+        this.state.error = true;
+    }
+
+    get iframeUrl() {
+        const url = this.props.value;
+        if (!url) return '';
+
+        // Add protocol if missing
+        if (url && !url.match(/^https?:\/\//)) {
+            return `https://${url}`;
+        }
+        return url;
+    }
+}
+
+IFrameViewerWidget.template = "iframe_widget.IFrameViewerWidget";
+IFrameViewerWidget.components = {};
+
+registry.category("fields").add("iframe_viewer", IFrameViewerWidget);
+
+// Template definition
+const { xml } = owl;
+IFrameViewerWidget.template = xml`
+<div class="o_iframe_viewer_widget">
+    <style>
+        .o_field_iframe_viewer {
+            width: 100%;
+        }
+    </style>
+    <div t-if="iframeUrl" class="o_iframe_container mt-2" style="position: relative; width: 100%; height: 400px;">
+        <div t-if="state.loading" class="o_iframe_loading" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2;">
+            <i class="fa fa-spinner fa-spin fa-2x"></i>
+            <div class="mt-2">Loading...</div>
+        </div>
+        <div t-if="state.error" class="o_iframe_error alert alert-warning" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 2; text-align: center;">
+            <i class="fa fa-exclamation-triangle fa-2x"></i>
+            <div class="mt-2">Unable to load URL</div>
+            <small t-esc="iframeUrl"></small>
+        </div>
+        <iframe
+            t-ref="iframe"
+            t-att-src="iframeUrl"
+            t-on-load="onIframeLoad"
+            t-on-error="onIframeError"
+            style="width: 100%; height: 100%; border: 1px solid #ddd; border-radius: 4px;"
+            frameborder="0"
+            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+        ></iframe>
+    </div>
+    <div t-if="!iframeUrl" class="text-muted">
+        No URL specified
+    </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- Add new iframe_viewer_widget module for Odoo 16.0
- Provides iframe_viewer widget for displaying URLs in embedded iframes
- Includes secure iframe sandbox restrictions and error handling
- Features loading states and auto-protocol detection

## Features
- **Widget Name**: `iframe_viewer` 
- **Usage**: `<field name="preview_url" widget="iframe_viewer" />`
- **Security**: Iframe sandbox restrictions for safe content display
- **UX**: Loading indicators, error handling, and responsive design
- **Compatibility**: Odoo 16.0 with proper asset bundling

## Test Plan
- [ ] Install the module in Odoo 16.0 environment
- [ ] Create a model with a URL field
- [ ] Add the widget to a form view: `<field name="url_field" widget="iframe_viewer" />`
- [ ] Test with various URL formats (with/without protocol)
- [ ] Verify iframe loads correctly and shows loading/error states
- [ ] Test edit mode (URL input) and readonly mode (iframe display)

🤖 Generated with [Claude Code](https://claude.ai/code)