### PR TITLE
[16.0][ADD] budget_appropriation: add F4 preview for revenue appropriations

### DIFF
--- a/budget_appropriation/models/__init__.py
+++ b/budget_appropriation/models/__init__.py
@@ -1,4 +1,5 @@
 from . import budget_appropriation
 from . import budget_appropriation_line
 from . import budget_appropriation_f5_report
+from . import budget_appropriation_f4_report
 from . import budget_move

--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -314,3 +314,19 @@ class BudgetAppropriation(models.Model):
                 "active_model": "budget.appropriation",
             },
         }
+
+    def action_open_f4_preview(self):
+        """Open the budget appropriation F4 preview for revenue in full screen"""
+        self.ensure_one()
+        return {
+            "name": _("Budget Appropriation F4 Preview"),
+            "type": "ir.actions.client",
+            "tag": "budget_appropriation_f4_preview",
+            "target": "current",
+            "res_id": self.id,
+            "res_model": "budget.appropriation",
+            "context": {
+                "active_id": self.id,
+                "active_model": "budget.appropriation",
+            },
+        }

--- a/budget_appropriation/models/budget_appropriation_f4_report.py
+++ b/budget_appropriation/models/budget_appropriation_f4_report.py
@@ -1,0 +1,100 @@
+import logging
+
+from odoo import api, fields, models, _
+from ..utils.tree_builder import BudgetTreeBuilder, TreeConfig, BudgetTreeExporter
+
+_logger = logging.getLogger(__name__)
+
+
+class BudgetAppropriationF4Report(models.TransientModel):
+    _name = "budget.appropriation.f4.report"
+    _description = "Budget Appropriation F4 Report"
+
+    appropriation_id = fields.Many2one("budget.appropriation", string="Budget Appropriation", required=True)
+
+    @api.model
+    def get_f4_data(self, appropriation_id, options=None):
+        """Generate F4 hierarchical data for revenue budget appropriation"""
+        if options is None:
+            options = {}
+        
+        appropriation = self.env["budget.appropriation"].browse(appropriation_id)
+        
+        if not appropriation:
+            return {"error": "Invalid appropriation"}
+        
+        # Validate REVENUE type only
+        if appropriation.budget_type != 'revenue':
+            return {"error": "F4 report is only available for revenue type appropriations"}
+        
+        # Get appropriation lines
+        lines = appropriation.line_ids
+        
+        # Build hierarchy: Budget Accounts → Lines (no Activity/Fund for revenue)
+        hierarchy = self._build_hierarchy(lines)
+        
+        # Calculate totals
+        total_amount = sum(line.balance for line in lines)
+        
+        return {
+            "appropriation": {
+                "id": appropriation.id,
+                "name": appropriation.name,
+                "date": appropriation.date.strftime("%d/%m/%Y") if appropriation.date else "",
+                "state": appropriation.state,
+                "total_amount": total_amount,
+                "currency_symbol": appropriation.currency_id.symbol or "฿",
+                "fiscal_year": {
+                    "id": appropriation.date_range_fy_id.id,
+                    "name": appropriation.date_range_fy_id.name,
+                } if appropriation.date_range_fy_id else None,
+                "department": {
+                    "id": appropriation.department_analytic_id.id,
+                    "name": appropriation.department_analytic_id.name,
+                    "code": appropriation.department_analytic_id.code,
+                    "complete_name": self._get_complete_name_without_codes(appropriation.department_analytic_id),
+                } if appropriation.department_analytic_id else None,
+                "source": {
+                    "id": appropriation.source_analytic_id.id,
+                    "name": appropriation.source_analytic_id.name,
+                    "code": appropriation.source_analytic_id.code,
+                } if appropriation.source_analytic_id else None,
+                "journal": {
+                    "id": appropriation.journal_id.id,
+                    "name": appropriation.journal_id.name,
+                } if appropriation.journal_id else None,
+            },
+            "hierarchy": hierarchy,
+            "summary": {
+                "total_lines": len(lines),
+                "total_amount": total_amount,
+                "accounts_count": len(hierarchy),
+            }
+        }
+
+    def _build_hierarchy(self, lines):
+        """Build hierarchical tree structure for revenue: Account only"""
+        
+        if not lines:
+            return []
+        
+        # Configure tree builder for F4 reports (revenue - accounts only)
+        config = TreeConfig.for_f4_report()
+        tree_builder = BudgetTreeBuilder(config)
+        
+        # Build tree from lines
+        tree = tree_builder.build_tree(lines)
+        
+        # Export to Odoo-compatible format
+        return BudgetTreeExporter.to_odoo_hierarchy(tree)
+    
+    def _get_complete_name_without_codes(self, record):
+        """Get complete name without codes - helper method for appropriation data"""
+        if not record:
+            return ""
+        
+        if hasattr(record, 'complete_name') and record.complete_name:
+            # Remove codes from complete_name
+            import re
+            return re.sub(r'\[.*?\]\s*', '', record.complete_name)
+        return record.name

--- a/budget_appropriation/static/src/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview.js
+++ b/budget_appropriation/static/src/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview.js
@@ -1,0 +1,215 @@
+/** @odoo-module **/
+
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { ControlPanel } from "@web/search/control_panel/control_panel";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+export class BudgetAppropriationF4Preview extends Component {
+    setup() {
+        this.controlPanelDisplay = {
+            "top-right": false,
+            "bottom-right": false,
+        };
+
+        this.state = useState({
+            data: {},
+            loading: true,
+            error: null,
+            expandedNodes: new Set(),
+        });
+
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+        this.notification = useService("notification");
+
+        onWillStart(async () => {
+            await this.loadData();
+        });
+    }
+
+    async loadData() {
+        try {
+            this.state.loading = true;
+            this.state.error = null;
+
+            const appropriationId = this.activeId;
+            if (!appropriationId) {
+                console.error("Debug info - Available props:", {
+                    action: this.props.action,
+                    resId: this.props.resId,
+                    props: Object.keys(this.props)
+                });
+                throw new Error("ไม่พบ Budget Appropriation ID - กรุณาเปิดหน้าตัวอย่างจากรายการงบประมาณ");
+            }
+
+            const result = await this.orm.call(
+                "budget.appropriation.f4.report",
+                "get_f4_data",
+                [appropriationId]
+            );
+
+            if (result.error) {
+                throw new Error(result.error);
+            }
+
+            this.state.data = result;
+
+            // Auto-expand all nodes by default
+            if (result.hierarchy && result.hierarchy.length > 0) {
+                const allKeys = this.getAllNodeKeys(result.hierarchy);
+                allKeys.forEach(key => this.state.expandedNodes.add(key));
+            }
+
+        } catch (error) {
+            console.error("Error loading budget appropriation data:", error);
+            this.state.error = error.message || "เกิดข้อผิดพลาดในการโหลดข้อมูล";
+            this.notification.add("เกิดข้อผิดพลาดในการโหลดข้อมูล", { type: "danger" });
+        } finally {
+            this.state.loading = false;
+        }
+    }
+
+    // ---- Getters ----
+
+    get activeId() {
+        // Try to get ID from various sources
+        return this.props.action?.res_id ||
+               this.props.action?.context?.active_id ||
+               this.props.resId ||
+               this.props.action?.params?.id;
+    }
+
+    get context() {
+        return this.props.action?.context || {};
+    }
+
+    get appropriation() {
+        return this.state.data.appropriation || {};
+    }
+
+    get hierarchy() {
+        return this.state.data.hierarchy || [];
+    }
+
+    get totalAmount() {
+        // Calculate total from hierarchy root nodes
+        if (!this.state.data.hierarchy || this.state.data.hierarchy.length === 0) {
+            return 0;
+        }
+
+        return this.state.data.hierarchy.reduce((total, node) => {
+            return total + (node.total_amount || 0);
+        }, 0);
+    }
+
+    // ---- Event Handlers ----
+
+    onToggleNode(nodeKey) {
+        if (this.state.expandedNodes.has(nodeKey)) {
+            this.state.expandedNodes.delete(nodeKey);
+        } else {
+            this.state.expandedNodes.add(nodeKey);
+        }
+    }
+
+    onExpandAll() {
+        const allKeys = this.getAllNodeKeys(this.state.data.hierarchy || []);
+        allKeys.forEach(key => this.state.expandedNodes.add(key));
+    }
+
+    onCollapseAll() {
+        this.state.expandedNodes.clear();
+    }
+
+    onPrint() {
+        // Expand all nodes before printing
+        const allKeys = this.getAllNodeKeys(this.state.data.hierarchy || []);
+        allKeys.forEach(key => this.state.expandedNodes.add(key));
+
+        // Small delay to ensure DOM is updated before printing
+        setTimeout(() => {
+            window.print();
+        }, 100);
+    }
+
+    onRefresh() {
+        this.loadData();
+    }
+
+    onBack() {
+        // Go back to the appropriation form
+        this.actionService.doAction({
+            type: 'ir.actions.act_window',
+            res_model: 'budget.appropriation',
+            res_id: this.activeId,
+            views: [[false, 'form']],
+            target: 'current',
+        });
+    }
+
+    // ---- Helper Methods ----
+
+    getAllNodeKeys(nodes) {
+        const keys = [];
+        for (const node of nodes) {
+            keys.push(node.key);
+            if (node.children && node.children.length > 0) {
+                keys.push(...this.getAllNodeKeys(node.children));
+            }
+        }
+        return keys;
+    }
+
+    isNodeExpanded(nodeKey) {
+        return this.state.expandedNodes.has(nodeKey);
+    }
+
+    formatCurrency(amount) {
+        return new Intl.NumberFormat('th-TH', {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0
+        }).format(amount);
+    }
+
+    getMarginStyle(node) {
+        // For F4 (revenue), we only have account hierarchy
+        // Account level starts from 0 and increases for child accounts
+        if (node.type === 'account') {
+            const accountLevel = Math.max(0, node.level);
+            const marginLeft = 16 * accountLevel;
+            return `margin-left: ${marginLeft}px;`;
+        }
+        return '';
+    }
+
+    getNodeIcon(nodeType) {
+        const icons = {
+            account: "fa-file-text",
+            line: "fa-list-ul"
+        };
+        return icons[nodeType] || "fa-folder";
+    }
+
+    getNodeClass(nodeType, level) {
+        const baseClass = "budget-tree-node";
+        const typeClass = `node-${nodeType}`;
+        const levelClass = `level-${level}`;
+        return `${baseClass} ${typeClass} ${levelClass}`;
+    }
+
+    getNodeTypeLabel(nodeType) {
+        const labels = {
+            account: "รหัสงบประมาณ",
+            line: "รายการ"
+        };
+        return labels[nodeType] || "";
+    }
+}
+
+BudgetAppropriationF4Preview.template = "budget_appropriation.BudgetAppropriationF4Preview";
+BudgetAppropriationF4Preview.components = {
+    ControlPanel
+};
+
+registry.category("actions").add("budget_appropriation_f4_preview", BudgetAppropriationF4Preview);

--- a/budget_appropriation/static/src/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview.scss
+++ b/budget_appropriation/static/src/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview.scss
@@ -1,0 +1,164 @@
+// Budget Appropriation F4 Preview - Revenue Report Style
+
+.budget_appropriation_f4_preview {
+    background-color: #f5f5f5;
+
+    .budget_appropriation_content {
+        padding: 1rem;
+        min-height: 100vh;
+    }
+
+    // Report Container
+    .budget-report-container {
+        background: white;
+        padding: 2rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+
+        .report-header {
+            padding-bottom: 1rem;
+            margin-bottom: 2rem;
+
+            h3 {
+                margin: 0;
+                font-size: 1.375rem;
+                font-weight: 500;
+                color: #424242;
+                line-height: 1.5;
+            }
+
+            h4 {
+                margin: 0.5rem 0 0 0;
+                font-size: 1.2rem;
+                font-weight: normal;
+                color: #666;
+            }
+        }
+    }
+
+    // Report Table
+    .budget-report-table {
+        font-size: 1.175rem;
+
+        thead {
+            tr {
+                background-color: #f8f9fa;
+
+                th {
+                    font-weight: 600;
+                    padding: 0.75rem 0.5rem;
+                    border-bottom: 2px solid #dee2e6;
+                    vertical-align: middle;
+                }
+            }
+        }
+
+        tbody {
+            tr {
+                &.account {
+                    background-color: #fcfcfc;
+                    
+                    td:first-child {
+                        font-weight: bold;
+                    }
+                }
+
+                &.line {
+                    font-weight: normal;
+
+                    &:hover {
+                        background-color: #f8f9fa;
+                    }
+                }
+
+                td {
+                    padding: 0.5rem;
+                    vertical-align: middle;
+                    border-color: #e9ecef;
+                }
+            }
+        }
+
+        tfoot {
+            tr {
+                background-color: #f8f9fa;
+                font-weight: bold;
+
+                td {
+                    padding: 0.75rem 0.5rem;
+                    border-top: 2px solid #dee2e6;
+                }
+            }
+        }
+
+        // Expand/collapse button
+        .btn-link {
+            color: #333;
+            text-decoration: none;
+
+            &:hover {
+                color: #007bff;
+            }
+        }
+    }
+}
+
+// Print Styles
+@media print {
+    .budget_appropriation_f4_preview {
+        .o_control_panel {
+            display: none !important;
+        }
+
+        .budget_appropriation_content {
+            padding: 0 !important;
+            background-color: white !important;
+            min-height: auto !important;
+        }
+
+        .budget-report-container {
+            box-shadow: none !important;
+            padding: 0 !important;
+
+            .report-header {
+                page-break-after: avoid;
+            }
+        }
+
+        .budget-report-table {
+            font-size: 10pt !important;
+
+            thead {
+                display: table-header-group;
+            }
+
+            tbody {
+                tr {
+                    page-break-inside: avoid;
+
+                    &.account {
+                        background-color: white !important;
+                    }
+
+                    &.account td:first-child {
+                        font-weight: bold !important;
+                    }
+                }
+            }
+
+            td, th {
+                border: 1px solid #000 !important;
+                padding: 4px 8px !important;
+            }
+
+            // Hide expand/collapse buttons
+            button {
+                display: none !important;
+            }
+        }
+
+        // Force all rows to be visible for printing
+        tr {
+            display: table-row !important;
+        }
+    }
+}

--- a/budget_appropriation/static/src/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview.xml
+++ b/budget_appropriation/static/src/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <div t-name="budget_appropriation.BudgetAppropriationF4Preview" class="o_action budget_appropriation_f4_preview" owl="1">
+
+        <!-- Control Panel -->
+        <ControlPanel display="controlPanelDisplay">
+            <t t-set-slot="control-panel-bottom-left-buttons">
+                <div class="o_cp_buttons">
+                    <div class="btn-group me-2">
+                        <button
+                            type="button"
+                            class="btn btn-secondary"
+                            t-on-click="onBack"
+                            title="กลับ">
+                            <i class="fa fa-arrow-left"/> กลับ
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-secondary"
+                            t-on-click="onRefresh"
+                            title="รีเฟรช">
+                            <i class="fa fa-refresh"/>
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-secondary"
+                            t-on-click="onExpandAll"
+                            title="ขยายทั้งหมด">
+                            <i class="fa fa-expand"/>
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-secondary"
+                            t-on-click="onCollapseAll"
+                            title="ย่อทั้งหมด">
+                            <i class="fa fa-compress"/>
+                        </button>
+                    </div>
+                    <div class="btn-group">
+                        <button
+                            type="button"
+                            class="btn btn-primary"
+                            t-on-click="onPrint"
+                            title="พิมพ์">
+                            <i class="fa fa-print"/> พิมพ์
+                        </button>
+                    </div>
+                </div>
+            </t>
+        </ControlPanel>
+
+        <div class="o_content">
+            <!-- Loading State -->
+            <div t-if="state.loading" class="d-flex justify-content-center align-items-center p-5">
+                <div class="text-center">
+                    <div class="spinner-border text-primary mb-3" role="status">
+                        <span class="sr-only">กำลังโหลด...</span>
+                    </div>
+                    <div>กำลังโหลดข้อมูล...</div>
+                </div>
+            </div>
+
+            <!-- Error State -->
+            <div t-if="state.error and !state.loading" class="alert alert-danger m-3">
+                <h4 class="alert-heading">เกิดข้อผิดพลาด</h4>
+                <p t-esc="state.error"/>
+                <hr/>
+                <button class="btn btn-outline-danger" t-on-click="onRefresh">
+                    <i class="fa fa-refresh"/> ลองใหม่
+                </button>
+            </div>
+
+            <!-- Main Content -->
+            <div t-if="!state.loading and !state.error" class="budget_appropriation_content">
+                <!-- Budget Report Table -->
+                <div class="row justify-content-center">
+                    <div class="col-12" style="max-width: 960px;">
+                        <div class="budget-report-container">
+                            <div class="report-header text-center mb-4">
+                                <h3 t-if="appropriation.source" t-esc="appropriation.source.name" />
+                                <h3>ประมาณการ<t t-if="appropriation.journal" t-esc="appropriation.journal.name" /> ประจำปีงบประมาณ พ.ศ. <t t-if="appropriation.fiscal_year" t-esc="appropriation.fiscal_year.name" /></h3>
+                                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                                <h3 t-if="appropriation.department" t-esc="appropriation.department.complete_name" />
+                                <h3>วงเงิน <t t-esc="formatCurrency(totalAmount)"/> บาท</h3>
+                            </div>
+
+                            <!-- Report Table -->
+                            <div class="table-responsive">
+                                <table class="table table-bordered table-sm budget-report-table">
+                                    <thead>
+                                        <tr class="table-active">
+                                            <th width="80%">รายการ</th>
+                                            <th width="20%" class="text-end">จำนวนเงิน</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-if="hierarchy.length > 0">
+                                            <t t-foreach="hierarchy" t-as="rootNode" t-key="rootNode.key">
+                                                <t t-call="budget_appropriation.F4TableRow">
+                                                    <t t-set="node" t-value="rootNode"/>
+                                                    <t t-set="level" t-value="0"/>
+                                                </t>
+                                            </t>
+                                        </t>
+                                    </tbody>
+                                    <tfoot>
+                                        <tr class="table-active fw-bold">
+                                            <td class="text-end">
+                                                <strong>ยอดรวมทั้งหมด</strong>
+                                            </td>
+                                            <td class="text-end">
+                                                <strong>
+                                                    <t t-esc="formatCurrency(totalAmount)"/> บาท
+                                                </strong>
+                                            </td>
+                                        </tr>
+                                    </tfoot>
+                                </table>
+                            </div>
+
+                            <!-- Empty State -->
+                            <div t-if="hierarchy.length === 0" class="text-center py-5">
+                                <div class="text-muted">
+                                    <i class="fa fa-folder-open fa-3x mb-3"/>
+                                    <h4>ไม่มีข้อมูล</h4>
+                                    <p>ไม่พบรายการจัดสรรงบประมาณ</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Recursive Table Row Template for F4 (Revenue - Accounts Only) -->
+    <t t-name="budget_appropriation.F4TableRow" owl="1">
+        <tr t-attf-class="{{node.type}} {{node.type !== 'line' ? 'font-weight-bold' : ''}}">
+            <td>
+                <div t-att-style="getMarginStyle(node)">
+                    <div class="d-flex align-items-center">
+                        <button
+                            t-if="node.children and node.children.length > 0"
+                            type="button"
+                            class="btn btn-sm btn-link p-0 me-2"
+                            t-on-click="() => this.onToggleNode(node.key)"
+                            style="width: 20px;">
+                            <i t-att-class="isNodeExpanded(node.key) ? 'fa fa-minus-square-o' : 'fa fa-plus-square-o'"/>
+                        </button>
+                        <div t-else="" style="width: 20px; display: inline-block;" class="me-2"></div>
+                        <span>
+                            <t t-if="node.type === 'account'">
+                                <t t-esc="node.code"/> - <t t-esc="node.name"/>
+                                <t t-if="node.line_details and node.line_details.length > 0">
+                                    <t t-foreach="node.line_details" t-as="detail" t-key="detail.id">
+                                        <t t-if="detail.note">
+                                            <div class="text-muted" style="white-space: pre-line;"><t t-esc="detail.note"/></div>
+                                        </t>
+                                    </t>
+                                </t>
+                            </t>
+                            <t t-else="">
+                                <t t-esc="node.name"/>
+                                <t t-if="node.code">
+                                    <span class="text-muted"> (<t t-esc="node.code"/>)</span>
+                                </t>
+                            </t>
+                        </span>
+                    </div>
+                </div>
+            </td>
+            <td class="text-end">
+                <t t-if="node.total_amount != 0 or node.type !== 'line'">
+                    <t t-esc="formatCurrency(node.total_amount)"/>
+                </t>
+            </td>
+        </tr>
+
+        <!-- Children Rows -->
+        <t t-if="isNodeExpanded(node.key) and node.children and node.children.length > 0">
+            <t t-foreach="node.children" t-as="childNode" t-key="childNode.key">
+                <t t-call="budget_appropriation.F4TableRow">
+                    <t t-set="node" t-value="childNode"/>
+                    <t t-set="level" t-value="level + 1"/>
+                </t>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/budget_appropriation/utils/tree_builder.py
+++ b/budget_appropriation/utils/tree_builder.py
@@ -72,6 +72,16 @@ class TreeConfig:
             calculate_rollups=True,
             amount_field='amount'
         )
+    
+    @classmethod
+    def for_f4_report(cls):
+        """Predefined config for F4 reports (revenue - accounts only)"""
+        return cls(
+            dimensions=['account'],
+            include_empty=False,
+            calculate_rollups=True,
+            amount_field='balance'
+        )
 
 
 class TreeNode:

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -87,9 +87,16 @@
                         <page string="Preview" name="preview" attrs="{'invisible': [('id', '=', False)]}">
                             <div class="o_budget_preview_container">
                                 <div class="text-center p-3">
-                                    <button type="object" name="action_open_f5_preview" class="btn btn-primary btn-lg">
+                                    <!-- F5 Preview for Expense -->
+                                    <button type="object" name="action_open_f5_preview" class="btn btn-primary btn-lg me-2" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
                                         <i class="fa fa-eye" />
                                         เปิดดูตัวอย่างแบบละเอียด (F5)
+                                    </button>
+                                    
+                                    <!-- F4 Preview for Revenue -->
+                                    <button type="object" name="action_open_f4_preview" class="btn btn-success btn-lg" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}">
+                                        <i class="fa fa-eye" />
+                                        เปิดดูตัวอย่างรายรับ (F4)
                                     </button>
                                 </div>
                             </div>

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -83,9 +83,16 @@
                         <page string="Preview" name="preview" attrs="{'invisible': [('id', '=', False)]}">
                             <div class="o_budget_preview_container">
                                 <div class="text-center p-3">
-                                    <button type="object" name="action_open_f5_preview" class="btn btn-primary btn-lg">
+                                    <!-- F5 Preview for Expense -->
+                                    <button type="object" name="action_open_f5_preview" class="btn btn-primary btn-lg me-2" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
                                         <i class="fa fa-eye" />
                                         เปิดดูตัวอย่างแบบละเอียด (F5)
+                                    </button>
+                                    
+                                    <!-- F4 Preview for Revenue -->
+                                    <button type="object" name="action_open_f4_preview" class="btn btn-success btn-lg" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}">
+                                        <i class="fa fa-eye" />
+                                        เปิดดูตัวอย่างรายรับ (F4)
                                     </button>
                                 </div>
                             </div>

--- a/budget_appropriation_offset/models/__init__.py
+++ b/budget_appropriation_offset/models/__init__.py
@@ -2,3 +2,4 @@
 from . import budget_appropriation_offset
 from . import budget_appropriation
 from . import budget_appropriation_line
+from . import budget_appropriation_f4_report

--- a/budget_appropriation_offset/models/budget_appropriation_f4_report.py
+++ b/budget_appropriation_offset/models/budget_appropriation_f4_report.py
@@ -1,0 +1,112 @@
+import logging
+
+from odoo import api, fields, models, _
+
+_logger = logging.getLogger(__name__)
+
+
+class BudgetAppropriationF4ReportOffset(models.TransientModel):
+    _inherit = "budget.appropriation.f4.report"
+
+    @api.model
+    def get_f4_data(self, appropriation_id, options=None):
+        """Enhanced F4 data with offset information for revenue appropriations"""
+        # Get base F4 data from parent
+        result = super().get_f4_data(appropriation_id, options)
+        
+        if result.get("error"):
+            return result
+            
+        appropriation = self.env["budget.appropriation"].browse(appropriation_id)
+        
+        if not appropriation or appropriation.budget_type != 'revenue':
+            return result
+        
+        # Enhance appropriation data with offset information
+        if "appropriation" in result:
+            result["appropriation"].update({
+                "offset_total": appropriation.offset_total,
+                "total_revenue_net": appropriation.total_revenue_net,
+                "has_offsets": bool(appropriation.offset_ids),
+            })
+        
+        # Add offset details to summary
+        if "summary" in result:
+            result["summary"].update({
+                "offset_total": appropriation.offset_total,
+                "total_revenue_net": appropriation.total_revenue_net,
+                "offsets_count": len(appropriation.offset_ids),
+            })
+        
+        # Enhance hierarchy with offset data
+        if "hierarchy" in result:
+            result["hierarchy"] = self._enhance_hierarchy_with_offsets(result["hierarchy"], appropriation)
+        
+        return result
+    
+    def _enhance_hierarchy_with_offsets(self, hierarchy, appropriation):
+        """Enhance hierarchy nodes with offset information"""
+        enhanced_hierarchy = []
+        
+        for node in hierarchy:
+            enhanced_node = dict(node)
+            enhanced_node = self._add_offset_data_to_node(enhanced_node, appropriation)
+            enhanced_hierarchy.append(enhanced_node)
+        
+        return enhanced_hierarchy
+    
+    def _add_offset_data_to_node(self, node, appropriation):
+        """Recursively add offset data to hierarchy nodes"""
+        # Add offset data to account nodes that have line details
+        if node.get('type') == 'account' and node.get('line_details'):
+            node['offsets'] = []
+            total_node_offsets = 0
+            
+            # Find offsets for this account's lines
+            for line_detail in node.get('line_details', []):
+                line_id = line_detail.get('id')
+                if line_id:
+                    line = appropriation.line_ids.filtered(lambda l: l.id == line_id)
+                    if line and line.offset_ids:
+                        for offset in line.offset_ids:
+                            offset_data = {
+                                'id': offset.id,
+                                'name': offset.name or f"หักโอน {offset.amount:,.0f} บาท",
+                                'amount': offset.amount,
+                                'note': offset.note,
+                                'state': offset.state,
+                                'state_label': dict(offset._fields['state'].selection).get(offset.state, offset.state),
+                                'from_department': {
+                                    'id': offset.from_department_analytic_id.id,
+                                    'name': offset.from_department_analytic_id.name,
+                                    'code': offset.from_department_analytic_id.code,
+                                } if offset.from_department_analytic_id else None,
+                                'to_department': {
+                                    'id': offset.to_department_analytic_id.id,
+                                    'name': offset.to_department_analytic_id.name,
+                                    'code': offset.to_department_analytic_id.code,
+                                } if offset.to_department_analytic_id else None,
+                            }
+                            node['offsets'].append(offset_data)
+                            total_node_offsets += offset.amount
+            
+            # Update node amounts to show net after offsets
+            if total_node_offsets > 0:
+                node['offset_total'] = total_node_offsets
+                node['amount_before_offset'] = node.get('amount', 0)
+                node['net_amount'] = node.get('total_amount', 0) - total_node_offsets
+                node['has_offsets'] = True
+            else:
+                node['offset_total'] = 0
+                node['net_amount'] = node.get('total_amount', 0)
+                node['has_offsets'] = False
+        
+        # Recursively process children
+        if 'children' in node and node['children']:
+            enhanced_children = []
+            for child in node['children']:
+                enhanced_child = self._add_offset_data_to_node(child, appropriation)
+                enhanced_children.append(enhanced_child)
+            node['children'] = enhanced_children
+        
+        return node

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.js
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.js
@@ -6,21 +6,19 @@ import { patch } from "@web/core/utils/patch";
 // Simple patch for F4 Preview to show offset information
 patch(BudgetAppropriationF4Preview.prototype, "budget_appropriation_offset.BudgetAppropriationF4PreviewOffset", {
     
-    // ---- Simple Getters ----
+    // ---- Simple Helper Methods ----
 
-    get hasOffsets() {
+    hasOffsetsData() {
         return this.appropriation.has_offsets || false;
     },
 
-    get offsetTotal() {
+    getOffsetTotal() {
         return this.appropriation.offset_total || 0;
     },
 
-    get totalRevenueNet() {
+    getTotalRevenueNet() {
         return this.appropriation.total_revenue_net || this.totalAmount;
     },
-
-    // ---- Simple Helper Methods ----
 
     hasNodeOffsets(node) {
         return node.has_offsets && node.offsets && node.offsets.length > 0;

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.js
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.js
@@ -3,20 +3,10 @@
 import { BudgetAppropriationF4Preview } from "@budget_appropriation/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview";
 import { patch } from "@web/core/utils/patch";
 
-// Patch the F4 Preview component to enhance with offset functionality
+// Simple patch for F4 Preview to show offset information
 patch(BudgetAppropriationF4Preview.prototype, "budget_appropriation_offset.BudgetAppropriationF4PreviewOffset", {
     
-    setup() {
-        this._super(...arguments);
-        
-        // Add offset-specific state
-        Object.assign(this.state, {
-            showOffsets: true,
-            showNetAmounts: true,
-        });
-    },
-
-    // ---- Enhanced Getters ----
+    // ---- Simple Getters ----
 
     get hasOffsets() {
         return this.appropriation.has_offsets || false;
@@ -30,73 +20,9 @@ patch(BudgetAppropriationF4Preview.prototype, "budget_appropriation_offset.Budge
         return this.appropriation.total_revenue_net || this.totalAmount;
     },
 
-    // ---- Enhanced Event Handlers ----
-
-    onToggleOffsets() {
-        this.state.showOffsets = !this.state.showOffsets;
-    },
-
-    onToggleNetAmounts() {
-        this.state.showNetAmounts = !this.state.showNetAmounts;
-    },
-
-    // ---- Enhanced Helper Methods ----
-
-    formatCurrencyWithSign(amount) {
-        const formatted = this.formatCurrency(Math.abs(amount));
-        return amount >= 0 ? formatted : `(${formatted})`;
-    },
-
-    getOffsetStateClass(state) {
-        const stateClasses = {
-            'draft': 'badge-secondary',
-            'waiting_to_process': 'badge-warning',
-            'done': 'badge-success',
-            'cancelled': 'badge-danger'
-        };
-        return stateClasses[state] || 'badge-secondary';
-    },
+    // ---- Simple Helper Methods ----
 
     hasNodeOffsets(node) {
         return node.has_offsets && node.offsets && node.offsets.length > 0;
-    },
-
-    getNodeNetAmount(node) {
-        if (this.state.showNetAmounts && node.has_offsets) {
-            return node.net_amount || 0;
-        }
-        return node.total_amount || 0;
-    },
-
-    getNodeDisplayAmount(node) {
-        if (this.state.showNetAmounts && node.has_offsets) {
-            return {
-                gross: node.total_amount || 0,
-                offset: node.offset_total || 0,
-                net: node.net_amount || 0,
-                showBreakdown: true
-            };
-        }
-        return {
-            gross: node.total_amount || 0,
-            offset: 0,
-            net: node.total_amount || 0,
-            showBreakdown: false
-        };
-    },
-
-    getOffsetIcon(offset) {
-        const stateIcons = {
-            'draft': 'fa-pencil',
-            'waiting_to_process': 'fa-clock-o',
-            'done': 'fa-check',
-            'cancelled': 'fa-times'
-        };
-        return stateIcons[offset.state] || 'fa-exchange';
     }
-});
-
-// Extend the template name to use the enhanced version
-patch(BudgetAppropriationF4Preview, "budget_appropriation_offset.BudgetAppropriationF4PreviewOffsetTemplate", {
-    template: "budget_appropriation_offset.BudgetAppropriationF4PreviewOffset",
 });

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.js
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.js
@@ -1,0 +1,102 @@
+/** @odoo-module **/
+
+import { BudgetAppropriationF4Preview } from "@budget_appropriation/components/budget_appropriation_f4_preview/budget_appropriation_f4_preview";
+import { patch } from "@web/core/utils/patch";
+
+// Patch the F4 Preview component to enhance with offset functionality
+patch(BudgetAppropriationF4Preview.prototype, "budget_appropriation_offset.BudgetAppropriationF4PreviewOffset", {
+    
+    setup() {
+        this._super(...arguments);
+        
+        // Add offset-specific state
+        Object.assign(this.state, {
+            showOffsets: true,
+            showNetAmounts: true,
+        });
+    },
+
+    // ---- Enhanced Getters ----
+
+    get hasOffsets() {
+        return this.appropriation.has_offsets || false;
+    },
+
+    get offsetTotal() {
+        return this.appropriation.offset_total || 0;
+    },
+
+    get totalRevenueNet() {
+        return this.appropriation.total_revenue_net || this.totalAmount;
+    },
+
+    // ---- Enhanced Event Handlers ----
+
+    onToggleOffsets() {
+        this.state.showOffsets = !this.state.showOffsets;
+    },
+
+    onToggleNetAmounts() {
+        this.state.showNetAmounts = !this.state.showNetAmounts;
+    },
+
+    // ---- Enhanced Helper Methods ----
+
+    formatCurrencyWithSign(amount) {
+        const formatted = this.formatCurrency(Math.abs(amount));
+        return amount >= 0 ? formatted : `(${formatted})`;
+    },
+
+    getOffsetStateClass(state) {
+        const stateClasses = {
+            'draft': 'badge-secondary',
+            'waiting_to_process': 'badge-warning',
+            'done': 'badge-success',
+            'cancelled': 'badge-danger'
+        };
+        return stateClasses[state] || 'badge-secondary';
+    },
+
+    hasNodeOffsets(node) {
+        return node.has_offsets && node.offsets && node.offsets.length > 0;
+    },
+
+    getNodeNetAmount(node) {
+        if (this.state.showNetAmounts && node.has_offsets) {
+            return node.net_amount || 0;
+        }
+        return node.total_amount || 0;
+    },
+
+    getNodeDisplayAmount(node) {
+        if (this.state.showNetAmounts && node.has_offsets) {
+            return {
+                gross: node.total_amount || 0,
+                offset: node.offset_total || 0,
+                net: node.net_amount || 0,
+                showBreakdown: true
+            };
+        }
+        return {
+            gross: node.total_amount || 0,
+            offset: 0,
+            net: node.total_amount || 0,
+            showBreakdown: false
+        };
+    },
+
+    getOffsetIcon(offset) {
+        const stateIcons = {
+            'draft': 'fa-pencil',
+            'waiting_to_process': 'fa-clock-o',
+            'done': 'fa-check',
+            'cancelled': 'fa-times'
+        };
+        return stateIcons[offset.state] || 'fa-exchange';
+    }
+});
+
+// Extend the template name to use the enhanced version
+patch(BudgetAppropriationF4Preview, "budget_appropriation_offset.BudgetAppropriationF4PreviewOffsetTemplate", {
+    template: "budget_appropriation_offset.BudgetAppropriationF4PreviewOffset",
+});

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.scss
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.scss
@@ -1,198 +1,25 @@
-// Budget Appropriation F4 Preview with Offset Support
+// Simple styling for F4 Preview with Offset Support
 
 .budget_appropriation_f4_preview {
     
-    // Offset Details Styling
-    .offset-details {
-        margin-top: 0.75rem;
-        padding: 0.5rem;
-        background-color: #fff8e1;
-        border-radius: 4px;
-        border-left: 3px solid #ff9800;
-        font-size: 0.9rem;
-
-        .detail-header {
-            margin-bottom: 0.5rem;
-            font-size: 0.85rem;
-            
-            i {
-                margin-right: 0.25rem;
-            }
-        }
-
-        .detail-item {
-            margin-bottom: 0.4rem;
-            padding: 0.3rem;
-            background-color: white;
-            border-radius: 3px;
-            border: 1px solid #ffcc02;
-
-            &:last-child {
-                margin-bottom: 0;
-            }
-
-            .detail-content {
-                display: flex;
-                flex-wrap: wrap;
-                align-items: center;
-                gap: 0.5rem;
-                font-size: 0.8rem;
-
-                .detail-name {
-                    font-weight: 500;
-                    color: #212529;
-                    flex: 1;
-                    min-width: 150px;
-                    
-                    i {
-                        margin-right: 0.25rem;
-                        color: #ff9800;
-                    }
-                }
-
-                .detail-amount {
-                    font-weight: 600;
-                    white-space: nowrap;
-                }
-
-                .detail-state {
-                    font-size: 0.7rem;
-                    padding: 0.1rem 0.4rem;
-                    border-radius: 10px;
-                    font-weight: 500;
-                    text-transform: uppercase;
-                    
-                    &.badge-secondary {
-                        background-color: #f8f9fa;
-                        color: #6c757d;
-                    }
-                    
-                    &.badge-warning {
-                        background-color: #fff3cd;
-                        color: #856404;
-                    }
-                    
-                    &.badge-success {
-                        background-color: #d1e7dd;
-                        color: #0f5132;
-                    }
-                    
-                    &.badge-danger {
-                        background-color: #f8d7da;
-                        color: #721c24;
-                    }
-                }
-            }
-
-            .detail-description {
-                margin-top: 0.3rem;
-                font-size: 0.75rem;
-                color: #6c757d;
-                font-style: italic;
-                padding-left: 0.5rem;
-                border-left: 2px solid #ffcc02;
-            }
-        }
+    // Simple offset text styling
+    .text-danger.small {
+        font-size: 0.85rem;
     }
-
-    // Enhanced table styling for offset columns
-    .budget-report-table {
-        thead th {
-            &:nth-last-child(3) {
-                background-color: #f8f9fa;
-            }
-            &:nth-last-child(2) {
-                background-color: #fff8e1;
-            }
-            &:nth-last-child(1) {
-                background-color: #e8f5e8;
-            }
-        }
-
-        tbody {
-            tr {
-                td.text-danger {
-                    background-color: rgba(255, 193, 7, 0.1);
-                }
-                
-                td.text-success {
-                    background-color: rgba(40, 167, 69, 0.1);
-                }
-            }
-        }
-
-        tfoot {
-            tr {
-                td.text-danger {
-                    background-color: rgba(255, 193, 7, 0.2);
-                    border-top: 2px solid #ffc107;
-                }
-                
-                td.text-success {
-                    background-color: rgba(40, 167, 69, 0.2);
-                    border-top: 2px solid #28a745;
-                }
-            }
-        }
-    }
-
-    // Offset badge styling
-    .badge-warning {
-        background-color: #ffc107;
-        color: #212529;
-        
-        i {
-            margin-right: 0.25rem;
-        }
+    
+    .text-success.small {
+        font-size: 0.85rem;
+        font-weight: 500;
     }
 }
 
-// Print styles for offset information
+// Print styles
 @media print {
     .budget_appropriation_f4_preview {
-        .offset-details {
-            background-color: #f5f5f5 !important;
-            border-left: 2px solid #333 !important;
-            
-            .detail-item {
-                background-color: white !important;
-                border: 1px solid #333 !important;
-                
-                .detail-content {
-                    font-size: 8pt !important;
-                }
-                
-                .detail-state {
-                    background-color: #e9ecef !important;
-                    color: #000 !important;
-                }
-            }
-        }
-
-        .budget-report-table {
-            thead th {
-                &:nth-last-child(3),
-                &:nth-last-child(2),
-                &:nth-last-child(1) {
-                    background-color: #f8f9fa !important;
-                }
-            }
-
-            tbody td.text-danger,
-            tbody td.text-success {
-                background-color: white !important;
-            }
-
-            tfoot td.text-danger,
-            tfoot td.text-success {
-                background-color: #f8f9fa !important;
-                border-top: 2px solid #333 !important;
-            }
-        }
-
-        .badge-warning {
-            background-color: #e9ecef !important;
+        .text-danger.small,
+        .text-success.small {
             color: #000 !important;
+            font-size: 8pt !important;
         }
     }
 }

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.scss
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.scss
@@ -11,6 +11,27 @@
         font-size: 0.85rem;
         font-weight: 500;
     }
+
+    // Footer summary styling
+    .budget-report-table {
+        tfoot {
+            tr.table-secondary {
+                background-color: #f8f9fa;
+            }
+            
+            tr.table-warning {
+                background-color: #fff3cd;
+            }
+            
+            tr.table-success {
+                background-color: #d1e7dd;
+                
+                td {
+                    border-top: 2px solid #198754;
+                }
+            }
+        }
+    }
 }
 
 // Print styles
@@ -20,6 +41,24 @@
         .text-success.small {
             color: #000 !important;
             font-size: 8pt !important;
+        }
+
+        .budget-report-table {
+            tfoot {
+                tr.table-secondary,
+                tr.table-warning,
+                tr.table-success {
+                    background-color: #f8f9fa !important;
+                    
+                    td {
+                        border-top: 1px solid #000 !important;
+                    }
+                }
+                
+                tr.table-success td {
+                    border-top: 2px solid #000 !important;
+                }
+            }
         }
     }
 }

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.scss
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.scss
@@ -1,0 +1,198 @@
+// Budget Appropriation F4 Preview with Offset Support
+
+.budget_appropriation_f4_preview {
+    
+    // Offset Details Styling
+    .offset-details {
+        margin-top: 0.75rem;
+        padding: 0.5rem;
+        background-color: #fff8e1;
+        border-radius: 4px;
+        border-left: 3px solid #ff9800;
+        font-size: 0.9rem;
+
+        .detail-header {
+            margin-bottom: 0.5rem;
+            font-size: 0.85rem;
+            
+            i {
+                margin-right: 0.25rem;
+            }
+        }
+
+        .detail-item {
+            margin-bottom: 0.4rem;
+            padding: 0.3rem;
+            background-color: white;
+            border-radius: 3px;
+            border: 1px solid #ffcc02;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+
+            .detail-content {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                gap: 0.5rem;
+                font-size: 0.8rem;
+
+                .detail-name {
+                    font-weight: 500;
+                    color: #212529;
+                    flex: 1;
+                    min-width: 150px;
+                    
+                    i {
+                        margin-right: 0.25rem;
+                        color: #ff9800;
+                    }
+                }
+
+                .detail-amount {
+                    font-weight: 600;
+                    white-space: nowrap;
+                }
+
+                .detail-state {
+                    font-size: 0.7rem;
+                    padding: 0.1rem 0.4rem;
+                    border-radius: 10px;
+                    font-weight: 500;
+                    text-transform: uppercase;
+                    
+                    &.badge-secondary {
+                        background-color: #f8f9fa;
+                        color: #6c757d;
+                    }
+                    
+                    &.badge-warning {
+                        background-color: #fff3cd;
+                        color: #856404;
+                    }
+                    
+                    &.badge-success {
+                        background-color: #d1e7dd;
+                        color: #0f5132;
+                    }
+                    
+                    &.badge-danger {
+                        background-color: #f8d7da;
+                        color: #721c24;
+                    }
+                }
+            }
+
+            .detail-description {
+                margin-top: 0.3rem;
+                font-size: 0.75rem;
+                color: #6c757d;
+                font-style: italic;
+                padding-left: 0.5rem;
+                border-left: 2px solid #ffcc02;
+            }
+        }
+    }
+
+    // Enhanced table styling for offset columns
+    .budget-report-table {
+        thead th {
+            &:nth-last-child(3) {
+                background-color: #f8f9fa;
+            }
+            &:nth-last-child(2) {
+                background-color: #fff8e1;
+            }
+            &:nth-last-child(1) {
+                background-color: #e8f5e8;
+            }
+        }
+
+        tbody {
+            tr {
+                td.text-danger {
+                    background-color: rgba(255, 193, 7, 0.1);
+                }
+                
+                td.text-success {
+                    background-color: rgba(40, 167, 69, 0.1);
+                }
+            }
+        }
+
+        tfoot {
+            tr {
+                td.text-danger {
+                    background-color: rgba(255, 193, 7, 0.2);
+                    border-top: 2px solid #ffc107;
+                }
+                
+                td.text-success {
+                    background-color: rgba(40, 167, 69, 0.2);
+                    border-top: 2px solid #28a745;
+                }
+            }
+        }
+    }
+
+    // Offset badge styling
+    .badge-warning {
+        background-color: #ffc107;
+        color: #212529;
+        
+        i {
+            margin-right: 0.25rem;
+        }
+    }
+}
+
+// Print styles for offset information
+@media print {
+    .budget_appropriation_f4_preview {
+        .offset-details {
+            background-color: #f5f5f5 !important;
+            border-left: 2px solid #333 !important;
+            
+            .detail-item {
+                background-color: white !important;
+                border: 1px solid #333 !important;
+                
+                .detail-content {
+                    font-size: 8pt !important;
+                }
+                
+                .detail-state {
+                    background-color: #e9ecef !important;
+                    color: #000 !important;
+                }
+            }
+        }
+
+        .budget-report-table {
+            thead th {
+                &:nth-last-child(3),
+                &:nth-last-child(2),
+                &:nth-last-child(1) {
+                    background-color: #f8f9fa !important;
+                }
+            }
+
+            tbody td.text-danger,
+            tbody td.text-success {
+                background-color: white !important;
+            }
+
+            tfoot td.text-danger,
+            tfoot td.text-success {
+                background-color: #f8f9fa !important;
+                border-top: 2px solid #333 !important;
+            }
+        }
+
+        .badge-warning {
+            background-color: #e9ecef !important;
+            color: #000 !important;
+        }
+    }
+}

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
@@ -1,40 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates xml:space="preserve">
-    
+
     <!-- Simple extension to show offset info in header -->
     <div t-name="budget_appropriation_offset.BudgetAppropriationF4PreviewOffset" class="o_action budget_appropriation_f4_preview" owl="1" t-inherit="budget_appropriation.BudgetAppropriationF4Preview" t-inherit-mode="extension">
 
         <!-- Show net revenue in header if there are offsets -->
         <xpath expr="//h3[contains(text(), 'วงเงิน')]" position="after">
             <h3 t-if="hasOffsetsData()">รายรับสุทธิ <t t-esc="formatCurrency(getTotalRevenueNet())"/> บาท</h3>
-        </xpath>
-
-    </div>
-
-    <!-- Simple override of F4TableRow to show offset details -->
-    <t t-name="budget_appropriation.F4TableRow" owl="1" t-inherit="budget_appropriation.F4TableRow" t-inherit-mode="extension">
-        
-        <!-- Add offset details after line details -->
-        <xpath expr="//t[@t-if='node.line_details and node.line_details.length > 0']" position="after">
-            <!-- Simple offset display -->
-            <t t-if="hasNodeOffsets(node)">
-                <t t-foreach="node.offsets" t-as="offset" t-key="offset.id">
-                    <div class="text-muted small" style="margin-left: 20px;">
-                        หักโอน: <t t-esc="offset.name"/> -<t t-esc="formatCurrency(offset.amount)"/> บาท
-                        <t t-if="offset.note"> (<t t-esc="offset.note"/>)</t>
-                    </div>
-                </t>
-            </t>
-        </xpath>
-
-        <!-- Update amount display to show net amount if there are offsets -->
-        <xpath expr="//t[@t-esc='formatCurrency(node.total_amount)']" position="replace">
-            <t t-if="!hasNodeOffsets(node)" t-esc="formatCurrency(node.total_amount)"/>
-            <t t-if="hasNodeOffsets(node)">
-                <div><t t-esc="formatCurrency(node.total_amount)"/></div>
-                <div class="text-danger small">หัก <t t-esc="formatCurrency(node.offset_total)"/></div>
-                <div class="text-success small">คงเหลือ <t t-esc="formatCurrency(node.net_amount)"/></div>
-            </t>
         </xpath>
 
         <!-- Add offset summary rows after the existing footer -->
@@ -60,6 +32,33 @@
                     </strong>
                 </td>
             </tr>
+        </xpath>
+    </div>
+
+    <!-- Simple override of F4TableRow to show offset details -->
+    <t t-name="budget_appropriation.F4TableRow" owl="1" t-inherit="budget_appropriation.F4TableRow" t-inherit-mode="extension">
+
+        <!-- Add offset details after line details -->
+        <xpath expr="//t[@t-if='node.line_details and node.line_details.length > 0']" position="after">
+            <!-- Simple offset display -->
+            <t t-if="hasNodeOffsets(node)">
+                <t t-foreach="node.offsets" t-as="offset" t-key="offset.id">
+                    <div class="text-muted small" style="margin-left: 20px;">
+                        หักโอน: <t t-esc="offset.name"/> -<t t-esc="formatCurrency(offset.amount)"/> บาท
+                        <t t-if="offset.note"> (<t t-esc="offset.note"/>)</t>
+                    </div>
+                </t>
+            </t>
+        </xpath>
+
+        <!-- Update amount display to show net amount if there are offsets -->
+        <xpath expr="//t[@t-esc='formatCurrency(node.total_amount)']" position="replace">
+            <t t-if="!hasNodeOffsets(node)" t-esc="formatCurrency(node.total_amount)"/>
+            <t t-if="hasNodeOffsets(node)">
+                <div><t t-esc="formatCurrency(node.total_amount)"/></div>
+                <div class="text-danger small">หัก <t t-esc="formatCurrency(node.offset_total)"/></div>
+                <div class="text-success small">คงเหลือ <t t-esc="formatCurrency(node.net_amount)"/></div>
+            </t>
         </xpath>
 
     </t>

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
@@ -1,204 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates xml:space="preserve">
+    
+    <!-- Simple extension to show offset info in header -->
     <div t-name="budget_appropriation_offset.BudgetAppropriationF4PreviewOffset" class="o_action budget_appropriation_f4_preview" owl="1" t-inherit="budget_appropriation.BudgetAppropriationF4Preview" t-inherit-mode="extension">
 
-        <!-- Enhanced Control Panel with Offset Controls -->
-        <xpath expr="//div[hasclass('btn-group')][2]" position="after">
-            <div class="btn-group me-2" t-if="hasOffsets">
-                <button
-                    type="button"
-                    t-att-class="state.showOffsets ? 'btn btn-warning' : 'btn btn-outline-warning'"
-                    t-on-click="onToggleOffsets"
-                    title="แสดง/ซ่อน รายการหักโอน">
-                    <i class="fa fa-exchange"/> หักโอน
-                </button>
-                <button
-                    type="button"
-                    t-att-class="state.showNetAmounts ? 'btn btn-info' : 'btn btn-outline-info'"
-                    t-on-click="onToggleNetAmounts"
-                    title="แสดง/ซ่อน จำนวนสุทธิ">
-                    <i class="fa fa-calculator"/> สุทธิ
-                </button>
-            </div>
-        </xpath>
-
-        <!-- Enhanced Report Header with Offset Information -->
+        <!-- Show net revenue in header if there are offsets -->
         <xpath expr="//h3[contains(text(), 'วงเงิน')]" position="after">
-            <div t-if="hasOffsets" class="mt-2">
-                <h4 class="text-muted">หักโอน <t t-esc="formatCurrency(offsetTotal)"/> บาท</h4>
-                <h4 class="text-success">รายรับสุทธิ <t t-esc="formatCurrency(totalRevenueNet)"/> บาท</h4>
-            </div>
-        </xpath>
-
-        <!-- Enhanced Table Headers -->
-        <xpath expr="//th[contains(text(), 'จำนวนเงิน')]" position="replace">
-            <th width="15%" class="text-end" t-if="!hasOffsets or !state.showNetAmounts">จำนวนเงิน</th>
-            <th width="12%" class="text-end" t-if="hasOffsets and state.showNetAmounts">จำนวนเงิน</th>
-            <th width="12%" class="text-end" t-if="hasOffsets and state.showNetAmounts">หักโอน</th>
-            <th width="12%" class="text-end" t-if="hasOffsets and state.showNetAmounts">สุทธิ</th>
-        </xpath>
-
-        <!-- Enhanced Footer with Net Totals -->
-        <xpath expr="//tfoot//tr" position="replace">
-            <tr class="table-active fw-bold">
-                <td class="text-end">
-                    <strong t-if="!hasOffsets or !state.showNetAmounts">ยอดรวมทั้งหมด</strong>
-                    <strong t-if="hasOffsets and state.showNetAmounts">ยอดรวมทั้งหมด</strong>
-                </td>
-                <td class="text-end" t-if="!hasOffsets or !state.showNetAmounts">
-                    <strong>
-                        <t t-esc="formatCurrency(totalAmount)"/> บาท
-                    </strong>
-                </td>
-                <td class="text-end" t-if="hasOffsets and state.showNetAmounts">
-                    <strong>
-                        <t t-esc="formatCurrency(totalAmount)"/> บาท
-                    </strong>
-                </td>
-                <td class="text-end" t-if="hasOffsets and state.showNetAmounts">
-                    <strong class="text-danger">
-                        <t t-esc="formatCurrency(offsetTotal)"/> บาท
-                    </strong>
-                </td>
-                <td class="text-end" t-if="hasOffsets and state.showNetAmounts">
-                    <strong class="text-success">
-                        <t t-esc="formatCurrency(totalRevenueNet)"/> บาท
-                    </strong>
-                </td>
-            </tr>
+            <h3 t-if="hasOffsets">รายรับสุทธิ <t t-esc="formatCurrency(totalRevenueNet)"/> บาท</h3>
         </xpath>
 
     </div>
 
-    <!-- Enhanced Table Row Template with Offset Support -->
-    <t t-name="budget_appropriation_offset.F4TableRowWithOffsets" owl="1">
-        <tr t-attf-class="{{node.type}} {{node.type !== 'line' ? 'font-weight-bold' : ''}}">
-            <td>
-                <div t-att-style="getMarginStyle(node)">
-                    <div class="d-flex align-items-center">
-                        <button
-                            t-if="node.children and node.children.length > 0"
-                            type="button"
-                            class="btn btn-sm btn-link p-0 me-2"
-                            t-on-click="() => this.onToggleNode(node.key)"
-                            style="width: 20px;">
-                            <i t-att-class="isNodeExpanded(node.key) ? 'fa fa-minus-square-o' : 'fa fa-plus-square-o'"/>
-                        </button>
-                        <div t-else="" style="width: 20px; display: inline-block;" class="me-2"></div>
-                        <span>
-                            <t t-if="node.type === 'account'">
-                                <t t-esc="node.code"/> - <t t-esc="node.name"/>
-                                <t t-if="hasNodeOffsets(node) and state.showOffsets">
-                                    <span class="badge badge-warning ms-2">
-                                        <i class="fa fa-exchange"/> มีหักโอน
-                                    </span>
-                                </t>
-                                
-                                <!-- Line Details -->
-                                <t t-if="node.line_details and node.line_details.length > 0">
-                                    <t t-foreach="node.line_details" t-as="detail" t-key="detail.id">
-                                        <t t-if="detail.note">
-                                            <div class="text-muted" style="white-space: pre-line;"><t t-esc="detail.note"/></div>
-                                        </t>
-                                    </t>
-                                </t>
-                                
-                                <!-- Offset Details -->
-                                <t t-if="hasNodeOffsets(node) and state.showOffsets">
-                                    <div class="mt-2 offset-details">
-                                        <div class="detail-header">
-                                            <i class="fa fa-exchange text-warning"/> 
-                                            <small class="fw-bold text-warning">รายการหักโอน:</small>
-                                        </div>
-                                        <t t-foreach="node.offsets" t-as="offset" t-key="offset.id">
-                                            <div class="detail-item">
-                                                <div class="detail-content">
-                                                    <span class="detail-name">
-                                                        <i t-att-class="'fa ' + getOffsetIcon(offset)"/>
-                                                        <t t-esc="offset.name"/>
-                                                    </span>
-                                                    <span class="detail-amount text-danger">
-                                                        -<t t-esc="formatCurrency(offset.amount)"/> บาท
-                                                    </span>
-                                                    <span t-att-class="'detail-state badge ' + getOffsetStateClass(offset.state)">
-                                                        <t t-esc="offset.state_label"/>
-                                                    </span>
-                                                </div>
-                                                <t t-if="offset.from_department or offset.to_department">
-                                                    <div class="detail-description">
-                                                        <t t-if="offset.from_department">
-                                                            จาก: <t t-esc="offset.from_department.name"/>
-                                                        </t>
-                                                        <t t-if="offset.to_department">
-                                                            → <t t-esc="offset.to_department.name"/>
-                                                        </t>
-                                                    </div>
-                                                </t>
-                                                <t t-if="offset.note">
-                                                    <div class="detail-description"><t t-esc="offset.note"/></div>
-                                                </t>
-                                            </div>
-                                        </t>
-                                    </div>
-                                </t>
-                            </t>
-                            <t t-else="">
-                                <t t-esc="node.name"/>
-                                <t t-if="node.code">
-                                    <span class="text-muted"> (<t t-esc="node.code"/>)</span>
-                                </t>
-                            </t>
-                        </span>
-                    </div>
-                </div>
-            </td>
-            
-            <!-- Amount Columns -->
-            <t t-set="displayAmount" t-value="getNodeDisplayAmount(node)"/>
-            
-            <!-- Single Amount Column (when not showing breakdown) -->
-            <td class="text-end" t-if="!displayAmount.showBreakdown">
-                <t t-if="node.total_amount != 0 or node.type !== 'line'">
-                    <t t-esc="formatCurrency(displayAmount.gross)"/>
-                </t>
-            </td>
-            
-            <!-- Triple Amount Columns (when showing breakdown) -->
-            <td class="text-end" t-if="displayAmount.showBreakdown">
-                <t t-if="node.total_amount != 0 or node.type !== 'line'">
-                    <t t-esc="formatCurrency(displayAmount.gross)"/>
-                </t>
-            </td>
-            <td class="text-end text-danger" t-if="displayAmount.showBreakdown">
-                <t t-if="displayAmount.offset != 0">
-                    <t t-esc="formatCurrency(displayAmount.offset)"/>
-                </t>
-            </td>
-            <td class="text-end text-success" t-if="displayAmount.showBreakdown">
-                <t t-if="node.total_amount != 0 or node.type !== 'line'">
-                    <t t-esc="formatCurrency(displayAmount.net)"/>
-                </t>
-            </td>
-        </tr>
-
-        <!-- Children Rows -->
-        <t t-if="isNodeExpanded(node.key) and node.children and node.children.length > 0">
-            <t t-foreach="node.children" t-as="childNode" t-key="childNode.key">
-                <t t-call="budget_appropriation_offset.F4TableRowWithOffsets">
-                    <t t-set="node" t-value="childNode"/>
-                    <t t-set="level" t-value="level + 1"/>
-                </t>
-            </t>
-        </t>
-    </t>
-
-    <!-- Override the original F4TableRow to use the enhanced version -->
+    <!-- Simple override of F4TableRow to show offset details -->
     <t t-name="budget_appropriation.F4TableRow" owl="1" t-inherit="budget_appropriation.F4TableRow" t-inherit-mode="extension">
-        <xpath expr="." position="replace">
-            <t t-call="budget_appropriation_offset.F4TableRowWithOffsets">
-                <t t-set="node" t-value="node"/>
-                <t t-set="level" t-value="level"/>
+        
+        <!-- Add offset details after line details -->
+        <xpath expr="//t[@t-if='node.line_details and node.line_details.length > 0']" position="after">
+            <!-- Simple offset display -->
+            <t t-if="hasNodeOffsets(node)">
+                <t t-foreach="node.offsets" t-as="offset" t-key="offset.id">
+                    <div class="text-muted small" style="margin-left: 20px;">
+                        หักโอน: <t t-esc="offset.name"/> -<t t-esc="formatCurrency(offset.amount)"/> บาท
+                        <t t-if="offset.note"> (<t t-esc="offset.note"/>)</t>
+                    </div>
+                </t>
             </t>
         </xpath>
+
+        <!-- Update amount display to show net amount if there are offsets -->
+        <xpath expr="//t[@t-esc='formatCurrency(node.total_amount)']" position="replace">
+            <t t-if="!hasNodeOffsets(node)" t-esc="formatCurrency(node.total_amount)"/>
+            <t t-if="hasNodeOffsets(node)">
+                <div><t t-esc="formatCurrency(node.total_amount)"/></div>
+                <div class="text-danger small">หัก <t t-esc="formatCurrency(node.offset_total)"/></div>
+                <div class="text-success small">คงเหลือ <t t-esc="formatCurrency(node.net_amount)"/></div>
+            </t>
+        </xpath>
+
     </t>
+
 </templates>

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
@@ -6,7 +6,7 @@
 
         <!-- Show net revenue in header if there are offsets -->
         <xpath expr="//h3[contains(text(), 'วงเงิน')]" position="after">
-            <h3 t-if="hasOffsets">รายรับสุทธิ <t t-esc="formatCurrency(totalRevenueNet)"/> บาท</h3>
+            <h3 t-if="hasOffsetsData()">รายรับสุทธิ <t t-esc="formatCurrency(getTotalRevenueNet())"/> บาท</h3>
         </xpath>
 
     </div>

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <div t-name="budget_appropriation_offset.BudgetAppropriationF4PreviewOffset" class="o_action budget_appropriation_f4_preview" owl="1" t-inherit="budget_appropriation.BudgetAppropriationF4Preview" t-inherit-mode="extension">
+
+        <!-- Enhanced Control Panel with Offset Controls -->
+        <xpath expr="//div[hasclass('btn-group')][2]" position="after">
+            <div class="btn-group me-2" t-if="hasOffsets">
+                <button
+                    type="button"
+                    t-att-class="state.showOffsets ? 'btn btn-warning' : 'btn btn-outline-warning'"
+                    t-on-click="onToggleOffsets"
+                    title="แสดง/ซ่อน รายการหักโอน">
+                    <i class="fa fa-exchange"/> หักโอน
+                </button>
+                <button
+                    type="button"
+                    t-att-class="state.showNetAmounts ? 'btn btn-info' : 'btn btn-outline-info'"
+                    t-on-click="onToggleNetAmounts"
+                    title="แสดง/ซ่อน จำนวนสุทธิ">
+                    <i class="fa fa-calculator"/> สุทธิ
+                </button>
+            </div>
+        </xpath>
+
+        <!-- Enhanced Report Header with Offset Information -->
+        <xpath expr="//h3[contains(text(), 'วงเงิน')]" position="after">
+            <div t-if="hasOffsets" class="mt-2">
+                <h4 class="text-muted">หักโอน <t t-esc="formatCurrency(offsetTotal)"/> บาท</h4>
+                <h4 class="text-success">รายรับสุทธิ <t t-esc="formatCurrency(totalRevenueNet)"/> บาท</h4>
+            </div>
+        </xpath>
+
+        <!-- Enhanced Table Headers -->
+        <xpath expr="//th[contains(text(), 'จำนวนเงิน')]" position="replace">
+            <th width="15%" class="text-end" t-if="!hasOffsets or !state.showNetAmounts">จำนวนเงิน</th>
+            <th width="12%" class="text-end" t-if="hasOffsets and state.showNetAmounts">จำนวนเงิน</th>
+            <th width="12%" class="text-end" t-if="hasOffsets and state.showNetAmounts">หักโอน</th>
+            <th width="12%" class="text-end" t-if="hasOffsets and state.showNetAmounts">สุทธิ</th>
+        </xpath>
+
+        <!-- Enhanced Footer with Net Totals -->
+        <xpath expr="//tfoot//tr" position="replace">
+            <tr class="table-active fw-bold">
+                <td class="text-end">
+                    <strong t-if="!hasOffsets or !state.showNetAmounts">ยอดรวมทั้งหมด</strong>
+                    <strong t-if="hasOffsets and state.showNetAmounts">ยอดรวมทั้งหมด</strong>
+                </td>
+                <td class="text-end" t-if="!hasOffsets or !state.showNetAmounts">
+                    <strong>
+                        <t t-esc="formatCurrency(totalAmount)"/> บาท
+                    </strong>
+                </td>
+                <td class="text-end" t-if="hasOffsets and state.showNetAmounts">
+                    <strong>
+                        <t t-esc="formatCurrency(totalAmount)"/> บาท
+                    </strong>
+                </td>
+                <td class="text-end" t-if="hasOffsets and state.showNetAmounts">
+                    <strong class="text-danger">
+                        <t t-esc="formatCurrency(offsetTotal)"/> บาท
+                    </strong>
+                </td>
+                <td class="text-end" t-if="hasOffsets and state.showNetAmounts">
+                    <strong class="text-success">
+                        <t t-esc="formatCurrency(totalRevenueNet)"/> บาท
+                    </strong>
+                </td>
+            </tr>
+        </xpath>
+
+    </div>
+
+    <!-- Enhanced Table Row Template with Offset Support -->
+    <t t-name="budget_appropriation_offset.F4TableRowWithOffsets" owl="1">
+        <tr t-attf-class="{{node.type}} {{node.type !== 'line' ? 'font-weight-bold' : ''}}">
+            <td>
+                <div t-att-style="getMarginStyle(node)">
+                    <div class="d-flex align-items-center">
+                        <button
+                            t-if="node.children and node.children.length > 0"
+                            type="button"
+                            class="btn btn-sm btn-link p-0 me-2"
+                            t-on-click="() => this.onToggleNode(node.key)"
+                            style="width: 20px;">
+                            <i t-att-class="isNodeExpanded(node.key) ? 'fa fa-minus-square-o' : 'fa fa-plus-square-o'"/>
+                        </button>
+                        <div t-else="" style="width: 20px; display: inline-block;" class="me-2"></div>
+                        <span>
+                            <t t-if="node.type === 'account'">
+                                <t t-esc="node.code"/> - <t t-esc="node.name"/>
+                                <t t-if="hasNodeOffsets(node) and state.showOffsets">
+                                    <span class="badge badge-warning ms-2">
+                                        <i class="fa fa-exchange"/> มีหักโอน
+                                    </span>
+                                </t>
+                                
+                                <!-- Line Details -->
+                                <t t-if="node.line_details and node.line_details.length > 0">
+                                    <t t-foreach="node.line_details" t-as="detail" t-key="detail.id">
+                                        <t t-if="detail.note">
+                                            <div class="text-muted" style="white-space: pre-line;"><t t-esc="detail.note"/></div>
+                                        </t>
+                                    </t>
+                                </t>
+                                
+                                <!-- Offset Details -->
+                                <t t-if="hasNodeOffsets(node) and state.showOffsets">
+                                    <div class="mt-2 offset-details">
+                                        <div class="detail-header">
+                                            <i class="fa fa-exchange text-warning"/> 
+                                            <small class="fw-bold text-warning">รายการหักโอน:</small>
+                                        </div>
+                                        <t t-foreach="node.offsets" t-as="offset" t-key="offset.id">
+                                            <div class="detail-item">
+                                                <div class="detail-content">
+                                                    <span class="detail-name">
+                                                        <i t-att-class="'fa ' + getOffsetIcon(offset)"/>
+                                                        <t t-esc="offset.name"/>
+                                                    </span>
+                                                    <span class="detail-amount text-danger">
+                                                        -<t t-esc="formatCurrency(offset.amount)"/> บาท
+                                                    </span>
+                                                    <span t-att-class="'detail-state badge ' + getOffsetStateClass(offset.state)">
+                                                        <t t-esc="offset.state_label"/>
+                                                    </span>
+                                                </div>
+                                                <t t-if="offset.from_department or offset.to_department">
+                                                    <div class="detail-description">
+                                                        <t t-if="offset.from_department">
+                                                            จาก: <t t-esc="offset.from_department.name"/>
+                                                        </t>
+                                                        <t t-if="offset.to_department">
+                                                            → <t t-esc="offset.to_department.name"/>
+                                                        </t>
+                                                    </div>
+                                                </t>
+                                                <t t-if="offset.note">
+                                                    <div class="detail-description"><t t-esc="offset.note"/></div>
+                                                </t>
+                                            </div>
+                                        </t>
+                                    </div>
+                                </t>
+                            </t>
+                            <t t-else="">
+                                <t t-esc="node.name"/>
+                                <t t-if="node.code">
+                                    <span class="text-muted"> (<t t-esc="node.code"/>)</span>
+                                </t>
+                            </t>
+                        </span>
+                    </div>
+                </div>
+            </td>
+            
+            <!-- Amount Columns -->
+            <t t-set="displayAmount" t-value="getNodeDisplayAmount(node)"/>
+            
+            <!-- Single Amount Column (when not showing breakdown) -->
+            <td class="text-end" t-if="!displayAmount.showBreakdown">
+                <t t-if="node.total_amount != 0 or node.type !== 'line'">
+                    <t t-esc="formatCurrency(displayAmount.gross)"/>
+                </t>
+            </td>
+            
+            <!-- Triple Amount Columns (when showing breakdown) -->
+            <td class="text-end" t-if="displayAmount.showBreakdown">
+                <t t-if="node.total_amount != 0 or node.type !== 'line'">
+                    <t t-esc="formatCurrency(displayAmount.gross)"/>
+                </t>
+            </td>
+            <td class="text-end text-danger" t-if="displayAmount.showBreakdown">
+                <t t-if="displayAmount.offset != 0">
+                    <t t-esc="formatCurrency(displayAmount.offset)"/>
+                </t>
+            </td>
+            <td class="text-end text-success" t-if="displayAmount.showBreakdown">
+                <t t-if="node.total_amount != 0 or node.type !== 'line'">
+                    <t t-esc="formatCurrency(displayAmount.net)"/>
+                </t>
+            </td>
+        </tr>
+
+        <!-- Children Rows -->
+        <t t-if="isNodeExpanded(node.key) and node.children and node.children.length > 0">
+            <t t-foreach="node.children" t-as="childNode" t-key="childNode.key">
+                <t t-call="budget_appropriation_offset.F4TableRowWithOffsets">
+                    <t t-set="node" t-value="childNode"/>
+                    <t t-set="level" t-value="level + 1"/>
+                </t>
+            </t>
+        </t>
+    </t>
+
+    <!-- Override the original F4TableRow to use the enhanced version -->
+    <t t-name="budget_appropriation.F4TableRow" owl="1" t-inherit="budget_appropriation.F4TableRow" t-inherit-mode="extension">
+        <xpath expr="." position="replace">
+            <t t-call="budget_appropriation_offset.F4TableRowWithOffsets">
+                <t t-set="node" t-value="node"/>
+                <t t-set="level" t-value="level"/>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
@@ -37,38 +37,16 @@
             </t>
         </xpath>
 
-        <!-- Replace footer with summary for revenue with offsets -->
-        <xpath expr="//tfoot//tr" position="replace">
-            <!-- Show simple total if no offsets -->
-            <tr class="table-active fw-bold" t-if="!hasOffsetsData()">
-                <td class="text-end">
-                    <strong>ยอดรวมทั้งหมด</strong>
-                </td>
-                <td class="text-end">
-                    <strong>
-                        <t t-esc="formatCurrency(totalAmount)"/> บาท
-                    </strong>
-                </td>
-            </tr>
-            
-            <!-- Show detailed summary if has offsets -->
+        <!-- Add offset summary rows after the existing footer -->
+        <xpath expr="//tfoot" position="inside">
+            <!-- Show detailed offset summary if has offsets -->
             <tr class="table-secondary" t-if="hasOffsetsData()">
-                <td class="text-end">
-                    <strong>งบประมาณทั้งหมด</strong>
-                </td>
-                <td class="text-end">
-                    <strong>
-                        <t t-esc="formatCurrency(totalAmount)"/> บาท
-                    </strong>
-                </td>
-            </tr>
-            <tr class="table-warning" t-if="hasOffsetsData()">
                 <td class="text-end">
                     <strong>หักโอน</strong>
                 </td>
                 <td class="text-end">
                     <strong class="text-danger">
-                        <t t-esc="formatCurrency(getOffsetTotal())"/> บาท
+                        -<t t-esc="formatCurrency(getOffsetTotal())"/> บาท
                     </strong>
                 </td>
             </tr>

--- a/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
+++ b/budget_appropriation_offset/static/src/components/budget_appropriation_f4_preview_offset/budget_appropriation_f4_preview_offset.xml
@@ -37,6 +37,53 @@
             </t>
         </xpath>
 
+        <!-- Replace footer with summary for revenue with offsets -->
+        <xpath expr="//tfoot//tr" position="replace">
+            <!-- Show simple total if no offsets -->
+            <tr class="table-active fw-bold" t-if="!hasOffsetsData()">
+                <td class="text-end">
+                    <strong>ยอดรวมทั้งหมด</strong>
+                </td>
+                <td class="text-end">
+                    <strong>
+                        <t t-esc="formatCurrency(totalAmount)"/> บาท
+                    </strong>
+                </td>
+            </tr>
+            
+            <!-- Show detailed summary if has offsets -->
+            <tr class="table-secondary" t-if="hasOffsetsData()">
+                <td class="text-end">
+                    <strong>งบประมาณทั้งหมด</strong>
+                </td>
+                <td class="text-end">
+                    <strong>
+                        <t t-esc="formatCurrency(totalAmount)"/> บาท
+                    </strong>
+                </td>
+            </tr>
+            <tr class="table-warning" t-if="hasOffsetsData()">
+                <td class="text-end">
+                    <strong>หักโอน</strong>
+                </td>
+                <td class="text-end">
+                    <strong class="text-danger">
+                        <t t-esc="formatCurrency(getOffsetTotal())"/> บาท
+                    </strong>
+                </td>
+            </tr>
+            <tr class="table-success fw-bold" t-if="hasOffsetsData()">
+                <td class="text-end">
+                    <strong>รายรับสุทธิ</strong>
+                </td>
+                <td class="text-end">
+                    <strong class="text-success">
+                        <t t-esc="formatCurrency(getTotalRevenueNet())"/> บาท
+                    </strong>
+                </td>
+            </tr>
+        </xpath>
+
     </t>
 
 </templates>


### PR DESCRIPTION
## Summary
Add F4 Preview functionality for revenue-type budget appropriations, providing a simplified hierarchical view focused only on budget accounts.

## Features
- **Revenue-specific preview**: Only shows for `budget_type == 'revenue'` appropriations
- **Simplified hierarchy**: Displays only hierarchical budget accounts (no Activity/Fund dimensions)
- **Clean interface**: Similar visual style to F5 but streamlined for revenue data
- **No project/procurement details**: Revenue side doesn't include project or procurement plan information
- **Conditional UI**: F5 button for expense types, F4 button for revenue types
- **Print support**: Print-optimized styling for professional reports
- **Full functionality**: Expand/collapse, refresh, navigation controls

## Technical Implementation
- **New model**: `budget.appropriation.f4.report` transient model for F4 data generation
- **Client component**: JavaScript F4 preview component using OWL framework
- **Tree builder**: Extended with `for_f4_report()` configuration for accounts-only hierarchy
- **UI updates**: Updated budget appropriation form with conditional preview buttons
- **Styling**: Complete SCSS styling for professional report format

## Test plan
- [ ] Test F4 preview appears only for revenue-type appropriations
- [ ] Test F5 preview appears only for expense-type appropriations  
- [ ] Test F4 shows hierarchical budget accounts without Activity/Fund
- [ ] Test expand/collapse functionality works correctly
- [ ] Test print functionality produces clean output
- [ ] Test navigation and refresh controls work properly
- [ ] Test error handling for invalid appropriations

🤖 Generated with [Claude Code](https://claude.ai/code)