### PR TITLE
[16.0][ADD] budget_account_portal: add public portal for budget accounts

### DIFF
--- a/budget/views/budget_account_views.xml
+++ b/budget/views/budget_account_views.xml
@@ -22,52 +22,6 @@
         </field>
     </record>
 
-    <!-- View budget.account kanban -->
-    <record id="view_budget_account_kanban" model="ir.ui.view">
-        <field name="name">view.budget.account.kanban</field>
-        <field name="model">budget.account</field>
-        <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile">
-                <templates>
-                    <t t-name="kanban-box">
-                        <div class="oe_kanban_card oe_kanban_global_click">
-                            <div class="o_kanban_record_top">
-                                <div class="o_kanban_record_headings">
-                                    <strong class="o_kanban_record_title">
-                                        <field name="code" />
- -                                        <field name="name" />
-                                    </strong>
-                                </div>
-                                <div class="o_kanban_manage_button_section">
-                                    <a class="o_kanban_manage_toggle_button" href="#">
-                                        <i class="fa fa-ellipsis-v" role="img" aria-label="Manage" title="Manage" />
-                                    </a>
-                                </div>
-                            </div>
-                            <div class="o_kanban_record_body">
-                                <div class="o_kanban_tags_section">
-                                    <span class="badge" t-att-class="record.budget_type.raw_value == 'revenue' ? 'badge-success' : 'badge-primary'">
-                                        <field name="budget_type" />
-                                    </span>
-                                    <span t-if="record.budgetable.raw_value" class="badge badge-info">Budgetable</span>
-                                    <span t-if="record.deprecated.raw_value" class="badge badge-warning">Deprecated</span>
-                                </div>
-                                <div t-if="record.parent_id.value" class="o_kanban_record_subtitle">
-                                    Parent: <field name="parent_id" />
-                                </div>
-                                <div t-if="record.children_count.raw_value > 0" class="o_kanban_record_subtitle">
-                                    <i class="fa fa-sitemap" title="Sub-accounts" />
-                                    <field name="children_count" />
- sub-accounts
-                                </div>
-                            </div>
-                        </div>
-                    </t>
-                </templates>
-            </kanban>
-        </field>
-    </record>
-
     <!-- View budget.account form -->
     <record id="view_budget_account_form" model="ir.ui.view">
         <field name="name">view.budget.account.form</field>
@@ -95,6 +49,11 @@
                             <field name="deprecated" />
                         </group>
                     </group>
+                    <notebook>
+                        <page name="note" string="Note">
+                            <field name="note" />
+                        </page>
+                    </notebook>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_ids" widget="mail_thread" />
@@ -152,7 +111,7 @@
         <field name="name">รหัสงบประมาณ</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">budget.account</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">tree,form</field>
         <field name="domain">[]</field>
         <field name="context">{
             'search_default_active': 1,

--- a/budget_account_portal/__init__.py
+++ b/budget_account_portal/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import controllers
+from . import models

--- a/budget_account_portal/__manifest__.py
+++ b/budget_account_portal/__manifest__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Budget Account Portal",
+    "version": "16.0.1.0.0",
+    "author": "",
+    "website": "",
+    "category": "",
+    "depends": ["budget", "web", "portal", "procurement_plan_budget"],
+    "data": ["views/portal_templates.xml"],
+    "assets": {
+        "web.assets_backend": ["budget_account_portal/static/src/**/*"],
+    },
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/budget_account_portal/__manifest__.py
+++ b/budget_account_portal/__manifest__.py
@@ -8,7 +8,9 @@
     "depends": ["budget", "web", "portal", "procurement_plan_budget"],
     "data": ["views/portal_templates.xml"],
     "assets": {
-        "web.assets_backend": ["budget_account_portal/static/src/**/*"],
+        "web.assets_frontend": [
+            "/budget_account_portal/static/src/scss/portal.scss"
+        ],
     },
     "application": False,
     "installable": True,

--- a/budget_account_portal/controllers/__init__.py
+++ b/budget_account_portal/controllers/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import budget_account

--- a/budget_account_portal/controllers/budget_account.py
+++ b/budget_account_portal/controllers/budget_account.py
@@ -14,6 +14,26 @@ class BudgetAccount(http.Controller):
     def index(self, **kw):
         expense_accounts = request.env["budget.account"].sudo().get_as_flat_list('expense')
         revenue_accounts = request.env["budget.account"].sudo().get_as_flat_list('revenue')
-        values = {"revenue_accounts": revenue_accounts, "expense_accounts": expense_accounts}
+
+        analytic_plan_activities_plan = request.env.ref('account_analytic_kmitl.analytic_plan_activities')
+        analytic_plan_activities = request.env['account.analytic.account'].sudo().get_as_flat_list(analytic_plan_activities_plan.id)
+
+        analytic_plan_departments_plan = request.env.ref('account_analytic_kmitl.analytic_plan_departments')
+        analytic_plan_departments = request.env['account.analytic.account'].sudo().get_as_flat_list(analytic_plan_departments_plan.id)
+
+        analytic_plan_funds_plan = request.env.ref('account_analytic_kmitl.analytic_plan_funds')
+        analytic_plan_funds = request.env['account.analytic.account'].sudo().get_as_flat_list(analytic_plan_funds_plan.id)
+
+        analytic_plan_sources_plan = request.env.ref('account_analytic_kmitl.analytic_plan_sources')
+        analytic_plan_sources = request.env['account.analytic.account'].sudo().get_as_flat_list(analytic_plan_sources_plan.id)
+
+        values = {
+            "revenue_accounts": revenue_accounts,
+            "expense_accounts": expense_accounts,
+            "analytic_plan_activities": analytic_plan_activities,
+            "analytic_plan_departments": analytic_plan_departments,
+            "analytic_plan_funds": analytic_plan_funds,
+            "analytic_plan_sources": analytic_plan_sources,
+        }
 
         return request.render("budget_account_portal.portal_budget_account", values)

--- a/budget_account_portal/controllers/budget_account.py
+++ b/budget_account_portal/controllers/budget_account.py
@@ -1,0 +1,19 @@
+import logging
+
+from odoo import http, _
+from odoo.http import request, serialize_exception
+from odoo.tools import html_escape, pycompat
+from odoo.addons.web.controllers.main import ExcelExport
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class BudgetAccount(http.Controller):
+    @http.route("/budget/budget_account", type="http", auth="public", website=True)
+    def index(self, **kw):
+        expense_accounts = request.env["budget.account"].sudo().get_as_flat_list('expense')
+        revenue_accounts = request.env["budget.account"].sudo().get_as_flat_list('revenue')
+        values = {"revenue_accounts": revenue_accounts, "expense_accounts": expense_accounts}
+
+        return request.render("budget_account_portal.portal_budget_account", values)

--- a/budget_account_portal/models/__init__.py
+++ b/budget_account_portal/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import budget_account

--- a/budget_account_portal/models/__init__.py
+++ b/budget_account_portal/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import budget_account
+from . import account_analytic_account

--- a/budget_account_portal/models/account_analytic_account.py
+++ b/budget_account_portal/models/account_analytic_account.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    hierarchy_level = fields.Integer(
+        string="Level",
+        compute="_compute_hierarchy_level",
+        store=False,
+        recursive=True,
+    )
+
+    @api.depends("parent_id.hierarchy_level")
+    def _compute_hierarchy_level(self):
+        for record in self:
+            if record.parent_id:
+                record.hierarchy_level = record.parent_id.hierarchy_level + 1
+            else:
+                record.hierarchy_level = 0
+
+    @api.model
+    def get_as_flat_list(self, plan_id):
+        domain = [('plan_id', '=', plan_id), ('parent_id', '=', False)]
+        roots = self.search(domain, order="code")
+
+        def flatten_node(node):
+            result = [node]
+            for child in node.child_ids:
+                result.extend(flatten_node(child))
+            return result
+
+        flat_list = []
+        for node in roots:
+            flat_list.extend(flatten_node(node))
+
+        return flat_list

--- a/budget_account_portal/models/budget_account.py
+++ b/budget_account_portal/models/budget_account.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class BudgetAccount(models.Model):
+    _inherit = 'budget.account'
+
+    @api.model
+    def get_as_flat_list(self, budget_type='expense'):
+        domain = [('budget_type', '=', budget_type), ('parent_id', '=', False)]
+        roots = self.search(domain, order="code")
+
+        def flatten_node(node):
+            result = [node]
+            for child in node.child_ids:
+                result.extend(flatten_node(child))
+            return result
+
+        flat_list = []
+        for node in roots:
+            flat_list.extend(flatten_node(node))
+
+        return flat_list

--- a/budget_account_portal/static/src/scss/portal.scss
+++ b/budget_account_portal/static/src/scss/portal.scss
@@ -1,0 +1,11 @@
+#budget_accounts_portal {
+    .accordion-header {
+        border-bottom: 1px solid $gray-300;
+    }
+
+    .accordion-button:not(.collapsed) {
+        color: $o-brand-primary;
+        background-color: rgba($o-brand-primary, 0.15);
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .125);
+    }
+}

--- a/budget_account_portal/views/portal_templates.xml
+++ b/budget_account_portal/views/portal_templates.xml
@@ -2,10 +2,310 @@
 <odoo>
     <template id="portal_budget_account" name="Budget Account Portal">
         <t t-call="portal.portal_layout">
-            <div id="budget_account_portal" class="container mt16">
-                <div class="card-header bg-white">
-                    <h2>รายรับ (Revenue)</h2>
-                    <table class="table table-sm">
+            <div id="budget_accounts_portal" class="container mt16">
+                <h1>รหัสงบประมาณ</h1>
+                <div class="card bg-white">
+                    <div class="card">
+                        <div class="accordion accordion-flush" id="budget_accounts">
+                            <div class="accordion-item">
+                                <h2 class="accordion-header" id="sources-header">
+                                    <button
+                                        class="accordion-button collapsed"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#sources-collapse"
+                                        aria-expanded="false"
+                                        aria-controls="sources-collapse"
+                                    >
+                                        <span class="lead">แหล่งเงิน</span>
+                                    </button>
+                                </h2>
+                                <div
+                                    id="sources-collapse"
+                                    class="accordion-collapse collapse"
+                                    aria-labelledby="sources-header"
+                                >
+                                    <div class="accordion-body">
+                                        <table class="table table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th
+                                                        scope="col"
+                                                        style="width: 140px"
+                                                    >
+                                                        รหัสงบประมาณ
+                                                    </th>
+                                                    <th scope="col">ชื่อรายการ</th>
+                                                    <th cope="col">หมายเหตุ</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <t
+                                                    t-foreach="analytic_plan_sources"
+                                                    t-as="line"
+                                                >
+                                                    <tr
+                                                        t-attf-class="#{'text-decoration-line-through ' if not line.active else ''}"
+                                                    >
+                                                        <td
+                                                            class="text-center"
+                                                            scope="row"
+                                                            t-out="line.code"
+                                                            style="width: 140px"
+                                                        />
+                                                        <td
+                                                            t-out="line.name"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                        />
+                                                        <td>
+                                                            <t t-if="not line.active">
+                                                                <span
+                                                                    class="badge text-bg-danger"
+                                                                    >ยกเลิกใช้งาน</span
+                                                                >
+                                                            </t>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="accordion-item">
+                                <h2 class="accordion-header" id="funds-header">
+                                    <button
+                                        class="accordion-button collapsed"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#funds-collapse"
+                                        aria-expanded="false"
+                                        aria-controls="funds-collapse"
+                                    >
+                                        <span class="lead">กองทุน</span>
+                                    </button>
+                                </h2>
+                                <div
+                                    id="funds-collapse"
+                                    class="accordion-collapse collapse"
+                                    aria-labelledby="funds-header"
+                                >
+                                    <div class="accordion-body">
+                                        <table class="table table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th
+                                                        scope="col"
+                                                        style="width: 140px"
+                                                    >
+                                                        รหัสงบประมาณ
+                                                    </th>
+                                                    <th scope="col">ชื่อรายการ</th>
+                                                    <th cope="col">หมายเหตุ</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <t
+                                                    t-foreach="analytic_plan_funds"
+                                                    t-as="line"
+                                                >
+                                                    <tr
+                                                        t-attf-class="#{'text-decoration-line-through ' if not line.active else ''}"
+                                                    >
+                                                        <td
+                                                            class="text-center"
+                                                            scope="row"
+                                                            t-out="line.code"
+                                                            style="width: 140px"
+                                                        />
+                                                        <td
+                                                            t-out="line.name"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                        />
+                                                        <td>
+                                                            <t t-if="not line.active">
+                                                                <span
+                                                                    class="badge text-bg-danger"
+                                                                    >ยกเลิกใช้งาน</span
+                                                                >
+                                                            </t>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="accordion-item">
+                                <h2 class="accordion-header" id="departments-header">
+                                    <button
+                                        class="accordion-button collapsed"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#departments-collapse"
+                                        aria-expanded="false"
+                                        aria-controls="departments-collapse"
+                                    >
+                                        <span class="lead">หน่วยงาน</span>
+                                    </button>
+                                </h2>
+                                <div
+                                    id="departments-collapse"
+                                    class="accordion-collapse collapse"
+                                    aria-labelledby="departments-header"
+                                >
+                                    <div class="accordion-body">
+                                        <table class="table table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th
+                                                        scope="col"
+                                                        style="width: 140px"
+                                                    >
+                                                        รหัสงบประมาณ
+                                                    </th>
+                                                    <th scope="col">ชื่อรายการ</th>
+                                                    <th cope="col">หมายเหตุ</th>
+                                                </tr>
+                                            </thead>
+
+                                            <tbody>
+                                                <t
+                                                    t-foreach="analytic_plan_departments"
+                                                    t-as="line"
+                                                >
+                                                    <tr
+                                                        t-attf-class="#{'text-decoration-line-through ' if not line.active else ''}"
+                                                    >
+                                                        <td
+                                                            class="text-center"
+                                                            scope="row"
+                                                            t-out="line.code"
+                                                            style="width: 140px"
+                                                        />
+                                                        <td
+                                                            t-out="line.name"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                        />
+                                                        <td>
+                                                            <t t-if="not line.active">
+                                                                <span
+                                                                    class="badge text-bg-danger"
+                                                                    >ยกเลิกใช้งาน</span
+                                                                >
+                                                            </t>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="accordion-item">
+                                <h2 class="accordion-header" id="activities-header">
+                                    <button
+                                        class="accordion-button collapsed"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#activities-collapse"
+                                        aria-expanded="false"
+                                        aria-controls="activities-collapse"
+                                    >
+                                        <span class="lead"
+                                            >ด้าน/แผนงาน/กิจกรรม</span
+                                        >
+                                    </button>
+                                </h2>
+                                <div
+                                    id="activities-collapse"
+                                    class="accordion-collapse collapse"
+                                    aria-labelledby="activities-header"
+                                >
+                                    <div class="accordion-body">
+                                        <table class="table table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th
+                                                        scope="col"
+                                                        style="width: 140px"
+                                                    >
+                                                        รหัสงบประมาณ
+                                                    </th>
+                                                    <th scope="col">ชื่อรายการ</th>
+                                                    <th cope="col">หมายเหตุ</th>
+                                                </tr>
+                                            </thead>
+
+                                            <tbody>
+                                                <t
+                                                    t-foreach="analytic_plan_activities"
+                                                    t-as="line"
+                                                >
+                                                    <tr
+                                                        t-attf-class="#{'text-decoration-line-through ' if not line.active else ''}"
+                                                    >
+                                                        <td
+                                                            class="text-center"
+                                                            scope="row"
+                                                            t-out="line.code"
+                                                            style="width: 140px"
+                                                        />
+                                                        <td
+                                                            t-out="line.name"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                        />
+                                                        <td>
+                                                            <t t-if="not line.active">
+                                                                <span
+                                                                    class="badge text-bg-danger"
+                                                                    >ยกเลิกใช้งาน</span
+                                                                >
+                                                            </t>
+                                                        </td>
+                                                    </tr>
+                                                </t>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                            <t
+                                t-call="budget_account_portal.portal_revenue_budget_accounts_table"
+                            />
+
+                            <t
+                                t-call="budget_account_portal.portal_expense_budget_accounts_table"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
+    <template id="portal_revenue_budget_accounts_table">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="revenue-header">
+                <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#revenue-collapse"
+                    aria-expanded="false"
+                    aria-controls="revenue-collapse"
+                >
+                    <span class="lead">ประเภทงบรายรับ</span>
+                </button>
+            </h2>
+            <div
+                id="revenue-collapse"
+                class="accordion-collapse collapse"
+                aria-labelledby="revenue-header"
+            >
+                <div class="accordion-body">
+                    <table class="table table-sm" id="revenues">
                         <thead>
                             <tr>
                                 <th>รหัสงบประมาณ</th>
@@ -15,12 +315,20 @@
                         </thead>
                         <tbody>
                             <t t-foreach="revenue_accounts" t-as="account">
-                                <tr t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}">
-                                    <td scope="row" t-out="account.code" t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px" />
+                                <tr
+                                    t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}"
+                                >
+                                    <td
+                                        scope="row"
+                                        t-out="account.code"
+                                        t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px"
+                                    />
                                     <td t-out="account.name" />
                                     <td>
                                         <t t-if="account.deprecated">
-                                            <span class="badge text-bg-danger">ยกเลิกใช้งาน</span>
+                                            <span class="badge text-bg-danger"
+                                                >ยกเลิกใช้งาน</span
+                                            >
                                         </t>
                                         <t t-if="account.budgetable">
                                             <div class="">✅ ระบุงบประมาณ</div>
@@ -38,9 +346,31 @@
                         </tbody>
                     </table>
                 </div>
-                <div class="mt-4 card-header bg-white">
-                    <h2>รายจ่าย (Expense)</h2>
-                    <table class="table table-sm">
+            </div>
+        </div>
+    </template>
+
+    <template id="portal_expense_budget_accounts_table">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="expense-header">
+                <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#expense-collapse"
+                    aria-expanded="false"
+                    aria-controls="expense-collapse"
+                >
+                    <span class="lead">ประเภทงบรายจ่าย</span>
+                </button>
+            </h2>
+            <div
+                id="expense-collapse"
+                class="accordion-collapse collapse"
+                aria-labelledby="expense-header"
+            >
+                <div class="accordion-body">
+                    <table class="table table-sm" id="expenses">
                         <thead>
                             <tr>
                                 <th>รหัสงบประมาณ</th>
@@ -51,17 +381,31 @@
                         </thead>
                         <tbody>
                             <t t-foreach="expense_accounts" t-as="account">
-                                <tr t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}">
-                                    <td scope="row" t-out="account.code" t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px" />
+                                <tr
+                                    t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}"
+                                >
+                                    <td
+                                        scope="row"
+                                        t-out="account.code"
+                                        t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px"
+                                    />
                                     <td t-out="account.name" />
                                     <td>
-                                        <t t-foreach="account.fund_analytic_ids" t-as="fund">
-                                            <span class="badge text-bg-info ml-1" t-out="'[' + fund.code + '] ' + fund.name" />
+                                        <t
+                                            t-foreach="account.fund_analytic_ids"
+                                            t-as="fund"
+                                        >
+                                            <span
+                                                class="badge text-bg-info ml-1"
+                                                t-out="'[' + fund.code + '] ' + fund.name"
+                                            />
                                         </t>
                                     </td>
                                     <td>
                                         <t t-if="account.deprecated">
-                                            <span class="badge text-bg-danger">ยกเลิกใช้งาน</span>
+                                            <span class="badge text-bg-danger"
+                                                >ยกเลิกใช้งาน</span
+                                            >
                                         </t>
                                         <t t-if="account.budgetable">
                                             <div class="">✅ ระบุงบประมาณ</div>
@@ -77,6 +421,6 @@
                     </table>
                 </div>
             </div>
-        </t>
+        </div>
     </template>
 </odoo>

--- a/budget_account_portal/views/portal_templates.xml
+++ b/budget_account_portal/views/portal_templates.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="portal_budget_account" name="Budget Account Portal">
+        <t t-call="portal.portal_layout">
+            <div id="budget_account_portal" class="container mt16">
+                <div class="card-header bg-white">
+                    <h2>รายรับ (Revenue)</h2>
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>รหัสงบประมาณ</th>
+                                <th>ชื่อรายการ</th>
+                                <th>หมายเหตุ</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-foreach="revenue_accounts" t-as="account">
+                                <tr t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}">
+                                    <td scope="row" t-out="account.code" t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px" />
+                                    <td t-out="account.name" />
+                                    <td>
+                                        <t t-if="account.deprecated">
+                                            <span class="badge text-bg-danger">ยกเลิกใช้งาน</span>
+                                        </t>
+                                        <t t-if="account.budgetable">
+                                            <div class="">✅ ระบุงบประมาณ</div>
+                                        </t>
+                                        <t t-else="">
+                                            <div class="">❌ ระบุงบประมาณ</div>
+                                        </t>
+                                        <t t-if="account.procurement_plan">
+                                            <div class="">✅ แผนจัดซื้อจัดจ้าง</div>
+                                        </t>
+                                        <div t-out="account.note" />
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="mt-4 card-header bg-white">
+                    <h2>รายจ่าย (Expense)</h2>
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>รหัสงบประมาณ</th>
+                                <th>ชื่อรายการ</th>
+                                <th>กองทุน</th>
+                                <th>หมายเหตุ</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-foreach="expense_accounts" t-as="account">
+                                <tr t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}">
+                                    <td scope="row" t-out="account.code" t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px" />
+                                    <td t-out="account.name" />
+                                    <td>
+                                        <t t-foreach="account.fund_analytic_ids" t-as="fund">
+                                            <span class="badge text-bg-info ml-1" t-out="'[' + fund.code + '] ' + fund.name" />
+                                        </t>
+                                    </td>
+                                    <td>
+                                        <t t-if="account.deprecated">
+                                            <span class="badge text-bg-danger">ยกเลิกใช้งาน</span>
+                                        </t>
+                                        <t t-if="account.budgetable">
+                                            <div class="">✅ ระบุงบประมาณ</div>
+                                        </t>
+                                        <t t-else="">
+                                            <div class="">❌ ระบุงบประมาณ</div>
+                                        </t>
+                                        <div t-out="account.note" />
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/budget_account_portal/views/portal_templates.xml
+++ b/budget_account_portal/views/portal_templates.xml
@@ -26,12 +26,13 @@
                                     aria-labelledby="sources-header"
                                 >
                                     <div class="accordion-body">
-                                        <table class="table table-sm">
+                                        <table class="table table-sm table-hover">
                                             <thead>
                                                 <tr>
                                                     <th
                                                         scope="col"
-                                                        style="width: 140px"
+                                                        style="width: 160px"
+                                                        class="text-center"
                                                     >
                                                         รหัสงบประมาณ
                                                     </th>
@@ -51,11 +52,11 @@
                                                             class="text-center"
                                                             scope="row"
                                                             t-out="line.code"
-                                                            style="width: 140px"
+                                                            style="width: 160px"
                                                         />
                                                         <td
                                                             t-out="line.name"
-                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level)}px"
                                                         />
                                                         <td>
                                                             <t t-if="not line.active">
@@ -91,12 +92,13 @@
                                     aria-labelledby="funds-header"
                                 >
                                     <div class="accordion-body">
-                                        <table class="table table-sm">
+                                        <table class="table table-sm table-hover">
                                             <thead>
                                                 <tr>
                                                     <th
                                                         scope="col"
-                                                        style="width: 140px"
+                                                        style="width: 160px"
+                                                        class="text-center"
                                                     >
                                                         รหัสงบประมาณ
                                                     </th>
@@ -116,11 +118,11 @@
                                                             class="text-center"
                                                             scope="row"
                                                             t-out="line.code"
-                                                            style="width: 140px"
+                                                            style="width: 160px"
                                                         />
                                                         <td
                                                             t-out="line.name"
-                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level)}px"
                                                         />
                                                         <td>
                                                             <t t-if="not line.active">
@@ -156,12 +158,13 @@
                                     aria-labelledby="departments-header"
                                 >
                                     <div class="accordion-body">
-                                        <table class="table table-sm">
+                                        <table class="table table-sm table-hover">
                                             <thead>
                                                 <tr>
                                                     <th
                                                         scope="col"
-                                                        style="width: 140px"
+                                                        style="width: 160px"
+                                                        class="text-center"
                                                     >
                                                         รหัสงบประมาณ
                                                     </th>
@@ -182,11 +185,11 @@
                                                             class="text-center"
                                                             scope="row"
                                                             t-out="line.code"
-                                                            style="width: 140px"
+                                                            style="width: 160px"
                                                         />
                                                         <td
                                                             t-out="line.name"
-                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level)}px"
                                                         />
                                                         <td>
                                                             <t t-if="not line.active">
@@ -213,9 +216,7 @@
                                         aria-expanded="false"
                                         aria-controls="activities-collapse"
                                     >
-                                        <span class="lead"
-                                            >ด้าน/แผนงาน/กิจกรรม</span
-                                        >
+                                        <span class="lead">ด้าน/แผนงาน/กิจกรรม</span>
                                     </button>
                                 </h2>
                                 <div
@@ -224,12 +225,13 @@
                                     aria-labelledby="activities-header"
                                 >
                                     <div class="accordion-body">
-                                        <table class="table table-sm">
+                                        <table class="table table-sm table-hover">
                                             <thead>
                                                 <tr>
                                                     <th
                                                         scope="col"
-                                                        style="width: 140px"
+                                                        style="width: 160px"
+                                                        class="text-center"
                                                     >
                                                         รหัสงบประมาณ
                                                     </th>
@@ -250,11 +252,11 @@
                                                             class="text-center"
                                                             scope="row"
                                                             t-out="line.code"
-                                                            style="width: 140px"
+                                                            style="width: 160px"
                                                         />
                                                         <td
                                                             t-out="line.name"
-                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level + 1)}px"
+                                                            t-attf-style="padding-left: #{20 * (line.hierarchy_level)}px"
                                                         />
                                                         <td>
                                                             <t t-if="not line.active">
@@ -305,10 +307,12 @@
                 aria-labelledby="revenue-header"
             >
                 <div class="accordion-body">
-                    <table class="table table-sm" id="revenues">
+                    <table class="table table-sm table-hover" id="revenues">
                         <thead>
                             <tr>
-                                <th>รหัสงบประมาณ</th>
+                                <th class="text-center" style="width: 160px">
+                                    รหัสงบประมาณ
+                                </th>
                                 <th>ชื่อรายการ</th>
                                 <th>หมายเหตุ</th>
                             </tr>
@@ -319,11 +323,15 @@
                                     t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}"
                                 >
                                     <td
+                                        class="text-center"
                                         scope="row"
                                         t-out="account.code"
-                                        t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px"
+                                        style="width: 160px"
                                     />
-                                    <td t-out="account.name" />
+                                    <td
+                                        t-out="account.name"
+                                        t-attf-style="padding-left: #{20 * (account.hierarchy_level)}px"
+                                    />
                                     <td>
                                         <t t-if="account.deprecated">
                                             <span class="badge text-bg-danger"
@@ -370,10 +378,12 @@
                 aria-labelledby="expense-header"
             >
                 <div class="accordion-body">
-                    <table class="table table-sm" id="expenses">
+                    <table class="table table-sm table-hover" id="expenses">
                         <thead>
                             <tr>
-                                <th>รหัสงบประมาณ</th>
+                                <th scope="col"
+                                                        style="width: 160px"
+                                                        class="text-center">รหัสงบประมาณ</th>
                                 <th>ชื่อรายการ</th>
                                 <th>กองทุน</th>
                                 <th>หมายเหตุ</th>
@@ -384,12 +394,11 @@
                                 <tr
                                     t-attf-class="account-row #{'text-decoration-line-through ' if account.deprecated else ''}"
                                 >
+                                    <td class="text-center" scope="row" t-out="account.code" style="width: 160px" />
                                     <td
-                                        scope="row"
-                                        t-out="account.code"
-                                        t-attf-style="padding-left: #{16 * (account.hierarchy_level + 1)}px"
+                                        t-out="account.name"
+                                        t-attf-style="padding-left: #{20 * (account.hierarchy_level)}px"
                                     />
-                                    <td t-out="account.name" />
                                     <td>
                                         <t
                                             t-foreach="account.fund_analytic_ids"


### PR DESCRIPTION
## Summary
- Add new `budget_account_portal` module to provide public web portal for viewing budget accounts
- Add `get_as_flat_list()` method to `budget.account` model for hierarchical flattening
- Add portal template displaying revenue and expense accounts in hierarchical tables
- Add `note` field to budget account form view
- Remove kanban view from budget account (simplified to tree/form only)

## Features
- **Public Portal**: Web interface at `/budget/budget_account` showing all budget accounts
- **Hierarchical Display**: Visual indentation based on account hierarchy level
- **Account Information**: Shows code, name, fund associations, budgetable status, and notes
- **Deprecated Marking**: Strike-through styling for deprecated accounts
- **Separate Tables**: Revenue and expense accounts displayed in separate sections

## Technical Details
- New module: `budget_account_portal`
- Dependencies: `budget`, `web`, `portal`, `procurement_plan_budget`
- Controller: `BudgetAccount` with public route
- Model extension: `budget.account.get_as_flat_list(budget_type)`
- Template: `portal_budget_account` using portal layout

## Test plan
- [ ] Install `budget_account_portal` module
- [ ] Navigate to `/budget/budget_account` (public access)
- [ ] Verify revenue accounts displayed with proper hierarchy
- [ ] Verify expense accounts displayed with fund associations
- [ ] Verify deprecated accounts shown with strike-through
- [ ] Verify budgetable and procurement plan indicators
- [ ] Test account notes are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)