### PR TITLE
[16.0][IMP] procurement_plan: make procurement method optional

### DIFF
--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -81,7 +81,7 @@ class ProcurementPlan(models.Model):
     procurement_method_id = fields.Many2one(
         comodel_name="procurement.method",
         string="Procurement Method",
-        required=True,
+        required=False,
         tracking=True,
         states=READONLY_STATES,
     )

--- a/procurement_plan_budget/i18n/th.po
+++ b/procurement_plan_budget/i18n/th.po
@@ -1,0 +1,114 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* procurement_plan_budget
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-15 06:10+0000\n"
+"PO-Revision-Date: 2025-10-15 13:12+0700\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.7\n"
+
+#. module: procurement_plan_budget
+#: model:ir.model,name:procurement_plan_budget.model_budget_appropriation
+msgid "Budget Appropriation"
+msgstr "จัดสรรงบประมาณ"
+
+#. module: procurement_plan_budget
+#: model:ir.model,name:procurement_plan_budget.model_budget_appropriation_line
+msgid "Budget Appropriation Line"
+msgstr "รายการจัดสรรงบประมาณ"
+
+#. module: procurement_plan_budget
+#: model:ir.model.fields,field_description:procurement_plan_budget.field_budget_appropriation_line__procurement_method_id
+msgid "Procurement Method"
+msgstr "วิธีจัดซื้อจัดจ้าง"
+
+#. module: procurement_plan_budget
+#: model:ir.model,name:procurement_plan_budget.model_procurement_plan
+#: model:ir.model.fields,field_description:procurement_plan_budget.field_budget_appropriation_line__procurement_plan_id
+msgid "Procurement Plan"
+msgstr "แผนจัดซื้อจัดจ้าง"
+
+#. module: procurement_plan_budget
+#. odoo-python
+#: code:addons/procurement_plan_budget/models/budget_appropriation_line.py:0
+#, python-format
+msgid "The procurement plan has been created from this budget appropriation: <a href=\"%(link)s\" target=\"_blank\">%(name)s</a>"
+msgstr ""
+
+#. module: procurement_plan_budget
+#. odoo-python
+#: code:addons/procurement_plan_budget/models/budget_appropriation_line.py:0
+#, python-format
+msgid "This record has been created from: <a href=\"%(link)s\" target=\"_blank\">%(name)s</a>"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model:ir.model.fields,field_description:procurement_plan_budget.field_budget_appropriation_line__procurement_plan_unit
+msgid "Unit of Measure"
+msgstr "หน่วยนับ"
+
+#. module: procurement_plan_budget
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "e.g. ชิ้น, รายการ, ตัว, ชุด"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model:ir.model.fields,field_description:procurement_plan_budget.field_budget_appropriation_line__enable_procurement_plan
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "จัดสรรแผนจัดซื้อจัดจ้าง"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model:ir.model.fields,field_description:procurement_plan_budget.field_budget_appropriation_line__procurement_plan_amount
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "จำนวน"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid ""
+"ตัวอย่างการกรอกข้อมูล                            <br/>\n"
+"                        ตัวอย่าง 1. \"ปรับปรุงห้องเรียนและห้องปฏิบัติการ อาคารปฏิบัติการพิเศษจอมไตร จำนวน 7 ห้อง วงเงินรวม 5,250,000 บาท\" <br/"
+">\n"
+"                        ตัวอย่าง 2. \"เครื่องล้างเครื่องมือด้วยคลื่นเสียงความถี่สูง จำนวน 1 เครื่อง วงเงินรวม 45,000 บาท\" <br/>"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model:ir.model.fields,help:procurement_plan_budget.field_budget_appropriation_line__procurement_plan
+msgid "ติ๊กถูกเพื่อระบุว่าเป็นประเภทงบลงทุน จะสามารถจัดสรรแผนจัดซื้อจัดจ้างได้"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model:ir.model.fields,field_description:procurement_plan_budget.field_budget_appropriation_line__procurement_plan
+msgid "ทำแผนจัดซื้อจัดจ้าง"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "บาท"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "ระบบจะนำข้อมูลส่วนนี้ไปสร้างเป็นแผนจัดซื้อจัดจ้างหลังจากจัดสรรงบประมาณเสร็จสิ้น"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "วงเงินรวม"
+msgstr ""
+
+#. module: procurement_plan_budget
+#: model_terms:ir.ui.view,arch_db:procurement_plan_budget.view_budget_appropriation_line_form_procurement_plan
+msgid "แผนจัดซื้อจัดจ้าง"
+msgstr ""

--- a/procurement_plan_budget/views/budget_appropriation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_views.xml
@@ -12,7 +12,7 @@
                 <field name="procurement_plan" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='balance']" position="after">
-                <field name="enable_procurement_plan" string="จัดสรรแผนจัดซื้อจัดจ้าง" attrs="{'invisible': [('procurement_plan', '=', False)]}" />
+                <field name="enable_procurement_plan" string="จัดสรรงบประมาณงบลงทุน" attrs="{'invisible': [('procurement_plan', '=', False)]}" />
             </xpath>
             <xpath expr="//group" position="after">
                 <group name="procurement_plan" string="แผนจัดซื้อจัดจ้าง" attrs="{'invisible': [('enable_procurement_plan', '=', False)]}">
@@ -52,7 +52,7 @@
         <xpath expr="//field[@name='line_ids']/tree" position="inside">
             <field name="procurement_plan" invisible="1" />
             <field name="enable_procurement_plan" invisible="1" />
-            <field name="description" invisible="1" />
+            <field name="description" string="Name" invisible="1" />
             <field name="procurement_plan_amount" invisible="1" />
             <field name="procurement_plan_unit" invisible="1" />
         </xpath>


### PR DESCRIPTION
## Summary
- Make procurement method field optional instead of required in procurement plans
- Update budget appropriation view labels for better clarity
- Add translation files for procurement_plan_budget module

## Test plan
- [ ] Create a new procurement plan without selecting procurement method
- [ ] Verify existing procurement plans still work correctly
- [ ] Check that budget appropriation labels display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)