### PR TITLE
[16.0][ADD] budget_analytic_account: add budgetable field to analytic accounts

### DIFF
--- a/budget_analytic_account/__init__.py
+++ b/budget_analytic_account/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/budget_analytic_account/__manifest__.py
+++ b/budget_analytic_account/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Budget Analytic Account",
+    "version": "16.0.1.0.0",
+    "category": "KMITL/Budgeting",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": ["analytic"],
+    "data": [
+        "views/account_analytic_account_views.xml"
+    ],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/budget_analytic_account/i18n/th.po
+++ b/budget_analytic_account/i18n/th.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* budget_analytic_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-27 16:19+0000\n"
+"PO-Revision-Date: 2025-10-27 16:19+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: budget_analytic_account
+#: model:ir.model,name:budget_analytic_account.model_account_analytic_account
+msgid "Analytic Account"
+msgstr "บัญชีวิเคราะห์"
+
+#. module: budget_analytic_account
+#: model:ir.model.fields,field_description:budget_analytic_account.field_account_analytic_account__budgetable
+#: model_terms:ir.ui.view,arch_db:budget_analytic_account.view_account_analytic_account_search
+msgid "Budgetable"
+msgstr "ระบุงบประมาณได้"
+
+#. module: budget_analytic_account
+#: model_terms:ir.ui.view,arch_db:budget_analytic_account.view_account_analytic_account_form
+msgid "Budgeting"
+msgstr "งบประมาณ"
+
+#. module: budget_analytic_account
+#: model:ir.model.fields,help:budget_analytic_account.field_account_analytic_account__budgetable
+msgid "ติ๊กถูกเพื่อระบุว่ารหัสค่าใช้จ่ายสามารถจัดสรรงบประมาณได้"
+msgstr ""

--- a/budget_analytic_account/models/__init__.py
+++ b/budget_analytic_account/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import analytic_account_analytic

--- a/budget_analytic_account/models/__init__.py
+++ b/budget_analytic_account/models/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from . import analytic_account_analytic
+from . import account_analytic_account

--- a/budget_analytic_account/models/account_analytic_account.py
+++ b/budget_analytic_account/models/account_analytic_account.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    budgetable = fields.Boolean(
+        tracking=True,
+        copy=True,
+        default=False,
+        help="ติ๊กถูกเพื่อระบุว่ารหัสค่าใช้จ่ายสามารถจัดสรรงบประมาณได้",
+    )

--- a/budget_analytic_account/views/account_analytic_account_views.xml
+++ b/budget_analytic_account/views/account_analytic_account_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- View account.analytic.account form -->
+    <record id="view_account_analytic_account_form" model="ir.ui.view">
+        <field name="name">view.account.analytic.account.form (Budgetable)</field>
+        <field name="model">account.analytic.account</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="inside">
+                <group string="Budgeting">
+                    <group>
+                        <field name="budgetable" />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+
+    <!-- View account.analytic.account tree -->
+    <record id="view_account_analytic_account_tree" model="ir.ui.view">
+        <field name="name">view.account.analytic.account.tree (Budgetable)</field>
+        <field name="model">account.analytic.account</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_list"/>
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="inside">
+                <field name="budgetable" optional="hide" />
+            </xpath>
+        </field>
+    </record>
+
+
+    <!-- View account.analytic.account search -->
+    <record id="view_account_analytic_account_search" model="ir.ui.view">
+        <field name="name">view.account.analytic.account.search (Budgetable)</field>
+        <field name="model">account.analytic.account</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//name[@name='inactive']" position="before">
+                <filter string="Budgetable" domain="[('budgetabke', '=', True)]" name="inactive"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_analytic_account/views/account_analytic_account_views.xml
+++ b/budget_analytic_account/views/account_analytic_account_views.xml
@@ -37,7 +37,7 @@
         <field name="model">account.analytic.account</field>
         <field name="inherit_id" ref="analytic.view_account_analytic_account_search"/>
         <field name="arch" type="xml">
-            <xpath expr="//name[@name='inactive']" position="before">
+            <xpath expr="//filter[@name='inactive']" position="before">
                 <filter string="Budgetable" domain="[('budgetabke', '=', True)]" name="inactive"/>
             </xpath>
         </field>

--- a/budget_analytic_account/views/account_analytic_account_views.xml
+++ b/budget_analytic_account/views/account_analytic_account_views.xml
@@ -38,7 +38,7 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_account_search"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='inactive']" position="before">
-                <filter string="Budgetable" domain="[('budgetabke', '=', True)]" name="inactive"/>
+                <filter string="Budgetable" domain="[('budgetable', '=', True)]" name="inactive"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Add new module `budget_analytic_account`
- Extends `account.analytic.account` with `budgetable` boolean field
- Allows marking which analytic accounts can be used for budget allocation

## Test plan
- [ ] Install the module
- [ ] Navigate to Accounting > Configuration > Analytic Accounts
- [ ] Verify "Budgetable" field appears on analytic account form
- [ ] Test toggling the budgetable field and verify it's tracked in chatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)