### PR TITLE
[16.0][ADD] purchase_request_vendor_kmitl: require vendor for purchases under 100k

### DIFF
--- a/purchase_request_vendor_kmitl/__init__.py
+++ b/purchase_request_vendor_kmitl/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import wizard

--- a/purchase_request_vendor_kmitl/__manifest__.py
+++ b/purchase_request_vendor_kmitl/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Purchase Request Vendor KMITL",
+    "version": "16.0.1.0.0",
+    "category": "KMITL",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": ["purchase_request_kmitl"],
+    "data": [
+        "data/purchase_request_exception.xml",
+        "views/purchase_request_views.xml"
+    ],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/purchase_request_vendor_kmitl/data/purchase_request_exception.xml
+++ b/purchase_request_vendor_kmitl/data/purchase_request_exception.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="pr_exception_vendor_kmitl" model="exception.rule">
+        <field name="name">การจัดซื้อจัดจ้าง ไม่เกิน 100,000 บาท ต้องระบุชื่อผู้ขาย</field>
+        <field name="description">วงเงินไม่เกิน 100,000</field>
+        <field name="model">purchase.request</field>
+        <field name="exception_type">by_py_code</field>
+        <field name="code"><![CDATA[
+if self.is_required_partner_id and not self.partner_id:
+    failed = True
+]]>
+        </field>
+    </record>
+</odoo>

--- a/purchase_request_vendor_kmitl/i18n/th.po
+++ b/purchase_request_vendor_kmitl/i18n/th.po
@@ -19,7 +19,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request_vendor_kmitl.view_purchase_request_form
 msgid ""
 "If vendor name not found, contact procurement staff to add the information"
-msgstr "ถ้าหากไม่พบชื่อผู้ขาย ให้แจ้งเจ้าหน้าที่พัสดุ/ผู้รับผิดชอบงาน เพื่อเพิ่มข้อมูล"
+msgstr "ถ้าหากไม่พบชื่อผู้ขายที่ต้องการ ให้แจ้งเจ้าหน้าที่พัสดุ/ผู้รับผิดชอบงาน เพื่อเพิ่มข้อมูล"
 
 #. module: purchase_request_vendor_kmitl
 #: model:ir.model.fields,field_description:purchase_request_vendor_kmitl.field_purchase_request__is_required_partner_id

--- a/purchase_request_vendor_kmitl/i18n/th.po
+++ b/purchase_request_vendor_kmitl/i18n/th.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* purchase_request_vendor_kmitl
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-28 07:12+0000\n"
+"PO-Revision-Date: 2025-10-28 07:12+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_request_vendor_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_request_vendor_kmitl.view_purchase_request_form
+msgid ""
+"If vendor name not found, contact procurement staff to add the information"
+msgstr "ถ้าหากไม่พบชื่อผู้ขาย ให้แจ้งเจ้าหน้าที่พัสดุ/ผู้รับผิดชอบงาน เพื่อเพิ่มข้อมูล"
+
+#. module: purchase_request_vendor_kmitl
+#: model:ir.model.fields,field_description:purchase_request_vendor_kmitl.field_purchase_request__is_required_partner_id
+msgid "Is Required Partner"
+msgstr ""
+
+#. module: purchase_request_vendor_kmitl
+#: model:ir.model.fields,field_description:purchase_request_vendor_kmitl.field_purchase_request__partner_id
+msgid "Partner"
+msgstr "ผู้ขาย"
+
+#. module: purchase_request_vendor_kmitl
+#: model:ir.model,name:purchase_request_vendor_kmitl.model_purchase_request
+msgid "Purchase Request"
+msgstr "คำขอซื้อขอจ้าง"
+
+#. module: purchase_request_vendor_kmitl
+#: model:ir.model,name:purchase_request_vendor_kmitl.model_purchase_request_line_make_purchase_order
+msgid "Purchase Request Line Make Purchase Order"
+msgstr ""
+
+#. module: purchase_request_vendor_kmitl
+#: model:exception.rule,name:purchase_request_vendor_kmitl.pr_exception_vendor_kmitl
+msgid "การจัดซื้อจัดจ้าง ไม่เกิน 100,000 บาท ต้องระบุชื่อผู้ขาย"
+msgstr ""
+
+#. module: purchase_request_vendor_kmitl
+#: model:exception.rule,description:purchase_request_vendor_kmitl.pr_exception_vendor_kmitl
+msgid "วงเงินไม่เกิน 100,000"
+msgstr ""

--- a/purchase_request_vendor_kmitl/models/__init__.py
+++ b/purchase_request_vendor_kmitl/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import purchase_request

--- a/purchase_request_vendor_kmitl/models/purchase_request.py
+++ b/purchase_request_vendor_kmitl/models/purchase_request.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseRequest(models.Model):
+    _inherit = 'purchase.request'
+
+    partner_id = fields.Many2one("res.partner", tracking=True)
+
+    is_required_partner_id = fields.Boolean(compute="_compute_is_required_partner_id")
+
+    @api.depends("state", "estimated_cost")
+    def _compute_is_required_partner_id(self):
+        for rec in self:
+            if rec.estimated_cost < 100000:
+                rec.is_required_partner_id = True
+            else:
+                rec.is_required_partner_id = False
+
+    @api.onchange("is_required_partner_id")
+    def _onchange_is_required_partner_id(self):
+        for rec in self:
+            if not is_required_partner_id:
+                rec.partner_id = False

--- a/purchase_request_vendor_kmitl/models/purchase_request.py
+++ b/purchase_request_vendor_kmitl/models/purchase_request.py
@@ -25,5 +25,5 @@ class PurchaseRequest(models.Model):
     @api.onchange("is_required_partner_id")
     def _onchange_is_required_partner_id(self):
         for rec in self:
-            if not is_required_partner_id:
+            if not rec.is_required_partner_id:
                 rec.partner_id = False

--- a/purchase_request_vendor_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_vendor_kmitl/views/purchase_request_views.xml
@@ -12,7 +12,7 @@
                     <group>
                         <field name="is_required_partner_id" invisible="1" />
                         <field name="partner_id" attrs="{'invisible': [('is_required_partner_id', '!=', True)], 'required': [('is_required_partner_id', '=', True)]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
-                        <div colspan="2" class="alert alert-warning show" role="alert">If vendor name not found, contact procurement staff to add the information</div>
+                        <div attrs="{'invisible': [('is_required_partner_id', '!=', True)]}" colspan="2" class="alert alert-warning show" role="alert">If vendor name not found, contact procurement staff to add the information</div>
                     </group>
                 </group>
 

--- a/purchase_request_vendor_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_vendor_kmitl/views/purchase_request_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- View purchase.request form -->
+    <record id="view_purchase_request_form" model="ir.ui.view">
+        <field name="name">view.purchase.request.form</field>
+        <field name="model">purchase.request</field>
+        <field name="inherit_id" ref="purchase_request.view_purchase_request_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='line_ids']" position="before">
+                <group>
+                    <group>
+                        <field name="is_required_partner_id" invisible="1" />
+                        <field name="partner_id" attrs="{'invisible': [('is_required_partner_id', '!=', True)], 'required': [('is_required_partner_id', '=', True)]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
+                        <div colspan="2" class="alert alert-warning show" role="alert">If vendor name not found, contact procurement staff to add the information</div>
+                    </group>
+                </group>
+
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/purchase_request_vendor_kmitl/wizard/__init__.py
+++ b/purchase_request_vendor_kmitl/wizard/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from . import purchase_request_line_make_purchase_order

--- a/purchase_request_vendor_kmitl/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_vendor_kmitl/wizard/purchase_request_line_make_purchase_order.py
@@ -1,0 +1,27 @@
+# Copyright 2018-2019 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+from datetime import datetime
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import get_lang
+
+
+class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
+    _inherit = "purchase.request.line.make.purchase.order"
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        active_model = self.env.context.get("active_model", False)
+        if active_model != "purchase.request":
+            return res
+
+        active_id = self.env.context.get("active_id", False)
+        request_id = self.env[active_model].browse(active_id)
+        if not request_id:
+            return res
+
+        if request_id.partner_id:
+            res["supplier_id"] = request_id.partner_id.id
+        return res


### PR DESCRIPTION
## Summary
- Add new module `purchase_request_vendor_kmitl` to enforce vendor selection for purchase requests under 100,000 THB
- Implements conditional vendor field requirement based on estimated cost
- Adds exception rule validation to prevent approval without vendor
- Auto-populates vendor selection in purchase order wizard

## Features
- **Vendor Field**: Added `partner_id` field to purchase requests with conditional visibility
- **Computed Requirement**: Automatically determines if vendor is required when `estimated_cost < 100,000`
- **Exception Validation**: Blocks approval if vendor is not selected when required
- **Wizard Integration**: Auto-fills vendor in PO creation wizard from purchase request
- **User Guidance**: Alert message displayed when vendor not found

## Test plan
- [ ] Create purchase request with estimated cost < 100k - verify vendor field is required
- [ ] Create purchase request with estimated cost ≥ 100k - verify vendor field is optional
- [ ] Try to approve PR without vendor when cost < 100k - verify exception is raised
- [ ] Create PO from PR with vendor set - verify vendor auto-populates in wizard
- [ ] Test that alert message displays correctly in the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)