### PR TITLE
[16.0][ADD] purchase_request_hide_create_po_button: conditionally hide create PO button

### DIFF
--- a/purchase_request_hide_create_po_button/__init__.py
+++ b/purchase_request_hide_create_po_button/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_request_hide_create_po_button/__manifest__.py
+++ b/purchase_request_hide_create_po_button/__manifest__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Purchase Request Hide Create PO Button",
+    "version": "16.0.1.0.0",
+    "category": "Purchase Management",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": ["purchase_request"],
+    "data": [
+        "views/purchase_request_views.xml"
+    ],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/purchase_request_hide_create_po_button/models/__init__.py
+++ b/purchase_request_hide_create_po_button/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import purchase_request

--- a/purchase_request_hide_create_po_button/models/purchase_request.py
+++ b/purchase_request_hide_create_po_button/models/purchase_request.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseRequest(models.Model):
+    _inherit = 'purchase.request'
+
+    hide_create_po_button = fields.Boolean(compute="_hide_create_po_button")
+
+    @api.depends('state')
+    def _hide_create_po_button(self):
+        for rec in self:
+            rec.hide_create_po_button = True
+            if rec.state in ('approved', 'in_progress') and rec.purchase_count == 0:
+                rec.hide_create_po_button = False

--- a/purchase_request_hide_create_po_button/views/purchase_request_views.xml
+++ b/purchase_request_hide_create_po_button/views/purchase_request_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <odoo>
+
+    <!-- View purchase.request form -->
+    <record id="view_purchase_request_form" model="ir.ui.view">
+        <field name="name">view.purchase.request.form</field>
+        <field name="model">purchase.request</field>
+        <field name="inherit_id" ref="purchase_request.view_purchase_request_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="inside">
+                <field name="hide_create_po_button" invisible="1" />
+            </xpath>
+            <xpath expr="//button[@name='%(action_purchase_request_line_make_purchase_order)d']" position="attributes">
+                <attribute name="states"/>
+                <attribute name="attrs">{'invisible':[('hide_create_po_button', '=', True)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+  </odoo>

--- a/purchase_request_hide_create_po_button/views/purchase_request_views.xml
+++ b/purchase_request_hide_create_po_button/views/purchase_request_views.xml
@@ -10,7 +10,7 @@
             <xpath expr="//form" position="inside">
                 <field name="hide_create_po_button" invisible="1" />
             </xpath>
-            <xpath expr="//button[@name='%(action_purchase_request_line_make_purchase_order)d']" position="attributes">
+            <xpath expr="//button[@name='%(purchase_request.action_purchase_request_line_make_purchase_order)d']" position="attributes">
                 <attribute name="states"/>
                 <attribute name="attrs">{'invisible':[('hide_create_po_button', '=', True)]}</attribute>
             </xpath>


### PR DESCRIPTION
## Summary
- Adds a new module `purchase_request_hide_create_po_button` that conditionally hides the "Create PO" button on purchase requests
- The button is only visible when the purchase request is in `approved` or `in_progress` state AND has no purchase orders (`purchase_count == 0`)
- Prevents users from creating duplicate purchase orders and improves workflow control

## Implementation Details
- **Model Extension**: Added `hide_create_po_button` computed field to `purchase.request` model
- **Logic**: Button is hidden by default, only shown when state is approved/in_progress and no POs exist
- **View Modification**: Modified the "Create PO" button visibility using `attrs` instead of `states` for more flexible control

## Test Plan
- [ ] Create a new purchase request
- [ ] Verify "Create PO" button is hidden in draft state
- [ ] Approve the purchase request
- [ ] Verify "Create PO" button is now visible
- [ ] Create a purchase order from the request
- [ ] Verify "Create PO" button is hidden again after PO is created
- [ ] Test with purchase request in different states (draft, rejected, done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)