### PR TITLE
[16.0][IMP] budget_account_portal: add priority sorting for activities

### DIFF
--- a/budget_account_portal/models/account_analytic_account.py
+++ b/budget_account_portal/models/account_analytic_account.py
@@ -40,4 +40,19 @@ class AccountAnalyticAccount(models.Model):
         for node in roots:
             flat_list.extend(flatten_node(node))
 
+        def sort_key(node):
+            priority_codes = ['00', '09', '06']
+            # Extract first 2 digits of code for priority sorting
+            code_prefix = node.code[:2] if len(node.code) >= 2 else node.code
+
+            if code_prefix in priority_codes:
+                # Return tuple with priority index first, then code
+                return (priority_codes.index(code_prefix), node.code)
+            else:
+                # Non-priority codes come after priority ones, sorted by code
+                return (len(priority_codes), node.code)
+
+        if plan_id == self.env.ref('account_analytic_kmitl.analytic_plan_activities').id:
+            return sorted(flat_list, key=sort_key)
+
         return flat_list


### PR DESCRIPTION
## Summary
- Adds custom sorting logic to prioritize specific activity codes in portal display
- Priority codes (00, 09, 06) appear first in hierarchical lists
- Maintains alphabetical order within priority groups and for other activities
- Applied only to the activities analytic plan

## Test plan
- [ ] Verify activities with codes 00, 09, 06 appear at the top of activity lists in portal
- [ ] Confirm alphabetical sorting is maintained within priority groups
- [ ] Check that non-priority activities are sorted alphabetically after priority ones
- [ ] Test with various activity code combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)