### PR TITLE
[16.0][IMP] purchase_request: optimize field visibility in tree views

### DIFF
--- a/purchase_request_account_fiscal_year/views/purchase_request_views.xml
+++ b/purchase_request_account_fiscal_year/views/purchase_request_views.xml
@@ -21,7 +21,7 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="after">
-                <field name="account_fiscal_year_id" optional="show" />
+                <field name="account_fiscal_year_id" optional="hide" />
             </xpath>
         </field>
     </record>

--- a/purchase_request_contract_type/views/purchase_request_views.xml
+++ b/purchase_request_contract_type/views/purchase_request_views.xml
@@ -21,7 +21,7 @@
         <field name="inherit_id" ref="l10n_th_gov_purchase_request.view_purchase_request_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='procurement_method_id']" position="after">
-                <field name="contract_type" optional="show" />
+                <field name="contract_type" optional="hide" />
             </xpath>
         </field>
     </record>

--- a/purchase_request_kmitl/i18n/th.po
+++ b/purchase_request_kmitl/i18n/th.po
@@ -1407,7 +1407,7 @@ msgstr ""
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__name
 msgid "Request Reference"
-msgstr "รหัสเอกสาร แบบขอซื้อ/จ้าง (พ.1)"
+msgstr "เลขที่"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form

--- a/purchase_request_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_kmitl/views/purchase_request_views.xml
@@ -6,10 +6,13 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='requested_by']" position="after">
-                <field name="procurement_type_id" optional="show" />
+                <field name="procurement_type_id" optional="hide" />
             </xpath>
             <xpath expr="//field[@name='estimated_cost']" position="attributes">
                 <attribute name="optional">show</attribute>
+            </xpath>
+            <xpath expr="//field[@name='main_exception_id']" position="attributes">
+                <attribute name="optional">hide</attribute>
             </xpath>
         </field>
     </record>

--- a/purchase_request_operating_unit/views/purchase_request_views.xml
+++ b/purchase_request_operating_unit/views/purchase_request_views.xml
@@ -21,7 +21,7 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_tree"/>
         <field name="arch" type="xml">
             <field name="requested_by" position="after">
-                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"  optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Optimized default field visibility in purchase request tree views across multiple modules
- Set `procurement_type_id` to `optional="hide"` by default (was `optional="show"`)
- Set `main_exception_id` to `optional="hide"` by default
- Kept `estimated_cost` as `optional="show"` for visibility

## Benefits
- Cleaner initial view with less clutter
- Users can still enable hidden fields via column selector
- Focuses on most frequently used fields

## Modules Affected
- `purchase_request_kmitl` - Main module view improvements
- `purchase_request_account_fiscal_year` - Field visibility adjustment
- `purchase_request_contract_type` - Field visibility adjustment
- `purchase_request_operating_unit` - Field visibility adjustment

## Test plan
- [ ] Verify purchase request tree view displays correctly with new field visibility
- [ ] Confirm hidden fields are accessible via column selector
- [ ] Check all affected modules maintain proper functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)