### PR TITLE
[16.0][ADD] purchase_order_payment_type: add payment type tracking

### DIFF
--- a/purchase_order_account_move_request/__manifest__.py
+++ b/purchase_order_account_move_request/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    'depends': ['purchase', 'account_move_request'],
+    'depends': ['purchase', 'account_move_request', 'purchase_order_payment_type'],
     "data": [
         "views/purchase_order_views.xml"
     ],

--- a/purchase_order_account_move_request/models/purchase_order.py
+++ b/purchase_order_account_move_request/models/purchase_order.py
@@ -54,7 +54,8 @@ class PurchaseOrder(models.Model):
                 Command.create(line._prepare_move_request_line_vals())
                 for line in self.order_line
             ],
-            "ref": self.name
+            "ref": self.name,
+            "payment_type": self.payment_type,
         }
 
     def action_move_request(self):

--- a/purchase_order_link_purchase_request/__init__.py
+++ b/purchase_order_link_purchase_request/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_order_link_purchase_request/__manifest__.py
+++ b/purchase_order_link_purchase_request/__manifest__.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 {
-    "name": "Purchase Request Payment Type",
+    "name": "Purchase Order Link Purchase Request",
     "version": "16.0.1.0.0",
     "category": "Purchase Management",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    "depends": [
-        "l10n_th_gov_purchase_request",
-        "purchase_order_payment_type",
-        "purchase_order_link_purchase_request"
-    ],
-    "data": ["views/purchase_request_views.xml"],
+    "depends": ["purchase_request"],
+    "data": [],
     "installable": True,
     "auto_install": False,
     "license": "LGPL-3",

--- a/purchase_order_link_purchase_request/models/__init__.py
+++ b/purchase_order_link_purchase_request/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import purchase_order

--- a/purchase_order_link_purchase_request/models/purchase_order.py
+++ b/purchase_order_link_purchase_request/models/purchase_order.py
@@ -16,7 +16,7 @@ class PurchaseOrder(models.Model):
         string="Purchase Request",
     )
 
-    @api.depends("purchase_request_lines")
+    @api.depends("order_line.purchase_request_lines")
     def _compute_request_id(self):
         for rec in self:
             for request_line in rec.order_line.mapped('purchase_request_lines'):

--- a/purchase_order_link_purchase_request/models/purchase_order.py
+++ b/purchase_order_link_purchase_request/models/purchase_order.py
@@ -19,6 +19,9 @@ class PurchaseOrder(models.Model):
     @api.depends("order_line.purchase_request_lines")
     def _compute_request_id(self):
         for rec in self:
-            for request_line in rec.order_line.mapped('purchase_request_lines'):
-                rec.request_id = request_line.request_id.id
-                break
+            for line in rec.order_line:
+                for request_line in line.purchase_request_lines:
+                    rec.request_id = request_line.request_id.id
+                    break
+                if rec.request_id:
+                    break

--- a/purchase_order_link_purchase_request/models/purchase_order.py
+++ b/purchase_order_link_purchase_request/models/purchase_order.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    request_id = fields.Many2one(
+        "purchase.request",
+        compute="_compute_request_id",
+        string="Purchase Request",
+    )
+
+    @api.depends("purchase_request_lines")
+    def _compute_request_id(self):
+        for rec in self:
+            for request_line in rec.order_line.mapped('purchase_request_lines'):
+                rec.request_id = request_line.request_id.id
+                break

--- a/purchase_order_payment_type/__init__.py
+++ b/purchase_order_payment_type/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_order_payment_type/__manifest__.py
+++ b/purchase_order_payment_type/__manifest__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 {
-    "name": "Purchase Request Payment Type",
+    "name": "Purchase Order Payment Type",
     "version": "16.0.1.0.0",
     "category": "Purchase Management",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    "depends": ["l10n_th_gov_purchase_request", "purchase_order_payment_type"],
-    "data": ["views/purchase_request_views.xml"],
+    "depends": ["purchase"],
+    "data": ["views/purchase_order_views.xml"],
     "installable": True,
     "auto_install": False,
     "license": "LGPL-3",

--- a/purchase_order_payment_type/i18n/th.po
+++ b/purchase_order_payment_type/i18n/th.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* purchase_order_payment_type
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-13 09:16+0000\n"
+"PO-Revision-Date: 2025-11-13 09:16+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_order_payment_type
+#: model:ir.model.fields.selection,name:purchase_order_payment_type.selection__purchase_order__payment_type__direct
+msgid "Direct paid"
+msgstr "จ่ายตรง"
+
+#. module: purchase_order_payment_type
+#: model:ir.model.fields.selection,name:purchase_order_payment_type.selection__purchase_order__payment_type__loan
+msgid "Loan"
+msgstr "เงินยืม"
+
+#. module: purchase_order_payment_type
+#: model:ir.model.fields,field_description:purchase_order_payment_type.field_purchase_order__payment_type
+#: model_terms:ir.ui.view,arch_db:purchase_order_payment_type.view_purchase_order_search
+msgid "Payment Type"
+msgstr "ประเภทการเบิกจ่าย"
+
+#. module: purchase_order_payment_type
+#: model:ir.model.fields.selection,name:purchase_order_payment_type.selection__purchase_order__payment_type__prepaid
+msgid "Prepaid"
+msgstr "สำรองจ่าย"
+
+#. module: purchase_order_payment_type
+#: model:ir.model,name:purchase_order_payment_type.model_purchase_order
+msgid "Purchase Order"
+msgstr "คำสั่งซื้อ"

--- a/purchase_order_payment_type/models/__init__.py
+++ b/purchase_order_payment_type/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import purchase_order

--- a/purchase_order_payment_type/models/purchase_order.py
+++ b/purchase_order_payment_type/models/purchase_order.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    payment_type = fields.Selection(
+        [("direct", "Direct paid"), ("loan", "Loan"), ("prepaid", "Prepaid")],
+        tracking=True,
+        string="Payment Type",
+    )

--- a/purchase_order_payment_type/models/purchase_order.py
+++ b/purchase_order_payment_type/models/purchase_order.py
@@ -10,8 +10,15 @@ _logger = logging.getLogger(__name__)
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
+    READONLY_STATES = {
+        'purchase': [('readonly', True)],
+        'done': [('readonly', True)],
+        'cancel': [('readonly', True)],
+    }
+
     payment_type = fields.Selection(
         [("direct", "Direct paid"), ("loan", "Loan"), ("prepaid", "Prepaid")],
         tracking=True,
         string="Payment Type",
+        states=READONLY_STATES,
     )

--- a/purchase_order_payment_type/views/purchase_order_views.xml
+++ b/purchase_order_payment_type/views/purchase_order_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- View purchase.order form -->
+    <record id="view_purchase_order_form" model="ir.ui.view">
+        <field name="name">view.purchase.order.form (Payment Type)</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/group[1]" position="inside">
+                <field name="payment_type" required="1" />
+            </xpath>
+        </field>
+    </record>
+
+
+    <!-- View purchase.order tree -->
+    <record id="view_purchase_order_tree" model="ir.ui.view">
+        <field name="name">view.purchase.order.tree (Payment Type)</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_view_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='amount_total']" position="after">
+                <field name="payment_type" optional="hide" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_purchase_order_search" model="ir.ui.view">
+        <field name="name">purchase.order.list.select (Payment Type)</field>
+        <field name="model">purchase.order</field>
+        <field name="priority">30</field>
+        <field name="inherit_id" ref="purchase.purchase_order_view_search" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="before">
+                <field name="payment_type" />
+            </field>
+            <xpath expr="//group" position="inside">
+                <filter string="Payment Type" name="payment_type" domain="[]" context="{'group_by': 'payment_type'}"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/purchase_request_payment_type/__init__.py
+++ b/purchase_request_payment_type/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import models
+from . import wizard

--- a/purchase_request_payment_type/__manifest__.py
+++ b/purchase_request_payment_type/__manifest__.py
@@ -10,7 +10,7 @@
         "purchase_order_payment_type",
         "purchase_order_link_purchase_request"
     ],
-    "data": ["views/purchase_request_views.xml"],
+    "data": ["data/purchase_exception.xml", "views/purchase_request_views.xml"],
     "installable": True,
     "auto_install": False,
     "license": "LGPL-3",

--- a/purchase_request_payment_type/data/purchase_exception.xml
+++ b/purchase_request_payment_type/data/purchase_exception.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="0">
+    <record id="po_payment_type_should_be_the_same_as_pr" model="exception.rule">
+        <field name="name">ข้อมูลประเภทการเบิกจ่ายในใบสั่งซื้อ/จ้าง (PO) ต้องตรงกับในใบพ.1 (PR)</field>
+        <field name="description">ข้อมูลใบสั่งซื้อ/จ้าง</field>
+        <field name="model">purchase.order</field>
+        <field name="exception_type">by_py_code</field>
+        <field name="code">
+if self.request_id and self.request_id.payment_type != self.payment_type:
+    failed = True
+        </field>
+    </record>
+</odoo>

--- a/purchase_request_payment_type/wizard/__init__.py
+++ b/purchase_request_payment_type/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_request_line_make_purchase_order

--- a/purchase_request_payment_type/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_payment_type/wizard/purchase_request_line_make_purchase_order.py
@@ -1,0 +1,18 @@
+import logging
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import get_lang
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
+    _inherit = "purchase.request.line.make.purchase.order"
+
+    @api.model
+    def _prepare_purchase_order(self, picking_type, group_id, company, origin):
+        vals = super()._prepare_purchase_order(picking_type, group_id, company, origin)
+        vals.update({
+            "payment_type": self.item_ids.request_id.payment_type,
+        })
+        return vals


### PR DESCRIPTION
## Summary

- Add new module `purchase_order_payment_type` to track payment types on purchase orders
- Extend `purchase_request_payment_type` wizard to propagate payment type from request to order
- Update `purchase_order_account_move_request` to include payment type in move requests

## Changes

**New Module: purchase_order_payment_type**
- Adds `payment_type` field to purchase orders with three options:
  - Direct paid
  - Loan  
  - Prepaid
- Field is tracked for audit trail
- UI integration in purchase order form view

**purchase_request_payment_type Enhancement**
- New wizard to transfer payment type from purchase request to generated purchase order
- Maintains payment type consistency across procurement workflow

**purchase_order_account_move_request Integration**
- Payment type now included in account move request preparation
- Ensures financial documents maintain payment type information

## Test plan

- [ ] Install `purchase_order_payment_type` module
- [ ] Create purchase order and verify payment type field is available
- [ ] Set different payment types and verify tracking works
- [ ] Create purchase request with payment type
- [ ] Generate purchase order from request and verify payment type propagates
- [ ] Create account move request from purchase order and verify payment type is included

Generated with [Claude Code](https://claude.com/claude-code)