### PR TITLE
[16.0][ADD] agx_sarabun: auto-assign admin to manager group

### DIFF
--- a/agx_sarabun/__manifest__.py
+++ b/agx_sarabun/__manifest__.py
@@ -14,6 +14,7 @@
         # Data
         "data/sarabun_sequence.xml",
         "data/sarabun_document_type.xml",
+        "data/sarabun_role.xml",
         "report/paperformat.xml",
         "report/report_sarabun.xml",
         # Wizard

--- a/agx_sarabun/data/sarabun_role.xml
+++ b/agx_sarabun/data/sarabun_role.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Sarabun Role Master Data -->
+
+        <record id="role_system_admin" model="sarabun.role">
+            <field name="name">ผู้ดูแลระบบ</field>
+            <field name="code">ADMIN</field>
+            <field name="sequence">1</field>
+            <field name="role_category">executive</field>
+            <field name="role_type">static</field>
+            <field name="user_ids" eval="[(4, ref('base.user_admin'))]" />
+            <field name="description">ผู้ดูแลระบบสารบรรณอิเล็กทรอนิกส์</field>
+        </record>
+
+        <record id="role_director" model="sarabun.role">
+            <field name="name">ผู้อำนวยการ</field>
+            <field name="code">DIR</field>
+            <field name="sequence">10</field>
+            <field name="role_category">executive</field>
+            <field name="role_type">static</field>
+            <field name="description">ผู้อำนวยการหน่วยงาน</field>
+        </record>
+
+        <record id="role_lecturer" model="sarabun.role">
+            <field name="name">อาจารย์</field>
+            <field name="code">LECTURER</field>
+            <field name="sequence">20</field>
+            <field name="role_category">academic</field>
+            <field name="role_type">static</field>
+            <field name="description">อาจารย์ผู้สอน</field>
+        </record>
+
+        <record id="role_academic_support" model="sarabun.role">
+            <field name="name">เจ้าหน้าที่สนับสนุนงานวิชาการ</field>
+            <field name="code">ACAD_SUPPORT</field>
+            <field name="sequence">30</field>
+            <field name="role_category">executive</field>
+            <field name="role_type">static</field>
+            <field name="description">เจ้าหน้าที่สนับสนุนงานวิชาการ</field>
+        </record>
+
+    </data>
+</odoo>

--- a/agx_sarabun/security/security.xml
+++ b/agx_sarabun/security/security.xml
@@ -20,6 +20,7 @@
             <field name="name">Manager</field>
             <field name="category_id" ref="module_category_sarabun"/>
             <field name="implied_ids" eval="[(4, ref('group_sarabun_user'))]"/>
+            <field name="users" eval="[(4, ref('base.user_admin'))]" />
         </record>
     </data>
 


### PR DESCRIPTION
## Summary
Automatically assign the admin user to the sarabun manager group when the module is installed.

This ensures that admin users have full access to Sarabun documents and settings without manual configuration.

## Changes
- Added admin user to `group_sarabun_manager` in the security.xml configuration