### PR TITLE
[16.0][IMP] agx_sarabun: add read/unread tracking to inbox

### DIFF
--- a/agx_sarabun/models/res_users.py
+++ b/agx_sarabun/models/res_users.py
@@ -15,9 +15,10 @@ class ResUsers(models.Model):
         user = self.env.user
 
         # Build domain for recipients the current user can access
-        # and that are in 'new' state (unread/unactioned)
+        # that are in 'new' state and not yet read (read_date is null)
         recipients = Recipient.sudo().search([
             ("state", "=", "new"),
+            ("read_date", "=", False),
             ("document_id.state", "=", "sent"),
         ], order="create_date desc")
 

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -251,6 +251,17 @@ class SarabunDocument(models.Model):
         compute="_compute_report_preview_url",
     )
 
+    # === Read Status (for current user) ===
+    read_status = fields.Selection(
+        selection=[
+            ("unread", "Unread"),
+            ("read", "Read"),
+        ],
+        string="Read Status",
+        compute="_compute_read_status",
+        search="_search_read_status",
+    )
+
     # === References ===
     reference_ids = fields.One2many(
         comodel_name="sarabun.reference",
@@ -394,6 +405,39 @@ class SarabunDocument(models.Model):
         for record in self:
             record.attachment_count = len(record.attachment_ids)
 
+    @api.depends("recipient_ids", "recipient_ids.read_date", "recipient_ids.user_id")
+    def _compute_read_status(self):
+        """Compute read status for current user"""
+        user = self.env.user
+        for record in self:
+            recipient = record.recipient_ids.filtered(
+                lambda r: r._can_user_access(user)
+            )[:1]
+            if recipient and recipient.read_date:
+                record.read_status = "read"
+            else:
+                record.read_status = "unread"
+
+    def _search_read_status(self, operator, value):
+        """Enable search on read_status for search panel"""
+        user = self.env.user
+        Recipient = self.env["sarabun.document.recipient"]
+
+        if operator == "=" and value == "read":
+            recipients = Recipient.search([
+                ("user_id", "=", user.id),
+                ("read_date", "!=", False),
+            ])
+        elif operator == "=" and value == "unread":
+            recipients = Recipient.search([
+                ("user_id", "=", user.id),
+                ("read_date", "=", False),
+            ])
+        else:
+            return [("id", "=", False)]
+
+        return [("id", "in", recipients.mapped("document_id").ids)]
+
     # === Onchange ===
     @api.onchange("route_template_id")
     def _onchange_route_template_id(self):
@@ -507,6 +551,33 @@ class SarabunDocument(models.Model):
         if not self.current_user_recipient_id:
             raise UserError(_("No pending action for you."))
         return self.current_user_recipient_id.action_reject()
+
+    def action_mark_as_unread(self):
+        """Mark current user's recipient as unread and redirect to inbox"""
+        self.ensure_one()
+        user = self.env.user
+        for recipient in self.recipient_ids.filtered(lambda r: r._can_user_access(user)):
+            recipient.sudo().mark_as_unread()
+
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Inbox"),
+            "res_model": "sarabun.document",
+            "view_mode": "tree,kanban,form",
+            "domain": [("recipient_ids.user_id", "=", user.id)],
+            "context": {},
+            "target": "current",
+            "views": [
+                (self.env.ref("agx_sarabun.sarabun_document_view_tree_inbox").id, "tree"),
+                (self.env.ref("agx_sarabun.sarabun_document_view_kanban").id, "kanban"),
+                (self.env.ref("agx_sarabun.sarabun_document_view_form").id, "form"),
+            ],
+        }
+
+    def action_mark_as_read(self):
+        """Mark current user's recipient as read (for tree view button)"""
+        self.ensure_one()
+        self._mark_recipient_read()
 
     def action_view_origin(self):
         """View origin record"""

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -402,11 +402,37 @@ class SarabunDocumentRecipient(models.Model):
         self.ensure_one()
         if self.state == "new" and not self.read_date:
             self.read_date = fields.Datetime.now()
+            self._notify_inbox_updated()
 
     def mark_as_unread(self):
         """Mark recipient as unread"""
         self.ensure_one()
         self.read_date = False
+        self._notify_inbox_updated()
+
+    def _notify_inbox_updated(self):
+        """Send bus notification to update systray"""
+        users_to_notify = self.env["res.users"]
+
+        if self.recipient_type == "user":
+            users_to_notify = self.user_id
+        elif self.recipient_type == "department" and self.department_id:
+            if self.department_id.sarabun_officer_ids:
+                users_to_notify = self.department_id.sarabun_officer_ids
+            elif self.department_id.manager_id:
+                users_to_notify = self.department_id.manager_id.user_id
+        elif self.recipient_type == "role" and self.role_id:
+            users_to_notify = self.role_id.get_users_for_document(self.document_id)
+
+        for user in users_to_notify:
+            self.env['bus.bus']._sendone(
+                user.partner_id,
+                'sarabun_inbox/updated',
+                {
+                    'refresh': True,
+                    'document_id': self.document_id.id,
+                }
+            )
 
     def read(self, fields=None, load="_classic_read"):
         """Override to track read_date when recipient form is opened"""

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -403,6 +403,11 @@ class SarabunDocumentRecipient(models.Model):
         if self.state == "new" and not self.read_date:
             self.read_date = fields.Datetime.now()
 
+    def mark_as_unread(self):
+        """Mark recipient as unread"""
+        self.ensure_one()
+        self.read_date = False
+
     def read(self, fields=None, load="_classic_read"):
         """Override to track read_date when recipient form is opened"""
         result = super().read(fields=fields, load=load)

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -325,7 +325,7 @@
                     <filter string="Date" name="group_date" context="{'group_by': 'date'}"/>
                 </group>
                 <searchpanel>
-                    <field name="read_status" string="สถานะการอ่าน" select="one" icon="fa-envelope"/>
+                    <field name="state" string="สถานะเอกสาร" select="one" icon="fa-flag"/>
                 </searchpanel>
             </search>
         </field>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -56,6 +56,39 @@
         </field>
     </record>
 
+    <!-- Tree View for Inbox (กล่องขาเข้า - with read/unread) -->
+    <record id="sarabun_document_view_tree_inbox" model="ir.ui.view">
+        <field name="name">sarabun.document.view.tree.inbox</field>
+        <field name="model">sarabun.document</field>
+        <field name="arch" type="xml">
+            <tree string="Inbox"
+                  decoration-muted="state == 'completed'"
+                  decoration-warning="read_status == 'unread'">
+                <field name="name"/>
+                <field name="date"/>
+                <field name="document_type_id"/>
+                <field name="subject"/>
+                <field name="sender_display" string="From"/>
+                <field name="activity_ids" widget="list_activity" optional="show"/>
+                <field name="urgency" optional="hide"/>
+                <field name="routing_progress" widget="progressbar"/>
+                <field name="state" widget="badge"
+                       decoration-info="state == 'draft'"
+                       decoration-warning="state == 'sent'"
+                       decoration-success="state == 'completed'"
+                       decoration-danger="state == 'cancelled'"/>
+                <field name="read_status" invisible="1"/>
+                <!-- Inline buttons at end of row -->
+                <button name="action_mark_as_read" type="object"
+                        icon="fa-envelope-open-o" title="Mark as Read"
+                        attrs="{'invisible': [('read_status', '=', 'read')]}"/>
+                <button name="action_mark_as_unread" type="object"
+                        icon="fa-envelope" title="Mark as Unread"
+                        attrs="{'invisible': [('read_status', '=', 'unread')]}"/>
+            </tree>
+        </field>
+    </record>
+
     <!-- Form View -->
     <record id="sarabun_document_view_form" model="ir.ui.view">
         <field name="name">sarabun.document.view.form</field>
@@ -69,6 +102,8 @@
                     <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': [('current_user_can_approve', '=', False)]}"/>
                     <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': ['|', ('current_user_recipient_id', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_print_report" string="Print" type="object" icon="fa-print" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+                    <button name="action_mark_as_unread" string="Mark as Unread" type="object" icon="fa-envelope"
+                            attrs="{'invisible': ['|', ('state', '=', 'draft'), ('read_status', '=', 'unread')]}"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed"/>
                 </header>
@@ -212,6 +247,7 @@
                     <field name="current_user_can_acknowledge" invisible="1"/>
                     <field name="current_user_can_approve" invisible="1"/>
                     <field name="has_delegated_report" invisible="1"/>
+                    <field name="read_status" invisible="1"/>
                 </sheet>
                 <!-- Attachment preview -->
                 <div class="o_attachment_preview"
@@ -255,6 +291,42 @@
                     <filter string="Sender Department" name="group_sender" context="{'group_by': 'sender_department_id'}"/>
                     <filter string="Date" name="group_date" context="{'group_by': 'date'}"/>
                 </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Search View for Inbox (with search panel) -->
+    <record id="sarabun_document_view_search_inbox" model="ir.ui.view">
+        <field name="name">sarabun.document.view.search.inbox</field>
+        <field name="model">sarabun.document</field>
+        <field name="arch" type="xml">
+            <search string="Inbox">
+                <field name="name"/>
+                <field name="subject"/>
+                <field name="sender_display" string="Sender"/>
+                <field name="sender_department_id"/>
+                <field name="document_type_id"/>
+                <separator/>
+                <filter string="Unread" name="unread" domain="[('read_status', '=', 'unread')]"/>
+                <filter string="Read" name="read" domain="[('read_status', '=', 'read')]"/>
+                <separator/>
+                <filter string="Pending Action" name="pending_action"
+                        domain="[('recipient_ids.user_id', '=', uid), ('recipient_ids.state', '=', 'new')]"/>
+                <separator/>
+                <filter string="Sent" name="sent" domain="[('state', '=', 'sent')]"/>
+                <filter string="Completed" name="completed" domain="[('state', '=', 'completed')]"/>
+                <separator/>
+                <filter string="Urgent" name="urgent" domain="[('urgency', 'in', ['urgent', 'very_urgent', 'immediate'])]"/>
+                <separator/>
+                <group expand="0" string="Group By">
+                    <filter string="Document Type" name="group_type" context="{'group_by': 'document_type_id'}"/>
+                    <filter string="State" name="group_state" context="{'group_by': 'state'}"/>
+                    <filter string="Sender Department" name="group_sender" context="{'group_by': 'sender_department_id'}"/>
+                    <filter string="Date" name="group_date" context="{'group_by': 'date'}"/>
+                </group>
+                <searchpanel>
+                    <field name="read_status" string="สถานะการอ่าน" select="one" icon="fa-envelope"/>
+                </searchpanel>
             </search>
         </field>
     </record>
@@ -338,18 +410,20 @@
         <field name="name">Inbox</field>
         <field name="res_model">sarabun.document</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="domain">[('recipient_ids.user_id', '=', uid), ('recipient_ids.state', '=', 'new')]</field>
+        <!-- Show all documents where user is a recipient (including completed) -->
+        <field name="domain">[('recipient_ids.user_id', '=', uid)]</field>
         <field name="context">{}</field>
+        <field name="search_view_id" ref="sarabun_document_view_search_inbox"/>
         <field name="view_ids" eval="[(5, 0, 0),
-            (0, 0, {'view_mode': 'tree', 'view_id': ref('sarabun_document_view_tree_incoming')}),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('sarabun_document_view_tree_inbox')}),
             (0, 0, {'view_mode': 'kanban', 'view_id': ref('sarabun_document_view_kanban')}),
             (0, 0, {'view_mode': 'form', 'view_id': ref('sarabun_document_view_form')})]"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-                No pending documents
+                No incoming documents
             </p>
             <p>
-                Documents requiring your action will appear here.
+                Documents sent to you will appear here.
             </p>
         </field>
     </record>

--- a/agx_sarabun/views/sarabun_menus.xml
+++ b/agx_sarabun/views/sarabun_menus.xml
@@ -5,6 +5,7 @@
         name="e-Sarabun"
         sequence="50"
         web_icon="agx_sarabun,static/description/icon.png"
+        action="action_sarabun_document_inbox"
         groups="group_sarabun_user"/>
 
     <!-- Documents Menu -->


### PR DESCRIPTION
Add comprehensive read/unread functionality to the sarabun document inbox with visual indicators and filtering. Documents now track whether recipients have opened them, with unread documents highlighted in orange and completed documents in grey. Users can mark documents as unread from the form view or toggle status from the inbox tree view using inline buttons. A search panel allows filtering by read status alongside other document attributes.