### PR TITLE
[16.0][ADD] kmitl_project: add public portal pages

### DIFF
--- a/kmitl_project/controller/kmitl_project.py
+++ b/kmitl_project/controller/kmitl_project.py
@@ -70,3 +70,45 @@ class KmitlProjectPortal(portal.CustomerPortal):
         values = self._get_page_view_values(project_sudo, access_token, {'kmitl_project': project_sudo}, False, False, **kw)
 
         return request.render("kmitl_project.portal_my_kmitl_project", values)
+
+    @http.route(['/projects', '/projects/page/<int:page>'], type='http', auth="public", website=True)
+    def portal_public_projects(self, page=1, **kw):
+        """Public list of KMITL Projects (excludes draft)"""
+        KmitlProject = request.env['kmitl.project'].sudo()
+
+        # Exclude draft state
+        domain = [("state", "!=", "draft")]
+        projects_count = KmitlProject.search_count(domain)
+
+        pager = portal_pager(
+            url="/projects",
+            total=projects_count,
+            page=page,
+            step=self._items_per_page
+        )
+
+        projects = KmitlProject.search(
+            domain, order='id desc',
+            limit=self._items_per_page,
+            offset=pager['offset']
+        )
+
+        values = {
+            'projects': projects,
+            'page_name': 'public_projects',
+            'pager': pager,
+            'default_url': '/projects',
+        }
+        return request.render("kmitl_project.portal_public_projects", values)
+
+    @http.route(['/project/<int:project_id>'], type='http', auth="public", website=True)
+    def portal_public_project(self, project_id=None, **kw):
+        """Public detail view (excludes draft)"""
+        project_sudo = request.env['kmitl.project'].sudo().browse(project_id)
+
+        # Block access to non-existent or draft projects
+        if not project_sudo.exists() or project_sudo.state == 'draft':
+            return request.redirect('/projects')
+
+        values = {'kmitl_project': project_sudo, 'page_name': 'public_project'}
+        return request.render("kmitl_project.portal_my_kmitl_project", values)

--- a/kmitl_project/views/portal_templates.xml
+++ b/kmitl_project/views/portal_templates.xml
@@ -17,6 +17,71 @@
         </xpath>
     </template>
 
+    <!-- Public Projects List View -->
+    <template id="portal_public_projects" name="Public KMITL Projects">
+        <t t-call="portal.portal_layout">
+            <t t-set="breadcrumbs_searchbar" t-value="True" />
+
+            <t t-call="portal.portal_searchbar">
+                <t t-set="title">โครงการ</t>
+            </t>
+
+            <t t-if="not projects">
+                <div class="alert alert-info">ยังไม่มีโครงการในระบบ</div>
+            </t>
+            <t t-else="">
+                <t t-call="portal.portal_table">
+                    <thead>
+                        <tr>
+                            <th>รหัสโครงการ</th>
+                            <th>ชื่อโครงการ</th>
+                            <th>ปีงบประมาณ</th>
+                            <th>หน่วยงาน</th>
+                            <th>สถานะ</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <t t-foreach="projects" t-as="project">
+                            <tr>
+                                <td>
+                                    <a t-attf-href="/project/#{project.id}">
+                                        <span
+                                            t-field="project.key"
+                                            t-if="project.key"
+                                        />
+                                        <span t-else="">-</span>
+                                    </a>
+                                </td>
+                                <td>
+                                    <a t-attf-href="/project/#{project.id}">
+                                        <span t-field="project.name" />
+                                    </a>
+                                </td>
+                                <td>
+                                    <span
+                                        t-field="project.account_fiscal_year_id.name"
+                                        t-if="project.account_fiscal_year_id"
+                                    />
+                                    <span t-else="">-</span>
+                                </td>
+                                <td>
+                                    <span
+                                        t-field="project.department_id.name"
+                                        t-if="project.department_id"
+                                    />
+                                    <span t-else="">-</span>
+                                </td>
+                                <td>
+                                    <span t-field="project.state" />
+                                </td>
+                            </tr>
+                        </t>
+                    </tbody>
+                </t>
+            </t>
+        </t>
+    </template>
+
     <!-- Projects List View -->
     <template id="portal_my_kmitl_projects" name="My KMITL Projects">
         <t t-call="portal.portal_layout">


### PR DESCRIPTION
## Summary
Add public portal pages to allow visitors to view KMITL projects without authentication.

## Changes
- `/projects`: Public list view showing all projects except draft state
- `/project/<id>`: Public detail view with access control to prevent viewing draft projects
- Reuses existing portal templates for consistent UI styling

## Test Plan
1. Visit `/projects` without login - should show all projects except draft
2. Click a project link - should navigate to `/project/<id>` detail page
3. Try direct access to draft project via `/project/<draft_id>` - should redirect to `/projects`