### PR TITLE
[16.0][IMP] purchase_order_kmit, purchase_manual_delivery: ปรับสถานะและปุ่มของสัญญา

### DIFF
--- a/purchase_manual_delivery_kmitl/__manifest__.py
+++ b/purchase_manual_delivery_kmitl/__manifest__.py
@@ -7,10 +7,11 @@
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
     'depends': ['purchase_manual_delivery'],
-    'data': [
-        'data/settings.xml',
-        'wizards/create_manual_stock_picking.xml',
-        'views/stock_picking_views.xml',
+    "data": [
+        "data/settings.xml",
+        "views/purchase_order_views.xml",
+        "views/stock_picking_views.xml",
+        "wizards/create_manual_stock_picking.xml"
     ],
     'installable': True,
     'auto_install': False,

--- a/purchase_manual_delivery_kmitl/i18n/th.po
+++ b/purchase_manual_delivery_kmitl/i18n/th.po
@@ -35,8 +35,13 @@ msgstr "ตั้งค่าการกำหนดค่า"
 
 #. module: purchase_manual_delivery
 #: model_terms:ir.ui.view,arch_db:purchase_manual_delivery.purchase_order_view_form_inherit
-msgid "Confirm Order"
-msgstr ""
+msgid "Confirm PO"
+msgstr "ยืนยันข้อมูล"
+
+#. module: purchase_manual_delivery_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_manual_delivery_kmitl.view_purchase_order_form
+msgid "Confirm PO"
+msgstr "ยินยันข้อมูล"
 
 #. module: purchase_manual_delivery
 #: model_terms:ir.ui.view,arch_db:purchase_manual_delivery.purchase_order_view_form_inherit

--- a/purchase_manual_delivery_kmitl/views/purchase_order_views.xml
+++ b/purchase_manual_delivery_kmitl/views/purchase_order_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <odoo>
+      
+    <!-- View purchase.order form -->
+    <record id="view_purchase_order_form" model="ir.ui.view">
+        <field name="name">view.purchase.order.form</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase_manual_delivery.purchase_order_view_form_inherit"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='button_confirm_manual'][@states='draft']" position="attributes">
+              <attribute name="string">Confirm PO</attribute>
+            </xpath>
+        </field>
+    </record>
+
+  </odoo>

--- a/purchase_order_kmitl/i18n/th.po
+++ b/purchase_order_kmitl/i18n/th.po
@@ -813,10 +813,10 @@ msgid ""
 "offers."
 msgstr "การเรียกประกวดราคา คือ เมื่อคุณต้องการสร้างคำขอใบเสนอราคากับผู้จำหน่ายหลายรายสำหรับชุดสินค้าที่กำหนดเพื่อเปรียบเทียบข้อเสนอ"
 
-#. module: purchase
+#. module: purchase, purchase_order_kmitl
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
-msgid "Cancel"
-msgstr "ยกเลิก"
+msgid "Cancel PO"
+msgstr "ยกเลิกสัญญา"
 
 #. module: purchase
 #. odoo-python
@@ -824,7 +824,7 @@ msgstr "ยกเลิก"
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_report__state__cancel
 #, python-format
 msgid "Cancelled"
-msgstr "ยกเลิก"
+msgstr "ยกเลิกสัญญา"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.report_purchaseorder_document
@@ -1102,7 +1102,7 @@ msgstr "โดเมน"
 #. module: purchase
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_report__state__done
 msgid "Done"
-msgstr "เสร็จสิ้น"
+msgstr "ปิดสัญญา"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_res_company__po_double_validation_amount
@@ -1117,7 +1117,7 @@ msgstr "ดาวน์โหลด"
 #. module: purchase
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_order__state__draft
 msgid "Draft"
-msgstr "ใบแจ้งขอใบเสนอราคา"
+msgstr "ร่าง"
 
 #. module: purchase
 #: model:ir.model.fields.selection,name:purchase.selection__purchase_report__state__draft
@@ -1419,12 +1419,22 @@ msgstr "ล็อก"
 msgid "Lock Confirmed Orders"
 msgstr "ล็อคคำสั่งซื้อที่ยืนยันแล้ว"
 
+#. module: purchase_order_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_order_kmitl.view_purchase_order_form
+msgid "Done"
+msgstr "ปิดสัญญา"
+
+#. module: purchase_order_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_order_kmitl.view_purchase_order_form
+msgid "Cancel PO"
+msgstr "ยกเลิกสัญญา"
+
 #. module: purchase
 #. odoo-python
 #: code:addons/purchase/controllers/portal.py:0 model:ir.model.fields.selection,name:purchase.selection__purchase_order__state__done
 #, python-format
-msgid "Locked"
-msgstr "ล็อก"
+msgid "Done"
+msgstr "ปิดสัญญา"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__message_main_attachment_id
@@ -1943,8 +1953,6 @@ msgstr "ระยะเวลาในการจัดซื้อ"
 #: model:ir.model.fields,field_description:purchase.field_account_payment__purchase_id
 #: model:ir.model.fields,field_description:purchase.field_purchase_bill_union__purchase_order_id
 #: model:ir.model.fields.selection,name:purchase.selection__account_analytic_applicability__business_domain__purchase_order
-#: model:ir.model.fields.selection,name:purchase.selection__purchase_order__state__purchase
-#: model:ir.model.fields.selection,name:purchase.selection__purchase_report__state__purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form model_terms:ir.ui.view,arch_db:purchase.purchase_order_graph
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_kpis_tree model_terms:ir.ui.view,arch_db:purchase.purchase_order_pivot
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_portal_content model_terms:ir.ui.view,arch_db:purchase.purchase_order_tree
@@ -1952,6 +1960,13 @@ msgstr "ระยะเวลาในการจัดซื้อ"
 #, python-format
 msgid "Purchase Order"
 msgstr "คำสั่งซื้อ"
+
+#. modules: purchase, purchase_order_kmitl
+#: model:ir.model.fields.selection,name:purchase.selection__purchase_order__state__purchase
+#: model:ir.model.fields.selection,name:purchase.selection__purchase_report__state__purchase
+#, python-format
+msgid "Open"
+msgstr "ใช้งานอยู่"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.report_purchaseorder_document

--- a/purchase_order_kmitl/models/purchase_order.py
+++ b/purchase_order_kmitl/models/purchase_order.py
@@ -33,3 +33,8 @@ class PurchaseOrder(models.Model):
         states=READONLY_STATES,
         tracking=True
     )
+
+    state = fields.Selection(selection_add=[
+        ("purchase", "Open"),
+        ("done", "Done")
+    ])

--- a/purchase_order_kmitl/views/purchase_order_views.xml
+++ b/purchase_order_kmitl/views/purchase_order_views.xml
@@ -34,6 +34,22 @@
             <xpath expr="//field[@name='product_id']" position="attributes">
                 <attribute name="optional">show</attribute>
             </xpath>
+             <xpath expr="//field[@name='state']" position="replace">
+                <field name="state" widget="statusbar" statusbar_visible="draft,purchase,done,cancel" readonly="1"/>
+            </xpath>
+            <xpath expr="//button[@name='button_cancel']" position="attributes">
+                <attribute name="string">Cancel PO</attribute>
+                <attribute name="states">purchase</attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_draft']" position="attributes">
+                <attribute name="states">done,cancel</attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_done']" position="attributes">
+                <attribute name="string">Done</attribute>
+            </xpath>
+            <xpath expr="//button[@name='button_unlock']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
แสดงสถานะของสัญญา/ใบสั่งซื้อ/จ้างดังนี้

ร่าง (Draft) | หลักจากอนุมัติ พจ.1 มาสร้าง ใบ PO จะเปลี่ยนเป็นสถานะ ร่าง (Draft)
ยืนยัน (Open) | หลังจากบันทึกข้อมูลใบ PO แล้วกดปุ่ม "ยืนยันข้อมูล" เดิมแสดงเป็น Confirm PO ให้แก้ไขเป็น "ยืนยันข้อมูล TH / Confirm PO EN" จะเปลี่ยนเป็นสถานะ ใช้งานอยู่ (Open)
ปิดสัญญา (Done) | หลังจากดำเนินการตามสัญญาครบถ้วนแล้วกดปุ่ม "ปิดสัญญา TH / Done EN"
ยกเลิกสัญญา (Cancelled) | ต้องกดปุ่ม "ยกเลิกสัญญา TH / Cancel PO EN " 
สถานะที่สามารถกดปุ่ม Cancel ได้

Open -> Cancelled 
Cancelled -> Reset to Draft 
Done -> Reset to Draft