### PR TITLE
[16.0][FIX] budget_appropriation: fix template names

### DIFF
--- a/budget_appropriation/controllers/budget_appropriation.py
+++ b/budget_appropriation/controllers/budget_appropriation.py
@@ -102,7 +102,7 @@ class BudgetAppropriation(http.Controller):
             return request.not_found()
 
         return http.request.render(
-            "budget_appropriation_portal.expense",
+            "budget_appropriation.expense",
             {
                 "object": first,
                 "objects": appropriations,
@@ -134,7 +134,7 @@ class BudgetAppropriation(http.Controller):
         report = request.env['budget.appropriation.f5.report'].get_f5_data_flat(budget_appropriation_id)
 
         return http.request.render(
-            "budget_appropriation_portal.expense_content",
+            "budget_appropriation.expense",
             {
                 "object": app_id,
                 "report": report,
@@ -182,7 +182,7 @@ class BudgetAppropriation(http.Controller):
             return request.not_found()
 
         return http.request.render(
-            "budget_appropriation_portal.expense_content",
+            "budget_appropriation.expense",
             {
                 "object": first,
                 "objects": appropriations,


### PR DESCRIPTION
## Summary
Fixed template name references in budget_appropriation controller. Changed incorrect `budget_appropriation_portal.*` template names to the correct `budget_appropriation.expense` template to match actual template definitions.

## Changes
- Line 105: `budget_appropriation_portal.expense` → `budget_appropriation.expense`
- Line 137: `budget_appropriation_portal.expense_content` → `budget_appropriation.expense`
- Line 185: `budget_appropriation_portal.expense_content` → `budget_appropriation.expense`

## Testing
Verify that the budget appropriation portal renders correctly with the updated template references.