### PR TITLE
[16.0][FIX] procurement_plan_budget: fix duplicate messages

### DIFF
--- a/procurement_plan_budget/models/budget_appropriation.py
+++ b/procurement_plan_budget/models/budget_appropriation.py
@@ -18,17 +18,27 @@ class BudgetAppropriation(models.Model):
         self._log_message_on_linked_documents()
 
     def _log_message_on_linked_documents(self):
-        for line in self.line_ids:
-            if line.procurement_plan_id:
-                self.message_post(
-                    body=line._message_link_to_procurement_plan(),
-                    message_type="comment",
-                )
+        procurement_lines = self.line_ids.filtered(lambda l: l.procurement_plan_id)
+        if not procurement_lines:
+            return
 
-                line.procurement_plan_id.message_post(
-                    body=line._message_link_back_from_procurement_plan(),
-                    message_type="comment",
-                )
+        # Post a single consolidated message on budget.appropriation
+        body_parts = []
+        for line in procurement_lines:
+            body_parts.append(line._message_link_to_procurement_plan())
+
+        if body_parts:
+            self.message_post(
+                body="<br/>".join(body_parts),
+                message_type="comment",
+            )
+
+        # Post individual messages on each procurement.plan
+        for line in procurement_lines:
+            line.procurement_plan_id.message_post(
+                body=line._message_link_back_from_procurement_plan(),
+                message_type="comment",
+            )
 
     def _get_record_url(self):
         return "/web#id={}&model={}&view_type=form".format(


### PR DESCRIPTION
## Summary
- Consolidate all procurement plan messages into a single message_post call on budget.appropriation
- Prevents duplicate messages when multiple lines with procurement plans are processed
- Still posts individual messages to each procurement.plan record for proper tracking

## Test Plan
- Create a budget appropriation with multiple lines linked to procurement plans
- Post the appropriation and verify only one message appears on the budget record
- Verify individual messages still appear on each procurement plan record