### PR TITLE
[16.0][FIX] procurement_plan_budget: fix TypeError when analytic_distribution is False

### DIFF
--- a/procurement_plan_budget/models/budget_appropriation_line.py
+++ b/procurement_plan_budget/models/budget_appropriation_line.py
@@ -48,7 +48,7 @@ class BudgetAppropriationLine(models.Model):
             procurement_plan_id = self._create_procurement_plan()
             account_id = procurement_plan_id.analytic_account_id
 
-            distribution = vals['analytic_distribution']
+            distribution = vals['analytic_distribution'] or {}
             distribution[str(account_id.id)] = 100
             vals['analytic_distribution'] = distribution
             vals['procurement_plan_id'] = procurement_plan_id.id


### PR DESCRIPTION
## Summary

Fixes a TypeError that occurs when posting a budget appropriation with `enable_procurement_plan=True` but without any analytic dimensions populated. The `analytic_distribution` field can be `False` when empty, but the code was treating it as a dictionary without checking.

## Changes

- Handle the case where `analytic_distribution` is `False` by converting it to an empty dict before assignment
- Uses defensive coding pattern: `distribution = vals['analytic_distribution'] or {}`

## Test Scenario

Create a budget appropriation with `enable_procurement_plan=True` and leave all analytic dimension fields empty. Posting the appropriation should now succeed without the TypeError.