### PR TITLE
[16.0][IMP] agx_sarabun: add document recall feature

### DIFF
--- a/agx_sarabun/__manifest__.py
+++ b/agx_sarabun/__manifest__.py
@@ -19,6 +19,7 @@
         "report/report_sarabun.xml",
         # Wizard
         "wizard/sarabun_routing_wizard_views.xml",
+        "views/sarabun_document_recall_wizard_views.xml",
         # Views
         "views/portal_template.xml",
         "views/sarabun_document_type_views.xml",

--- a/agx_sarabun/i18n/th.po
+++ b/agx_sarabun/i18n/th.po
@@ -303,6 +303,11 @@ msgid "Cancelled"
 msgstr "ยกเลิกแล้ว"
 
 #. module: agx_sarabun
+#: model:ir.model.fields.selection,name:agx_sarabun.selection__sarabun_document_recipient__state__cancelled_by_recall
+msgid "Cancelled (Recalled)"
+msgstr "ยกเลิก (เรียกคืน)"
+
+#. module: agx_sarabun
 #. odoo-python
 #: code:addons/agx_sarabun/models/sarabun_document_sequence.py:0
 #, python-format
@@ -1846,6 +1851,51 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:agx_sarabun.sarabun_document_recipient_view_search
 msgid "Rejected"
 msgstr ""
+
+#. module: agx_sarabun
+#: model:ir.model.fields.selection,name:agx_sarabun.selection__sarabun_document__state__recalled
+msgid "Recalled"
+msgstr "เรียกคืนแล้ว"
+
+#. module: agx_sarabun
+#. odoo-python
+#: code:addons/agx_sarabun/models/sarabun_document.py:0
+msgid "Recall Document"
+msgstr "เรียกคืนเอกสาร"
+
+#. module: agx_sarabun
+#: model:ir.model.fields,field_description:agx_sarabun.field_sarabun_document_recall_wizard__reason
+msgid "Reason for Recall"
+msgstr "เหตุผลในการเรียกคืน"
+
+#. module: agx_sarabun
+#. odoo-python
+#: code:addons/agx_sarabun/models/sarabun_document.py:0
+#, python-format
+msgid "Only sent documents can be recalled."
+msgstr "สามารถเรียกคืนได้เฉพาะเอกสารที่ส่งแล้วเท่านั้น"
+
+#. module: agx_sarabun
+#. odoo-python
+#: code:addons/agx_sarabun/models/sarabun_document.py:0
+#, python-format
+msgid "Only the sender can recall this document."
+msgstr "เฉพาะผู้ส่งเท่านั้นที่สามารถเรียกคืนเอกสาร"
+
+#. module: agx_sarabun
+#. odoo-python
+#: code:addons/agx_sarabun/models/sarabun_document.py:0
+#: code:addons/agx_sarabun/wizard/sarabun_document_recall_wizard.py:0
+#, python-format
+msgid "Please provide a reason for recalling this document."
+msgstr "กรุณาระบุเหตุผลในการเรียกคืนเอกสาร"
+
+#. module: agx_sarabun
+#. odoo-python
+#: code:addons/agx_sarabun/models/sarabun_document.py:0
+#, python-format
+msgid "Document recalled.\\nReason: %s"
+msgstr "เรียกคืนเอกสารแล้ว\\nเหตุผล: %s"
 
 #. module: agx_sarabun
 #: model:ir.model.fields,field_description:agx_sarabun.field_sarabun_recipient_reject_wizard__comment

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -10,6 +10,7 @@ READONLY_STATES = {
     "sent": [("readonly", True)],
     "completed": [("readonly", True)],
     "cancelled": [("readonly", True)],
+    "recalled": [("readonly", True)],
 }
 
 
@@ -191,6 +192,7 @@ class SarabunDocument(models.Model):
             ("sent", "Sent"),
             ("completed", "Completed"),
             ("cancelled", "Cancelled"),
+            ("recalled", "Recalled"),
         ],
         string="Status",
         required=True,
@@ -198,6 +200,30 @@ class SarabunDocument(models.Model):
         copy=False,
         tracking=True,
         default="draft",
+    )
+
+    # === Recall Tracking ===
+    recalled_by_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Recalled By",
+        readonly=True,
+        tracking=True,
+    )
+    recalled_date = fields.Datetime(
+        string="Recall Date",
+        readonly=True,
+    )
+    recall_reason = fields.Text(
+        string="Recall Reason",
+        readonly=True,
+    )
+    can_recall = fields.Boolean(
+        compute="_compute_can_recall",
+        string="Can Recall",
+    )
+    has_actioned_recipients = fields.Boolean(
+        compute="_compute_has_actioned_recipients",
+        string="Has Actioned Recipients",
     )
 
     # === Routing ===
@@ -394,6 +420,23 @@ class SarabunDocument(models.Model):
         for record in self:
             record.attachment_count = len(record.attachment_ids)
 
+    @api.depends("state", "sender_user_id")
+    def _compute_can_recall(self):
+        """Check if current user can recall this document (only sender)"""
+        for record in self:
+            record.can_recall = (
+                record.state == "sent" and record.sender_user_id == self.env.user
+            )
+
+    @api.depends("recipient_ids.state")
+    def _compute_has_actioned_recipients(self):
+        """Check if any recipients have acted on the document"""
+        for record in self:
+            actioned = record.recipient_ids.filtered(
+                lambda r: r.state in ("acknowledged", "approved", "rejected")
+            )
+            record.has_actioned_recipients = bool(actioned)
+
     # === Onchange ===
     @api.onchange("route_template_id")
     def _onchange_route_template_id(self):
@@ -486,6 +529,92 @@ class SarabunDocument(models.Model):
                 body=_("Document cancelled."),
                 message_type="notification",
             )
+
+    def action_recall(self):
+        """Open recall wizard to collect reason"""
+        self.ensure_one()
+
+        if self.state != "sent":
+            raise UserError(_("Only sent documents can be recalled."))
+
+        if self.sender_user_id != self.env.user:
+            raise UserError(_("Only the sender can recall this document."))
+
+        return {
+            "name": _("Recall Document"),
+            "type": "ir.actions.act_window",
+            "res_model": "sarabun.document.recall.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_document_id": self.id,
+                "default_has_actioned_recipients": self.has_actioned_recipients,
+            },
+        }
+
+    def action_do_recall(self, reason):
+        """Execute recall operation"""
+        self.ensure_one()
+
+        # Validate permissions and state
+        if self.state != "sent":
+            raise UserError(_("Only sent documents can be recalled."))
+        if self.sender_user_id != self.env.user:
+            raise UserError(_("Only the sender can recall this document."))
+        if not reason or not reason.strip():
+            raise UserError(_("Please provide a reason for recall."))
+
+        # Cancel active recipients
+        active_recipients = self.recipient_ids.filtered(lambda r: r.state == "new")
+        for recipient in active_recipients:
+            recipient._send_recall_notification()
+        active_recipients.write({"state": "cancelled_by_recall"})
+
+        # Cancel activities
+        activities = self.activity_ids.filtered(lambda a: a.user_id)
+        if activities:
+            activities.action_feedback(
+                feedback=_("Document recalled by %s") % self.env.user.name
+            )
+
+        # Update document state
+        self.write({
+            "state": "recalled",
+            "recalled_by_user_id": self.env.user.id,
+            "recalled_date": fields.Datetime.now(),
+            "recall_reason": reason,
+        })
+
+        # Post message
+        self.message_post(
+            body=_("Document recalled.\nReason: %s") % reason,
+            message_type="notification",
+        )
+
+        # Callback to origin model
+        self._on_document_recalled()
+
+        return True
+
+    def _on_document_recalled(self):
+        """Trigger callback to origin model"""
+        if self.origin_model and self.origin_res_id:
+            try:
+                origin = self.env[self.origin_model].sudo().browse(self.origin_res_id)
+                if origin.exists() and hasattr(origin, "_on_sarabun_recalled"):
+                    _logger.info(
+                        "Calling _on_sarabun_recalled on %s (id=%s)",
+                        self.origin_model,
+                        self.origin_res_id,
+                    )
+                    origin._on_sarabun_recalled(self)
+            except Exception as e:
+                _logger.exception(
+                    "Error calling _on_sarabun_recalled for %s (id=%s): %s",
+                    self.origin_model,
+                    self.origin_res_id,
+                    e,
+                )
 
     def action_acknowledge(self):
         """Acknowledge - delegate to current recipient"""

--- a/agx_sarabun/models/sarabun_document_mixin.py
+++ b/agx_sarabun/models/sarabun_document_mixin.py
@@ -127,6 +127,23 @@ class SarabunDocumentMixin(models.AbstractModel):
         """
         pass
 
+    def _on_sarabun_recalled(self, document):
+        """
+        Callback when sarabun document is recalled by sender.
+        Override this to handle recall in your model.
+
+        Args:
+            document: The recalled sarabun.document record
+
+        Example:
+            def _on_sarabun_recalled(self, document):
+                self.message_post(
+                    body=_("Sarabun document %s was recalled. Reason: %s")
+                    % (document.name, document.recall_reason)
+                )
+        """
+        pass
+
     def _on_sarabun_action(self, document, recipient, action):
         """
         Callback for every action on sarabun document.

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -81,6 +81,7 @@ class SarabunDocumentRecipient(models.Model):
             ("acknowledged", "Acknowledged"),
             ("approved", "Approved"),
             ("rejected", "Rejected"),
+            ("cancelled_by_recall", "Cancelled (Recalled)"),
         ],
         string="Status",
         default="new",
@@ -396,6 +397,40 @@ class SarabunDocumentRecipient(models.Model):
             lambda a: a.user_id == self.env.user
         )
         activities.action_feedback(feedback=_("Action completed"))
+
+    def _send_recall_notification(self):
+        """Send bus notification that document was recalled"""
+        self.ensure_one()
+        users = self._get_notification_users()
+
+        for user in users:
+            self.env["bus.bus"]._sendone(
+                user.partner_id,
+                "sarabun_inbox/updated",
+                {
+                    "refresh": True,
+                    "recalled": True,
+                    "subject": self.document_id.subject or self.document_id.name,
+                    "document_id": self.document_id.id,
+                },
+            )
+
+    def _get_notification_users(self):
+        """Get users to notify based on recipient type"""
+        self.ensure_one()
+        users = self.env["res.users"]
+
+        if self.recipient_type == "user":
+            users = self.user_id
+        elif self.recipient_type == "department" and self.department_id:
+            if self.department_id.sarabun_officer_ids:
+                users = self.department_id.sarabun_officer_ids
+            elif self.department_id.manager_id:
+                users = self.department_id.manager_id.user_id
+        elif self.recipient_type == "role" and self.role_id:
+            users = self.role_id.get_users_for_document(self.document_id)
+
+        return users
 
     def mark_as_read(self):
         """Mark recipient as read (first time opening)"""

--- a/agx_sarabun/security/ir.model.access.csv
+++ b/agx_sarabun/security/ir.model.access.csv
@@ -26,3 +26,4 @@ access_sarabun_document_recipient_user,sarabun.document.recipient.user,model_sar
 access_sarabun_document_recipient_manager,sarabun.document.recipient.manager,model_sarabun_document_recipient,group_sarabun_manager,1,1,1,1
 access_sarabun_recipient_reject_wizard,sarabun.recipient.reject.wizard,model_sarabun_recipient_reject_wizard,group_sarabun_user,1,1,1,1
 access_sarabun_route_selection_wizard,sarabun.route.selection.wizard,model_sarabun_route_selection_wizard,group_sarabun_user,1,1,1,1
+access_sarabun_document_recall_wizard,sarabun.document.recall.wizard,model_sarabun_document_recall_wizard,group_sarabun_user,1,1,1,1

--- a/agx_sarabun/views/sarabun_document_recall_wizard_views.xml
+++ b/agx_sarabun/views/sarabun_document_recall_wizard_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sarabun_document_recall_wizard_view_form" model="ir.ui.view">
+        <field name="name">sarabun.document.recall.wizard.form</field>
+        <field name="model">sarabun.document.recall.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Recall Document">
+                <div class="alert alert-warning" role="alert"
+                     attrs="{'invisible': [('has_actioned_recipients', '=', False)]}">
+                    <strong>คำเตือน:</strong> มีผู้รับบางรายได้รับทราบหรืออนุมัติเอกสารนี้แล้ว
+                    ผู้รับจะได้รับการแจ้งเตือนเรื่องการเรียกคืน
+                </div>
+                <group>
+                    <field name="has_actioned_recipients" invisible="1"/>
+                    <field name="document_name" readonly="1"/>
+                    <field name="document_subject" readonly="1"/>
+                </group>
+                <group>
+                    <field name="reason"
+                           placeholder="ระบุเหตุผลในการเรียกคืนเอกสาร..."
+                           required="1"
+                           nolabel="1"/>
+                </group>
+                <footer>
+                    <button string="เรียกคืนเอกสาร"
+                            name="action_confirm_recall"
+                            type="object"
+                            class="btn-primary"/>
+                    <button string="ยกเลิก"
+                            name="action_cancel"
+                            type="object"
+                            class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -5,7 +5,7 @@
         <field name="name">sarabun.document.view.tree</field>
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
-            <tree string="Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
+            <tree string="Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state in ('cancelled', 'recalled')">
                 <field name="name"/>
                 <field name="date"/>
                 <field name="document_type_id"/>
@@ -24,7 +24,7 @@
         <field name="name">sarabun.document.view.tree.incoming</field>
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
-            <tree string="Incoming Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
+            <tree string="Incoming Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state in ('cancelled', 'recalled')">
                 <field name="name"/>
                 <field name="date"/>
                 <field name="document_type_id"/>
@@ -43,7 +43,7 @@
         <field name="name">sarabun.document.view.tree.outgoing</field>
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
-            <tree string="Outgoing Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
+            <tree string="Outgoing Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state in ('cancelled', 'recalled')">
                 <field name="name"/>
                 <field name="date"/>
                 <field name="document_type_id"/>
@@ -68,6 +68,7 @@
                     <button name="action_acknowledge" string="Acknowledge" type="object" class="btn-primary" attrs="{'invisible': [('current_user_can_acknowledge', '=', False)]}"/>
                     <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': [('current_user_can_approve', '=', False)]}"/>
                     <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': ['|', ('current_user_recipient_id', '=', False), ('state', '!=', 'sent')]}"/>
+                    <button name="action_recall" string="เรียกคืน" type="object" class="btn-warning" attrs="{'invisible': [('can_recall', '=', False)]}" groups="agx_sarabun.group_sarabun_user"/>
                     <button name="action_print_report" string="Print" type="object" icon="fa-print" attrs="{'invisible': [('state', '=', 'draft')]}"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed"/>
@@ -212,6 +213,7 @@
                     <field name="current_user_can_acknowledge" invisible="1"/>
                     <field name="current_user_can_approve" invisible="1"/>
                     <field name="has_delegated_report" invisible="1"/>
+                    <field name="can_recall" invisible="1"/>
                 </sheet>
                 <!-- Attachment preview -->
                 <div class="o_attachment_preview"
@@ -246,6 +248,7 @@
                 <filter string="Sent" name="sent" domain="[('state', '=', 'sent')]"/>
                 <filter string="Completed" name="completed" domain="[('state', '=', 'completed')]"/>
                 <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancelled')]"/>
+                <filter string="เรียกคืนแล้ว" name="recalled" domain="[('state', '=', 'recalled')]"/>
                 <separator/>
                 <filter string="Urgent" name="urgent" domain="[('urgency', 'in', ['urgent', 'very_urgent', 'immediate'])]"/>
                 <separator/>

--- a/agx_sarabun/wizard/__init__.py
+++ b/agx_sarabun/wizard/__init__.py
@@ -2,3 +2,4 @@
 from . import sarabun_routing_wizard
 from . import sarabun_signing_wizard
 from . import sarabun_route_selection_wizard
+from . import sarabun_document_recall_wizard

--- a/agx_sarabun/wizard/sarabun_document_recall_wizard.py
+++ b/agx_sarabun/wizard/sarabun_document_recall_wizard.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class SarabunDocumentRecallWizard(models.TransientModel):
+    _name = "sarabun.document.recall.wizard"
+    _description = "Sarabun Document Recall Wizard"
+
+    document_id = fields.Many2one(
+        comodel_name="sarabun.document",
+        string="Document",
+        required=True,
+    )
+    has_actioned_recipients = fields.Boolean(
+        string="Has Actioned Recipients",
+        help="Some recipients have already acknowledged or approved",
+    )
+    reason = fields.Text(
+        string="Reason for Recall",
+        required=True,
+        help="Explain why this document is being recalled",
+    )
+
+    # Display fields
+    document_name = fields.Char(
+        related="document_id.name",
+        readonly=True,
+    )
+    document_subject = fields.Char(
+        related="document_id.subject",
+        readonly=True,
+    )
+
+    def action_confirm_recall(self):
+        """Confirm and execute the recall"""
+        self.ensure_one()
+
+        if not self.reason or not self.reason.strip():
+            raise UserError(_("Please provide a reason for recalling this document."))
+
+        self.document_id.action_do_recall(self.reason)
+
+        return {"type": "ir.actions.act_window_close"}
+
+    def action_cancel(self):
+        """Cancel the recall"""
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
## Summary

Add document recall/withdrawal functionality to the agx_sarabun electronic correspondence system. Senders can now recall sent documents before completion with a required reason for audit trail. Recipients are notified via bus notification, and origin models can handle recall events via callback.

## Key Features

- New "recalled" state separate from "cancelled"
- Recall allowed anytime before completion with warning if recipients acted
- Reason required for audit trail and compliance
- Only document sender can recall (not managers)
- Full Thai language translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)