### PR TITLE
[16.0][IMP] purchase_request_approval: replace tier_validation with agx_sarabun

### DIFF
--- a/kmitl_depends_dev/__manifest__.py
+++ b/kmitl_depends_dev/__manifest__.py
@@ -20,7 +20,7 @@
                 'partner_vat_required', 'stock_scrap_attachment', 'stock_scrap_hide_location_id', 'stock_scrap_origin_readonly_done',
                 'procurement_method_no_security', 'purchase_order_hide_create_bill_button', 'purchase_order_procurement_committee',
                 'purchase_order_received_qty_percent', 'purchase_order_report_kmitl', 'purchase_request_activity_kmitl',
-                'purchase_request_approval_disbursement', 'purchase_request_approval_attach_existing_attachments', 'purchase_request_approval_tier_validation',
+                'purchase_request_approval_disbursement', 'purchase_request_approval_attach_existing_attachments', 'purchase_request_approval_sarabun',
                 'purchase_request_attachment', 'purchase_request_hide_create_po_button', 'purchase_request_operating_unit_access_all',
                 'purchase_sequence_kmitl', 'purchase_request_sarabun', 'purchase_request_sequence_kmitl',
                 'purchase_request_ux_kmitl', 'purchase_work_acceptance_invoice_plan_deliverables', 'purchase_work_acceptance_invoice_plan_usability',

--- a/purchase_request_approval/__manifest__.py
+++ b/purchase_request_approval/__manifest__.py
@@ -16,6 +16,7 @@
         "thai_date_utils",
         "portal",
         "purchase_request_egp",
+        "agx_sarabun",
     ],
     "data": [
         "data/purchase_request_approval_sequence.xml",

--- a/purchase_request_approval/models/purchase_request_approval.py
+++ b/purchase_request_approval/models/purchase_request_approval.py
@@ -10,7 +10,7 @@ _logger = logging.getLogger(__name__)
 
 class PurchaseRequestApproval(models.Model):
     _name = "purchase.request.approval"
-    _inherit = ["mail.thread", "mail.activity.mixin", "portal.mixin", "thai.date.mixin", "tier.validation"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "portal.mixin", "thai.date.mixin", "sarabun.document.mixin"]
     _inherits = {"purchase.request": "request_id"}
 
     _description = "Purchase Request Approval"
@@ -101,6 +101,12 @@ class PurchaseRequestApproval(models.Model):
     )
 
     requesting_department_id = fields.Many2one('hr.department', string='Department', tracking=True)
+
+    main_sarabun_document_id = fields.Many2one(
+        comodel_name="sarabun.document",
+        string="Main Sarabun Document",
+        copy=False,
+    )
 
     report_html_url = fields.Char(compute="_compute_report_html_url")
 
@@ -250,3 +256,53 @@ class PurchaseRequestApproval(models.Model):
         action["views"] = [(form.id, "form")]
         action["res_id"] = self.request_id.id
         return action
+
+    def _prepare_sarabun_document_vals(self):
+        """Prepare values for creating a sarabun document."""
+        self.ensure_one()
+        vals = super()._prepare_sarabun_document_vals()
+        vals["subject"] = f"Purchase Request Approval: {self.name}"
+        return vals
+
+    def _on_sarabun_completed(self, document):
+        """Called when sarabun document routing is completed."""
+        _logger.info(
+            "Sarabun completed for PA %s from document %s",
+            self.name, document.name
+        )
+        self.button_approved()
+        self.message_post(
+            body=_("Approved via Sarabun document: %s") % document.name,
+        )
+
+    def _on_sarabun_rejected(self, document, recipient):
+        """Called when sarabun document is rejected."""
+        self.button_rejected()
+        reason = recipient.comment if recipient else _("No reason provided")
+        self.message_post(
+            body=_("Rejected via Sarabun. Reason: %s") % reason,
+        )
+
+    def action_submit_to_sarabun(self):
+        """Submit PA to Sarabun for approval routing."""
+        self.ensure_one()
+        if self.state != 'to_approve':
+            raise UserError(_("Only approvals in 'to_approve' state can be submitted to Sarabun."))
+
+        result = self.action_create_sarabun_document()
+        document = self.env["sarabun.document"].browse(result.get("res_id"))
+        self.main_sarabun_document_id = document
+        self.message_post(
+            body=_("Submitted to Sarabun: %s") % document.name,
+        )
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": 'sarabun.document',
+            "res_id": document.id,
+            "view_mode": "form",
+            "target": "current",
+        }
+
+    def _get_sarabun_report_action(self):
+        """Delegate Sarabun report to PA report."""
+        return self.env.ref("purchase_request_approval.action_report_purchase_request_approval")

--- a/purchase_request_approval/views/purchase_request_approval_views.xml
+++ b/purchase_request_approval/views/purchase_request_approval_views.xml
@@ -73,6 +73,13 @@
                         class="oe_highlight"
                     />
                     <button
+                        name="action_submit_to_sarabun"
+                        string="ส่งอนุมัติผ่าน Sarabun"
+                        type="object"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', ('state', '!=', 'to_approve'), ('sarabun_document_count', '>', 0)]}"
+                    />
+                    <button
                         name="button_approved"
                         states="to_approve"
                         string="Approve"
@@ -97,6 +104,16 @@
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+                        <field name="sarabun_document_count" invisible="1" />
+                        <button
+                            type="object"
+                            name="action_view_sarabun_documents"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                            attrs="{'invisible': [('sarabun_document_count', '=', 0)]}"
+                        >
+                            <field name="sarabun_document_count" widget="statinfo" string="Sarabun"/>
+                        </button>
                         <button
                             class="oe_stat_button"
                             type="object"

--- a/purchase_request_approval_sarabun/__init__.py
+++ b/purchase_request_approval_sarabun/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_request_approval_sarabun/__manifest__.py
+++ b/purchase_request_approval_sarabun/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Purchase Request Approval Sarabun',
+    'version': '16.0.1.0.0',
+    'summary': 'Purchase Request Approval Sarabun Integration',
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "category": "KMITL",
+    'depends': [
+        'purchase_request_approval',
+        'agx_sarabun',
+    ],
+    "data": [
+        "data/sarabun_route_template_data.xml",
+        "views/purchase_request_approval_views.xml",
+        "views/sarabun_document_views.xml",
+    ],
+    'installable': True,
+    'auto_install': False,
+    'license': 'LGPL-3',
+}

--- a/purchase_request_approval_sarabun/data/sarabun_route_template_data.xml
+++ b/purchase_request_approval_sarabun/data/sarabun_route_template_data.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Document Type -->
+        <record id="document_type_purchase_approval" model="sarabun.document.type">
+            <field name="name">Purchase Request Approval</field>
+            <field name="code">purchase_approval</field>
+            <field name="description">Purchase request approval routing</field>
+        </record>
+
+        <!-- Default Route Template -->
+        <record id="route_template_purchase_approval" model="sarabun.route.template">
+            <field name="name">Purchase Approval Route</field>
+            <field name="description">Standard approval route for purchase requests</field>
+            <field name="origin_model">purchase.request.approval</field>
+            <field name="document_type_id" ref="document_type_purchase_approval"/>
+            <field name="active">True</field>
+        </record>
+
+        <!-- Route Line: Manager Approval -->
+        <record id="route_line_manager_approve" model="sarabun.route.template.line">
+            <field name="template_id" ref="route_template_purchase_approval"/>
+            <field name="sequence">10</field>
+            <field name="routing_type">approve</field>
+            <field name="recipient_type">user</field>
+            <field name="user_id" ref="base.user_admin"/>
+        </record>
+    </data>
+</odoo>

--- a/purchase_request_approval_sarabun/data/sarabun_route_template_data.xml
+++ b/purchase_request_approval_sarabun/data/sarabun_route_template_data.xml
@@ -1,19 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <!-- Document Type -->
-        <record id="document_type_purchase_approval" model="sarabun.document.type">
-            <field name="name">Purchase Request Approval</field>
-            <field name="code">purchase_approval</field>
-            <field name="description">Purchase request approval routing</field>
-        </record>
-
         <!-- Default Route Template -->
         <record id="route_template_purchase_approval" model="sarabun.route.template">
             <field name="name">Purchase Approval Route</field>
-            <field name="description">Standard approval route for purchase requests</field>
+            <field name="description">Standard approval route for purchase request approvals</field>
             <field name="origin_model">purchase.request.approval</field>
-            <field name="document_type_id" ref="document_type_purchase_approval"/>
+            <field name="sequence">10</field>
             <field name="active">True</field>
         </record>
 

--- a/purchase_request_approval_sarabun/models/__init__.py
+++ b/purchase_request_approval_sarabun/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import purchase_request_approval

--- a/purchase_request_approval_sarabun/models/purchase_request_approval.py
+++ b/purchase_request_approval_sarabun/models/purchase_request_approval.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import logging
+from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseRequestApproval(models.Model):
+    _inherit = 'purchase.request.approval'
+
+    def _prepare_sarabun_document_vals(self):
+        """Override to add Thai subject formatting."""
+        vals = super()._prepare_sarabun_document_vals()
+        vals.update({
+            "subject": f"ขออนุมัติจัดซื้อจัดจ้าง: {self.name}",
+        })
+        return vals

--- a/purchase_request_approval_sarabun/views/purchase_request_approval_views.xml
+++ b/purchase_request_approval_sarabun/views/purchase_request_approval_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Hide direct approve/reject when using Sarabun -->
+    <record id="view_purchase_request_approval_form_sarabun" model="ir.ui.view">
+        <field name="name">purchase.request.approval.form.sarabun</field>
+        <field name="model">purchase.request.approval</field>
+        <field name="inherit_id" ref="purchase_request_approval.view_purchase_request_approval_form"/>
+        <field name="arch" type="xml">
+            <button name="button_approved" position="attributes">
+                <attribute name="attrs">{'invisible': [('sarabun_document_count', '>', 0)]}</attribute>
+            </button>
+            <button name="button_rejected" position="attributes">
+                <attribute name="attrs">{'invisible': [('sarabun_document_count', '>', 0)]}</attribute>
+            </button>
+        </field>
+    </record>
+
+    <!-- Add Sarabun review filter -->
+    <record id="view_purchase_request_approval_filter_sarabun" model="ir.ui.view">
+        <field name="name">purchase.request.approval.search.sarabun</field>
+        <field name="model">purchase.request.approval</field>
+        <field name="inherit_id" ref="purchase_request_approval.view_purchase_request_approval_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//search" position="inside">
+                <filter name="needs_sarabun_review"
+                    string="Needs my Sarabun Review"
+                    domain="[('main_sarabun_document_id.current_user_recipient_id', '!=', False)]"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_request_approval_sarabun/views/purchase_request_approval_views.xml
+++ b/purchase_request_approval_sarabun/views/purchase_request_approval_views.xml
@@ -15,16 +15,16 @@
         </field>
     </record>
 
-    <!-- Add Sarabun review filter -->
+    <!-- Add Sarabun filters -->
     <record id="view_purchase_request_approval_filter_sarabun" model="ir.ui.view">
         <field name="name">purchase.request.approval.search.sarabun</field>
         <field name="model">purchase.request.approval</field>
         <field name="inherit_id" ref="purchase_request_approval.view_purchase_request_approval_search"/>
         <field name="arch" type="xml">
             <xpath expr="//search" position="inside">
-                <filter name="needs_sarabun_review"
-                    string="Needs my Sarabun Review"
-                    domain="[('main_sarabun_document_id.current_user_recipient_id', '!=', False)]"/>
+                <filter name="has_sarabun_document"
+                    string="Has Sarabun Document"
+                    domain="[('main_sarabun_document_id', '!=', False)]"/>
             </xpath>
         </field>
     </record>

--- a/purchase_request_approval_sarabun/views/sarabun_document_views.xml
+++ b/purchase_request_approval_sarabun/views/sarabun_document_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Add PA smart button to Sarabun document -->
+    <record id="view_sarabun_document_form_pa" model="ir.ui.view">
+        <field name="name">sarabun.document.form.pa</field>
+        <field name="model">sarabun.document</field>
+        <field name="inherit_id" ref="agx_sarabun.view_sarabun_document_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_view_origin']" position="after">
+                <button type="object"
+                    name="action_view_origin"
+                    class="oe_stat_button"
+                    icon="fa-shopping-cart"
+                    attrs="{'invisible': [('origin_model', '!=', 'purchase.request.approval')]}"
+                    string="Purchase Approval"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_request_approval_tier_validation/__manifest__.py
+++ b/purchase_request_approval_tier_validation/__manifest__.py
@@ -11,7 +11,7 @@
         "data/tier_validation.xml",
         "views/purchase_request_approval_views.xml"
     ],
-    'installable': True,
+    'installable': False,  # Deprecated - replaced by purchase_request_approval_sarabun
     'auto_install': False,
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
## Summary

Replace the tier_validation system with agx_sarabun in purchase_request_approval modules for improved approval workflow and richer portal integration.

## Changes

- **Base module:** Replaced `tier.validation` mixin with `sarabun.document.mixin` and implemented Sarabun callbacks
- **New module:** Created `purchase_request_approval_sarabun` with routing templates and view extensions
- **Deprecation:** Marked `purchase_request_approval_tier_validation` as uninstallable and removed from dependencies
- **UI improvements:** Added "Submit to Sarabun" button and smart button for document navigation

## Testing

- Create purchase request approval and submit for approval
- Verify Sarabun document is created with correct routing
- Test approval and rejection workflows
- Verify state transitions and chatter messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)