### PR TITLE
[16.0][FIX] purchase_request: fix requested_by field reverting on save

### DIFF
--- a/purchase_request_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_kmitl/views/purchase_request_views.xml
@@ -47,7 +47,6 @@
             <xpath expr="//page[@name='committee']" position="after">
                 <page name="logs" string="Operation">
                     <group>
-                        <field name="requested_by" widget="many2one_avatar_user" readonly="1" />
                         <field name="date_start" readonly="1" />
                     </group>
                 </page>

--- a/purchase_request_ux_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_ux_kmitl/views/purchase_request_views.xml
@@ -50,12 +50,7 @@
             <xpath expr="//field[@name='title']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//field[@name='requested_by']" position="replace">
-                <field
-                    name="requested_by"
-                    attrs="{'readonly': [('is_editable','=', False)]}"
-                />
-            </xpath>
+            <xpath expr="//field[@name='requested_by']" position="replace"/>
             <xpath expr="//field[@name='account_fiscal_year_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
@@ -139,6 +134,10 @@
                         />
                         <field
                             name="description"
+                            attrs="{'readonly': [('is_editable','=', False)]}"
+                        />
+                        <field
+                            name="requested_by"
                             attrs="{'readonly': [('is_editable','=', False)]}"
                         />
                         <field

--- a/purchase_request_ux_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_ux_kmitl/views/purchase_request_views.xml
@@ -50,8 +50,11 @@
             <xpath expr="//field[@name='title']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//field[@name='requested_by']" position="attributes">
-                <attribute name="invisible">1</attribute>
+            <xpath expr="//field[@name='requested_by']" position="replace">
+                <field
+                    name="requested_by"
+                    attrs="{'readonly': [('is_editable','=', False)]}"
+                />
             </xpath>
             <xpath expr="//field[@name='account_fiscal_year_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
@@ -136,10 +139,6 @@
                         />
                         <field
                             name="description"
-                            attrs="{'readonly': [('is_editable','=', False)]}"
-                        />
-                        <field
-                            name="requested_by"
                             attrs="{'readonly': [('is_editable','=', False)]}"
                         />
                         <field


### PR DESCRIPTION
## Summary
Fixed duplicate field definitions of `requested_by` that were causing the field to revert to its previous value when saving. The field was being rendered multiple times in the form with conflicting attributes, causing Odoo to become confused during save operations.

## Changes
- Removed duplicate `requested_by` field from the Operation tab
- Removed duplicate `requested_by` field from the purchase request details group  
- Modified the main `requested_by` field to use proper `readonly` attributes based on `is_editable` state

## Test Plan
- Open a purchase request in edit mode
- Edit the `requested_by` field
- Save the record
- Verify the field value is preserved (not reverted)