### PR TITLE
[16.0][IMP] purchase_request: remove department dependency

### DIFF
--- a/kmitl_demo/__manifest__.py
+++ b/kmitl_demo/__manifest__.py
@@ -19,7 +19,6 @@
         "purchase_request_vendor_kmitl",
         "purchase_request_tender_kmitl",
         "purchase_request_egp",
-        "purchase_request_department",
         "purchase_request_budget",
         "purchase_request_price_tax_included",
         "purchase_request_approval_kmitl",

--- a/purchase_order_kmitl/__manifest__.py
+++ b/purchase_order_kmitl/__manifest__.py
@@ -12,7 +12,7 @@
         "account_fiscal_year",
         "hr",
         "purchase_operating_unit",
-        "purchase_request_department",
+        "purchase_request_kmitl",
     ],
     "data": ["views/purchase_order_views.xml"],
     "application": False,

--- a/purchase_request_sarabun/__manifest__.py
+++ b/purchase_request_sarabun/__manifest__.py
@@ -10,7 +10,6 @@
     "depends": [
         "purchase_request_kmitl",
         "purchase_request_budget",
-        "purchase_request_department",
         "purchase_request_attachment",
         "l10n_th_amount_to_text",
         "l10n_th_fonts",

--- a/purchase_request_sequence_kmitl/__manifest__.py
+++ b/purchase_request_sequence_kmitl/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    'depends': ['hr_department_short_name', 'purchase_request_department'],
+    'depends': ['hr_department_short_name', 'purchase_request_kmitl'],
     'data': [],
     'installable': True,
     'auto_install': False,

--- a/purchase_request_ux_kmitl/__manifest__.py
+++ b/purchase_request_ux_kmitl/__manifest__.py
@@ -5,7 +5,7 @@
     "category": "Purchase Management",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    "depends": ["l10n_th_gov_purchase_request", "purchase_request_kmitl", 'purchase_request_responsible_user', 'purchase_request_department', 'purchase_request_account_fiscal_year', 'purchase_request_payment_type', 'purchase_request_egp', 'purchase_request_operating_unit'],
+    "depends": ["l10n_th_gov_purchase_request", "purchase_request_kmitl", 'purchase_request_responsible_user', 'purchase_request_account_fiscal_year', 'purchase_request_payment_type', 'purchase_request_egp', 'purchase_request_operating_unit'],
     "data": [
         "views/purchase_request_views.xml"
     ],


### PR DESCRIPTION
Replace the deprecated purchase_request_department module dependency with purchase_request_kmitl across all affected modules. This simplifies the module dependencies and aligns with the current architecture.

Changes:
- Removed purchase_request_department from kmitl_demo dependencies
- Updated purchase_order_kmitl to depend on purchase_request_kmitl
- Removed purchase_request_department from purchase_request_sarabun dependencies
- Updated purchase_request_sequence_kmitl to depend on purchase_request_kmitl
- Updated purchase_request_ux_kmitl dependencies