### PR TITLE
[16.0][FIX] purchase_request: restore purchase_request_department dependency

### DIFF
--- a/kmitl_demo/__manifest__.py
+++ b/kmitl_demo/__manifest__.py
@@ -19,6 +19,7 @@
         "purchase_request_vendor_kmitl",
         "purchase_request_tender_kmitl",
         "purchase_request_egp",
+        "purchase_request_department",
         "purchase_request_budget",
         "purchase_request_price_tax_included",
         "purchase_request_approval_kmitl",

--- a/purchase_order_kmitl/__manifest__.py
+++ b/purchase_order_kmitl/__manifest__.py
@@ -12,7 +12,7 @@
         "account_fiscal_year",
         "hr",
         "purchase_operating_unit",
-        "purchase_request",
+        "purchase_request_department",
     ],
     "data": ["views/purchase_order_views.xml"],
     "application": False,

--- a/purchase_request_sarabun/__manifest__.py
+++ b/purchase_request_sarabun/__manifest__.py
@@ -10,6 +10,7 @@
     "depends": [
         "purchase_request_kmitl",
         "purchase_request_budget",
+        "purchase_request_department",
         "purchase_request_attachment",
         "l10n_th_amount_to_text",
         "l10n_th_fonts",

--- a/purchase_request_sequence_kmitl/__manifest__.py
+++ b/purchase_request_sequence_kmitl/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    'depends': ['hr_department_short_name', 'purchase_request_kmitl'],
+    'depends': ['hr_department_short_name', 'purchase_request_department'],
     'data': [],
     'installable': True,
     'auto_install': False,

--- a/purchase_request_ux_kmitl/__manifest__.py
+++ b/purchase_request_ux_kmitl/__manifest__.py
@@ -5,7 +5,7 @@
     "category": "Purchase Management",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    "depends": ["l10n_th_gov_purchase_request", "purchase_request_kmitl", 'purchase_request_responsible_user', 'purchase_request_account_fiscal_year', 'purchase_request_payment_type', 'purchase_request_egp', 'purchase_request_operating_unit'],
+    "depends": ["l10n_th_gov_purchase_request", "purchase_request_kmitl", 'purchase_request_responsible_user', 'purchase_request_department', 'purchase_request_account_fiscal_year', 'purchase_request_payment_type', 'purchase_request_egp', 'purchase_request_operating_unit'],
     "data": [
         "views/purchase_request_views.xml"
     ],


### PR DESCRIPTION
Reverts the changes from PR #489 which removed the purchase_request_department dependency. Restoring this dependency to maintain proper module relationships and prevent import issues in dependent modules.

**Changes:**
- Restored purchase_request_department dependency in 5 modules
- Affects: kmitl_demo, purchase_order_kmitl, purchase_request_sarabun, purchase_request_sequence_kmitl, purchase_request_ux_kmitl