### PR TITLE
[16.0][FIX] purchase_request_approval_disbursement: make purchase_order_id searchable

### DIFF
--- a/purchase_request_approval_disbursement/models/purchase_request_approval.py
+++ b/purchase_request_approval_disbursement/models/purchase_request_approval.py
@@ -16,7 +16,7 @@ class PurchaseRequestApproval(models.Model):
         comodel_name='purchase.order',
         compute='_compute_purchase_order_id',
         string='Purchase Order',
-        store=False,
+        store=True,
     )
 
     display_purchase_order = fields.Char(


### PR DESCRIPTION
## Summary
Fixed Odoo field dependency warning by making the `purchase_order_id` computed field searchable. The `display_purchase_order` field depends on `purchase_order_id.name`, but the field wasn't stored, preventing proper dependency tracking.

## Changes
- Changed `purchase_order_id` from `store=False` to `store=True` in purchase_request_approval_disbursement model

This enables Odoo to properly track when purchase order names change and recompute dependent fields.