### PR TITLE
[16.0][FIX] Remove invalid asset paths from manifests

### DIFF
--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -29,9 +29,6 @@
         "views/res_config_settings_views.xml",
         "views/account_move_views.xml",
     ],
-    "assets": {
-        "web.assets_backend": ["budget/static/src/**/*"],
-    },
     "auto_install": False,
     "application": True,
     "license": "AGPL-3",

--- a/kmitl_project_widget_ztree/__manifest__.py
+++ b/kmitl_project_widget_ztree/__manifest__.py
@@ -9,9 +9,6 @@
     "data": [
         "views/kmitl_project_views.xml"
     ],
-    "assets": {
-        "web.assets_backend": ["kmitl_project_widget_ztree/static/src/**/*"],
-    },
     "application": False,
     "installable": True,
     "auto_install": False,

--- a/purchase_kmitl/__manifest__.py
+++ b/purchase_kmitl/__manifest__.py
@@ -10,11 +10,6 @@
     'data': [
         "views/purchase.xml"
     ],
-    'assets': {
-              'web.assets_backend': [
-                  'purchase_kmitl/static/src/**/*'
-              ],
-          },
     'installable': True,
     'auto_install': False,
     'license': 'LGPL-3',

--- a/purchase_request_kmitl/__manifest__.py
+++ b/purchase_request_kmitl/__manifest__.py
@@ -29,11 +29,6 @@
         "views/purchase_request_views.xml",
         "wizards/purchase_request_line_make_purchase_order_views.xml",
     ],
-    'assets': {
-              'web.assets_backend': [
-                  'purchase_request_kmitl/static/src/**/*'
-              ],
-    },
     "installable": True,
     "auto_install": False,
     "license": "LGPL-3",

--- a/stock_kmitl/__manifest__.py
+++ b/stock_kmitl/__manifest__.py
@@ -10,11 +10,6 @@
     'data': [
         "views/stock.xml"
     ],
-    'assets': {
-              'web.assets_backend': [
-                  'stock_kmitl/static/src/**/*'
-              ],
-          },
     'installable': True,
     'auto_install': False,
     'license': 'LGPL-3',


### PR DESCRIPTION
Remove asset declarations pointing to non-existent static/src directories from five modules (budget, purchase_request_kmitl, kmitl_project_widget_ztree, purchase_kmitl, stock_kmitl). These modules don't contain frontend assets and the declarations were causing IrAsset resolution errors in the logs.