### PR TITLE
[16.0][IMP] budget_report: improve performance and code quality

### DIFF
--- a/budget_report/models/budget_report_summary.py
+++ b/budget_report/models/budget_report_summary.py
@@ -8,9 +8,6 @@ from .budget_tree import BudgetTree
 
 _logger = logging.getLogger(__name__)
 
-BUDGET_TYPE = "revenue"
-
-
 class BudgetReportSummary(models.AbstractModel):
     _name = _description = "budget.report.summary"
 
@@ -269,6 +266,27 @@ class BudgetReportSummary(models.AbstractModel):
             ("root_plan_id.code", "=", "departments"),
         ], order="code,name")
 
+        # Batch query: get all department IDs that have data (2 queries total)
+        move_dept_ids = set(
+            r["department_analytic_id"][0]
+            for r in self.env["budget.move.line"].read_group(
+                [("parent_state", "=", "posted")],
+                ["department_analytic_id"],
+                ["department_analytic_id"],
+            )
+            if r["department_analytic_id"]
+        )
+        commitment_dept_ids = set(
+            r["department_analytic_id"][0]
+            for r in self.env["budget.commitment"].read_group(
+                [("state", "in", ["reserved", "obligated"])],
+                ["department_analytic_id"],
+                ["department_analytic_id"],
+            )
+            if r["department_analytic_id"]
+        )
+        depts_with_data = move_dept_ids | commitment_dept_ids
+
         # Build hierarchy structure
         dept_dict = {}
         roots = []
@@ -280,7 +298,7 @@ class BudgetReportSummary(models.AbstractModel):
                 "code": dept.code,
                 "complete_name": dept.complete_name,
                 "children": [],
-                "has_data": self._department_has_data(dept),
+                "has_data": dept.id in depts_with_data,
             }
             dept_dict[dept.id] = dept_data
 
@@ -292,20 +310,6 @@ class BudgetReportSummary(models.AbstractModel):
                 roots.append(dept_data)
 
         return roots
-
-    def _department_has_data(self, department):
-        """Check if department has budget data"""
-        has_moves = self.env["budget.move.line"].search_count([
-            ("department_analytic_id", "=", department.id),
-            ("parent_state", "=", "posted"),
-        ], limit=1)
-
-        has_commitments = self.env["budget.commitment"].search_count([
-            ("department_analytic_id", "=", department.id),
-            ("state", "in", ["reserved", "obligated"]),
-        ], limit=1)
-
-        return bool(has_moves or has_commitments)
 
     @api.model
     def get_filter_options(self):

--- a/budget_report/models/budget_tree.py
+++ b/budget_report/models/budget_tree.py
@@ -29,8 +29,6 @@ class BudgetNode:
             "parent_id": self.value["parent_id"],
             "parent_path": self.value["parent_path"],
             "node_level": self.value["node_level"],
-            "children": list(map(lambda child: child.to_dict(), self.children)),
-            "lines": self.lines,
         }
 
     def appropriation(self):
@@ -82,15 +80,6 @@ class BudgetNode:
     def return_unspend(self):
         return 0
 
-    def has_descendant(self):
-        if self.children:
-            return True
-
-        for child in self.children:
-            if child.has_descendant():
-                return True
-
-        return False
 
 
 class BudgetTree:

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.js
@@ -38,6 +38,8 @@ export class BudgetReportSummary extends Component {
             },
         });
 
+        this._filterOptionsLoaded = false;
+
         onWillStart(async () => {
             await this.loadData();
         });
@@ -58,11 +60,14 @@ export class BudgetReportSummary extends Component {
             this.state.filters = response.filters;
             this.state.departments = response.departments || null;
 
-            this.state.filterOptions = await this.orm.call(
-                "budget.report.summary",
-                "get_filter_options",
-                []
-            );
+            if (!this._filterOptionsLoaded) {
+                this.state.filterOptions = await this.orm.call(
+                    "budget.report.summary",
+                    "get_filter_options",
+                    []
+                );
+                this._filterOptionsLoaded = true;
+            }
         } catch (error) {
             console.error("Error loading data:", error);
             this.notification.add("เกิดข้อผิดพลาดในการโหลดข้อมูล: " + error.message, {
@@ -140,30 +145,41 @@ export class BudgetReportSummary extends Component {
         return this.state.expandedRows.has(rowKey);
     }
 
-    isRowVisible(row) {
-        if (!row || !this.state.rows || !row.row_key) {
-            return false;
-        }
-
-        if (!row.parent_row_id) {
-            return true; // Root rows are always visible
-        }
-
-        // Find parent row
-        const parentRow = this.state.rows.find(r => r && r.row_key === row.parent_row_id);
-        if (!parentRow || !parentRow.row_key) {
-            return true; // Show row if parent not found (defensive)
-        }
-
-        // Row is visible if parent is expanded and parent is visible (recursive)
-        return this.isRowExpanded(parentRow.row_key) && this.isRowVisible(parentRow);
-    }
-
     get visibleRows() {
         if (!this.state.rows || !Array.isArray(this.state.rows)) {
             return [];
         }
-        return this.state.rows.filter(row => row && row.row_key && this.isRowVisible(row));
+
+        // Build O(1) lookup map
+        const rowMap = new Map();
+        for (const row of this.state.rows) {
+            if (row && row.row_key) {
+                rowMap.set(row.row_key, row);
+            }
+        }
+
+        // Cache visibility results
+        const cache = new Map();
+        const isVisible = (row) => {
+            if (!row || !row.row_key) return false;
+            if (cache.has(row.row_key)) return cache.get(row.row_key);
+
+            let result;
+            if (!row.parent_row_id) {
+                result = true;
+            } else {
+                const parentRow = rowMap.get(row.parent_row_id);
+                if (!parentRow || !parentRow.row_key) {
+                    result = true;
+                } else {
+                    result = this.isRowExpanded(parentRow.row_key) && isVisible(parentRow);
+                }
+            }
+            cache.set(row.row_key, result);
+            return result;
+        };
+
+        return this.state.rows.filter(row => row && row.row_key && isVisible(row));
     }
 
     expandAll() {
@@ -326,7 +342,6 @@ export class BudgetReportSummary extends Component {
         // Add row-specific analytic filters based on row type
         await this._addRowAnalyticFilters(domain, row);
 
-        console.log('Final move line domain:', domain, 'Row:', row);
         return domain;
     }
 
@@ -351,14 +366,11 @@ export class BudgetReportSummary extends Component {
         // Add row-specific analytic filters
         await this._addRowAnalyticFilters(domain, row);
 
-        console.log('Final commitment domain:', domain, 'Row:', row);
         return domain;
     }
 
     // Add analytic filters based on row context using code-based filtering
     async _addRowAnalyticFilters(domain, row) {
-        console.log('Adding analytic filters for row:', row);
-
         // Use code-based filtering with ilike for simpler and more reliable filtering
         if (row.type === 'activity') {
             // For activity rows, filter by activity code and its children using prefix
@@ -466,8 +478,6 @@ export class BudgetReportSummary extends Component {
                 "get_analytic_ids_by_code_prefix",
                 [code, field_name]
             );
-            console.log(`${field_name} IDs for code ${code}:`, analyticIds);
-
             if (analyticIds && analyticIds.length > 0) {
                 domain.push([field_name, 'in', analyticIds]);
             }
@@ -484,8 +494,6 @@ export class BudgetReportSummary extends Component {
                 "get_budget_account_ids_by_code_prefix",
                 [code, parentCode]
             );
-            console.log(`Account IDs for code ${code}:`, accountIds);
-
             if (accountIds && accountIds.length > 0) {
                 domain.push(['account_id', 'in', accountIds]);
             }
@@ -512,14 +520,11 @@ export class BudgetReportSummary extends Component {
     // Get department IDs including children
     async _getDepartmentWithChildren(departmentIds) {
         try {
-            const allDeptIds = [];
-            for (const deptId of departmentIds) {
-                const children = await this._getAnalyticWithChildren(deptId, 'departments');
-                allDeptIds.push(...children);
-            }
-            return [...new Set(allDeptIds)]; // Remove duplicates
+            const results = await Promise.all(
+                departmentIds.map(deptId => this._getAnalyticWithChildren(deptId, 'departments'))
+            );
+            return [...new Set(results.flat())];
         } catch (error) {
-            console.warn("Failed to get department children, using original IDs:", error);
             return departmentIds;
         }
     }

--- a/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
+++ b/budget_report/static/src/components/budget_report_summary/budget_report_summary.xml
@@ -104,6 +104,14 @@
                     
                     <!-- Report Content -->
                     <div class="report-content">
+                        <div t-if="state.loading" class="d-flex justify-content-center align-items-center p-5">
+                            <div class="text-center">
+                                <div class="spinner-border text-primary mb-3" role="status">
+                                    <span class="visually-hidden">Loading...</span>
+                                </div>
+                                <div class="text-muted">กำลังโหลดข้อมูล...</div>
+                            </div>
+                        </div>
                         <div t-if="!state.loading" class="budget_report_summary_content">
                             <div class="row justify-content-center">
                                 <div class="col-12">
@@ -239,6 +247,12 @@
                                             </t>
                                         </tbody>
                                     </table>
+                                    <div t-if="!visibleRows.length" class="d-flex justify-content-center align-items-center p-5">
+                                        <div class="text-center text-muted">
+                                            <i class="fa fa-inbox fa-3x mb-3 d-block"/>
+                                            <p>ไม่พบข้อมูล</p>
+                                        </div>
+                                    </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- Remove redundant children/lines from BudgetNode serialization to reduce JSON payload
- Batch N+1 department queries using read_group (2 queries instead of N per page load)
- Cache filter options on initial load instead of fetching on every data refresh
- Optimize visibleRows visibility check from O(n²) to O(n) with Map-based lookup
- Parallelize department RPC calls with Promise.all for improved responsiveness
- Clean up debug console.log statements
- Add loading spinner and empty state UX

## Test plan
- Open "สรุปการใช้งบประมาณภาพรวม" report
- Verify loading spinner appears during data fetch
- Verify all expand/collapse functionality works
- Verify drill-down links open correct views
- Test department filter selection
- Check that no debug logs appear in browser console
- Test with empty data to verify empty state message