### PR TITLE
[16.0][IMP] budget: fix duplicate methods and add appropriation_type

### DIFF
--- a/budget/models/budget_controller.py
+++ b/budget/models/budget_controller.py
@@ -451,73 +451,6 @@ class BudgetController(models.AbstractModel):
         return total
 
     @api.model
-    def _line_matches_analytic_data(self, line, analytic_data):
-        """Check if budget move line matches analytic data hierarchically"""
-        # Exact match for budget account and source (no hierarchy)
-        if (line.account_id.id != analytic_data.get('account_id') or
-            (line.source_analytic_id.id if line.source_analytic_id else False) != analytic_data.get('source_analytic_id')):
-            return False
-
-        # For activities, departments, and funds, check hierarchical relationships
-        activity_match = self._analytic_accounts_match_hierarchical(
-            line.activity_analytic_id,
-            self.env['account.analytic.account'].browse(analytic_data.get('activity_analytic_id')) if analytic_data.get('activity_analytic_id') else False
-        )
-        department_match = self._analytic_accounts_match_hierarchical(
-            line.department_analytic_id,
-            self.env['account.analytic.account'].browse(analytic_data.get('department_analytic_id')) if analytic_data.get('department_analytic_id') else False
-        )
-        fund_match = self._analytic_accounts_match_hierarchical(
-            line.fund_analytic_id,
-            self.env['account.analytic.account'].browse(analytic_data.get('fund_analytic_id')) if analytic_data.get('fund_analytic_id') else False
-        )
-
-        return activity_match and department_match and fund_match
-
-    @api.model
-    def _analytic_accounts_match_hierarchical(self, move_account, commitment_account):
-        """
-        Check if analytic accounts match hierarchically.
-
-        For appropriations: move_account (parent) can provide budget for commitment_account (child)
-
-        Args:
-            move_account: Analytic account from move line (could be parent providing budget)
-            commitment_account: Analytic account needed for commitment (could be child needing budget)
-
-        Returns:
-            bool: True if accounts match hierarchically
-        """
-        # Handle None cases
-        if not move_account and not commitment_account:
-            return True
-        if not move_account or not commitment_account:
-            return False
-
-        # Exact match
-        if move_account.id == commitment_account.id:
-            return True
-
-        # Check if move_account is a parent of commitment_account
-        # This allows parent-level appropriations to cover child-level commitments
-        if commitment_account.parent_path and move_account.id:
-            # Extract parent IDs from commitment_account's parent_path
-            parent_ids = self._get_parent_ids_from_path(commitment_account.parent_path)
-            return move_account.id in parent_ids
-
-        return False
-
-    @api.model
-    def _get_parent_ids_from_path(self, parent_path):
-        """Extract parent IDs from parent_path field"""
-        if not parent_path:
-            return []
-
-        # parent_path format: "1/2/3/" - extract all IDs
-        path_parts = parent_path.strip('/').split('/')
-        return [int(id_str) for id_str in path_parts if id_str.isdigit()]
-
-    @api.model
     def _commitment_line_matches_analytic_data(self, commitment, analytic_data):
         """Check if commitment matches analytic data (exact match for commitments)"""
         # For commitments, we use exact matching since they represent specific allocations
@@ -558,11 +491,6 @@ class BudgetController(models.AbstractModel):
             return False
 
         return True
-
-    def _commitment_line_matches_analytic_data(self, line, analytic_data):
-        """Check if commitment line matches the given analytic data"""
-        # Same logic as budget move lines
-        return self._line_matches_analytic_data(line, analytic_data)
 
     def _analytic_matches_hierarchical(self, parent_id, child_id):
         """Check if analytic accounts match hierarchically"""

--- a/budget/models/budget_move.py
+++ b/budget/models/budget_move.py
@@ -254,6 +254,16 @@ class BudgetMove(models.Model):
         states=READONLY_STATES,
     )
 
+    appropriation_type = fields.Selection(
+        selection=[
+            ("initial", "งบประมาณต้นปี"),
+            ("supplementary", "งบประมาณเพิ่มเติม"),
+        ],
+        string="ประเภทการจัดสรร",
+        tracking=True,
+        help="ใช้แยกประเภทการจัดสรรงบประมาณ ต้นปี vs ระหว่างปี",
+    )
+
     total_amount = fields.Float(
         string="Total Amount",
         compute="_compute_amount",
@@ -278,6 +288,11 @@ class BudgetMove(models.Model):
         compute='_compute_first_account_id',
         store=False
     )
+
+    @api.depends('line_ids.account_id')
+    def _compute_first_account_id(self):
+        for move in self:
+            move.first_account_id = move.line_ids[:1].account_id
 
     @api.depends(
         "line_ids.balance",

--- a/budget/views/budget_move_views.xml
+++ b/budget/views/budget_move_views.xml
@@ -75,6 +75,7 @@
                             <field name="source_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' required="1" />
                             <field name="budget_type" options='{"no_create": True, "no_create_edit": True,"no_open": True}' required="1" attrs="{'readonly': [('id', '!=', False)]}" />
                             <field name="move_type" required="1" />
+                            <field name="appropriation_type" attrs="{'invisible': [('move_type', '!=', 'appropriation')]}" />
                         </group>
                     </group>
                     <notebook>

--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -158,6 +158,18 @@ class BudgetAppropriation(models.Model):
         default="expense",
         states=READONLY_STATES,
     )
+    appropriation_type = fields.Selection(
+        selection=[
+            ("initial", "งบประมาณต้นปี"),
+            ("supplementary", "งบประมาณเพิ่มเติม"),
+        ],
+        string="ประเภทการจัดสรร",
+        tracking=True,
+        copy=True,
+        default="initial",
+        states=READONLY_STATES,
+        help="ใช้แยกประเภทการจัดสรรงบประมาณ ต้นปี vs ระหว่างปี",
+    )
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
@@ -320,6 +332,7 @@ class BudgetAppropriation(models.Model):
     def budget_move_vals(self):
         vals = {
             "move_type": "appropriation",
+            "appropriation_type": self.appropriation_type,
             "date": self.date,
             "ref": self.ref,
             "department_analytic_id": self.department_analytic_id.id,

--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -167,6 +167,7 @@ class BudgetAppropriation(models.Model):
         tracking=True,
         copy=True,
         default="initial",
+        readonly=False,
         states=READONLY_STATES,
         help="ใช้แยกประเภทการจัดสรรงบประมาณ ต้นปี vs ระหว่างปี",
     )

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -58,6 +58,7 @@
                             <field name="department_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' required="1" />
                             <field name="source_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' required="1" />
                             <field name="budget_type" required="1" attrs="{'readonly': [('id', '!=', False)]}" />
+                            <field name="appropriation_type" />
                         </group>
                         <group string="ข้อมูลทั่วไป">
                             <field name="date" invisible="1" />


### PR DESCRIPTION
## Summary
- Fixed critical bug: removed duplicate `_commitment_line_matches_analytic_data` that incorrectly used hierarchical matching instead of exact matching for commitments
- Removed unused orphaned methods that duplicated logic
- Added missing `_compute_first_account_id` implementation
- Added `appropriation_type` field to distinguish initial vs supplementary budget allocations

## Changes
- budget_controller.py: Removed 72 lines of duplicate/orphaned code
- budget_move.py: Added appropriation_type field and _compute_first_account_id method
- budget_move_views.xml: Display appropriation_type when move_type is 'appropriation'