### PR TITLE
[16.0][IMP] agx_sarabun: per-user inbox read/unread

### DIFF
--- a/agx_sarabun/models/__init__.py
+++ b/agx_sarabun/models/__init__.py
@@ -8,5 +8,6 @@ from . import sarabun_routing_line
 from . import sarabun_document_recipient
 from . import sarabun_reference
 from . import sarabun_document_mixin
+from . import sarabun_inbox
 from . import hr_department
 from . import res_users

--- a/agx_sarabun/models/res_users.py
+++ b/agx_sarabun/models/res_users.py
@@ -11,26 +11,19 @@ class ResUsers(models.Model):
         Return recent unread sarabun documents (up to 10).
         Used by the systray notification widget.
         """
-        Recipient = self.env["sarabun.document.recipient"]
-        user = self.env.user
+        Inbox = self.env["sarabun.inbox"]
 
-        # Build domain for recipients the current user can access
-        # and that are in 'new' state (unread/unactioned)
-        recipients = Recipient.sudo().search([
-            ("state", "=", "new"),
+        entries = Inbox.search([
+            ("user_id", "=", self.env.user.id),
+            ("is_read", "=", False),
             ("document_id.state", "=", "sent"),
         ], order="create_date desc")
 
-        # Filter to only recipients this user can access
-        accessible_recipients = recipients.filtered(
-            lambda r: r._can_user_access(user)
-        )
-
-        # Get unique documents (a document may have multiple recipients)
+        # Deduplicate by document
         seen_docs = set()
         documents = []
-        for recipient in accessible_recipients:
-            doc = recipient.document_id
+        for entry in entries:
+            doc = entry.document_id
             if doc.id not in seen_docs:
                 seen_docs.add(doc.id)
                 documents.append({

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -235,6 +235,11 @@ class SarabunDocument(models.Model):
         compute="_compute_routing_counts",
     )
 
+    # === Current User Inbox ===
+    current_user_inbox_is_read = fields.Boolean(
+        compute="_compute_current_user_inbox_is_read",
+    )
+
     # === Current User Action ===
     current_user_recipient_id = fields.Many2one(
         comodel_name="sarabun.document.recipient",
@@ -388,6 +393,36 @@ class SarabunDocument(models.Model):
             record.current_user_can_approve = (
                 bool(recipient) and recipient.routing_type == "approve"
             )
+
+    def _compute_current_user_inbox_is_read(self):
+        for record in self:
+            inbox = self.env["sarabun.inbox"].search([
+                ("user_id", "=", self.env.user.id),
+                ("document_id", "=", record.id),
+            ], limit=1)
+            record.current_user_inbox_is_read = inbox.is_read if inbox else True
+
+    def action_mark_inbox_read(self):
+        """Mark inbox as read for current user"""
+        self.ensure_one()
+        inbox_entries = self.env["sarabun.inbox"].search([
+            ("user_id", "=", self.env.user.id),
+            ("document_id", "=", self.id),
+            ("is_read", "=", False),
+        ])
+        if inbox_entries:
+            inbox_entries.action_mark_read()
+
+    def action_mark_inbox_unread(self):
+        """Mark inbox as unread for current user"""
+        self.ensure_one()
+        inbox_entries = self.env["sarabun.inbox"].search([
+            ("user_id", "=", self.env.user.id),
+            ("document_id", "=", self.id),
+            ("is_read", "=", True),
+        ])
+        if inbox_entries:
+            inbox_entries.action_mark_unread()
 
     @api.depends("attachment_ids")
     def _compute_attachment_count(self):
@@ -739,6 +774,22 @@ class SarabunDocument(models.Model):
             if recipient._can_user_access(user):
                 recipient.mark_as_read()
 
+    def _mark_inbox_read(self):
+        """Mark inbox entries as read for current user"""
+        self.ensure_one()
+        inbox_entries = self.env["sarabun.inbox"].sudo().search([
+            ("user_id", "=", self.env.user.id),
+            ("document_id", "=", self.id),
+            ("is_read", "=", False),
+        ])
+        if inbox_entries:
+            inbox_entries.write({"is_read": True})
+            self.env["bus.bus"]._sendone(
+                self.env.user.partner_id,
+                "sarabun_inbox/updated",
+                {"refresh": True},
+            )
+
     def read(self, fields=None, load="_classic_read"):
         """Override to track read_date when document form is opened"""
         result = super().read(fields=fields, load=load)
@@ -749,6 +800,7 @@ class SarabunDocument(models.Model):
             for record in self:
                 if record.state == "sent":
                     record.sudo()._mark_recipient_read()
+                    record.sudo()._mark_inbox_read()
 
         return result
 

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -774,22 +774,6 @@ class SarabunDocument(models.Model):
             if recipient._can_user_access(user):
                 recipient.mark_as_read()
 
-    def _mark_inbox_read(self):
-        """Mark inbox entries as read for current user"""
-        self.ensure_one()
-        inbox_entries = self.env["sarabun.inbox"].sudo().search([
-            ("user_id", "=", self.env.user.id),
-            ("document_id", "=", self.id),
-            ("is_read", "=", False),
-        ])
-        if inbox_entries:
-            inbox_entries.write({"is_read": True})
-            self.env["bus.bus"]._sendone(
-                self.env.user.partner_id,
-                "sarabun_inbox/updated",
-                {"refresh": True},
-            )
-
     def read(self, fields=None, load="_classic_read"):
         """Override to track read_date when document form is opened"""
         result = super().read(fields=fields, load=load)
@@ -800,7 +784,6 @@ class SarabunDocument(models.Model):
             for record in self:
                 if record.state == "sent":
                     record.sudo()._mark_recipient_read()
-                    record.sudo()._mark_inbox_read()
 
         return result
 

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -225,6 +225,9 @@ class SarabunDocumentRecipient(models.Model):
         # Mark activities as done
         self._mark_activities_done()
 
+        # Mark inbox as read
+        self._mark_inbox_read_for_user(self.env.user)
+
         # Trigger callback on origin
         self.document_id._trigger_origin_action_callback(self, "acknowledge")
 
@@ -257,6 +260,9 @@ class SarabunDocumentRecipient(models.Model):
 
         # Mark activities as done
         self._mark_activities_done()
+
+        # Mark inbox as read
+        self._mark_inbox_read_for_user(self.env.user)
 
         # Trigger callback on origin
         self.document_id._trigger_origin_action_callback(self, "approve")
@@ -303,6 +309,9 @@ class SarabunDocumentRecipient(models.Model):
 
         # Mark activities as done
         self._mark_activities_done()
+
+        # Mark inbox as read
+        self._mark_inbox_read_for_user(self.env.user)
 
         # Trigger callback on origin
         self.document_id._trigger_origin_action_callback(self, "reject")
@@ -361,17 +370,15 @@ class SarabunDocumentRecipient(models.Model):
         elif self.recipient_type == "role" and self.role_id:
             users_to_notify = self.role_id.get_users_for_document(self.document_id)
 
-        routing_type_labels = dict(self._fields["routing_type"].selection)
-        action_label = routing_type_labels.get(self.routing_type, self.routing_type)
-
-        # for user in users_to_notify:
-        #     self.document_id.activity_schedule(
-        #         "mail.mail_activity_data_todo",
-        #         user_id=user.id,
-        #         summary=_("Document requires your action: %s") % action_label,
-        #         note=_("Document: %s\nSubject: %s")
-        #         % (self.document_id.name, self.document_id.subject),
-        #     )
+        # Create per-user inbox records
+        Inbox = self.env["sarabun.inbox"].sudo()
+        for user in users_to_notify:
+            Inbox.create({
+                "user_id": user.id,
+                "document_id": self.document_id.id,
+                "recipient_id": self.id,
+                "is_read": False,
+            })
 
         # Send bus notification for real-time systray update
         for user in users_to_notify:
@@ -389,6 +396,16 @@ class SarabunDocumentRecipient(models.Model):
             "is_notified": True,
             "notification_date": fields.Datetime.now(),
         })
+
+    def _mark_inbox_read_for_user(self, user):
+        """Mark inbox entries as read for a specific user"""
+        inbox = self.env["sarabun.inbox"].sudo().search([
+            ("user_id", "=", user.id),
+            ("recipient_id", "=", self.id),
+            ("is_read", "=", False),
+        ])
+        if inbox:
+            inbox.write({"is_read": True})
 
     def _mark_activities_done(self):
         """Mark related activities as done"""

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -370,15 +370,20 @@ class SarabunDocumentRecipient(models.Model):
         elif self.recipient_type == "role" and self.role_id:
             users_to_notify = self.role_id.get_users_for_document(self.document_id)
 
-        # Create per-user inbox records
+        # Create per-user inbox records (one per document per user)
         Inbox = self.env["sarabun.inbox"].sudo()
         for user in users_to_notify:
-            Inbox.create({
-                "user_id": user.id,
-                "document_id": self.document_id.id,
-                "recipient_id": self.id,
-                "is_read": False,
-            })
+            # Check if inbox already exists for this user-document combination
+            existing = Inbox.search([
+                ("user_id", "=", user.id),
+                ("document_id", "=", self.document_id.id),
+            ], limit=1)
+            if not existing:
+                Inbox.create({
+                    "user_id": user.id,
+                    "document_id": self.document_id.id,
+                    "is_read": False,
+                })
 
         # Send bus notification for real-time systray update
         for user in users_to_notify:
@@ -401,7 +406,7 @@ class SarabunDocumentRecipient(models.Model):
         """Mark inbox entries as read for a specific user"""
         inbox = self.env["sarabun.inbox"].sudo().search([
             ("user_id", "=", user.id),
-            ("recipient_id", "=", self.id),
+            ("document_id", "=", self.document_id.id),
             ("is_read", "=", False),
         ])
         if inbox:

--- a/agx_sarabun/models/sarabun_inbox.py
+++ b/agx_sarabun/models/sarabun_inbox.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from odoo import _, api, fields, models
+
+
+class SarabunInbox(models.Model):
+    """Per-user inbox read/unread status, independent of recipient state."""
+
+    _name = "sarabun.inbox"
+    _description = "Sarabun Inbox"
+    _order = "create_date desc"
+
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="User",
+        required=True,
+        index=True,
+        ondelete="cascade",
+    )
+    document_id = fields.Many2one(
+        comodel_name="sarabun.document",
+        string="Document",
+        required=True,
+        index=True,
+        ondelete="cascade",
+    )
+    recipient_id = fields.Many2one(
+        comodel_name="sarabun.document.recipient",
+        string="Recipient",
+        required=True,
+        ondelete="cascade",
+    )
+    is_read = fields.Boolean(
+        string="Read",
+        default=False,
+        index=True,
+    )
+
+    _sql_constraints = [
+        (
+            "unique_user_recipient",
+            "unique(user_id, recipient_id)",
+            "Duplicate inbox entry for user and recipient",
+        ),
+    ]
+
+    def action_mark_read(self):
+        """Mark inbox entries as read"""
+        self.write({"is_read": True})
+        self._notify_inbox_updated()
+
+    def action_mark_unread(self):
+        """Mark inbox entries as unread"""
+        self.write({"is_read": False})
+        self._notify_inbox_updated()
+
+    def _notify_inbox_updated(self):
+        """Send bus notification to refresh systray"""
+        for user_id in self.mapped("user_id").ids:
+            partner = self.env["res.users"].browse(user_id).partner_id
+            self.env["bus.bus"]._sendone(
+                partner,
+                "sarabun_inbox/updated",
+                {"refresh": True},
+            )

--- a/agx_sarabun/models/sarabun_inbox.py
+++ b/agx_sarabun/models/sarabun_inbox.py
@@ -23,12 +23,6 @@ class SarabunInbox(models.Model):
         index=True,
         ondelete="cascade",
     )
-    recipient_id = fields.Many2one(
-        comodel_name="sarabun.document.recipient",
-        string="Recipient",
-        required=True,
-        ondelete="cascade",
-    )
     is_read = fields.Boolean(
         string="Read",
         default=False,
@@ -37,9 +31,9 @@ class SarabunInbox(models.Model):
 
     _sql_constraints = [
         (
-            "unique_user_recipient",
-            "unique(user_id, recipient_id)",
-            "Duplicate inbox entry for user and recipient",
+            "unique_user_document",
+            "unique(user_id, document_id)",
+            "Duplicate inbox entry for user and document",
         ),
     ]
 

--- a/agx_sarabun/security/ir.model.access.csv
+++ b/agx_sarabun/security/ir.model.access.csv
@@ -26,3 +26,5 @@ access_sarabun_document_recipient_user,sarabun.document.recipient.user,model_sar
 access_sarabun_document_recipient_manager,sarabun.document.recipient.manager,model_sarabun_document_recipient,group_sarabun_manager,1,1,1,1
 access_sarabun_recipient_reject_wizard,sarabun.recipient.reject.wizard,model_sarabun_recipient_reject_wizard,group_sarabun_user,1,1,1,1
 access_sarabun_route_selection_wizard,sarabun.route.selection.wizard,model_sarabun_route_selection_wizard,group_sarabun_user,1,1,1,1
+access_sarabun_inbox_user,sarabun.inbox.user,model_sarabun_inbox,group_sarabun_user,1,1,1,0
+access_sarabun_inbox_manager,sarabun.inbox.manager,model_sarabun_inbox,group_sarabun_manager,1,1,1,1

--- a/agx_sarabun/security/security.xml
+++ b/agx_sarabun/security/security.xml
@@ -133,5 +133,13 @@
             <field name="groups" eval="[(4, ref('group_sarabun_manager'))]"/>
             <field name="domain_force">[(1, '=', 1)]</field>
         </record>
+
+        <!-- Inbox Rules -->
+        <record id="sarabun_inbox_user_rule" model="ir.rule">
+            <field name="name">Sarabun Inbox: Own Records Only</field>
+            <field name="model_id" ref="model_sarabun_inbox"/>
+            <field name="groups" eval="[(4, ref('group_sarabun_user'))]"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+        </record>
     </data>
 </odoo>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -6,14 +6,14 @@
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
             <tree string="Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
+                <field name="urgency" optional="hide"/>
+                <field name="recipient" string="To"/>
                 <field name="name"/>
-                <field name="date"/>
-                <field name="document_type_id"/>
                 <field name="subject"/>
                 <field name="sender_display" string="From"/>
-                <field name="recipient" string="To"/>
-                <field name="urgency" optional="hide"/>
-                <field name="routing_progress" widget="progressbar"/>
+                <field name="date"/>
+                <field name="document_type_id"/>
+                <field name="routing_progress" widget="progressbar" optional="hide" />
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-danger="state == 'cancelled'"/>
             </tree>
         </field>
@@ -24,17 +24,19 @@
         <field name="name">sarabun.document.view.tree.incoming</field>
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
-            <tree string="Incoming Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'" decoration-bf="current_user_inbox_is_read == False">
+            <tree string="Incoming Documents" decoration-success="state == 'completed'" decoration-primary="not current_user_inbox_is_read" decoration-muted="current_user_inbox_is_read == True or state == 'cancelled'">
                 <field name="current_user_inbox_is_read" invisible="1"/>
-                <field name="name" decoration-bf="current_user_inbox_is_read == False"/>
-                <field name="date"/>
-                <field name="document_type_id"/>
-                <field name="subject" decoration-bf="current_user_inbox_is_read == False"/>
-                <field name="sender_display" string="From"/>
-                <field name="activity_ids" widget="list_activity" optional="show"/>
                 <field name="urgency" optional="hide"/>
-                <field name="routing_progress" widget="progressbar"/>
+                <field name="sender_display" string="From"/>
+                <field name="name" decoration-bf="current_user_inbox_is_read == False"/>
+                <field name="subject" decoration-bf="current_user_inbox_is_read == False"/>
+                <field name="document_type_id"/>
+                <field name="activity_ids" widget="list_activity" optional="hide"/>
+                <field name="routing_progress" widget="progressbar" optional="hide" />
+                <field name="date"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-danger="state == 'cancelled'"/>
+                <button name="action_mark_inbox_read" type="object" icon="fa-envelope-open" attrs="{'invisible': [('current_user_inbox_is_read', '=', True)]}"/>
+                <button name="action_mark_inbox_unread" type="object" icon="fa-envelope" attrs="{'invisible': [('current_user_inbox_is_read', '=', False)]}"/>
             </tree>
         </field>
     </record>
@@ -45,13 +47,13 @@
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
             <tree string="Outgoing Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
-                <field name="name"/>
-                <field name="date"/>
-                <field name="document_type_id"/>
-                <field name="subject"/>
-                <field name="recipient" string="To"/>
                 <field name="urgency" optional="hide"/>
-                <field name="routing_progress" widget="progressbar"/>
+                <field name="recipient" string="To"/>
+                <field name="subject"/>
+                <field name="name"/>
+                <field name="document_type_id"/>
+                <field name="routing_progress" widget="progressbar" optional="hide" />
+                <field name="date"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-danger="state == 'cancelled'"/>
             </tree>
         </field>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -24,11 +24,12 @@
         <field name="name">sarabun.document.view.tree.incoming</field>
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
-            <tree string="Incoming Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
-                <field name="name"/>
+            <tree string="Incoming Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'" decoration-bf="current_user_inbox_is_read == False">
+                <field name="current_user_inbox_is_read" invisible="1"/>
+                <field name="name" decoration-bf="current_user_inbox_is_read == False"/>
                 <field name="date"/>
                 <field name="document_type_id"/>
-                <field name="subject"/>
+                <field name="subject" decoration-bf="current_user_inbox_is_read == False"/>
                 <field name="sender_display" string="From"/>
                 <field name="activity_ids" widget="list_activity" optional="show"/>
                 <field name="urgency" optional="hide"/>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -69,6 +69,7 @@
                     <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': [('current_user_can_approve', '=', False)]}"/>
                     <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': ['|', ('current_user_recipient_id', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_print_report" string="Print" type="object" icon="fa-print" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+                    <button name="action_mark_inbox_unread" string="Mark as Unread" type="object" class="btn-secondary" icon="fa-envelope" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed"/>
                 </header>
@@ -212,6 +213,7 @@
                     <field name="current_user_can_acknowledge" invisible="1"/>
                     <field name="current_user_can_approve" invisible="1"/>
                     <field name="has_delegated_report" invisible="1"/>
+                    <field name="current_user_inbox_is_read" invisible="1"/>
                 </sheet>
                 <!-- Attachment preview -->
                 <div class="o_attachment_preview"

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -69,6 +69,7 @@
                     <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': [('current_user_can_approve', '=', False)]}"/>
                     <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': ['|', ('current_user_recipient_id', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_print_report" string="Print" type="object" icon="fa-print" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+                    <button name="action_mark_inbox_read" string="Mark as Read" type="object" class="btn-secondary" icon="fa-envelope-open" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', True), ('state', '!=', 'sent')]}"/>
                     <button name="action_mark_inbox_unread" string="Mark as Unread" type="object" class="btn-secondary" icon="fa-envelope" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed"/>


### PR DESCRIPTION
## Summary
- New `sarabun.inbox` model tracks read/unread status per user per document
- Auto-mark read when opening document or performing actions (acknowledge/approve/reject)
- Manual mark read/unread toggle on document form header
- Systray counts unread from inbox instead of recipient state

## Motivation
Department/role recipients couldn't track individual user read status. The `read_date` field on recipient serves as audit trail and shouldn't be used for UI state. This separates concerns: `read_date` = audit trail (immutable), `is_read` = UI state (toggleable).

## Testing
- Create document, send to user/department/role recipients
- Verify systray badge shows correct unread count per user
- Open document → auto-marks as read, count decreases
- Click "Mark as Unread" → count increases
- Perform action → auto-marks as read
- Verify `read_date` unchanged when toggling read/unread