### PR TITLE
[16.0][IMP] agx_sarabun: notification sound only for new messages

### DIFF
--- a/agx_sarabun/static/src/js/sarabun_notification_handler.esm.js
+++ b/agx_sarabun/static/src/js/sarabun_notification_handler.esm.js
@@ -32,6 +32,14 @@ export const sarabunNotificationHandler = {
                         continue;
                     }
 
+                    // Only play sound/notification for new messages
+                    // New messages have subject or document_id in payload
+                    // Mark as read/unread only has {refresh: true}
+                    const isNewMessage = payload.subject || payload.document_id;
+                    if (!isNewMessage) {
+                        continue;
+                    }
+
                     // Show browser notification
                     if ("Notification" in window && Notification.permission === "granted") {
                         const notification = new Notification("เอกสารใหม่", {


### PR DESCRIPTION
## Summary
Play notification sound only when receiving new documents, not when marking messages as read/unread through inbox actions. The systray counter still updates in both cases for consistency.

## Test plan
- Receive a new Sarabun document → Sound should play
- Click mark as read/unread action → Sound should NOT play
- Verify systray updates in both cases