### PR TITLE
[16.0][FIX] purchase_request_budget: เงื่อนไขการกรอกรหัสงบประมาณในใบ พ.1

### DIFF
--- a/purchase_request_budget/data/purchase_request_exception.xml
+++ b/purchase_request_budget/data/purchase_request_exception.xml
@@ -6,8 +6,9 @@
         <field name="model">purchase.request</field>
         <field name="exception_type">by_py_code</field>
         <field name="code"><![CDATA[
-if not self.budget_account_id or not self.activity_analytic_id or not self.department_analytic_id or not self.fund_analytic_id or not self.source_analytic_id:
-    failed = True
+if self.state == 'to_verify':
+    if not self.budget_account_id or not self.activity_analytic_id or not self.department_analytic_id or not self.fund_analytic_id or not self.source_analytic_id:
+        failed = True
 ]]>
         </field>
     </record>

--- a/purchase_request_budget/models/purchase_request.py
+++ b/purchase_request_budget/models/purchase_request.py
@@ -100,7 +100,7 @@ class PurchaseRequest(models.Model):
     def _compute_is_budget_editable(self):
         can_edit = self.env.user.has_group("budget.group_budget_commitment")
         for rec in self:
-            if rec.state in ("to_approve") and (
+            if rec.state in ("to_verify", "to_approve") and (
                 not rec.budget_commitment_id
                 or rec.budget_commitment_id.state == "cancel"
             ):

--- a/purchase_request_budget/models/purchase_request_line.py
+++ b/purchase_request_budget/models/purchase_request_line.py
@@ -15,6 +15,15 @@ class PurchaseRequestLine(models.Model):
         related='request_id.analytic_distribution'
     )
 
+    product_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        domain=lambda self: self._get_unit_domain(),
+    )
+
+    def _get_unit_domain(self):
+        unit_category = self.env.ref('uom.product_uom_categ_unit')
+        return [('category_id', '=', unit_category.id)]
+
     @api.onchange("product_id")
     def onchange_product_id(self):
         pass

--- a/purchase_request_budget/views/purchase_request_views.xml
+++ b/purchase_request_budget/views/purchase_request_views.xml
@@ -35,15 +35,15 @@
                     <field name="is_budget_editable" invisible="1" />
                     <field name="analytic_distribution" invisible="1" />
 
-                    <field name="budget_account_id" required="1" attrs="{'readonly': [('is_budget_editable', '=', False)]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
+                    <field name="budget_account_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
                     <field name="budget_account_id" invisible="1" />
-                    <field name="activity_analytic_id" required="1" attrs="{'readonly': [('is_budget_editable', '=', False)]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
+                    <field name="activity_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
                     <field name="activity_analytic_id" invisible="1" />
-                    <field name="department_analytic_id" required="1" attrs="{'readonly': [('is_budget_editable', '=', False)]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
+                    <field name="department_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}" />
                     <field name="department_analytic_id" invisible="1" />
-                    <field name="fund_analytic_id" widget="selection" required="1" attrs="{'readonly': [('is_budget_editable', '=', False)]}" />
+                    <field name="fund_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" />
                     <field name="fund_analytic_id" widget="selection" invisible="1" />
-                    <field name="source_analytic_id" widget="selection" required="1" attrs="{'readonly': [('is_budget_editable', '=', False)]}" />
+                    <field name="source_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" />
                     <field name="source_analytic_id" widget="selection" invisible="1" />
                     <field name="product_id" invisible="1" />
                 </group>


### PR DESCRIPTION
Test Plan — PR #512: [FIX] purchase_request_budget เงื่อนไขการกรอกรหัสงบประมาณในใบ พ.1
สรุปการเปลี่ยนแปลง
ฟิลด์งบประมาณ (budget_account, activity, department, fund, source) ไม่บังคับกรอกตั้งแต่ต้น แต่จะบังคับเฉพาะเมื่อ state = to_verify
is_budget_editable เปิดให้แก้ได้ทั้งใน state to_verify และ to_approve (เดิมเฉพาะ to_approve)
Exception rule ตรวจสอบรหัสงบประมาณ เฉพาะเมื่อ state = to_verify (เดิมตรวจทุก state)
product_uom_id ในบรรทัด จำกัด domain ให้เลือกได้เฉพาะหน่วยนับประเภท Unit เท่านั้น

**1. การสร้างและ Submit ใบ พ.1 โดยไม่กรอกรหัสงบประมาณ
 

- [x] สร้างใบ พ.1 ใหม่ (state = draft) โดยไม่กรอก budget_account, activity, department, fund, source — ต้องบันทึกได้ ไม่ error

 

- [x] กด Submit (ส่งไปยัง state ถัดไป เช่น to_approve) โดยไม่กรอกรหัสงบประมาณ — ต้องผ่านได้ ไม่มี validation block

 

- [x] ฟิลด์งบประมาณยังแสดงบน form แต่ไม่มีดาวแดง (required indicator) ใน state draft

**2. ฟิลด์งบประมาณบังคับเมื่อ state = to_verify

- [x]  เมื่อใบ พ.1 อยู่ใน state to_verify ฟิลด์ทั้ง 5 มีดาวแดง (required)

 

- [x] พยายาม save/ยืนยันใบ พ.1 ขณะ state = to_verify โดยไม่กรอก budget_account_id — ต้อง error บอกว่าจำเป็น

- [x]  กรอกฟิลด์งบประมาณครบทั้ง 5 ใน state to_verify — ต้องผ่านได้ปกติ

**3. Exception Rule ตรวจสอบเฉพาะ state = to_verify

- [x] เมื่อ state = to_verify และไม่มีรหัสงบประมาณ — Exception rule ต้อง trigger (แสดง popup แจ้งเตือน)

- [x] เมื่อ state = to_verify และกรอกรหัสงบประมาณครบ — Exception rule ต้อง ไม่ trigger

**4. is_budget_editable — แก้ไขได้ใน to_verify และ to_approve

- [ ] ใบ พ.1 ใน state to_verify/to_approve ที่มี budget commitment ที่ active อยู่ — ฟิลด์งบประมาณต้อง ไม่สามารถแก้ไขได้

- [ ] ใบ พ.1 ใน state to_verify/to_approve ที่มี budget commitment ถูก cancel — ฟิลด์งบประมาณต้องแก้ไขได้

**5. product_uom_id domain จำกัดเฉพาะหน่วยนับประเภท Unit
 

- [x] เปิด form ใบ พ.1 และเพิ่มบรรทัดสินค้า — dropdown ของ product_uom_id แสดงเฉพาะหน่วยนับที่อยู่ใน category "Unit" (ชิ้น, อัน, ชุด ฯลฯ)

 

- [x] หน่วยนับประเภทอื่น (เช่น น้ำหนัก, ปริมาตร, เวลา) ต้องไม่ปรากฏใน dropdown

 

- [x] เลือกหน่วยนับที่ถูก domain ได้และบันทึกได้ปกติ

**6. Regression Test — ฟีเจอร์เดิมยังทำงานได้ปกติ
 

- [x] Workflow ปกติ: draft → submit → to_verify (กรอกงบประมาณ) → to_approve → approved ยังทำงานได้ครบถ้วน

- [x] การผูก budget commitment กับใบ พ.1 ยังทำงานได้ปกติ

- [x] User ที่มี group budget.group_budget_commitment เท่านั้นที่แก้ไขฟิลด์งบประมาณได้