### PR TITLE
[16.0][IMP] budget_project: add budget.project reservation model for kmitl_project

### DIFF
--- a/budget_project/__manifest__.py
+++ b/budget_project/__manifest__.py
@@ -23,9 +23,12 @@ Features:
         "kmitl_project"
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/budget_account_project_update.xml",
+        "views/budget_project_views.xml",
         "views/budget_account_views.xml",
         "views/budget_appropriation_views.xml",
+        "views/kmitl_project_views.xml",
         "views/menu_views.xml",
     ],
     "assets": {

--- a/budget_project/models/__init__.py
+++ b/budget_project/models/__init__.py
@@ -1,4 +1,6 @@
 from . import budget_account
+from . import budget_project
 from . import budget_move_line
 from . import budget_appropriation_line
 from . import budget_appropriation
+from . import kmitl_project

--- a/budget_project/models/budget_appropriation.py
+++ b/budget_project/models/budget_appropriation.py
@@ -1,27 +1,39 @@
-# -*- coding: utf-8 -*-
 import logging
 
-from odoo import models, fields, api, _
-from odoo.exceptions import UserError, ValidationError
+from odoo import _, fields, models
 
 _logger = logging.getLogger(__name__)
 
 
 class BudgetAppropriation(models.Model):
-    _inherit = 'budget.appropriation'
+    _inherit = "budget.appropriation"
 
     def action_post(self):
         super().action_post()
-        self._create_budget_project()
+        self._log_message_on_linked_documents()
 
-    def _create_budget_project(self):
-        for line in self.line_ids.filtered('enable_project'):
-            self.env['kmitl.project'].create({
-                # TODO: change date_range_fy_id to account_fiscal_year_id
-                "account_fiscal_year_id": line.appropriation_id.date_range_fy_id.id,
-                "name": line.description,
-                "project_type": line.project_type,
-                "user_id": line.appropriation_id.user_id.id,
-                "creating_user_id": line.appropriation_id.user_id.id,
-                "analytic_distribution": line.analytic_distribution,
-            })
+    def _log_message_on_linked_documents(self):
+        project_lines = self.line_ids.filtered(lambda l: l.budget_project_id)
+        if not project_lines:
+            return
+
+        # Post a single consolidated message on budget.appropriation
+        body_parts = []
+        for line in project_lines:
+            body_parts.append(line._message_link_to_budget_project())
+
+        if body_parts:
+            self.message_post(
+                body="<br/>".join(body_parts),
+                message_type="comment",
+            )
+
+        # Post individual messages on each budget.project
+        for line in project_lines:
+            line.budget_project_id.message_post(
+                body=line._message_link_back_from_budget_project(),
+                message_type="comment",
+            )
+
+    def _get_record_url(self):
+        return "/web#id={}&model={}&view_type=form".format(self.id, self._name)

--- a/budget_project/models/budget_appropriation_line.py
+++ b/budget_project/models/budget_appropriation_line.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 import logging
 
-from odoo import models, fields, api, _
-from odoo.exceptions import UserError, ValidationError
+from odoo import _, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -19,9 +17,62 @@ class BudgetAppropriationLine(models.Model):
 
     project_type = fields.Selection(related="account_id.project_type", store=True)
 
+    budget_project_id = fields.Many2one(
+        comodel_name="budget.project",
+        string="การกันเงินโครงการ",
+    )
+
     @api.depends("enable_project")
     def _compute_highlight_row(self):
         super()._compute_highlight_row()
         for rec in self:
             if rec.enable_project:
                 rec.highlight_row = True
+
+    def _prepare_budget_project_vals(self):
+        return {
+            "name": self.description,
+            "budget_amount": self.balance,
+            "budget_account_id": self.account_id.id,
+            "account_fiscal_year_id": self.account_fiscal_year_id.id,
+            "analytic_distribution": self.analytic_distribution,
+            "project_type": self.project_type,
+            "user_id": self.appropriation_id.user_id.id,
+            "company_id": self.appropriation_id.company_id.id,
+        }
+
+    def _create_budget_project(self):
+        self.ensure_one()
+        vals = self._prepare_budget_project_vals()
+        budget_project = self.env["budget.project"].create(vals)
+        self.budget_project_id = budget_project.id
+        return budget_project
+
+    def budget_move_line_vals(self):
+        vals = super().budget_move_line_vals()
+        if self.enable_project:
+            budget_project = self._create_budget_project()
+            vals["budget_project_id"] = budget_project.id
+        return vals
+
+    def _message_link_to_budget_project(self):
+        budget_project = self.budget_project_id
+        name = budget_project.name
+        link = budget_project._get_record_url()
+        return _(
+            'การกันเงินโครงการ/กิจกรรมถูกสร้างจากการจัดสรรงบประมาณ: '
+            '<a href="%(link)s" target="_blank">%(name)s</a>',
+            link=link,
+            name=name,
+        )
+
+    def _message_link_back_from_budget_project(self):
+        appropriation_id = self.appropriation_id
+        name = appropriation_id.name
+        link = appropriation_id._get_record_url()
+        return _(
+            'สร้างจากการจัดสรรงบประมาณ: '
+            '<a href="%(link)s" target="_blank">%(name)s</a>',
+            link=link,
+            name=name,
+        )

--- a/budget_project/models/budget_move_line.py
+++ b/budget_project/models/budget_move_line.py
@@ -12,4 +12,7 @@ class BudgetMoveLine(models.Model):
     )
 
     project_id = fields.Many2one(comodel_name="kmitl.project", string="โครงการ/กิจกรรม")
-    # project_analytic_id = fields.Many2one("account.analytic.account")
+    budget_project_id = fields.Many2one(
+        comodel_name="budget.project",
+        string="การกันเงินโครงการ",
+    )

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -34,6 +34,41 @@ class BudgetProject(models.Model):
         tracking=True,
     )
     analytic_distribution = fields.Json(string="Analytic Distribution")
+
+    # Analytic dimension fields for UI (computed from analytic_distribution)
+    activity_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="กิจกรรม",
+        compute="_compute_analytic_ids",
+        inverse="_inverse_activity_analytic_id",
+        store=False,
+        domain=[("root_plan_id.code", "=", "activities")],
+    )
+    department_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="ส่วนงาน",
+        compute="_compute_analytic_ids",
+        inverse="_inverse_department_analytic_id",
+        store=False,
+        domain=[("root_plan_id.code", "=", "departments")],
+    )
+    fund_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="กองทุน",
+        compute="_compute_analytic_ids",
+        inverse="_inverse_fund_analytic_id",
+        store=False,
+        domain=[("root_plan_id.code", "=", "funds")],
+    )
+    source_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="แหล่งเงิน",
+        compute="_compute_analytic_ids",
+        inverse="_inverse_source_analytic_id",
+        store=False,
+        domain=[("root_plan_id.code", "=", "sources")],
+    )
+
     project_type = fields.Selection(
         [("project", "Project/Activity"), ("strategic_project", "Strategic Project")],
         tracking=True,
@@ -69,6 +104,50 @@ class BudgetProject(models.Model):
     def _compute_is_matched(self):
         for rec in self:
             rec.is_matched = bool(rec.kmitl_project_id)
+
+    @api.depends("analytic_distribution")
+    def _compute_analytic_ids(self):
+        """Compute analytic_id fields from analytic_distribution JSON."""
+        for rec in self:
+            account_ids = [int(account_id) for account_id in rec.analytic_distribution or {}]
+            accounts = self.env["account.analytic.account"].browse(account_ids)
+            rec.activity_analytic_id = accounts.filtered(lambda a: a.root_plan_id.code == "activities")[:1]
+            rec.department_analytic_id = accounts.filtered(lambda a: a.root_plan_id.code == "departments")[:1]
+            rec.fund_analytic_id = accounts.filtered(lambda a: a.root_plan_id.code == "funds")[:1]
+            rec.source_analytic_id = accounts.filtered(lambda a: a.root_plan_id.code == "sources")[:1]
+
+    def _update_analytic_distribution(self, plan_code, analytic_id):
+        """Update analytic_distribution JSON when individual field changes."""
+        self.ensure_one()
+        distribution = dict(self.analytic_distribution or {})
+
+        # Remove old account for this plan
+        account_ids = [int(aid) for aid in distribution.keys()]
+        accounts = self.env["account.analytic.account"].browse(account_ids)
+        for account in accounts.filtered(lambda a: a.root_plan_id.code == plan_code):
+            del distribution[str(account.id)]
+
+        # Add new account
+        if analytic_id:
+            distribution[str(analytic_id.id)] = 100
+
+        self.analytic_distribution = distribution if distribution else False
+
+    def _inverse_activity_analytic_id(self):
+        for rec in self:
+            rec._update_analytic_distribution("activities", rec.activity_analytic_id)
+
+    def _inverse_department_analytic_id(self):
+        for rec in self:
+            rec._update_analytic_distribution("departments", rec.department_analytic_id)
+
+    def _inverse_fund_analytic_id(self):
+        for rec in self:
+            rec._update_analytic_distribution("funds", rec.fund_analytic_id)
+
+    def _inverse_source_analytic_id(self):
+        for rec in self:
+            rec._update_analytic_distribution("sources", rec.source_analytic_id)
 
     def write(self, vals):
         res = super().write(vals)

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -49,10 +49,6 @@ class BudgetProject(models.Model):
         required=True,
         default=lambda self: self.env.company,
     )
-    analytic_precision = fields.Integer(
-        default=2,
-        readonly=True,
-    )
     kmitl_project_id = fields.Many2one(
         comodel_name="kmitl.project",
         string="โครงการ/กิจกรรม",

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -1,0 +1,164 @@
+import logging
+
+from odoo import _, api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class BudgetProject(models.Model):
+    _name = "budget.project"
+    _description = "Budget Project Reservation"
+    _inherit = ["mail.thread"]
+    _order = "id desc"
+
+    name = fields.Char(
+        string="ชื่อโครงการ/กิจกรรม",
+        required=True,
+        tracking=True,
+    )
+    budget_amount = fields.Float(
+        string="งบประมาณ",
+        digits="Product Price",
+        tracking=True,
+    )
+    budget_account_id = fields.Many2one(
+        comodel_name="budget.account",
+        string="รหัสงบประมาณ",
+        required=True,
+        tracking=True,
+    )
+    account_fiscal_year_id = fields.Many2one(
+        comodel_name="account.fiscal.year",
+        string="ปีงบประมาณ",
+        required=True,
+        tracking=True,
+    )
+    analytic_distribution = fields.Json(string="Analytic Distribution")
+    project_type = fields.Selection(
+        [("project", "Project/Activity"), ("strategic_project", "Strategic Project")],
+        tracking=True,
+    )
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="ผู้รับผิดชอบ",
+        tracking=True,
+    )
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    kmitl_project_id = fields.Many2one(
+        comodel_name="kmitl.project",
+        string="โครงการ/กิจกรรม",
+        tracking=True,
+    )
+    is_matched = fields.Boolean(
+        string="เชื่อมโยงแล้ว",
+        compute="_compute_is_matched",
+        store=True,
+    )
+    budget_move_line_ids = fields.One2many(
+        comodel_name="budget.move.line",
+        inverse_name="budget_project_id",
+        string="Budget Move Lines",
+    )
+
+    @api.depends("kmitl_project_id")
+    def _compute_is_matched(self):
+        for rec in self:
+            rec.is_matched = bool(rec.kmitl_project_id)
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "kmitl_project_id" in vals and vals["kmitl_project_id"]:
+            for rec in self:
+                rec._on_match_project()
+        return res
+
+    def _on_match_project(self):
+        """Called when kmitl_project_id is set. Performs budget linking."""
+        self.ensure_one()
+        project = self.kmitl_project_id
+
+        # 1. Copy budget data to kmitl.project
+        project.write({
+            "budget_account_id": self.budget_account_id.id,
+            "budget_amount": self.budget_amount,
+            "analytic_distribution": self.analytic_distribution,
+        })
+
+        # 2. Create analytic_account_id on kmitl.project if not exists
+        if not project.analytic_account_id:
+            analytic_account = self.env["account.analytic.account"].create({
+                "name": project.name,
+                "company_id": project.company_id.id,
+                "plan_id": self.env.ref(
+                    "kmitl_project.analytic_plan_project"
+                ).id,
+            })
+            project.analytic_account_id = analytic_account.id
+
+        # 3. Inject analytic_account_id into budget.move.line.analytic_distribution
+        for move_line in self.budget_move_line_ids:
+            distribution = dict(move_line.analytic_distribution or {})
+            distribution[str(project.analytic_account_id.id)] = 100
+            move_line.analytic_distribution = distribution
+            move_line.project_id = project.id
+
+        # 4. Post chatter messages
+        self._post_match_messages()
+
+    def _post_match_messages(self):
+        """Post cross-link chatter messages on both records."""
+        self.ensure_one()
+        project = self.kmitl_project_id
+
+        # Message on budget.project
+        project_url = project._get_record_url()
+        self.message_post(
+            body=_(
+                'เชื่อมโยงกับโครงการ/กิจกรรม: <a href="%(link)s" target="_blank">%(name)s</a>',
+                link=project_url,
+                name=project.name,
+            ),
+            message_type="comment",
+        )
+
+        # Message on kmitl.project
+        reservation_url = self._get_record_url()
+        project.message_post(
+            body=_(
+                'เชื่อมโยงกับการกันเงิน: <a href="%(link)s" target="_blank">%(name)s</a>',
+                link=reservation_url,
+                name=self.name,
+            ),
+            message_type="comment",
+        )
+
+    def action_create_kmitl_project(self):
+        """Create a kmitl.project from this reservation and link it."""
+        self.ensure_one()
+        project = self.env["kmitl.project"].create({
+            "name": self.name,
+            "project_type": self.project_type or "project",
+            "account_fiscal_year_id": self.account_fiscal_year_id.id,
+            "budget_account_id": self.budget_account_id.id,
+            "budget_amount": self.budget_amount,
+            "user_id": self.user_id.id if self.user_id else self.env.user.id,
+            "creating_user_id": self.env.user.id,
+            "company_id": self.company_id.id,
+            "analytic_distribution": self.analytic_distribution,
+        })
+        self.kmitl_project_id = project.id
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "kmitl.project",
+            "res_id": project.id,
+            "view_mode": "form",
+            "target": "current",
+        }
+
+    def _get_record_url(self):
+        return "/web#id={}&model={}&view_type=form".format(self.id, self._name)

--- a/budget_project/models/budget_project.py
+++ b/budget_project/models/budget_project.py
@@ -49,6 +49,10 @@ class BudgetProject(models.Model):
         required=True,
         default=lambda self: self.env.company,
     )
+    analytic_precision = fields.Integer(
+        default=2,
+        readonly=True,
+    )
     kmitl_project_id = fields.Many2one(
         comodel_name="kmitl.project",
         string="โครงการ/กิจกรรม",

--- a/budget_project/models/kmitl_project.py
+++ b/budget_project/models/kmitl_project.py
@@ -1,0 +1,24 @@
+import logging
+
+from odoo import _, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class KmitlProject(models.Model):
+    _inherit = "kmitl.project"
+
+    budget_project_ids = fields.One2many(
+        comodel_name="budget.project",
+        inverse_name="kmitl_project_id",
+        string="การกันเงินงบประมาณ",
+    )
+
+    def _compute_is_editable(self):
+        super()._compute_is_editable()
+        for rec in self:
+            if rec.budget_project_ids:
+                rec.is_editable = False
+
+    def _get_record_url(self):
+        return "/web#id={}&model={}&view_type=form".format(self.id, self._name)

--- a/budget_project/security/ir.model.access.csv
+++ b/budget_project/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_budget_project_user,budget_project_user,model_budget_project,budget.group_budget_user,1,1,1,0
+access_budget_project_manager,budget_project_manager,model_budget_project,budget.group_budget_manager,1,1,1,1

--- a/budget_project/views/budget_appropriation_views.xml
+++ b/budget_project/views/budget_appropriation_views.xml
@@ -15,14 +15,15 @@
             <xpath expr="//group" position="after">
                 <group name="project" string="โครงการ/กิจกรรม" attrs="{'invisible': [('enable_project', '=', False)]}">
                     <div class="alert alert-info" role="alert" colspan="2">
-                        ระบบจะนำข้อมูลส่วนนี้ไปสร้างเป็นโครงการ/กิจกรรม
-                            <p class="fst-italic fw-light mt-1">
-                            ตัวอย่างการกรอกข้อมูล                            <br />
+                        ระบบจะนำข้อมูลส่วนนี้ไปสร้างเป็นการกันเงินโครงการ/กิจกรรม
+                        <p class="fst-italic fw-light mt-1">
+                            ตัวอย่างการกรอกข้อมูล<br />
                             ตัวอย่าง 1. "กิจกรรม KMITL Open House 2025" <br />
                             ตัวอย่าง 2. "โครงการเสริมสร้าง Soft Skill" <br />
                         </p>
                     </div>
-                    <field name="description" string="ชื่อโครงการ/กิจกรรม" attrs="{'required': [('enable_project', '=', True)]}" />
+                    <field name="description" string="ชื่อโครงการ/กิจกรรม" attrs="{'required': [('enable_project', '=', True)], 'invisible': [('budget_project_id', '!=', False)]}" />
+                    <field name="budget_project_id" attrs="{'invisible': [('budget_project_id', '=', False)]}" readonly="1" />
                     <field name="project_type" invisible="1" attrs="{'required': [('enable_project', '=', True)]}" />
                 </group>
             </xpath>
@@ -39,10 +40,11 @@
                 <field name="is_project" invisible="1" />
                 <field name="enable_project" invisible="1" />
                 <field name="project_type" invisible="1" />
+                <field name="budget_project_id" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='line_ids']/tree" position="attributes">
-            <attribute name="decoration-info">is_project</attribute>
-        </xpath>
+                <attribute name="decoration-info">is_project</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -30,6 +30,17 @@
                             <field name="is_matched" invisible="1" />
                         </group>
                     </group>
+                    <group string="มิติทางบัญชี">
+                        <group>
+                            <field name="activity_analytic_id" />
+                            <field name="department_analytic_id" />
+                        </group>
+                        <group>
+                            <field name="fund_analytic_id" />
+                            <field name="source_analytic_id" />
+                        </group>
+                        <field name="analytic_distribution" invisible="1" />
+                    </group>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" />

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -30,9 +30,6 @@
                             <field name="is_matched" invisible="1" />
                         </group>
                     </group>
-                    <group string="มิติทางบัญชี">
-                        <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting" />
-                    </group>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" />

--- a/budget_project/views/budget_project_views.xml
+++ b/budget_project/views/budget_project_views.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Form view -->
+    <record id="view_budget_project_form" model="ir.ui.view">
+        <field name="name">budget.project.form</field>
+        <field name="model">budget.project</field>
+        <field name="arch" type="xml">
+            <form string="การกันเงินโครงการ/กิจกรรม">
+                <header>
+                    <button name="action_create_kmitl_project" string="สร้างโครงการ/กิจกรรม" type="object" class="oe_highlight" attrs="{'invisible': [('is_matched', '=', True)]}" />
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="ชื่อโครงการ/กิจกรรม" />
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="account_fiscal_year_id" />
+                            <field name="budget_account_id" />
+                            <field name="budget_amount" />
+                            <field name="project_type" />
+                        </group>
+                        <group>
+                            <field name="user_id" />
+                            <field name="company_id" invisible="1" />
+                            <field name="kmitl_project_id" attrs="{'readonly': [('is_matched', '=', True)]}" />
+                            <field name="is_matched" invisible="1" />
+                        </group>
+                    </group>
+                    <group string="มิติทางบัญชี">
+                        <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting" />
+                    </group>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="message_ids" />
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <!-- Tree view -->
+    <record id="view_budget_project_tree" model="ir.ui.view">
+        <field name="name">budget.project.tree</field>
+        <field name="model">budget.project</field>
+        <field name="arch" type="xml">
+            <tree string="การกันเงินโครงการ/กิจกรรม" decoration-success="is_matched == True" decoration-muted="is_matched == False">
+                <field name="name" />
+                <field name="account_fiscal_year_id" />
+                <field name="budget_account_id" />
+                <field name="budget_amount" />
+                <field name="project_type" />
+                <field name="kmitl_project_id" />
+                <field name="is_matched" />
+            </tree>
+        </field>
+    </record>
+
+    <!-- Search view -->
+    <record id="view_budget_project_search" model="ir.ui.view">
+        <field name="name">budget.project.search</field>
+        <field name="model">budget.project</field>
+        <field name="arch" type="xml">
+            <search string="การกันเงินโครงการ/กิจกรรม">
+                <field name="name" />
+                <field name="kmitl_project_id" />
+                <field name="account_fiscal_year_id" />
+                <filter name="not_matched" string="ยังไม่เชื่อมโยง" domain="[('is_matched', '=', False)]" />
+                <filter name="matched" string="เชื่อมโยงแล้ว" domain="[('is_matched', '=', True)]" />
+                <group expand="0" string="Group By">
+                    <filter name="group_fiscal_year" string="ปีงบประมาณ" context="{'group_by': 'account_fiscal_year_id'}" />
+                    <filter name="group_matched" string="สถานะการเชื่อมโยง" context="{'group_by': 'is_matched'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="action_budget_project" model="ir.actions.act_window">
+        <field name="name">การกันเงินโครงการ/กิจกรรม</field>
+        <field name="res_model">budget.project</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_budget_project_search" />
+    </record>
+
+</odoo>

--- a/budget_project/views/kmitl_project_views.xml
+++ b/budget_project/views/kmitl_project_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Extend kmitl.project form to show linked budget reservations -->
+    <record id="view_kmitl_project_form_budget_project" model="ir.ui.view">
+        <field name="name">view.kmitl.project.form.budget.project</field>
+        <field name="model">kmitl.project</field>
+        <field name="inherit_id" ref="kmitl_project.view_kmitl_project_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='settings']" position="before">
+                <page name="budget_reservation" string="การกันเงินงบประมาณ">
+                    <field name="budget_project_ids" readonly="1">
+                        <tree>
+                            <field name="name" />
+                            <field name="budget_amount" />
+                            <field name="budget_account_id" />
+                            <field name="account_fiscal_year_id" />
+                            <field name="is_matched" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_project/views/menu_views.xml
+++ b/budget_project/views/menu_views.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <menuitem
+        id="menu_budget_project"
+        name="การกันเงินโครงการ/กิจกรรม"
+        parent="budget_appropriation.menu_budget_appropriation_root"
+        action="action_budget_project"
+        sequence="25"
+    />
+
 </odoo>


### PR DESCRIPTION
## Summary

- Introduce `budget.project` as an intermediary reservation model between `budget.appropriation` and `kmitl.project`, separating budget allocation from project approval workflows
- On posting an appropriation, a `budget.project` reservation is created (instead of directly creating `kmitl.project`), storing name, budget amount, budget account, fiscal year, and analytic dimensions
- Users can link an existing `kmitl.project` via dropdown or create one directly from the reservation using the "สร้างโครงการ/กิจกรรม" button; linking triggers analytic account creation and injects the `kmitl_project` dimension into `budget.move.line.analytic_distribution`
- Adds a dedicated menu "การกันเงินโครงการ/กิจกรรม" with tree/form views and matched/unmatched filters for tracking reservation status

## Test plan

- [ ] Post a `budget.appropriation` with a line where `enable_project=True` and verify a `budget.project` record is created
- [ ] Verify `budget.move.line` has `budget_project_id` but no `kmitl_project` analytic dimension yet
- [ ] Use "สร้างโครงการ/กิจกรรม" button to create a `kmitl.project` from the reservation; verify data is copied and analytic account is created
- [ ] Link an existing `kmitl.project` via dropdown and verify `budget.move.line.analytic_distribution` includes the project dimension
- [ ] Verify chatter messages appear on both `budget.project` and `kmitl.project`
- [ ] Verify `kmitl.project.is_editable = False` once linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)