### PR TITLE
[16.0][IMP] procurement_plan_budget: add procurement plan summary tabs

### DIFF
--- a/procurement_plan_budget/__manifest__.py
+++ b/procurement_plan_budget/__manifest__.py
@@ -5,10 +5,11 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    "depends": ["budget_appropriation", "procurement_plan", "web"],
+    "depends": ["budget_appropriation", "procurement_plan", "budget_appropriation_summary", "web"],
     "data": [
         "views/budget_appropriation_views.xml",
-        "views/procurement_plan_views.xml"
+        "views/procurement_plan_views.xml",
+        "views/budget_appropriation_compilation_views.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/procurement_plan_budget/models/__init__.py
+++ b/procurement_plan_budget/models/__init__.py
@@ -2,3 +2,4 @@
 from . import budget_appropriation_line
 from . import budget_appropriation
 from . import procurement_plan
+from . import budget_appropriation_compilation

--- a/procurement_plan_budget/models/budget_appropriation.py
+++ b/procurement_plan_budget/models/budget_appropriation.py
@@ -10,6 +10,19 @@ _logger = logging.getLogger(__name__)
 class BudgetAppropriation(models.Model):
     _inherit = "budget.appropriation"
 
+    procurement_plan_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_procurement_plan_ids",
+        store=False,
+        readonly=True,
+    )
+
+    @api.depends("line_ids.enable_procurement_plan", "line_ids.procurement_plan_amount", "line_ids.procurement_plan_unit", "line_ids.procurement_plan_id")
+    def _compute_procurement_plan_ids(self):
+        for record in self:
+            line_ids = record.line_ids.filtered(lambda x: x.enable_procurement_plan)
+            record.procurement_plan_ids = line_ids
+
     def action_review(self):
         super().action_review()
 
@@ -41,6 +54,4 @@ class BudgetAppropriation(models.Model):
             )
 
     def _get_record_url(self):
-        return "/web#id={}&model={}&view_type=form".format(
-            self.id, self._name
-        )
+        return "/web#id={}&model={}&view_type=form".format(self.id, self._name)

--- a/procurement_plan_budget/models/budget_appropriation_compilation.py
+++ b/procurement_plan_budget/models/budget_appropriation_compilation.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class BudgetAppropriationCompilation(models.Model):
+    _inherit = "budget.appropriation.compilation"
+
+    procurement_plan_line_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_procurement_plan_line_ids",
+        store=False,
+        readonly=True,
+    )
+
+    @api.depends(
+        "expense_appropriation_ids.line_ids.enable_procurement_plan",
+        "expense_appropriation_ids.line_ids.procurement_plan_amount",
+        "expense_appropriation_ids.line_ids.procurement_plan_unit",
+        "expense_appropriation_ids.line_ids.procurement_plan_id",
+    )
+    def _compute_procurement_plan_line_ids(self):
+        for rec in self:
+            rec.procurement_plan_line_ids = rec.expense_appropriation_ids.line_ids.filtered(
+                lambda l: l.enable_procurement_plan
+            )

--- a/procurement_plan_budget/views/budget_appropriation_compilation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_compilation_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_budget_appropriation_compilation_form_procurement_plan" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.compilation.form.procurement.plan</field>
+        <field name="model">budget.appropriation.compilation</field>
+        <field name="inherit_id" ref="budget_appropriation_summary.view_budget_appropriation_compilation_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='expense_appropriations']" position="after">
+                <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง">
+                    <field name="procurement_plan_line_ids" readonly="1" nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="appropriation_id" string="ใบจัดสรรงบประมาณ" optional="hide" />
+                            <field name="description" string="ชื่อรายการ" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="procurement_plan_amount" string="จำนวน" />
+                            <field name="procurement_plan_unit" string="หน่วย" />
+                            <field name="balance" string="วงเงินรวม" sum="รวม" />
+                            <field name="procurement_plan_id" string="แผนจัดซื้อจัดจ้าง" invisible="1" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/procurement_plan_budget/views/budget_appropriation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_views.xml
@@ -58,20 +58,16 @@
                 <attribute name="decoration-info">procurement_plan</attribute>
             </xpath>
             <xpath expr="//notebook/page[@name='line_ids']" position="after">
-                <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง"
+                <page name="procurement_plan_summary" string="แผนจัดซื้อจัดจ้าง"
                       attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
-                    <field name="line_ids" readonly="1"
-                           domain="[('enable_procurement_plan', '=', True)]"
-                           nolabel="1">
+                    <field name="procurement_plan_ids" readonly="1" nolabel="1">
                         <tree create="false" edit="false" delete="false">
-                            <field name="enable_procurement_plan" invisible="1" />
                             <field name="description" string="ชื่อรายการ" />
                             <field name="account_id" string="รหัสงบประมาณ" />
                             <field name="activity_analytic_id" string="กิจกรรม" />
                             <field name="procurement_plan_amount" string="จำนวน" />
                             <field name="procurement_plan_unit" string="หน่วย" />
                             <field name="balance" string="วงเงินรวม" sum="รวม" />
-                            <field name="procurement_plan_id" string="แผนจัดซื้อจัดจ้าง" />
                         </tree>
                     </field>
                 </page>

--- a/procurement_plan_budget/views/budget_appropriation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_views.xml
@@ -57,6 +57,25 @@
             <xpath expr="//field[@name='line_ids']/tree" position="attributes">
                 <attribute name="decoration-info">procurement_plan</attribute>
             </xpath>
+            <xpath expr="//notebook/page[@name='line_ids']" position="after">
+                <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง"
+                      attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="line_ids" readonly="1"
+                           domain="[('enable_procurement_plan', '=', True)]"
+                           nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="enable_procurement_plan" invisible="1" />
+                            <field name="description" string="ชื่อรายการ" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="procurement_plan_amount" string="จำนวน" />
+                            <field name="procurement_plan_unit" string="หน่วย" />
+                            <field name="balance" string="วงเงินรวม" sum="รวม" />
+                            <field name="procurement_plan_id" string="แผนจัดซื้อจัดจ้าง" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary

- Add computed `procurement_plan_ids` (store=False) on `budget.appropriation` filtered to lines with `enable_procurement_plan=True`, shown in a new readonly "แผนจัดซื้อจัดจ้าง" tab (expense appropriations only)
- Add computed `procurement_plan_line_ids` (store=False) on `budget.appropriation.compilation` aggregating procurement plan lines across all linked expense appropriations, shown in a new "สรุปแผนจัดซื้อจัดจ้าง" tab
- Add `ready` state to `procurement.plan` with validation requiring all planning fields before transitioning; add `can_edit_description` field to allow description edits in draft/new; store analytic convenience fields and add source/fund filters to search panel

## Test plan
- [ ] Open an expense `budget.appropriation` — confirm "แผนจัดซื้อจัดจ้าง" tab shows only lines with `enable_procurement_plan=True`
- [ ] Open a revenue `budget.appropriation` — confirm tab is hidden
- [ ] Open a `budget.appropriation.compilation` — confirm "สรุปแผนจัดซื้อจัดจ้าง" tab shows procurement plan lines from all linked expense appropriations
- [ ] On a `procurement.plan` in "new" state, click "Ready" without filling all planning fields — confirm validation error; fill all fields and confirm transition succeeds