### PR TITLE
[16.0][IMP] procurement_plan_budget: add procurement plan summary tab

### DIFF
--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -85,7 +85,6 @@ class ProcurementPlan(models.Model):
         string="Procurement Method",
         required=False,
         tracking=True,
-        states=READONLY_STATES,
     )
     state = fields.Selection(
         [

--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -2,6 +2,7 @@ import logging
 
 from odoo.tools.misc import format_amount
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -89,8 +90,9 @@ class ProcurementPlan(models.Model):
     state = fields.Selection(
         [
             ("draft", "Draft"),
-            ("new", "Not started yet"),
+            ("new", "New"),
             ("on_hold", "On Hold"),
+            ("ready", "Ready"),
             ("in_progress", "In progress"),
             ("done", "Done"),
             ("cancel", "Cancelled"),
@@ -150,6 +152,18 @@ class ProcurementPlan(models.Model):
         string="Currency",
         readonly=True,
     )
+
+    can_edit_description = fields.Boolean(
+        store=False, compute="_compute_can_edit_description"
+    )
+
+    @api.depends("state")
+    def _compute_can_edit_description(self):
+        for record in self:
+            if record.state in ("draft", "new"):
+                record.can_edit_description = True
+            else:
+                record.can_edit_description = False
 
     analytic_account_id = fields.Many2one(
         "account.analytic.account",
@@ -226,6 +240,20 @@ class ProcurementPlan(models.Model):
     def action_new(self):
         self.write({"state": "new"})
 
+    def action_ready(self):
+        if self.state not in ("new"):
+            raise UserError(_("Record must be in new state to be set to ready."))
+        if (
+            not self.purchase_request_eta
+            or not self.procurement_announcement_eta
+            or not self.approval_signing_eta
+            or not self.contract_order_signing_eta
+            or not self.acceptance_eta
+            or not self.procurement_method_id
+        ):
+            raise UserError(_("กรุณาระบุแผนการดำเนินงานให้เสร็จสิ้นทั้งหมด"))
+        self.write({"state": "ready"})
+
     def action_on_hold(self):
         self.write({"state": "on_hold"})
 
@@ -237,6 +265,7 @@ class ProcurementPlan(models.Model):
 
     can_edit = fields.Boolean(compute="_compute_can_edit")
 
+    @api.depends("state")
     def _compute_can_edit(self):
         for rec in self:
             if rec.state == "draft":
@@ -247,9 +276,17 @@ class ProcurementPlan(models.Model):
     def name_get(self):
         res = []
         for rec in self:
-            source_name = rec.source_analytic_id.name if rec.source_analytic_id else _("ไม่ระบุแหล่งเงิน")
+            source_name = (
+                rec.source_analytic_id.name
+                if rec.source_analytic_id
+                else _("ไม่ระบุแหล่งเงิน")
+            )
             res.append(
-                (rec.id, _(f"[%s] %s งบประมาณ {rec.total_price:,.2f} บาท - %s") % (rec.name, rec.description, source_name))
+                (
+                    rec.id,
+                    _(f"[%s] %s งบประมาณ {rec.total_price:,.2f} บาท - %s")
+                    % (rec.name, rec.description, source_name),
+                )
             )
         return res
 
@@ -276,7 +313,7 @@ class ProcurementPlan(models.Model):
         compute="_compute_analytic_id",
         inverse="_inverse_activity_analytic",
         domain=[("root_plan_id.code", "=", "activities")],
-        store=False,
+        store=True,
         tracking=True,
         states=READONLY_STATES,
     )
@@ -287,7 +324,7 @@ class ProcurementPlan(models.Model):
         compute="_compute_analytic_id",
         inverse="_inverse_department_analytic",
         domain=[("root_plan_id.code", "=", "departments")],
-        store=False,
+        store=True,
         tracking=True,
         states=READONLY_STATES,
     )
@@ -298,7 +335,7 @@ class ProcurementPlan(models.Model):
         compute="_compute_analytic_id",
         inverse="_inverse_fund_analytic",
         domain=[("root_plan_id.code", "=", "funds")],
-        store=False,
+        store=True,
         tracking=True,
         states=READONLY_STATES,
     )
@@ -309,7 +346,7 @@ class ProcurementPlan(models.Model):
         compute="_compute_analytic_id",
         inverse="_inverse_source_analytic",
         domain=[("root_plan_id.code", "=", "sources")],
-        store=False,
+        store=True,
         tracking=True,
         states=READONLY_STATES,
     )

--- a/procurement_plan/views/procurement_plan_views.xml
+++ b/procurement_plan/views/procurement_plan_views.xml
@@ -72,12 +72,12 @@
                         <page string="การดำเนินงาน">
                             <group>
                                 <group string="แผน">
-                                    <field name="procurement_method_id" widget="selection" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
-                                    <field name="purchase_request_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
-                                    <field name="procurement_announcement_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
-                                    <field name="approval_signing_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
-                                    <field name="contract_order_signing_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
-                                    <field name="acceptance_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
+                                    <field name="procurement_method_id" widget="radio" attrs="{'readonly': [('state', 'not in', ('draft', 'new'))]}" />
+                                    <field name="purchase_request_eta" attrs="{'readonly': [('state', 'not in', ('draft', 'new'))]}" />
+                                    <field name="procurement_announcement_eta" attrs="{'readonly': [('state', 'not in', ('draft', 'new'))]}" />
+                                    <field name="approval_signing_eta" attrs="{'readonly': [('state', 'not in', ('draft', 'new'))]}" />
+                                    <field name="contract_order_signing_eta" attrs="{'readonly': [('state', 'not in', ('draft', 'new'))]}" />
+                                    <field name="acceptance_eta" attrs="{'readonly': [('state', 'not in', ('draft', 'new'))]}" />
                                 </group>
                             </group>
                         </page>

--- a/procurement_plan/views/procurement_plan_views.xml
+++ b/procurement_plan/views/procurement_plan_views.xml
@@ -26,7 +26,7 @@
         <field name="arch" type="xml">
             <form string="Procurement Plan">
                 <header>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,new,in_progress,done" />
+                    <field name="state" widget="statusbar" statusbar_visible="draft,new,ready,in_progress,done" />
                     <button name="action_ready" string="Ready" type="object" class="btn-primary" states="new" />
                 </header>
                 <sheet>

--- a/procurement_plan/views/procurement_plan_views.xml
+++ b/procurement_plan/views/procurement_plan_views.xml
@@ -27,9 +27,11 @@
             <form string="Procurement Plan">
                 <header>
                     <field name="state" widget="statusbar" statusbar_visible="draft,new,in_progress,done" />
+                    <button name="action_ready" string="Ready" type="object" class="btn-primary" states="new" />
                 </header>
                 <sheet>
                     <field name="can_edit" invisible="1"/>
+                    <field name="can_edit_description" invisible="1"/>
                     <div class="oe_button_box" name="button_box">
                         <field name="budget_commitment_count" invisible="1" />
                         <button name="action_open_budget_commitments" type="object" class="oe_stat_button" icon="fa-money" attrs="{'invisible': [('budget_commitment_count', '=', 0)]}">
@@ -47,17 +49,15 @@
                     </div>
                     <group>
                         <group name="basic">
-                            <field name="description" placeholder="e.g. ครุภัณฑ์วิทยาศาสตร์และการแพทย์, ปรับปรุงห้องปฏิบัติการฟิสิกส์" attrs="{'readonly': [('can_edit', '=', False)]}" />
-                            <field name="procurement_method_id" widget="selection" attrs="{'readonly': [('can_edit', '=', False)]}" />
-
+                            <field name="description" placeholder="e.g. ครุภัณฑ์วิทยาศาสตร์และการแพทย์, ปรับปรุงห้องปฏิบัติการฟิสิกส์" attrs="{'readonly': [('can_edit_description', '=', False)]}" />
                             <label for="amount" string="จำนวน" />
                             <div class="o_row">
                                 <field name="amount" attrs="{'readonly': [('can_edit', '=', False)]}"  />
                                 <field name="unit" placeholder="e.g. ชิ้น, รายการ, ตัว, ชุด" attrs="{'readonly': [('can_edit', '=', False)]}"  />
                             </div>
                             <field name="total_price" attrs="{'readonly': [('can_edit', '=', False)]}" />
-                            <field name="note" placeholder="Notes..." />
                             <field name="user_id" widget="many2one_avatar_user" required="1" attrs="{'readonly': [('can_edit', '=', False)]}" />
+                            <field name="note" placeholder="Notes..." />
                         </group>
                         <group>
                             <field name="account_fiscal_year_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': [('id', '!=', False)]}" />
@@ -69,14 +69,15 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="ข้อมูลแผนการดำเนินงาน">
+                        <page string="การดำเนินงาน">
                             <group>
-                                <group>
-                                    <field name="purchase_request_eta" />
-                                    <field name="procurement_announcement_eta" />
-                                    <field name="approval_signing_eta" />
-                                    <field name="contract_order_signing_eta" />
-                                    <field name="acceptance_eta" />
+                                <group string="แผน">
+                                    <field name="procurement_method_id" widget="selection" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
+                                    <field name="purchase_request_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
+                                    <field name="procurement_announcement_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
+                                    <field name="approval_signing_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
+                                    <field name="contract_order_signing_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
+                                    <field name="acceptance_eta" attrs="{'readonly': [('state', 'in', 'draft', 'new')]}" />
                                 </group>
                             </group>
                         </page>
@@ -128,8 +129,10 @@
                     <filter string="สถานะ" name="group_by_state" context="{'group_by': 'state'}" />
                 </group>
                 <searchpanel>
-                    <field name="state" icon="fa-calendar" enable_counters="1" />
-                    <field name="procurement_method_id" icon="fa-calendar" enable_counters="1" />
+                    <field name="state" icon="fa-calendar" select="multi" enable_counters="1" />
+                    <field name="source_analytic_id" icon="fa-money" select="multi" />
+                    <field name="fund_analytic_id" icon="fa-university" select="multi" />
+                    <field name="procurement_method_id" icon="fa-calendar" select="multi" />
                 </searchpanel>
             </search>
         </field>

--- a/procurement_plan_budget/__manifest__.py
+++ b/procurement_plan_budget/__manifest__.py
@@ -5,10 +5,11 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    "depends": ["budget_appropriation", "procurement_plan", "web"],
+    "depends": ["budget_appropriation", "procurement_plan", "budget_appropriation_summary", "web"],
     "data": [
         "views/budget_appropriation_views.xml",
-        "views/procurement_plan_views.xml"
+        "views/procurement_plan_views.xml",
+        "views/budget_appropriation_compilation_views.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/procurement_plan_budget/models/__init__.py
+++ b/procurement_plan_budget/models/__init__.py
@@ -2,3 +2,4 @@
 from . import budget_appropriation_line
 from . import budget_appropriation
 from . import procurement_plan
+from . import budget_appropriation_compilation

--- a/procurement_plan_budget/models/budget_appropriation.py
+++ b/procurement_plan_budget/models/budget_appropriation.py
@@ -10,6 +10,19 @@ _logger = logging.getLogger(__name__)
 class BudgetAppropriation(models.Model):
     _inherit = "budget.appropriation"
 
+    procurement_plan_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_procurement_plan_ids",
+        store=False,
+        readonly=True,
+    )
+
+    @api.depends("line_ids.enable_procurement_plan", "line_ids.procurement_plan_amount", "line_ids.procurement_plan_unit", "line_ids.procurement_plan_id")
+    def _compute_procurement_plan_ids(self):
+        for record in self:
+            line_ids = record.line_ids.filtered(lambda x: x.enable_procurement_plan)
+            record.procurement_plan_ids = line_ids
+
     def action_review(self):
         super().action_review()
 
@@ -41,6 +54,4 @@ class BudgetAppropriation(models.Model):
             )
 
     def _get_record_url(self):
-        return "/web#id={}&model={}&view_type=form".format(
-            self.id, self._name
-        )
+        return "/web#id={}&model={}&view_type=form".format(self.id, self._name)

--- a/procurement_plan_budget/models/budget_appropriation_compilation.py
+++ b/procurement_plan_budget/models/budget_appropriation_compilation.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class BudgetAppropriationCompilation(models.Model):
+    _inherit = "budget.appropriation.compilation"
+
+    procurement_plan_line_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_procurement_plan_line_ids",
+        store=False,
+        readonly=True,
+    )
+
+    @api.depends(
+        "expense_appropriation_ids.line_ids.enable_procurement_plan",
+        "expense_appropriation_ids.line_ids.procurement_plan_amount",
+        "expense_appropriation_ids.line_ids.procurement_plan_unit",
+        "expense_appropriation_ids.line_ids.procurement_plan_id",
+    )
+    def _compute_procurement_plan_line_ids(self):
+        for rec in self:
+            rec.procurement_plan_line_ids = rec.expense_appropriation_ids.line_ids.filtered(
+                lambda l: l.enable_procurement_plan
+            )

--- a/procurement_plan_budget/views/budget_appropriation_compilation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_compilation_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_budget_appropriation_compilation_form_procurement_plan" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.compilation.form.procurement.plan</field>
+        <field name="model">budget.appropriation.compilation</field>
+        <field name="inherit_id" ref="budget_appropriation_summary.view_budget_appropriation_compilation_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='expense_appropriations']" position="after">
+                <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง">
+                    <field name="procurement_plan_line_ids" readonly="1" nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="appropriation_id" string="ใบจัดสรรงบประมาณ" optional="hide" />
+                            <field name="description" string="ชื่อรายการ" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="procurement_plan_amount" string="จำนวน" />
+                            <field name="procurement_plan_unit" string="หน่วย" />
+                            <field name="balance" string="วงเงินรวม" sum="รวม" />
+                            <field name="procurement_plan_id" string="แผนจัดซื้อจัดจ้าง" invisible="1" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/procurement_plan_budget/views/budget_appropriation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_views.xml
@@ -58,20 +58,16 @@
                 <attribute name="decoration-info">procurement_plan</attribute>
             </xpath>
             <xpath expr="//notebook/page[@name='line_ids']" position="after">
-                <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง"
+                <page name="procurement_plan_summary" string="แผนจัดซื้อจัดจ้าง"
                       attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
-                    <field name="line_ids" readonly="1"
-                           domain="[('enable_procurement_plan', '=', True)]"
-                           nolabel="1">
+                    <field name="procurement_plan_ids" readonly="1" nolabel="1">
                         <tree create="false" edit="false" delete="false">
-                            <field name="enable_procurement_plan" invisible="1" />
                             <field name="description" string="ชื่อรายการ" />
                             <field name="account_id" string="รหัสงบประมาณ" />
                             <field name="activity_analytic_id" string="กิจกรรม" />
                             <field name="procurement_plan_amount" string="จำนวน" />
                             <field name="procurement_plan_unit" string="หน่วย" />
                             <field name="balance" string="วงเงินรวม" sum="รวม" />
-                            <field name="procurement_plan_id" string="แผนจัดซื้อจัดจ้าง" />
                         </tree>
                     </field>
                 </page>

--- a/procurement_plan_budget/views/budget_appropriation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_views.xml
@@ -57,6 +57,25 @@
             <xpath expr="//field[@name='line_ids']/tree" position="attributes">
                 <attribute name="decoration-info">procurement_plan</attribute>
             </xpath>
+            <xpath expr="//notebook/page[@name='line_ids']" position="after">
+                <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง"
+                      attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="line_ids" readonly="1"
+                           domain="[('enable_procurement_plan', '=', True)]"
+                           nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="enable_procurement_plan" invisible="1" />
+                            <field name="description" string="ชื่อรายการ" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="procurement_plan_amount" string="จำนวน" />
+                            <field name="procurement_plan_unit" string="หน่วย" />
+                            <field name="balance" string="วงเงินรวม" sum="รวม" />
+                            <field name="procurement_plan_id" string="แผนจัดซื้อจัดจ้าง" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- Add "ready" state to `procurement.plan` with validation requiring all planning fields before transitioning
- Add procurement plan summary tab to `budget.appropriation` form showing procurement-enabled lines
- Add procurement plan summary tab to `budget.appropriation.compilation` form aggregating lines across all expense appropriations
- Improve procurement plan UX: store analytic fields, add source/fund searchpanel filters, separate description editability from other fields