### PR TITLE
[16.0][IMP] budget_appropriation: restrict initial appropriation post to managers

### DIFF
--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -276,10 +276,16 @@ class BudgetAppropriation(models.Model):
                     "budget.appropriation"
                 ) or _("New")
 
-    @api.depends("date", "state")
+    @api.depends("date", "state", "appropriation_type")
     def _compute_hide_post_button(self):
+        is_manager = self.env.user.has_group("budget.group_budget_manager")
         for record in self:
-            record.hide_post_button = record.state != "review"
+            if record.state != "review":
+                record.hide_post_button = True
+            elif not is_manager and record.appropriation_type == "initial":
+                record.hide_post_button = True
+            else:
+                record.hide_post_button = False
 
     @api.depends("state")
     def _compute_hide_review_button(self):
@@ -299,6 +305,15 @@ class BudgetAppropriation(models.Model):
 
     def action_post(self):
         """Post appropriation and create budget move"""
+        is_manager = self.env.user.has_group("budget.group_budget_manager")
+        if not is_manager:
+            initial = self.filtered(lambda r: r.appropriation_type == "initial")
+            if initial:
+                raise UserError(
+                    _(
+                        "เฉพาะผู้จัดการงบประมาณเท่านั้นที่สามารถอนุมัติการจัดสรรงบประมาณต้นปีได้"
+                    )
+                )
         self._create_budget_move()
         self.write({"state": "posted"})
 


### PR DESCRIPTION
## Summary
- `budget_user` can post only supplementary (mid-year) appropriations (`appropriation_type = supplementary`)
- Posting initial (start-of-year) appropriations (`appropriation_type = initial`) is restricted to `budget_manager` group
- The Post button is hidden in the UI for `budget_user` on initial appropriations, and a server-side guard raises a `UserError` to prevent bypassing via RPC

## Test plan
- [ ] Login as `budget_user`, open an initial appropriation in review state — Post button should be hidden
- [ ] Login as `budget_user`, open a supplementary appropriation in review state — Post button should be visible and functional
- [ ] Login as `budget_manager` — Post button should be visible for both initial and supplementary appropriations