### PR TITLE
[16.0][IMP] budget_appropriation_summary: show note in F4/F5 reports

### DIFF
--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -395,12 +395,14 @@ class BudgetAppropriationCompilation(models.Model):
     def _merge_f5_last_level_nodes(self, data):
         """Merge last-level account nodes with the same id for non-itemized mode."""
 
-        def merge_children(nodes):
+        def merge_children(nodes, clear_text=False):
             merged = []
             seen = {}
             for node in nodes:
                 if node.get("children"):
-                    node["children"] = merge_children(node["children"])
+                    node["children"] = merge_children(
+                        node["children"], clear_text=clear_text
+                    )
                 # Merge leaf account nodes (no children) by id
                 if (
                     node.get("type") == "account"
@@ -416,8 +418,9 @@ class BudgetAppropriationCompilation(models.Model):
                             "amount_total", 0
                         ) + node.get("amount_total", 0)
                     else:
-                        node["description"] = ""
-                        node["note"] = ""
+                        if clear_text:
+                            node["description"] = ""
+                            node["note"] = ""
                         seen[key] = node
                         merged.append(node)
                 else:
@@ -428,11 +431,15 @@ class BudgetAppropriationCompilation(models.Model):
             if key == "details":
                 for detail in data.get("details", []):
                     if detail.get("hierarchy"):
-                        detail["hierarchy"] = merge_children(detail["hierarchy"])
+                        detail["hierarchy"] = merge_children(
+                            detail["hierarchy"], clear_text=False
+                        )
             elif key == "overview" and data.get("overview"):
                 overview = data["overview"]
                 if overview.get("hierarchy"):
-                    overview["hierarchy"] = merge_children(overview["hierarchy"])
+                    overview["hierarchy"] = merge_children(
+                        overview["hierarchy"], clear_text=True
+                    )
         return data
 
     def action_confirm(self):

--- a/budget_appropriation_summary/report/report_compilation_f4.xml
+++ b/budget_appropriation_summary/report/report_compilation_f4.xml
@@ -181,17 +181,17 @@
                             <div class="account-content">
                                 <t t-out="node.get('name', '')" />
                             </div>
-                            <div
+                            <!-- <div
                                 t-if="node.get('description')"
                                 class="account-description"
                             >
                                 <t t-out="node.get('description', '')" />
-                            </div>
+                            </div> -->
                             <div
                                 t-if="node.get('note')"
                                 class="account-note"
                             >
-                                <t t-out="node.get('note', '')" />
+                                <t t-out="node.get('note', '').strip()" />
                             </div>
                         </t>
                         <t t-else="">

--- a/budget_appropriation_summary/report/report_compilation_f4.xml
+++ b/budget_appropriation_summary/report/report_compilation_f4.xml
@@ -187,6 +187,12 @@
                             >
                                 <t t-out="node.get('description', '')" />
                             </div>
+                            <div
+                                t-if="node.get('note')"
+                                class="account-note"
+                            >
+                                <t t-out="node.get('note', '')" />
+                            </div>
                         </t>
                         <t t-else="">
                             <span class="node-content" t-out="node.get('name', '')" />
@@ -321,6 +327,14 @@
                 font-weight: 400;
                 font-size: 11px;
                 line-height: 1.50;
+            }
+
+            .account-note {
+                margin-left: 16px;
+                font-weight: 400;
+                font-size: 11px;
+                line-height: 1.50;
+                white-space: pre-wrap;
             }
 
             .amount-cell {

--- a/budget_appropriation_summary/report/report_compilation_f5.xml
+++ b/budget_appropriation_summary/report/report_compilation_f5.xml
@@ -156,18 +156,17 @@
                             <div class="account-content">
                                 <t t-out="node.get('name', '')" />
                             </div>
-                            <div
+                            <!-- <div
                                 t-if="node.get('description')"
                                 class="account-description"
                             >
                                 <t t-out="node.get('description', '')" />
-                            </div>
+                            </div> -->
                             <div
                                 t-if="node.get('note')"
                                 class="account-note"
-                            >
-                                <t t-out="node.get('note', '')" />
-                            </div>
+                                t-out="node.get('note', '').strip()"
+                            />
                         </t>
                         <t t-else="">
                             <span class="node-content" t-out="node.get('name', '')" />
@@ -329,7 +328,7 @@
             .account-note {
                 margin-left: 10px;
                 font-weight: 400;
-                font-size: 11px;
+                font-size: 7.5pt;
                 line-height: 1.50;
                 white-space: pre-wrap;
             }

--- a/budget_appropriation_summary/report/report_compilation_f5.xml
+++ b/budget_appropriation_summary/report/report_compilation_f5.xml
@@ -156,6 +156,18 @@
                             <div class="account-content">
                                 <t t-out="node.get('name', '')" />
                             </div>
+                            <div
+                                t-if="node.get('description')"
+                                class="account-description"
+                            >
+                                <t t-out="node.get('description', '')" />
+                            </div>
+                            <div
+                                t-if="node.get('note')"
+                                class="account-note"
+                            >
+                                <t t-out="node.get('note', '')" />
+                            </div>
                         </t>
                         <t t-else="">
                             <span class="node-content" t-out="node.get('name', '')" />
@@ -312,6 +324,14 @@
                 font-weight: 400;
                 font-size: 11px;
                 line-height: 1.50;
+            }
+
+            .account-note {
+                margin-left: 10px;
+                font-weight: 400;
+                font-size: 11px;
+                line-height: 1.50;
+                white-space: pre-wrap;
             }
 
             .amount-cell {


### PR DESCRIPTION
## Summary
- Display `note` (หมายเหตุ) below account name in F4 and F5 compilation report templates
- F5 now also renders `description` for account nodes (was missing before)
- Fix `_merge_f5_last_level_nodes` to preserve notes on per-appropriation detail pages; notes are only cleared on the cross-appropriation overview where merging makes them ambiguous

## Test plan
- [ ] Open a compilation record with appropriations that have notes on budget lines
- [ ] Generate F4 PDF/HTML — verify note appears below account name
- [ ] Generate F5 PDF/HTML — verify note and description appear on detail pages
- [ ] Verify F5 overview page does not show notes (cross-appropriation merge)