### PR TITLE
[16.0][ADD] account_asset_depreciation_board: standalone depreciation board

### DIFF
--- a/account_asset_depreciation_board/__init__.py
+++ b/account_asset_depreciation_board/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_asset_depreciation_board/__manifest__.py
+++ b/account_asset_depreciation_board/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Account Asset Depreciation Board",
+    "version": "16.0.1.0.0",
+    "summary": "Standalone depreciation board for batch-posting depreciation entries",
+    "category": "KMITL",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": ["account_asset_usability_kmitl"],
+    "data": [
+        "views/account_asset_line_views.xml",
+        "views/menuitem.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/account_asset_depreciation_board/__manifest__.py
+++ b/account_asset_depreciation_board/__manifest__.py
@@ -5,7 +5,7 @@
     "category": "KMITL",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    "depends": ["account_asset_usability_kmitl"],
+    "depends": ["account_asset_kmitl"],
     "data": [
         "views/account_asset_line_views.xml",
         "views/menuitem.xml",

--- a/account_asset_depreciation_board/i18n/th.po
+++ b/account_asset_depreciation_board/i18n/th.po
@@ -6,15 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-12 03:54+0000\n"
-"PO-Revision-Date: 2026-03-12 10:59+0700\n"
+"POT-Creation-Date: 2026-03-12 06:43+0000\n"
+"PO-Revision-Date: 2026-03-12 06:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 3.8\n"
 
 #. module: account_asset_depreciation_board
 #: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
@@ -30,13 +29,13 @@ msgstr "หมวดหมู่สินทรัพย์"
 #. module: account_asset_depreciation_board
 #: model:ir.model,name:account_asset_depreciation_board.model_account_asset_line
 msgid "Asset depreciation table line"
-msgstr "ตารางแจกแจงค่าเสื่อม"
+msgstr "ตารางค่าเสื่อม"
 
 #. module: account_asset_depreciation_board
 #: model:ir.actions.act_window,name:account_asset_depreciation_board.action_account_asset_line_depreciation_board
 #: model:ir.ui.menu,name:account_asset_depreciation_board.menu_asset_depreciation_board
 msgid "Depreciation Board"
-msgstr "ตารางแจกแจงค่าเสื่อม"
+msgstr "ตารางค่าเสื่อม"
 
 #. module: account_asset_depreciation_board
 #. odoo-python
@@ -48,12 +47,7 @@ msgstr "รายการค่าเสื่อม"
 #. module: account_asset_depreciation_board
 #: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
 msgid "Group By"
-msgstr ""
-
-#. module: account_asset_depreciation_board
-#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
-msgid "Month"
-msgstr "เดือน"
+msgstr "จัดกลุ่ม"
 
 #. module: account_asset_depreciation_board
 #: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
@@ -63,7 +57,7 @@ msgstr "รอดำเนินการ"
 #. module: account_asset_depreciation_board
 #: model:ir.actions.server,name:account_asset_depreciation_board.action_batch_post_depreciation
 msgid "Post Depreciation Entries"
-msgstr "ลงบัญชี"
+msgstr "สร้างรายการค่าเสื่อม (ส่งบัญชี)"
 
 #. module: account_asset_depreciation_board
 #: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
@@ -95,4 +89,14 @@ msgstr "ปีนี้"
 #. module: account_asset_depreciation_board
 #: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_tree_view
 msgid "Total Amount"
+msgstr "รวม"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_tree_view
+msgid "View Move"
+msgstr "ดูรายการบัญชี"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "วันที่"
 msgstr ""

--- a/account_asset_depreciation_board/i18n/th.po
+++ b/account_asset_depreciation_board/i18n/th.po
@@ -1,0 +1,98 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_asset_depreciation_board
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-12 03:54+0000\n"
+"PO-Revision-Date: 2026-03-12 10:59+0700\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.8\n"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "Asset"
+msgstr "ครุภัณฑ์/สินทรัพย์"
+
+#. module: account_asset_depreciation_board
+#: model:ir.model.fields,field_description:account_asset_depreciation_board.field_account_asset_line__profile_id
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "Asset Profile"
+msgstr "หมวดหมู่สินทรัพย์"
+
+#. module: account_asset_depreciation_board
+#: model:ir.model,name:account_asset_depreciation_board.model_account_asset_line
+msgid "Asset depreciation table line"
+msgstr "ตารางแจกแจงค่าเสื่อม"
+
+#. module: account_asset_depreciation_board
+#: model:ir.actions.act_window,name:account_asset_depreciation_board.action_account_asset_line_depreciation_board
+#: model:ir.ui.menu,name:account_asset_depreciation_board.menu_asset_depreciation_board
+msgid "Depreciation Board"
+msgstr "ตารางแจกแจงค่าเสื่อม"
+
+#. module: account_asset_depreciation_board
+#. odoo-python
+#: code:addons/account_asset_depreciation_board/models/account_asset_line.py:0
+#, python-format
+msgid "Depreciation Entries"
+msgstr "รายการค่าเสื่อม"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "Group By"
+msgstr ""
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "Month"
+msgstr "เดือน"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "Pending"
+msgstr "รอดำเนินการ"
+
+#. module: account_asset_depreciation_board
+#: model:ir.actions.server,name:account_asset_depreciation_board.action_batch_post_depreciation
+msgid "Post Depreciation Entries"
+msgstr "ลงบัญชี"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_tree_view
+msgid "Posted"
+msgstr "ลงบัญชีแล้ว"
+
+#. module: account_asset_depreciation_board
+#. odoo-python
+#: code:addons/account_asset_depreciation_board/models/account_asset_line.py:0
+#, python-format
+msgid ""
+"The following lines cannot be posted: %s\n"
+"Only pending depreciation lines on open assets are allowed."
+msgstr ""
+"ไม่สามารถบันทึกรายการต่อไปนี้ได้: %s\n"
+"อนุญาตเฉพาะรายการค่าเสื่อมราคาที่รอดำเนินการของครุภัณฑ์/สินทรัพย์ที่ยังเปิดใช้งานอยู่เท่านั้น"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "This Month"
+msgstr "เดือนนี้"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_search_view
+msgid "This Year"
+msgstr "ปีนี้"
+
+#. module: account_asset_depreciation_board
+#: model_terms:ir.ui.view,arch_db:account_asset_depreciation_board.account_asset_line_tree_view
+msgid "Total Amount"
+msgstr ""

--- a/account_asset_depreciation_board/models/__init__.py
+++ b/account_asset_depreciation_board/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_asset_line

--- a/account_asset_depreciation_board/models/account_asset_line.py
+++ b/account_asset_depreciation_board/models/account_asset_line.py
@@ -1,0 +1,38 @@
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class AccountAssetLine(models.Model):
+    _inherit = "account.asset.line"
+
+    profile_id = fields.Many2one(
+        comodel_name="account.asset.profile",
+        string="Asset Profile",
+        related="asset_id.profile_id",
+        store=True,
+    )
+
+    def action_batch_create_move(self):
+        """Batch-post depreciation journal entries for selected lines."""
+        invalid = self.filtered(
+            lambda l: l.type != "depreciate"
+            or l.move_check
+            or l.init_entry
+            or l.parent_state != "open"
+        )
+        if invalid:
+            raise UserError(
+                _(
+                    "The following lines cannot be posted: %s\n"
+                    "Only pending depreciation lines on open assets are allowed."
+                )
+                % ", ".join(invalid.mapped("name"))
+            )
+        created_move_ids = self.create_move()
+        return {
+            "name": _("Depreciation Entries"),
+            "type": "ir.actions.act_window",
+            "res_model": "account.move",
+            "view_mode": "list,form",
+            "domain": [("id", "in", created_move_ids)],
+        }

--- a/account_asset_depreciation_board/views/account_asset_line_views.xml
+++ b/account_asset_depreciation_board/views/account_asset_line_views.xml
@@ -17,6 +17,13 @@
                 <field name="remaining_value"/>
                 <field name="move_check" string="Posted"/>
                 <field name="currency_id" invisible="1"/>
+                <button
+                    name="open_move"
+                    icon="fa-folder-open-o"
+                    string="View Move"
+                    type="object"
+                    attrs="{'invisible': [('move_check', '!=', True)]}"
+                />
             </tree>
         </field>
     </record>

--- a/account_asset_depreciation_board/views/account_asset_line_views.xml
+++ b/account_asset_depreciation_board/views/account_asset_line_views.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_asset_line_tree_view" model="ir.ui.view">
+        <field name="name">account.asset.line.tree.depreciation.board</field>
+        <field name="model">account.asset.line</field>
+        <field name="arch" type="xml">
+            <tree
+                decoration-info="not move_check"
+                decoration-muted="move_check"
+            >
+                <field name="asset_id"/>
+                <field name="profile_id"/>
+                <field name="line_date"/>
+                <field name="amount" sum="Total Amount"/>
+                <field name="depreciated_value"/>
+                <field name="remaining_value"/>
+                <field name="move_check" string="Posted"/>
+                <field name="currency_id" invisible="1"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="account_asset_line_search_view" model="ir.ui.view">
+        <field name="name">account.asset.line.search.depreciation.board</field>
+        <field name="model">account.asset.line</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="asset_id"/>
+                <field name="profile_id"/>
+                <field name="line_date"/>
+                <filter
+                    name="pending"
+                    string="Pending"
+                    domain="[
+                        ('type', '=', 'depreciate'),
+                        ('move_check', '=', False),
+                        ('init_entry', '=', False),
+                        ('parent_state', '=', 'open'),
+                    ]"
+                />
+                <filter
+                    name="posted"
+                    string="Posted"
+                    domain="[('move_check', '=', True)]"
+                />
+                <separator/>
+                <filter
+                    name="this_month"
+                    string="This Month"
+                    domain="[
+                        ('line_date', '>=', (context_today() + relativedelta(day=1)).strftime('%Y-%m-%d')),
+                        ('line_date', '&lt;=', (context_today() + relativedelta(day=31)).strftime('%Y-%m-%d')),
+                    ]"
+                />
+                <filter
+                    name="this_year"
+                    string="This Year"
+                    domain="[
+                        ('line_date', '>=', (context_today() + relativedelta(month=1, day=1)).strftime('%Y-%m-%d')),
+                        ('line_date', '&lt;=', (context_today() + relativedelta(month=12, day=31)).strftime('%Y-%m-%d')),
+                    ]"
+                />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_profile"
+                        string="Asset Profile"
+                        context="{'group_by': 'profile_id'}"
+                    />
+                    <filter
+                        name="group_month"
+                        string="Month"
+                        context="{'group_by': 'line_date:month'}"
+                    />
+                    <filter
+                        name="group_asset"
+                        string="Asset"
+                        context="{'group_by': 'asset_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_account_asset_line_depreciation_board" model="ir.actions.act_window">
+        <field name="name">Depreciation Board</field>
+        <field name="res_model">account.asset.line</field>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="account_asset_line_tree_view"/>
+        <field name="search_view_id" ref="account_asset_line_search_view"/>
+        <field name="context">{"search_default_pending": 1}</field>
+    </record>
+
+    <record id="action_batch_post_depreciation" model="ir.actions.server">
+        <field name="name">Post Depreciation Entries</field>
+        <field name="model_id" ref="account_asset_management.model_account_asset_line"/>
+        <field name="binding_model_id" ref="account_asset_management.model_account_asset_line"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_batch_create_move()</field>
+        <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
+    </record>
+
+</odoo>

--- a/account_asset_depreciation_board/views/account_asset_line_views.xml
+++ b/account_asset_depreciation_board/views/account_asset_line_views.xml
@@ -75,8 +75,8 @@
                         context="{'group_by': 'profile_id'}"
                     />
                     <filter
-                        name="group_month"
-                        string="Month"
+                        name="group_date"
+                        string="วันที่"
                         context="{'group_by': 'line_date:month'}"
                     />
                     <filter

--- a/account_asset_depreciation_board/views/menuitem.xml
+++ b/account_asset_depreciation_board/views/menuitem.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <menuitem
+        id="menu_asset_depreciation_board"
+        name="Depreciation Board"
+        parent="account_asset_usability_kmitl.menu_assets"
+        action="action_account_asset_line_depreciation_board"
+    />
+
+</odoo>

--- a/account_asset_depreciation_board/views/menuitem.xml
+++ b/account_asset_depreciation_board/views/menuitem.xml
@@ -4,7 +4,7 @@
     <menuitem
         id="menu_asset_depreciation_board"
         name="Depreciation Board"
-        parent="account_asset_usability_kmitl.menu_assets"
+        parent="account_asset_kmitl.menu_assets"
         action="action_account_asset_line_depreciation_board"
     />
 

--- a/account_asset_depreciation_board/views/menuitem.xml
+++ b/account_asset_depreciation_board/views/menuitem.xml
@@ -6,6 +6,7 @@
         name="Depreciation Board"
         parent="account_asset_kmitl.menu_assets"
         action="action_account_asset_line_depreciation_board"
+        sequence="15"
     />
 
 </odoo>

--- a/account_asset_kmitl/views/menuitem.xml
+++ b/account_asset_kmitl/views/menuitem.xml
@@ -20,6 +20,7 @@
         name="Asset"
         parent="menu_assets"
         action="account_asset_management.account_asset_action"
+        sequence="10"
     />
 
     <menuitem
@@ -27,6 +28,7 @@
         name="Parent Asset"
         parent="menu_assets"
         action="l10n_th_account_asset_management.action_account_asset_parent"
+        sequence="20"
     />
 
     <menuitem
@@ -34,47 +36,48 @@
         name="Computed Asset"
         parent="menu_assets"
         action="account_asset_management.account_asset_compute_action"
+        sequence="30"
     />
 
-    <menuitem 
+    <menuitem
         id="menu_asset_registration_root"
         name="Create Asset"
         parent="menu_assets_management"
         sequence="25"
     />
 
-    <menuitem 
-        id="menu_asset_configuration" 
-        name="Configuration" 
+    <menuitem
+        id="menu_asset_configuration"
+        name="Configuration"
         parent="menu_assets_management"
         groups="account.group_account_manager"
         sequence="50"
     />
 
-    <menuitem 
-        id="menu_asset_profile" 
-        name="Asset Profiles" 
+    <menuitem
+        id="menu_asset_profile"
+        name="Asset Profiles"
         parent="menu_asset_configuration"
         action="account_asset_management.account_asset_profile_action"
     />
 
-    <menuitem 
-        id="menu_asset_group" 
-        name="Asset Groups" 
+    <menuitem
+        id="menu_asset_group"
+        name="Asset Groups"
         parent="menu_asset_configuration"
         action="account_asset_management.account_asset_group_action"
     />
 
-    <menuitem 
-        id="menu_asset_sub_status" 
-        name="Asset Sub-Status" 
+    <menuitem
+        id="menu_asset_sub_status"
+        name="Asset Sub-Status"
         parent="menu_asset_configuration"
         action="l10n_th_account_asset_management.action_account_asset_sub_state"
     />
 
-    <menuitem 
-        id="menu_asset_location" 
-        name="Asset Locations" 
+    <menuitem
+        id="menu_asset_location"
+        name="Asset Locations"
         parent="menu_asset_configuration"
         action="l10n_th_gov_account_asset_management.action_account_asset_location"
     />


### PR DESCRIPTION
## Summary
Adds a new module that provides a standalone list view for account.asset.line with search filters and batch-posting capability. Users can now view all pending depreciation entries across all assets, filter by profile/month/asset, and batch-post journal entries without navigating individual asset forms.

## Changes
- New module with tree view, search filters (Pending/Posted, This Month/Year), grouping by profile/month/asset
- Batch-post action restricted to account.group_account_user
- Related field for asset profile to enable efficient filtering
- Menu item added under Assets

## Testing
1. Install module and navigate to Assets > Depreciation Board
2. Verify pending filter shows only unposted depreciation lines
3. Group by Asset Profile and filter by month
4. Select lines and use batch-post action to create journal entries
5. Confirm lines are marked as posted and entries are created