### PR TITLE
[16.0][ADD] account_asset_depreciation_import: import depreciation

### DIFF
--- a/account_asset_depreciation_import/__init__.py
+++ b/account_asset_depreciation_import/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/account_asset_depreciation_import/__manifest__.py
+++ b/account_asset_depreciation_import/__manifest__.py
@@ -1,0 +1,16 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Account Asset - Import Depreciation",
+    "summary": "Allow importing already-depreciated amounts when migrating assets.",
+    "version": "16.0.1.0.0",
+    "author": "KMITL",
+    "category": "Accounting & Finance",
+    "depends": ["account_asset_management"],
+    "license": "AGPL-3",
+    "data": [
+        "views/account_asset_views.xml",
+    ],
+    "installable": True,
+    "development_status": "Alpha",
+}

--- a/account_asset_depreciation_import/models/__init__.py
+++ b/account_asset_depreciation_import/models/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import account_asset
+from . import account_asset_line

--- a/account_asset_depreciation_import/models/account_asset.py
+++ b/account_asset_depreciation_import/models/account_asset.py
@@ -1,0 +1,355 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+
+class AccountAsset(models.Model):
+    _inherit = "account.asset"
+
+    already_depreciated_amount_import = fields.Monetary(
+        string="Already Depreciated Amount (Import)",
+        currency_field="currency_id",
+        default=0.0,
+        help="Amount already depreciated in a previous system. "
+        "This reduces the remaining depreciation schedule without "
+        "changing the per-period depreciation rate.",
+    )
+
+    @api.constrains("already_depreciated_amount_import", "depreciation_base")
+    def _check_already_depreciated_amount_import(self):
+        for asset in self:
+            if asset.already_depreciated_amount_import < 0:
+                raise ValidationError(
+                    _("Already Depreciated Amount (Import) must be >= 0.")
+                )
+            if asset.already_depreciated_amount_import > asset.depreciation_base:
+                raise ValidationError(
+                    _(
+                        "Already Depreciated Amount (Import) cannot exceed "
+                        "the depreciation base (%(base)s).",
+                        base=asset.depreciation_base,
+                    )
+                )
+
+    @api.depends(
+        "depreciation_base",
+        "depreciation_line_ids.type",
+        "depreciation_line_ids.amount",
+        "depreciation_line_ids.previous_id",
+        "depreciation_line_ids.init_entry",
+        "depreciation_line_ids.move_check",
+        "already_depreciated_amount_import",
+    )
+    def _compute_depreciation(self):
+        for asset in self:
+            lines = asset.depreciation_line_ids.filtered(
+                lambda l: l.type in ("depreciate", "remove")
+                and (l.init_entry or l.move_check)
+            )
+            value_depreciated = (
+                sum(line.amount for line in lines)
+                + asset.already_depreciated_amount_import
+            )
+            residual = asset.depreciation_base - value_depreciated
+            asset.update(
+                {"value_residual": residual, "value_depreciated": value_depreciated}
+            )
+
+    def _compute_depreciation_amount_per_fiscal_year(
+        self, table, line_dates, depreciation_start_date, depreciation_stop_date
+    ):
+        """Override to start fy_residual_amount reduced by the import amount."""
+        self.ensure_one()
+        # Temporarily reduce the starting residual so the FY loop stops earlier,
+        # while keeping period_amount based on full depreciation_base so the
+        # per-period rate stays consistent.
+        import_amount = self.already_depreciated_amount_import
+        if not import_amount:
+            return super()._compute_depreciation_amount_per_fiscal_year(
+                table, line_dates, depreciation_start_date, depreciation_stop_date
+            )
+
+        currency = self.company_id.currency_id
+        fy_residual_amount = self.depreciation_base - import_amount
+        i_max = len(table) - 1
+        asset_sign = self.depreciation_base >= 0 and 1 or -1
+        day_amount = 0.0
+        if self.days_calc:
+            days = (depreciation_stop_date - depreciation_start_date).days + 1
+            day_amount = self.depreciation_base / days
+
+        for i, entry in enumerate(table):
+            if self.method_time == "year":
+                # year_amount is still based on full depreciation_base via
+                # _compute_year_amount — this keeps per-period rate stable
+                year_amount = self._compute_year_amount(
+                    fy_residual_amount,
+                    depreciation_start_date,
+                    depreciation_stop_date,
+                    entry,
+                )
+                if self.method_period == "year":
+                    period_amount = year_amount
+                elif self.method_period == "quarter":
+                    period_amount = year_amount / 4
+                elif self.method_period == "month":
+                    period_amount = year_amount / 12
+                if i == i_max:
+                    if self.method in ["linear-limit", "degr-limit"]:
+                        fy_amount = fy_residual_amount - self.salvage_value
+                    else:
+                        fy_amount = fy_residual_amount
+                else:
+                    firstyear = i == 0 and True or False
+                    fy_factor = self._get_fy_duration_factor(entry, firstyear)
+                    fy_amount = year_amount * fy_factor
+                if (
+                    currency.compare_amounts(
+                        asset_sign * (fy_amount - fy_residual_amount), 0
+                    )
+                    > 0
+                ):
+                    fy_amount = fy_residual_amount
+                period_amount = currency.round(period_amount)
+                fy_amount = currency.round(fy_amount)
+            else:
+                fy_amount = False
+                if self.method_time == "number":
+                    number = self.method_number
+                else:
+                    number = len(line_dates)
+                period_amount = currency.round(self.depreciation_base / number)
+            entry.update(
+                {
+                    "period_amount": period_amount,
+                    "fy_amount": fy_amount,
+                    "day_amount": day_amount,
+                }
+            )
+            if self.method_time == "year":
+                fy_residual_amount -= fy_amount
+                if currency.is_zero(fy_residual_amount):
+                    break
+        i_max = i
+        table = table[: i_max + 1]
+        return table
+
+    def _compute_depreciation_table_lines(
+        self, table, depreciation_start_date, depreciation_stop_date, line_dates
+    ):
+        """Override to start with reduced remaining_value and non-zero depreciated_value."""
+        self.ensure_one()
+        import_amount = self.already_depreciated_amount_import
+        if not import_amount:
+            return super()._compute_depreciation_table_lines(
+                table, depreciation_start_date, depreciation_stop_date, line_dates
+            )
+
+        currency = self.company_id.currency_id
+        asset_sign = 1 if self.depreciation_base >= 0 else -1
+        i_max = len(table) - 1
+        remaining_value = self.depreciation_base - import_amount
+        depreciated_value = import_amount
+        company = self.company_id
+        fiscalyear_lock_date = company.fiscalyear_lock_date or fields.Date.to_date(
+            "1901-01-01"
+        )
+
+        for i, entry in enumerate(table):
+            lines = []
+            fy_amount_check = 0.0
+            fy_amount = entry["fy_amount"]
+            li_max = len(line_dates) - 1
+            prev_date = max(entry["date_start"], depreciation_start_date)
+            for li, line_date in enumerate(line_dates):
+                line_days = (line_date - prev_date).days + 1
+                if currency.is_zero(remaining_value):
+                    break
+
+                if line_date > min(
+                    entry["date_stop"], depreciation_stop_date
+                ) and not (i == i_max and li == li_max):
+                    prev_date = line_date
+                    break
+                else:
+                    prev_date = line_date + relativedelta(days=1)
+
+                if (
+                    self.method == "degr-linear"
+                    and currency.compare_amounts(
+                        asset_sign * (fy_amount - fy_amount_check), 0
+                    )
+                    < 0
+                ):
+                    break
+
+                if i == 0 and li == 0:
+                    if currency.compare_amounts(entry.get("day_amount"), 0) > 0:
+                        amount = line_days * entry.get("day_amount")
+                    else:
+                        amount = self._get_first_period_amount(
+                            table, entry, depreciation_start_date, line_dates
+                        )
+                        amount = currency.round(amount)
+                else:
+                    if currency.compare_amounts(entry.get("day_amount"), 0) > 0:
+                        amount = line_days * entry.get("day_amount")
+                    else:
+                        amount = entry.get("period_amount")
+
+                # last year, last entry — handle rounding deviations
+                if i == i_max and li == li_max:
+                    amount = remaining_value
+                    remaining_value = 0.0
+                else:
+                    remaining_value -= amount
+                fy_amount_check += amount
+                line = {
+                    "date": line_date,
+                    "days": line_days,
+                    "amount": amount,
+                    "depreciated_value": depreciated_value,
+                    "remaining_value": remaining_value,
+                    "init": fiscalyear_lock_date >= line_date,
+                }
+                lines.append(line)
+                depreciated_value += amount
+
+            if self.method_time == "year" and not entry.get("day_amount"):
+                if not currency.is_zero(fy_amount_check - fy_amount):
+                    diff = fy_amount_check - fy_amount
+                    amount = amount - diff
+                    remaining_value += diff
+                    lines[-1].update(
+                        {"amount": amount, "remaining_value": remaining_value}
+                    )
+                    depreciated_value -= diff
+
+            if not lines:
+                table.pop(i)
+            else:
+                entry["lines"] = lines
+            line_dates = line_dates[li:]
+
+        for entry in table:
+            if not entry["fy_amount"]:
+                entry["fy_amount"] = sum(line["amount"] for line in entry["lines"])
+
+    def compute_depreciation_board(self):
+        """Override to include import amount in depreciated_value initialisation."""
+        line_obj = self.env["account.asset.line"]
+
+        for asset in self:
+            import_amount = asset.already_depreciated_amount_import
+            if not import_amount:
+                # Delegate to super for assets without import amount
+                super(AccountAsset, asset).compute_depreciation_board()
+                continue
+
+            currency = asset.company_id.currency_id
+            if currency.is_zero(asset.value_residual):
+                continue
+            domain = [
+                ("asset_id", "=", asset.id),
+                ("type", "=", "depreciate"),
+                "|",
+                ("move_check", "=", True),
+                ("init_entry", "=", True),
+            ]
+            posted_lines = line_obj.search(domain, order="line_date desc")
+            if posted_lines:
+                last_line = posted_lines[0]
+            else:
+                last_line = line_obj
+            domain = [
+                ("asset_id", "=", asset.id),
+                ("type", "=", "depreciate"),
+                ("move_id", "=", False),
+                ("init_entry", "=", False),
+            ]
+            old_lines = line_obj.search(domain)
+            if old_lines:
+                old_lines.unlink()
+
+            table = asset._compute_depreciation_table()
+            if not table:
+                continue
+
+            asset._group_lines(table)
+
+            depreciated_value_posted = depreciated_value = 0.0
+            if posted_lines:
+                total_table_lines = sum(len(entry["lines"]) for entry in table)
+                move_check_lines = asset.depreciation_line_ids.filtered("move_check")
+                last_depreciation_date = last_line.line_date
+                last_date_in_table = table[-1]["lines"][-1]["date"]
+                if (last_date_in_table < last_depreciation_date) or (
+                    last_date_in_table == last_depreciation_date
+                    and total_table_lines != len(move_check_lines)
+                ):
+                    raise UserError(
+                        _(
+                            "The duration of the asset conflicts with the "
+                            "posted depreciation table entry dates."
+                        )
+                    )
+
+                for _table_i, entry in enumerate(table):
+                    residual_amount_table = entry["lines"][-1]["remaining_value"]
+                    if (
+                        entry["date_start"]
+                        <= last_depreciation_date
+                        <= entry["date_stop"]
+                    ):
+                        break
+
+                if entry["date_stop"] == last_depreciation_date:
+                    _table_i += 1
+                    _line_i = 0
+                else:
+                    entry = table[_table_i]
+                    date_min = entry["date_start"]
+                    for _line_i, line in enumerate(entry["lines"]):
+                        residual_amount_table = line["remaining_value"]
+                        if date_min <= last_depreciation_date <= line["date"]:
+                            break
+                        date_min = line["date"]
+                    if line["date"] == last_depreciation_date:
+                        _line_i += 1
+                table_i_start = _table_i
+                line_i_start = _line_i
+
+                depreciated_value_posted = depreciated_value = (
+                    sum(posted_line.amount for posted_line in posted_lines)
+                    + import_amount
+                )
+                residual_amount = asset.depreciation_base - depreciated_value
+                amount_diff = currency.round(residual_amount_table - residual_amount)
+                if amount_diff:
+                    if len(move_check_lines) == total_table_lines:
+                        table[table_i_start]["lines"].append(
+                            table[table_i_start]["lines"][line_i_start - 1]
+                        )
+                        line = table[table_i_start]["lines"][line_i_start]
+                        line["days"] = 0
+                        line["amount"] = amount_diff
+                    line = table[table_i_start]["lines"][line_i_start]
+                    line["amount"] -= amount_diff
+
+            else:
+                table_i_start = 0
+                line_i_start = 0
+                depreciated_value_posted = import_amount
+
+            asset._compute_depreciation_line(
+                depreciated_value_posted,
+                table_i_start,
+                line_i_start,
+                table,
+                last_line,
+                posted_lines,
+            )
+        return True

--- a/account_asset_depreciation_import/models/account_asset.py
+++ b/account_asset_depreciation_import/models/account_asset.py
@@ -205,6 +205,15 @@ class AccountAsset(models.Model):
                     amount = remaining_value
                     remaining_value = 0.0
                 else:
+                    # Cap amount to remaining_value to prevent negative residual
+                    if (
+                        currency.compare_amounts(
+                            asset_sign * amount,
+                            asset_sign * remaining_value,
+                        )
+                        > 0
+                    ):
+                        amount = remaining_value
                     remaining_value -= amount
                 fy_amount_check += amount
                 line = {

--- a/account_asset_depreciation_import/models/account_asset.py
+++ b/account_asset_depreciation_import/models/account_asset.py
@@ -1,7 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from dateutil.relativedelta import relativedelta
-
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -58,209 +56,43 @@ class AccountAsset(models.Model):
                 {"value_residual": residual, "value_depreciated": value_depreciated}
             )
 
-    def _compute_depreciation_amount_per_fiscal_year(
-        self, table, line_dates, depreciation_start_date, depreciation_stop_date
-    ):
-        """Override to start fy_residual_amount reduced by the import amount."""
-        self.ensure_one()
-        # Temporarily reduce the starting residual so the FY loop stops earlier,
-        # while keeping period_amount based on full depreciation_base so the
-        # per-period rate stays consistent.
-        import_amount = self.already_depreciated_amount_import
-        if not import_amount:
-            return super()._compute_depreciation_amount_per_fiscal_year(
-                table, line_dates, depreciation_start_date, depreciation_stop_date
-            )
-
-        currency = self.company_id.currency_id
-        fy_residual_amount = self.depreciation_base - import_amount
-        i_max = len(table) - 1
-        asset_sign = self.depreciation_base >= 0 and 1 or -1
-        day_amount = 0.0
-        if self.days_calc:
-            days = (depreciation_stop_date - depreciation_start_date).days + 1
-            day_amount = self.depreciation_base / days
-
-        for i, entry in enumerate(table):
-            if self.method_time == "year":
-                # year_amount is still based on full depreciation_base via
-                # _compute_year_amount — this keeps per-period rate stable
-                year_amount = self._compute_year_amount(
-                    fy_residual_amount,
-                    depreciation_start_date,
-                    depreciation_stop_date,
-                    entry,
-                )
-                if self.method_period == "year":
-                    period_amount = year_amount
-                elif self.method_period == "quarter":
-                    period_amount = year_amount / 4
-                elif self.method_period == "month":
-                    period_amount = year_amount / 12
-                if i == i_max:
-                    if self.method in ["linear-limit", "degr-limit"]:
-                        fy_amount = fy_residual_amount - self.salvage_value
-                    else:
-                        fy_amount = fy_residual_amount
-                else:
-                    firstyear = i == 0 and True or False
-                    fy_factor = self._get_fy_duration_factor(entry, firstyear)
-                    fy_amount = year_amount * fy_factor
-                if (
-                    currency.compare_amounts(
-                        asset_sign * (fy_amount - fy_residual_amount), 0
-                    )
-                    > 0
-                ):
-                    fy_amount = fy_residual_amount
-                period_amount = currency.round(period_amount)
-                fy_amount = currency.round(fy_amount)
-            else:
-                fy_amount = False
-                if self.method_time == "number":
-                    number = self.method_number
-                else:
-                    number = len(line_dates)
-                period_amount = currency.round(self.depreciation_base / number)
-            entry.update(
-                {
-                    "period_amount": period_amount,
-                    "fy_amount": fy_amount,
-                    "day_amount": day_amount,
-                }
-            )
-            if self.method_time == "year":
-                fy_residual_amount -= fy_amount
-                if currency.is_zero(fy_residual_amount):
-                    break
-        i_max = i
-        table = table[: i_max + 1]
-        return table
-
-    def _compute_depreciation_table_lines(
-        self, table, depreciation_start_date, depreciation_stop_date, line_dates
-    ):
-        """Override to start with reduced remaining_value and non-zero depreciated_value."""
-        self.ensure_one()
-        import_amount = self.already_depreciated_amount_import
-        if not import_amount:
-            return super()._compute_depreciation_table_lines(
-                table, depreciation_start_date, depreciation_stop_date, line_dates
-            )
-
-        currency = self.company_id.currency_id
-        asset_sign = 1 if self.depreciation_base >= 0 else -1
-        i_max = len(table) - 1
-        remaining_value = self.depreciation_base - import_amount
-        depreciated_value = import_amount
-        company = self.company_id
-        fiscalyear_lock_date = company.fiscalyear_lock_date or fields.Date.to_date(
-            "1901-01-01"
-        )
-
-        for i, entry in enumerate(table):
-            lines = []
-            fy_amount_check = 0.0
-            fy_amount = entry["fy_amount"]
-            li_max = len(line_dates) - 1
-            prev_date = max(entry["date_start"], depreciation_start_date)
-            for li, line_date in enumerate(line_dates):
-                line_days = (line_date - prev_date).days + 1
-                if currency.is_zero(remaining_value):
-                    break
-
-                if line_date > min(
-                    entry["date_stop"], depreciation_stop_date
-                ) and not (i == i_max and li == li_max):
-                    prev_date = line_date
-                    break
-                else:
-                    prev_date = line_date + relativedelta(days=1)
-
-                if (
-                    self.method == "degr-linear"
-                    and currency.compare_amounts(
-                        asset_sign * (fy_amount - fy_amount_check), 0
-                    )
-                    < 0
-                ):
-                    break
-
-                if i == 0 and li == 0:
-                    if currency.compare_amounts(entry.get("day_amount"), 0) > 0:
-                        amount = line_days * entry.get("day_amount")
-                    else:
-                        amount = self._get_first_period_amount(
-                            table, entry, depreciation_start_date, line_dates
-                        )
-                        amount = currency.round(amount)
-                else:
-                    if currency.compare_amounts(entry.get("day_amount"), 0) > 0:
-                        amount = line_days * entry.get("day_amount")
-                    else:
-                        amount = entry.get("period_amount")
-
-                # last year, last entry — handle rounding deviations
-                if i == i_max and li == li_max:
-                    amount = remaining_value
-                    remaining_value = 0.0
-                else:
-                    # Cap amount to remaining_value to prevent negative residual
-                    if (
-                        currency.compare_amounts(
-                            asset_sign * amount,
-                            asset_sign * remaining_value,
-                        )
-                        > 0
-                    ):
-                        amount = remaining_value
-                    remaining_value -= amount
-                fy_amount_check += amount
-                line = {
-                    "date": line_date,
-                    "days": line_days,
-                    "amount": amount,
-                    "depreciated_value": depreciated_value,
-                    "remaining_value": remaining_value,
-                    "init": fiscalyear_lock_date >= line_date,
-                }
-                lines.append(line)
-                depreciated_value += amount
-
-            if self.method_time == "year" and not entry.get("day_amount"):
-                if not currency.is_zero(fy_amount_check - fy_amount):
-                    diff = fy_amount_check - fy_amount
-                    amount = amount - diff
-                    remaining_value += diff
-                    lines[-1].update(
-                        {"amount": amount, "remaining_value": remaining_value}
-                    )
-                    depreciated_value -= diff
-
-            if not lines:
-                table.pop(i)
-            else:
-                entry["lines"] = lines
-            line_dates = line_dates[li:]
-
-        for entry in table:
-            if not entry["fy_amount"]:
-                entry["fy_amount"] = sum(line["amount"] for line in entry["lines"])
+    def _find_import_start_position(self, table, import_amount, currency):
+        """Walk the standard depreciation table and find where the import
+        amount is exhausted.  Returns ``(table_i, line_i)`` — the position
+        of the first *future* line.  The line at that position has its
+        ``amount`` adjusted to the portion not covered by the import.
+        """
+        accumulated = 0.0
+        for ti, entry in enumerate(table):
+            for li, line in enumerate(entry["lines"]):
+                accumulated += line["amount"]
+                if currency.compare_amounts(accumulated, import_amount) > 0:
+                    # Import falls in the middle of this line — adjust
+                    line["amount"] = currency.round(accumulated - import_amount)
+                    return ti, li
+                if currency.is_zero(accumulated - import_amount):
+                    # Import exactly covers through this line — next one
+                    li_next = li + 1
+                    if li_next >= len(entry["lines"]):
+                        return ti + 1, 0
+                    return ti, li_next
+        # Import covers everything (constraint should prevent this)
+        return len(table), 0
 
     def compute_depreciation_board(self):
-        """Override to include import amount in depreciated_value initialisation."""
+        """Override to skip depreciation lines covered by the import amount."""
         line_obj = self.env["account.asset.line"]
 
         for asset in self:
             import_amount = asset.already_depreciated_amount_import
             if not import_amount:
-                # Delegate to super for assets without import amount
                 super(AccountAsset, asset).compute_depreciation_board()
                 continue
 
             currency = asset.company_id.currency_id
             if currency.is_zero(asset.value_residual):
                 continue
+
             domain = [
                 ("asset_id", "=", asset.id),
                 ("type", "=", "depreciate"),
@@ -283,6 +115,7 @@ class AccountAsset(models.Model):
             if old_lines:
                 old_lines.unlink()
 
+            # Standard table computation — no import adjustments
             table = asset._compute_depreciation_table()
             if not table:
                 continue
@@ -291,6 +124,11 @@ class AccountAsset(models.Model):
 
             depreciated_value_posted = depreciated_value = 0.0
             if posted_lines:
+                # --- posted lines exist --------------------------------
+                # Standard logic: find starting position by date.
+                # Adding import_amount to depreciated_value_posted makes
+                # the residual comparison match the standard table, so
+                # amount_diff naturally stays ≈ 0.
                 total_table_lines = sum(len(entry["lines"]) for entry in table)
                 move_check_lines = asset.depreciation_line_ids.filtered("move_check")
                 last_depreciation_date = last_line.line_date
@@ -336,7 +174,9 @@ class AccountAsset(models.Model):
                     + import_amount
                 )
                 residual_amount = asset.depreciation_base - depreciated_value
-                amount_diff = currency.round(residual_amount_table - residual_amount)
+                amount_diff = currency.round(
+                    residual_amount_table - residual_amount
+                )
                 if amount_diff:
                     if len(move_check_lines) == total_table_lines:
                         table[table_i_start]["lines"].append(
@@ -349,8 +189,12 @@ class AccountAsset(models.Model):
                     line["amount"] -= amount_diff
 
             else:
-                table_i_start = 0
-                line_i_start = 0
+                # --- no posted lines -----------------------------------
+                # Skip table lines that are covered by the import amount,
+                # adjust the first future line's amount.
+                table_i_start, line_i_start = asset._find_import_start_position(
+                    table, import_amount, currency
+                )
                 depreciated_value_posted = import_amount
 
             asset._compute_depreciation_line(

--- a/account_asset_depreciation_import/models/account_asset.py
+++ b/account_asset_depreciation_import/models/account_asset.py
@@ -79,8 +79,39 @@ class AccountAsset(models.Model):
         # Import covers everything (constraint should prevent this)
         return len(table), 0
 
+    def _compute_depreciation_table(self):
+        """Override to return a table that starts after the imported amount.
+
+        The standard table is computed in full, then all lines covered by
+        ``already_depreciated_amount_import`` are removed and the first
+        remaining line's amount is adjusted for partial coverage.
+        ``depreciated_value`` / ``remaining_value`` on every kept line are
+        recalculated so they start from the import amount.
+        """
+        table = super()._compute_depreciation_table()
+        import_amount = self.already_depreciated_amount_import
+        if not import_amount or not table:
+            return table
+        currency = self.company_id.currency_id
+        ti, li = self._find_import_start_position(table, import_amount, currency)
+        if ti >= len(table):
+            return []
+        table = table[ti:]
+        if li > 0:
+            table[0]["lines"] = table[0]["lines"][li:]
+        # Recalculate cumulative values starting from the import amount.
+        dep_val = import_amount
+        rem_val = self.depreciation_base - dep_val
+        for entry in table:
+            for line in entry["lines"]:
+                line["depreciated_value"] = dep_val
+                rem_val -= line["amount"]
+                line["remaining_value"] = rem_val
+                dep_val += line["amount"]
+        return table
+
     def compute_depreciation_board(self):
-        """Override to skip depreciation lines covered by the import amount."""
+        """Override to pass the import amount as the initial depreciated value."""
         line_obj = self.env["account.asset.line"]
 
         for asset in self:
@@ -115,7 +146,7 @@ class AccountAsset(models.Model):
             if old_lines:
                 old_lines.unlink()
 
-            # Standard table computation — no import adjustments
+            # Table already trimmed to future lines by _compute_depreciation_table.
             table = asset._compute_depreciation_table()
             if not table:
                 continue
@@ -126,9 +157,8 @@ class AccountAsset(models.Model):
             if posted_lines:
                 # --- posted lines exist --------------------------------
                 # Standard logic: find starting position by date.
-                # Adding import_amount to depreciated_value_posted makes
-                # the residual comparison match the standard table, so
-                # amount_diff naturally stays ≈ 0.
+                # Adding import_amount to depreciated_value_posted aligns
+                # the residual comparison with the trimmed table's values.
                 total_table_lines = sum(len(entry["lines"]) for entry in table)
                 move_check_lines = asset.depreciation_line_ids.filtered("move_check")
                 last_depreciation_date = last_line.line_date
@@ -190,11 +220,8 @@ class AccountAsset(models.Model):
 
             else:
                 # --- no posted lines -----------------------------------
-                # Skip table lines that are covered by the import amount,
-                # adjust the first future line's amount.
-                table_i_start, line_i_start = asset._find_import_start_position(
-                    table, import_amount, currency
-                )
+                # Table already starts at the first future line.
+                table_i_start = line_i_start = 0
                 depreciated_value_posted = import_amount
 
             asset._compute_depreciation_line(

--- a/account_asset_depreciation_import/models/account_asset_line.py
+++ b/account_asset_depreciation_import/models/account_asset_line.py
@@ -1,0 +1,44 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountAssetLine(models.Model):
+    _inherit = "account.asset.line"
+
+    @api.depends("amount", "previous_id", "type")
+    def _compute_values(self):
+        """Override to include import amount in the first line's depreciated_value."""
+        self.depreciated_value = 0.0
+        self.remaining_value = 0.0
+        dlines = self
+        if self.env.context.get("no_compute_asset_line_ids"):
+            exclude_ids = self.env.context["no_compute_asset_line_ids"]
+            dlines = self.filtered(lambda l: l.id not in exclude_ids)
+        dlines = dlines.filtered(lambda l: l.type == "depreciate")
+        dlines = dlines.sorted(key=lambda l: l.line_date)
+        all_excluded_lines = self - dlines
+        all_excluded_lines.depreciated_value = 0
+        all_excluded_lines.remaining_value = 0
+        asset_ids = dlines.mapped("asset_id")
+        grouped_dlines = []
+        for asset in asset_ids:
+            grouped_dlines.append(dlines.filtered(lambda l: l.asset_id.id == asset.id))
+        for dlines in grouped_dlines:
+            for i, dl in enumerate(dlines):
+                if i == 0:
+                    depreciation_base = dl.depreciation_base
+                    import_amount = dl.asset_id.already_depreciated_amount_import
+                    if dl.previous_id:
+                        tmp = depreciation_base - dl.previous_id.remaining_value
+                        depreciated_value = tmp
+                    else:
+                        depreciated_value = import_amount
+                    remaining_value = (
+                        depreciation_base - depreciated_value - dl.amount
+                    )
+                else:
+                    depreciated_value += dl.previous_id.amount
+                    remaining_value -= dl.amount
+                dl.depreciated_value = depreciated_value
+                dl.remaining_value = remaining_value

--- a/account_asset_depreciation_import/tests/__init__.py
+++ b/account_asset_depreciation_import/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_account_asset_depreciation_import

--- a/account_asset_depreciation_import/tests/test_account_asset_depreciation_import.py
+++ b/account_asset_depreciation_import/tests/test_account_asset_depreciation_import.py
@@ -1,0 +1,338 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import SUPERUSER_ID, api, fields, registry
+from odoo.exceptions import ValidationError
+from odoo.tests import get_db_name, tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountAssetDepreciationImport(AccountTestInvoicingCommon):
+    """Tests for already_depreciated_amount_import on account.asset.
+
+    Scenario baseline:
+      - purchase_value = 60,000  salvage_value = 0
+      - linear, 5 years, period = year
+      - depreciation_base = 60,000  →  12,000/year
+    """
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        with registry(get_db_name()).cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            if not env.ref("l10n_generic_coa.configurable_chart_template", False):
+                coa = env["account.chart.template"].search([("visible", "=", True)])[:1]
+                chart_template_ref = coa.get_external_id()[coa.id]
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.asset_model = cls.env["account.asset"]
+        cls.profile = cls.env["account.asset.profile"].create(
+            {
+                "account_expense_depreciation_id": cls.company_data[
+                    "default_account_expense"
+                ].id,
+                "account_asset_id": cls.company_data["default_account_assets"].id,
+                "account_depreciation_id": cls.company_data[
+                    "default_account_assets"
+                ].id,
+                "journal_id": cls.company_data["default_journal_purchase"].id,
+                "name": "Test Profile - 5 Years Linear",
+                "method_time": "year",
+                "method_number": 5,
+                "method_period": "year",
+            }
+        )
+
+    def _make_asset(self, purchase_value=60000.0, import_amount=0.0, **kw):
+        """Helper: create a draft 5-year linear asset."""
+        vals = {
+            "name": "Test Asset",
+            "profile_id": self.profile.id,
+            "purchase_value": purchase_value,
+            "salvage_value": 0.0,
+            "already_depreciated_amount_import": import_amount,
+            "date_start": "2020-01-01",
+            "method_time": "year",
+            "method_number": 5,
+            "method_period": "year",
+        }
+        vals.update(kw)
+        return self.asset_model.create(vals)
+
+    # ------------------------------------------------------------------ #
+    # Constraint tests                                                     #
+    # ------------------------------------------------------------------ #
+
+    def test_constraint_negative_import(self):
+        """Import amount must not be negative."""
+        asset = self._make_asset()
+        with self.assertRaises(ValidationError):
+            asset.already_depreciated_amount_import = -1.0
+            asset._check_already_depreciated_amount_import()
+
+    def test_constraint_exceeds_base(self):
+        """Import amount must not exceed depreciation_base."""
+        asset = self._make_asset(purchase_value=60000.0)
+        with self.assertRaises(ValidationError):
+            asset.already_depreciated_amount_import = 60001.0
+            asset._check_already_depreciated_amount_import()
+
+    def test_constraint_equal_base_is_ok(self):
+        """Import amount equal to depreciation_base is valid."""
+        asset = self._make_asset(import_amount=60000.0)
+        # Should not raise
+        asset._check_already_depreciated_amount_import()
+
+    # ------------------------------------------------------------------ #
+    # _compute_depreciation: value_residual / value_depreciated           #
+    # ------------------------------------------------------------------ #
+
+    def test_compute_depreciation_no_import(self):
+        """Without import, residual = depreciation_base (no lines posted)."""
+        asset = self._make_asset()
+        asset.invalidate_recordset()
+        self.assertAlmostEqual(asset.value_residual, 60000.0)
+        self.assertAlmostEqual(asset.value_depreciated, 0.0)
+
+    def test_compute_depreciation_with_import(self):
+        """Import reduces residual immediately, before any board computation."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.invalidate_recordset()
+        self.assertAlmostEqual(asset.value_residual, 36000.0)
+        self.assertAlmostEqual(asset.value_depreciated, 24000.0)
+
+    def test_compute_depreciation_full_import(self):
+        """Full import → residual = 0, depreciated = full base."""
+        asset = self._make_asset(import_amount=60000.0)
+        asset.invalidate_recordset()
+        self.assertAlmostEqual(asset.value_residual, 0.0)
+        self.assertAlmostEqual(asset.value_depreciated, 60000.0)
+
+    # ------------------------------------------------------------------ #
+    # compute_depreciation_board: no import (unchanged behaviour)         #
+    # ------------------------------------------------------------------ #
+
+    def test_board_no_import_line_count(self):
+        """No import → 5 depreciation lines as normal."""
+        asset = self._make_asset()
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(lambda l: l.type == "depreciate")
+        # One purchase line + 5 depreciation lines
+        self.assertEqual(len(dlines), 5)
+
+    def test_board_no_import_amounts(self):
+        """No import → each period = 12,000."""
+        asset = self._make_asset()
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        for line in dlines:
+            self.assertAlmostEqual(line.amount, 12000.0)
+
+    # ------------------------------------------------------------------ #
+    # compute_depreciation_board: with import                             #
+    # ------------------------------------------------------------------ #
+
+    def test_board_import_line_count(self):
+        """24,000 import on 60,000/5yr asset → 3 depreciation lines (not 5)."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(lambda l: l.type == "depreciate")
+        self.assertEqual(len(dlines), 3)
+
+    def test_board_import_amounts_unchanged(self):
+        """Per-period rate stays at 12,000 even with import."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        for line in dlines:
+            self.assertAlmostEqual(line.amount, 12000.0)
+
+    def test_board_import_first_line_depreciated_value(self):
+        """First line's depreciated_value should equal the import amount."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        self.assertAlmostEqual(dlines[0].depreciated_value, 24000.0)
+
+    def test_board_import_last_line_remaining_value(self):
+        """Last line's remaining_value should be 0 (fully depreciated)."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)
+
+    def test_board_import_cumulative_depreciated_values(self):
+        """Cumulative depreciated_value on each line is correct."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        expected_depreciated = [24000.0, 36000.0, 48000.0]
+        for line, expected in zip(dlines, expected_depreciated):
+            self.assertAlmostEqual(line.depreciated_value, expected)
+
+    def test_board_import_cumulative_remaining_values(self):
+        """Cumulative remaining_value on each line is correct."""
+        asset = self._make_asset(import_amount=24000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        expected_remaining = [24000.0, 12000.0, 0.0]
+        for line, expected in zip(dlines, expected_remaining):
+            self.assertAlmostEqual(line.remaining_value, expected)
+
+    # ------------------------------------------------------------------ #
+    # Edge cases                                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_board_full_import_no_lines(self):
+        """Full import (= depreciation_base) → no depreciation lines generated."""
+        asset = self._make_asset(import_amount=60000.0)
+        # value_residual = 0, so compute_depreciation_board skips the asset
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(lambda l: l.type == "depreciate")
+        self.assertEqual(len(dlines), 0)
+
+    def test_board_import_one_period_left(self):
+        """48,000 import on 60,000/5yr → exactly 1 remaining line of 12,000."""
+        asset = self._make_asset(import_amount=48000.0)
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(lambda l: l.type == "depreciate")
+        self.assertEqual(len(dlines), 1)
+        self.assertAlmostEqual(dlines[0].amount, 12000.0)
+        self.assertAlmostEqual(dlines[0].depreciated_value, 48000.0)
+        self.assertAlmostEqual(dlines[0].remaining_value, 0.0)
+
+    def test_board_zero_import_is_normal(self):
+        """Zero import delegates to super and behaves identically to no-import case."""
+        asset_no_import = self._make_asset(import_amount=0.0)
+        asset_no_import.compute_depreciation_board()
+        asset_no_import.invalidate_recordset()
+
+        asset_zero = self._make_asset(import_amount=0.0)
+        asset_zero.compute_depreciation_board()
+        asset_zero.invalidate_recordset()
+
+        dlines_no = asset_no_import.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        dlines_zero = asset_zero.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+
+        self.assertEqual(len(dlines_no), len(dlines_zero))
+        for l1, l2 in zip(dlines_no, dlines_zero):
+            self.assertAlmostEqual(l1.amount, l2.amount)
+            self.assertAlmostEqual(l1.depreciated_value, l2.depreciated_value)
+            self.assertAlmostEqual(l1.remaining_value, l2.remaining_value)
+
+    # ------------------------------------------------------------------ #
+    # Degressive method                                                    #
+    # ------------------------------------------------------------------ #
+
+    def test_board_degressive_with_import(self):
+        """Degressive method: import reduces residual; rate applied to reduced base."""
+        profile_degr = self.env["account.asset.profile"].create(
+            {
+                "account_expense_depreciation_id": self.company_data[
+                    "default_account_expense"
+                ].id,
+                "account_asset_id": self.company_data["default_account_assets"].id,
+                "account_depreciation_id": self.company_data[
+                    "default_account_assets"
+                ].id,
+                "journal_id": self.company_data["default_journal_purchase"].id,
+                "name": "Degressive 5 Years",
+                "method": "degressive",
+                "method_time": "year",
+                "method_number": 5,
+                "method_period": "year",
+                "method_progress_factor": 0.40,
+            }
+        )
+        asset = self.asset_model.create(
+            {
+                "name": "Degressive Asset",
+                "profile_id": profile_degr.id,
+                "purchase_value": 100000.0,
+                "salvage_value": 0.0,
+                "already_depreciated_amount_import": 40000.0,
+                "date_start": "2020-01-01",
+                "method": "degressive",
+                "method_time": "year",
+                "method_number": 5,
+                "method_period": "year",
+                "method_progress_factor": 0.40,
+            }
+        )
+        asset.invalidate_recordset()
+        # value_residual = 100,000 - 40,000 = 60,000
+        self.assertAlmostEqual(asset.value_residual, 60000.0)
+
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        self.assertTrue(len(dlines) > 0)
+
+        # First period: 40% of 60,000 = 24,000
+        self.assertAlmostEqual(dlines[0].amount, 24000.0)
+        self.assertAlmostEqual(dlines[0].depreciated_value, 40000.0)
+
+        # Last line must exhaust remaining value (remaining_value = 0)
+        self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)
+
+    # ------------------------------------------------------------------ #
+    # Monthly period                                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_board_monthly_import_line_count(self):
+        """Monthly period: 24,000 import on 60,000/5yr → 36 months (not 60)."""
+        asset = self._make_asset(
+            import_amount=24000.0,
+            method_period="month",
+        )
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(lambda l: l.type == "depreciate")
+        self.assertEqual(len(dlines), 36)
+
+    def test_board_monthly_import_per_period_amount(self):
+        """Monthly: per-period = 12,000/12 = 1,000 (same rate as no-import)."""
+        asset = self._make_asset(
+            import_amount=24000.0,
+            method_period="month",
+        )
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        # All interior lines should be 1,000; only last may differ by rounding
+        for line in dlines[:-1]:
+            self.assertAlmostEqual(line.amount, 1000.0)
+        # Last line cleans up any rounding to reach 0 remaining
+        self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)

--- a/account_asset_depreciation_import/tests/test_account_asset_depreciation_import.py
+++ b/account_asset_depreciation_import/tests/test_account_asset_depreciation_import.py
@@ -336,3 +336,37 @@ class TestAccountAssetDepreciationImport(AccountTestInvoicingCommon):
             self.assertAlmostEqual(line.amount, 1000.0)
         # Last line cleans up any rounding to reach 0 remaining
         self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)
+
+    # ------------------------------------------------------------------ #
+    # No negative remaining_value (regression)                             #
+    # ------------------------------------------------------------------ #
+
+    def test_board_no_negative_remaining_value(self):
+        """Remaining value must never go negative on any depreciation line."""
+        asset = self._make_asset(
+            purchase_value=1500.0,
+            import_amount=100.0,
+            salvage_value=1.0,
+            date_start="2026-02-25",
+            method_number=3,
+            method_period="month",
+        )
+        asset.compute_depreciation_board()
+        asset.invalidate_recordset()
+        dlines = asset.depreciation_line_ids.filtered(
+            lambda l: l.type == "depreciate"
+        ).sorted("line_date")
+        self.assertTrue(len(dlines) > 0)
+        for line in dlines:
+            self.assertGreaterEqual(
+                line.remaining_value,
+                0.0,
+                f"Negative remaining_value {line.remaining_value} on {line.line_date}",
+            )
+            self.assertGreaterEqual(
+                line.amount,
+                0.0,
+                f"Negative amount {line.amount} on {line.line_date}",
+            )
+        self.assertAlmostEqual(dlines[-1].remaining_value, 0.0)
+        self.assertAlmostEqual(dlines[0].depreciated_value, 100.0)

--- a/account_asset_depreciation_import/views/account_asset_views.xml
+++ b/account_asset_depreciation_import/views/account_asset_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="account_asset_view_form_depreciation_import">
+        <field name="name">account.asset.form.depreciation.import</field>
+        <field name="model">account.asset</field>
+        <field name="inherit_id" ref="account_asset_management.account_asset_view_form" />
+        <field name="arch" type="xml">
+            <field name="salvage_value" position="after">
+                <field
+                    name="already_depreciated_amount_import"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary

Create new `account_asset_depreciation_import` module enabling import of already-depreciated amounts when migrating assets from other systems. This addresses the need to carry over prior depreciation records without recalculating from asset purchase.

The module adds `already_depreciated_amount_import` field to `account.asset` and adjusts all depreciation calculations to reduce the remaining schedule while maintaining consistent per-period rates. Includes comprehensive test coverage for linear/degressive methods, various periods (year/month), and edge cases.

## Test Coverage

- Constraint validation: negative amounts, exceeds base
- Compute depreciation: value_residual and value_depreciated
- Depreciation board: line counts, amounts, cumulative values
- Edge cases: full import, one period left, zero import
- Degressive method: rate applied to reduced residual
- Monthly periods: 36 months instead of 60 when 40% already depreciated

All tests pass and module follows OCA conventions.