### PR TITLE
[16.0][FIX] account_asset_operating_unit: remove deprecated _onchange_invoice_line_ids

### DIFF
--- a/account_asset_operating_unit/models/account_asset_line.py
+++ b/account_asset_operating_unit/models/account_asset_line.py
@@ -13,9 +13,3 @@ class AccountAssetLine(models.Model):
             move_data.update({"operating_unit_id": self.asset_id.operating_unit_id.id})
         return move_data
 
-    def create_move(self):
-        created_move_ids = super().create_move()
-        moves = self.env["account.move"].browse(created_move_ids)
-        for move in moves:
-            move._onchange_invoice_line_ids()
-        return created_move_ids

--- a/account_asset_operating_unit/wizard/account_asset_remove.py
+++ b/account_asset_operating_unit/wizard/account_asset_remove.py
@@ -19,5 +19,5 @@ class AccountAssetRemove(models.TransientModel):
         # Assign operating unit to journal entry if any
         if asset and move:
             move.operating_unit_id = asset.operating_unit_id
-            move._onchange_invoice_line_ids()
+            move.line_ids.write({"operating_unit_id": asset.operating_unit_id.id})
         return res


### PR DESCRIPTION
Fixes AttributeError when creating asset depreciation entries due to the missing _onchange_invoice_line_ids method in Odoo v16. The method is no longer needed since account.move.line.create() now automatically propagates operating_unit_id from the move to its lines. Removes the method override from AccountAssetLine and replaces the call with direct line update in AccountAssetRemove.