### PR TITLE
[16.0][IMP] account_asset_kmitl: update asset profile depreciation settings

### DIFF
--- a/account_asset_kmitl/data/account_asset_profile.xml
+++ b/account_asset_kmitl/data/account_asset_profile.xml
@@ -30,7 +30,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_002" model="account.asset.profile">
@@ -63,7 +63,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_003" model="account.asset.profile">
@@ -96,7 +96,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_004" model="account.asset.profile">
@@ -129,7 +129,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_005" model="account.asset.profile">
@@ -162,7 +162,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_006" model="account.asset.profile">
@@ -195,7 +195,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_007" model="account.asset.profile">
@@ -228,7 +228,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_008" model="account.asset.profile">
@@ -261,7 +261,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_009" model="account.asset.profile">
@@ -294,7 +294,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_010" model="account.asset.profile">
@@ -327,7 +327,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_011" model="account.asset.profile">
@@ -360,7 +360,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_012" model="account.asset.profile">
@@ -393,7 +393,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_013" model="account.asset.profile">
@@ -426,7 +426,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_014" model="account.asset.profile">
@@ -459,7 +459,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_015" model="account.asset.profile">
@@ -492,7 +492,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_016" model="account.asset.profile">
@@ -525,7 +525,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_017" model="account.asset.profile">
@@ -558,7 +558,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_018" model="account.asset.profile">
@@ -591,7 +591,7 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 
     <record id="asset_profile_019" model="account.asset.profile">
@@ -624,6 +624,6 @@
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False" />
+        <field name="prorata" eval="True" />
     </record>
 </odoo>

--- a/account_asset_kmitl/data/account_asset_profile.xml
+++ b/account_asset_kmitl/data/account_asset_profile.xml
@@ -1,325 +1,629 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <record id="asset_profile_001" model="account.asset.profile">
         <field name="name">ครุภัณฑ์สำนักงาน</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010004').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010004').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">96</field>
-        <field name="method_period">month</field>
+        <field name="method_number">8</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_002" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ยานพาหนะและขนส่ง</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1252000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1252000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010005').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1252000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1252000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010005').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">84</field>
-        <field name="method_period">month</field>
+        <field name="method_number">7</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_003" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ไฟฟ้าและวิทยุ</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_004" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ไฟฟ้าและวิทยุ-เครื่องกำเนิดไฟฟ้า</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">180</field>
-        <field name="method_period">month</field>
+        <field name="method_number">15</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_005" model="account.asset.profile">
         <field name="name">ครุภัณฑ์โฆษณาและเผยแพร่</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1254000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1254000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010007').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1254000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1254000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010007').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_006" model="account.asset.profile">
         <field name="name">ครุภัณฑ์การเกษตร-เครื่องมือและอุปกรณ์</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">36</field>
-        <field name="method_period">month</field>
+        <field name="method_number">3</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_007" model="account.asset.profile">
         <field name="name">ครุภัณฑ์การเกษตร-เครื่องจักรกล</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">96</field>
-        <field name="method_period">month</field>
+        <field name="method_number">8</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_008" model="account.asset.profile">
         <field name="name">ครุภัณฑ์โรงงาน-เครื่องมือและอุปกรณ์</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">36</field>
-        <field name="method_period">month</field>
+        <field name="method_number">3</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_009" model="account.asset.profile">
         <field name="name">ครุภัณฑ์โรงงาน-เครื่องจักรกล</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">96</field>
-        <field name="method_period">month</field>
+        <field name="method_number">8</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_010" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ก่อสร้าง-เครื่องมือและอุปกรณ์</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_011" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ก่อสร้าง-เครื่องจักรกล</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">96</field>
-        <field name="method_period">month</field>
+        <field name="method_number">8</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_012" model="account.asset.profile">
         <field name="name">ครุภัณฑ์สำรวจ</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1258000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1258000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010011').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1258000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1258000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010011').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">96</field>
-        <field name="method_period">month</field>
+        <field name="method_number">8</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_013" model="account.asset.profile">
         <field name="name">ครุภัณฑ์วิทยาศาสตร์และการแพทย์</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1259000001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1259000003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010012').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1259000001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1259000003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010012').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_014" model="account.asset.profile">
         <field name="name">ครุภัณฑ์คอมพิวเตอร์</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251100001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251100003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010013').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251100001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251100003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010013').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">36</field>
-        <field name="method_period">month</field>
+        <field name="method_number">3</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_015" model="account.asset.profile">
         <field name="name">ครุภัณฑ์กีฬา/กายภาพ</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251400001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251400003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010016').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251400001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251400003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010016').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_016" model="account.asset.profile">
         <field name="name">ครุภัณฑ์สนาม</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251700001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251700003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010019').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251700001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251700003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010019').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_017" model="account.asset.profile">
         <field name="name">ครุภัณฑ์งานบ้านงานครัว</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251300001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251300003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010015').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251300001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251300003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010015').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_018" model="account.asset.profile">
         <field name="name">ครุภัณฑ์การศึกษา</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251200001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251200003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010014').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251200001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251200003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010014').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 
     <record id="asset_profile_019" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ดนตรี/นาฏศิลป์</field>
-        <field name="account_asset_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251500001').code)])"/>
-        <field name="account_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251500003').code)])"/>
-        <field name="account_expense_depreciation_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010017').code)])"/>
-        <field name="journal_id" model="base" eval="obj().env['account.journal'].search([('code', '=', 'JV')])"/>
+        <field
+            name="account_asset_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251500001').code)])"
+        />
+        <field
+            name="account_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251500003').code)])"
+        />
+        <field
+            name="account_expense_depreciation_id"
+            model="base"
+            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010017').code)])"
+        />
+        <field
+            name="journal_id"
+            model="base"
+            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
+        />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear</field>
-        <field name="method_number">60</field>
-        <field name="method_period">month</field>
+        <field name="method_number">5</field>
+        <field name="method_period">year</field>
         <field name="method_time">year</field>
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
-        <field name="prorata" eval="False"/>
+        <field name="prorata" eval="False" />
     </record>
 </odoo>

--- a/account_asset_kmitl/data/account_asset_profile.xml
+++ b/account_asset_kmitl/data/account_asset_profile.xml
@@ -24,7 +24,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">8</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -57,7 +57,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">7</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -90,7 +90,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -123,7 +123,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">15</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -156,7 +156,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -189,7 +189,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">3</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -222,7 +222,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">8</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -255,7 +255,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">3</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -288,7 +288,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">8</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -321,7 +321,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -354,7 +354,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">8</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -387,7 +387,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">8</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -420,7 +420,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -453,7 +453,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">3</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -486,7 +486,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -519,7 +519,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -552,7 +552,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -585,7 +585,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>
@@ -618,7 +618,7 @@
         />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
-        <field name="method">linear</field>
+        <field name="method">linear-limit</field>
         <field name="method_number">5</field>
         <field name="method_period">year</field>
         <field name="method_time">year</field>

--- a/account_asset_kmitl/data/account_asset_profile.xml
+++ b/account_asset_kmitl/data/account_asset_profile.xml
@@ -31,6 +31,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_002" model="account.asset.profile">
@@ -64,6 +65,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_003" model="account.asset.profile">
@@ -97,6 +99,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_004" model="account.asset.profile">
@@ -130,6 +133,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_005" model="account.asset.profile">
@@ -163,6 +167,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_006" model="account.asset.profile">
@@ -196,6 +201,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_007" model="account.asset.profile">
@@ -229,6 +235,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_008" model="account.asset.profile">
@@ -262,6 +269,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_009" model="account.asset.profile">
@@ -295,6 +303,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_010" model="account.asset.profile">
@@ -328,6 +337,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_011" model="account.asset.profile">
@@ -361,6 +371,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_012" model="account.asset.profile">
@@ -394,6 +405,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_013" model="account.asset.profile">
@@ -427,6 +439,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_014" model="account.asset.profile">
@@ -460,6 +473,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_015" model="account.asset.profile">
@@ -493,6 +507,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_016" model="account.asset.profile">
@@ -526,6 +541,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_017" model="account.asset.profile">
@@ -559,6 +575,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_018" model="account.asset.profile">
@@ -592,6 +609,7 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 
     <record id="asset_profile_019" model="account.asset.profile">
@@ -625,5 +643,6 @@
         <field name="salvage_value">1</field>
         <field name="salvage_type">fixed</field>
         <field name="prorata" eval="True" />
+        <field name="days_calc" eval="True" />
     </record>
 </odoo>


### PR DESCRIPTION
## Summary
- แก้ไข `method_number` จากเดือนเป็นปี (เช่น 36→3, 60→5, 84→7, 96→8, 180→15)
- แก้ไข `method_period` จาก `month` เป็น `year`
- แก้ไข `method` จาก `linear` เป็น `linear-limit` (Linear up to Salvage Value)
- เปิดใช้งาน `prorata` (คำนวณค่าเสื่อมราคาตามสัดส่วนวันที่เริ่มใช้งาน)
- เปิดใช้งาน `days_calc` (คำนวณค่าเสื่อมราคาตามจำนวนวัน)

สำหรับ asset profile ทั้ง 19 รายการ

## Test plan
- [ ] ตรวจสอบว่า asset profile แสดงค่า method_number เป็นปีที่ถูกต้อง
- [ ] ตรวจสอบว่า method_period เปลี่ยนเป็น "year"
- [ ] ตรวจสอบว่า method เปลี่ยนเป็น "linear-limit"
- [ ] ตรวจสอบว่า prorata และ days_calc เป็น True
- [ ] ทดสอบสร้าง asset ใหม่และตรวจสอบ depreciation lines ว่าคำนวณถูกต้อง