### PR TITLE
[16.0][IMP] budget_appropriation_summary: add unique constraint

### DIFF
--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -7,6 +7,13 @@ class BudgetAppropriationCompilation(models.Model):
     _description = "Budget Appropriation Compilation"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "sequence, id"
+    _sql_constraints = [
+        (
+            "unique_department_source_fiscal_year",
+            "UNIQUE(department_analytic_id, source_analytic_id, account_fiscal_year_id)",
+            "มีข้อมูลรวมเล่มงบประมาณของหน่วยงาน แหล่งเงิน และปีงบประมาณนี้อยู่แล้ว",
+        ),
+    ]
 
     READONLY_STATES = {
         "confirmed": [("readonly", True)],


### PR DESCRIPTION
Add SQL unique constraint to the budget.appropriation.compilation model to prevent duplicate compilations with the same department, source, and fiscal year combination.

All three fields (department_analytic_id, source_analytic_id, account_fiscal_year_id) are required and form a natural unique key for this model.

🤖 Generated with Claude Code