### PR TITLE
[16.0][ADD] web_fiscal_year_systray: display current fiscal year on systray

### DIFF
--- a/web_fiscal_year_systray/__init__.py
+++ b/web_fiscal_year_systray/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/web_fiscal_year_systray/__manifest__.py
+++ b/web_fiscal_year_systray/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Fiscal Year Systray",
+    "version": "16.0.1.0.0",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "development_status": "Production/Stable",
+    "category": "Accounting",
+    "depends": ["account_fiscal_year_enhance"],
+    "assets": {
+        "web.assets_backend": [
+            "web_fiscal_year_systray/static/src/js/fiscal_year_systray.esm.js",
+            "web_fiscal_year_systray/static/src/xml/fiscal_year_systray.xml",
+        ],
+    },
+    "installable": True,
+    "auto_install": False,
+    "license": "AGPL-3",
+}

--- a/web_fiscal_year_systray/models/__init__.py
+++ b/web_fiscal_year_systray/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import res_company

--- a/web_fiscal_year_systray/models/res_company.py
+++ b/web_fiscal_year_systray/models/res_company.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model
+    def get_current_fiscal_year_name(self):
+        fy = self.env.company.find_daterange_fy(fields.Date.today())
+        return fy.name if fy else False

--- a/web_fiscal_year_systray/static/src/js/fiscal_year_systray.esm.js
+++ b/web_fiscal_year_systray/static/src/js/fiscal_year_systray.esm.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+const { Component, useState, onWillStart } = owl;
+
+export class FiscalYearSystray extends Component {
+    setup() {
+        this.rpc = useService("rpc");
+        this.state = useState({ fiscalYearName: false });
+
+        onWillStart(async () => {
+            try {
+                const name = await this.rpc("/web/dataset/call_kw/res.company/get_current_fiscal_year_name", {
+                    model: "res.company",
+                    method: "get_current_fiscal_year_name",
+                    args: [],
+                    kwargs: {},
+                });
+                this.state.fiscalYearName = name;
+            } catch (error) {
+                console.error("Failed to fetch current fiscal year:", error);
+            }
+        });
+    }
+}
+
+FiscalYearSystray.template = "web_fiscal_year_systray.FiscalYearSystray";
+
+registry.category("systray").add("web_fiscal_year_systray.FiscalYearSystray", {
+    Component: FiscalYearSystray,
+}, { sequence: 1 });

--- a/web_fiscal_year_systray/static/src/xml/fiscal_year_systray.xml
+++ b/web_fiscal_year_systray/static/src/xml/fiscal_year_systray.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web_fiscal_year_systray.FiscalYearSystray" owl="1">
+        <t t-if="state.fiscalYearName">
+            <span class="o_menu_systray_item d-flex align-items-center px-2">
+                <span class="text-muted small" t-esc="'ปีงบ ' + state.fiscalYearName"/>
+            </span>
+        </t>
+    </t>
+
+</templates>

--- a/web_fiscal_year_systray/static/src/xml/fiscal_year_systray.xml
+++ b/web_fiscal_year_systray/static/src/xml/fiscal_year_systray.xml
@@ -4,7 +4,7 @@
     <t t-name="web_fiscal_year_systray.FiscalYearSystray" owl="1">
         <t t-if="state.fiscalYearName">
             <span class="o_menu_systray_item d-flex align-items-center px-2">
-                <span class="text-muted small" t-esc="'ปีงบ ' + state.fiscalYearName"/>
+                <span class="text-white" t-esc="'ปีงบ พ.ศ. ' + state.fiscalYearName"/>
             </span>
         </t>
     </t>


### PR DESCRIPTION
Adds a new module that displays the current fiscal year on the Odoo systray. The module fetches the fiscal year via RPC and displays it as 'ปีงบ {year}' on the right side of the systray with minimal styling. It automatically hides itself if no fiscal year is found for today's date.