### PR TITLE
[16.0][IMP] account_payment_kmitl: remove post button from payment form

### DIFF
--- a/account_payment_kmitl/views/account_payment_views.xml
+++ b/account_payment_kmitl/views/account_payment_views.xml
@@ -8,9 +8,9 @@
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
 
-            <!-- Hide original Confirm (action_post) in draft - force submit flow -->
+            <!-- Hide Confirm (action_post) - posting is done from account.move -->
             <xpath expr="//button[@name='action_post']" position="attributes">
-                <attribute name="attrs">{'invisible': [('state', '!=', 'submitted')]}</attribute>
+                <attribute name="invisible">1</attribute>
             </xpath>
 
             <!-- Add Submit button before the hidden Confirm -->


### PR DESCRIPTION
## Summary

Hide the Confirm (action_post) button from account.payment forms. In KMITL's workflow, posting is handled from account.move by the accounting team, so the post button is unnecessary on the payment form.

Payment workflow now ends at submitted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)