### PR TITLE
[16.0][IMP] budget: optional commitment, required analytics

### DIFF
--- a/account_move_kmitl/views/account_move_views.xml
+++ b/account_move_kmitl/views/account_move_views.xml
@@ -34,11 +34,11 @@
                             <field name="analytic_distribution" invisible="1"/>
                         </group>
                         <group name="analytic_dimensions">
-                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" attrs="{'readonly': [('state', '=', 'posted')]}"/>
-                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" attrs="{'readonly': [('state', '=', 'posted')]}"/>
-                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" attrs="{'readonly': [('state', '=', 'posted')]}"/>
-                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" attrs="{'readonly': [('state', '=', 'posted')]}"/>
-                            <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': [('state', '=', 'posted')]}"/>
+                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
                         </group>
                     </group>
                     <div class="oe_button_box" name="button_box_budget">

--- a/account_move_kmitl/views/account_move_views.xml
+++ b/account_move_kmitl/views/account_move_views.xml
@@ -34,10 +34,10 @@
                             <field name="analytic_distribution" invisible="1"/>
                         </group>
                         <group name="analytic_dimensions">
-                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" attrs="{'required': [('budget_account_id', '!=', False)], 'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
                             <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
                         </group>
                     </group>

--- a/account_payment_budget/models/account_payment.py
+++ b/account_payment_budget/models/account_payment.py
@@ -58,8 +58,25 @@ class AccountPayment(models.Model):
             if analytic_accounts:
                 self.analytic_distribution = analytic_accounts
 
+    def _check_analytic_distribution_complete(self):
+        required_plan_codes = {"activities", "departments", "funds", "sources"}
+        if not self.analytic_distribution:
+            raise ValidationError(_("Analytic distribution is required."))
+        account_ids = [int(k) for k in self.analytic_distribution.keys()]
+        accounts = self.env["account.analytic.account"].browse(account_ids)
+        present_codes = set(accounts.mapped("root_plan_id.code"))
+        missing = required_plan_codes - present_codes
+        if missing:
+            raise ValidationError(
+                _("Missing required analytic dimensions: %s")
+                % ", ".join(missing)
+            )
+
     def action_post(self):
-        if self.budget_commitment_id and self.payment_type == 'outbound':
-            self._consume_commitment(amount=self.amount)
+        for payment in self:
+            if payment.payment_type == "outbound":
+                payment._check_analytic_distribution_complete()
+            if payment.budget_commitment_id and payment.payment_type == "outbound":
+                payment._consume_commitment(amount=payment.amount)
 
         return super().action_post()

--- a/account_payment_budget/views/account_payment_views.xml
+++ b/account_payment_budget/views/account_payment_views.xml
@@ -18,11 +18,11 @@
                                 <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
                             </group>
                             <group name="analytic_dimensions">
-                                <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                                <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                                <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                                <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                                <field name="budget_account_id" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
                             </group>
                         </group>
                     </page>

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -3,7 +3,7 @@
 import logging
 
 from odoo import Command, _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
@@ -278,6 +278,24 @@ class DisbursementRequest(models.Model):
                 budget = rec.budget_commitment_id
                 rec.budget_account_id = budget.account_id
                 rec.analytic_distribution = budget.analytic_distribution
+
+    @api.constrains("analytic_distribution")
+    def _check_analytic_distribution_complete(self):
+        required_plan_codes = {"activities", "departments", "funds", "sources"}
+        for rec in self:
+            if rec.state == "cancel":
+                continue
+            if not rec.analytic_distribution:
+                raise ValidationError(_("Analytic distribution is required."))
+            account_ids = [int(k) for k in rec.analytic_distribution.keys()]
+            accounts = self.env["account.analytic.account"].browse(account_ids)
+            present_codes = set(accounts.mapped("root_plan_id.code"))
+            missing = required_plan_codes - present_codes
+            if missing:
+                raise ValidationError(
+                    _("Missing required analytic dimensions: %s")
+                    % ", ".join(missing)
+                )
 
     @api.model
     def _search_source_analytic_id(self, operator, value):
@@ -567,6 +585,9 @@ class DisbursementRequest(models.Model):
                 "currency_id": self.currency_id.id,
                 "company_id": self.company_id.id,
                 "invoice_line_ids": invoice_lines,
+                "budget_commitment_id": self.budget_commitment_id.id,
+                "budget_account_id": self.budget_account_id.id,
+                "analytic_distribution": self.analytic_distribution,
             }
         )
 

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -77,13 +77,12 @@
                         </group>
                         <group>
                             <field name="company_id" groups="base.group_multi_company" />
-                            <field name="budget_commitment_id" required="1" />
-                            <field name="source_analytic_id" readonly="1" options="{'no_create': True, 'no_open': True}" />
-                            <field name="department_analytic_id" readonly="1" options="{'no_create': True, 'no_open': True}" />
-                            <field name="fund_analytic_id" readonly="1" options="{'no_create': True, 'no_open': True}" />
-                            <field name="activity_analytic_id" readonly="1" options="{'no_create': True, 'no_open': True}" />
-                            <field name="budget_account_id" readonly="1" required="1" options="{'no_create': True, 'no_open': True}" />
-                            <field name="budget_account_id" readonly="0" invisible="1"/>
+                            <field name="budget_commitment_id" />
+                            <field name="source_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
+                            <field name="department_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
+                            <field name="fund_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
+                            <field name="activity_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
+                            <field name="budget_account_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
                             <field name="analytic_distribution" invisible="1"/>
                         </group>
                     </group>

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -98,7 +98,7 @@
                                     <field name="tax_ids" widget="many2many_tags" />
                                     <field name="wht_tax_id" optional="show"/>
                                     <field name="account_id" />
-                                    <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting" />
+                                    <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting" readonly="1" />
                                     <field name="price_subtotal" />
                                     <field name="price_tax" optional="hide" />
                                     <field name="price_total" />


### PR DESCRIPTION
## Summary
- Make `budget_commitment_id` optional across disbursement, account.move, and account.payment pipeline
- Make `analytic_distribution` required with all 4 dimensions (activities, departments, funds, sources)
- Dimension fields become editable when no commitment, readonly when commitment is set
- Pass budget fields through disbursement bill creation to account.move header for pipeline continuity
- Add validation in account.payment to ensure complete analytic distribution before posting

## Test plan
- [ ] Create disbursement without budget_commitment_id → verify dimension fields are editable and required
- [ ] Create disbursement with budget_commitment_id → verify dimensions auto-populate and become readonly
- [ ] Try to save disbursement without all 4 dimensions → verify validation error
- [ ] Create bill from disbursement → verify budget fields flow to account.move header
- [ ] On account.move with budget_account_id → verify dimension fields are conditionally required and readonly when committed
- [ ] On account.payment (outbound) → verify dimension fields are required and readonly when committed
- [ ] Post payment without complete analytic_distribution → verify validation error