### PR TITLE
[FIX] budget: fix duplicate transfer record copy error

### DIFF
--- a/budget/models/budget_transfer.py
+++ b/budget/models/budget_transfer.py
@@ -228,7 +228,7 @@ class BudgetTransfer(models.Model):
         string="Transfer FROM Lines",
         domain=[("transfer_direction", "=", "from")],
         context={"default_transfer_direction": "from"},
-        copy=True,
+        copy=False,
         readonly=False,
         states=READONLY_STATES,
     )
@@ -239,7 +239,7 @@ class BudgetTransfer(models.Model):
         string="Transfer TO Lines",
         domain=[("transfer_direction", "=", "to")],
         context={"default_transfer_direction": "to"},
-        copy=True,
+        copy=False,
         readonly=False,
         states=READONLY_STATES,
     )


### PR DESCRIPTION
## Summary
Fix TypeError when duplicating budget.transfer records caused by multiple One2many fields copying the same related records.

## Changes
Set `copy=False` on `from_line_ids` and `to_line_ids` since they are domain-filtered views of `line_ids`, which already handles the copy operation. This prevents Odoo from attempting duplicate copies of the same transfer lines.

## Test Plan
- [ ] Duplicate a budget.transfer record — should succeed without error
- [ ] Verify the duplicated record has all transfer lines
- [ ] Verify the from/to line tabs display correctly