### PR TITLE
[16.0][ADD] purchase_guarantee_disbursement: guarantee refund via disbursement

### DIFF
--- a/purchase_guarantee_disbursement/__init__.py
+++ b/purchase_guarantee_disbursement/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/purchase_guarantee_disbursement/__manifest__.py
+++ b/purchase_guarantee_disbursement/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "KMITL",
     "website": "https://www.kmitl.ac.th",
     "category": "KMITL",
-    "depends": ["purchase_guarantee_kmitl", "disbursement"],
+    "depends": ["purchase_guarantee_account_payment", "disbursement"],
     "data": [
         "security/ir.model.access.csv",
         "views/disbursement_request_views.xml",

--- a/purchase_guarantee_disbursement/__manifest__.py
+++ b/purchase_guarantee_disbursement/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Purchase Guarantee Disbursement",
+    "version": "16.0.1.0.0",
+    "summary": "Create disbursement requests to refund purchase guarantees",
+    "author": "KMITL",
+    "website": "https://www.kmitl.ac.th",
+    "category": "KMITL",
+    "depends": ["purchase_guarantee_kmitl", "disbursement"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/disbursement_request_views.xml",
+        "views/purchase_guarantee_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/purchase_guarantee_disbursement/models/__init__.py
+++ b/purchase_guarantee_disbursement/models/__init__.py
@@ -1,2 +1,3 @@
+from . import account_move
 from . import disbursement_request
 from . import purchase_guarantee

--- a/purchase_guarantee_disbursement/models/__init__.py
+++ b/purchase_guarantee_disbursement/models/__init__.py
@@ -1,0 +1,2 @@
+from . import disbursement_request
+from . import purchase_guarantee

--- a/purchase_guarantee_disbursement/models/account_move.py
+++ b/purchase_guarantee_disbursement/models/account_move.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _post(self, soft=True):
+        posted = super()._post(soft=soft)
+        # Receipt: payment linked to guarantee → lock → received
+        payments = self.env["account.payment"].search([
+            ("move_id", "in", posted.ids),
+            ("purchase_guarantee_id", "!=", False),
+        ])
+        for payment in payments:
+            guarantee = payment.purchase_guarantee_id
+            if guarantee.state == "lock":
+                guarantee.state = "received"
+        # Refund: bill linked to guarantee → received → returned
+        for move in posted:
+            for guarantee in move.return_guarantee_ids:
+                if guarantee.state == "received":
+                    guarantee.state = "returned"
+        return posted

--- a/purchase_guarantee_disbursement/models/disbursement_request.py
+++ b/purchase_guarantee_disbursement/models/disbursement_request.py
@@ -1,0 +1,33 @@
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class DisbursementRequest(models.Model):
+    _inherit = "disbursement.request"
+
+    guarantee_id = fields.Many2one(
+        comodel_name="purchase.guarantee",
+        string="Purchase Guarantee",
+        ondelete="set null",
+        index=True,
+        tracking=True,
+    )
+
+    def _create_bill(self):
+        bill = super()._create_bill()
+        if self.guarantee_id:
+            self.guarantee_id.write({"bill_ids": [(4, bill.id)]})
+        return bill
+
+    def action_view_purchase_guarantee(self):
+        self.ensure_one()
+        if not self.guarantee_id:
+            raise UserError(_("No Purchase Guarantee linked to this request."))
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Purchase Guarantee"),
+            "res_model": "purchase.guarantee",
+            "res_id": self.guarantee_id.id,
+            "view_mode": "form",
+            "target": "current",
+        }

--- a/purchase_guarantee_disbursement/models/purchase_guarantee.py
+++ b/purchase_guarantee_disbursement/models/purchase_guarantee.py
@@ -5,6 +5,11 @@ from odoo.exceptions import UserError
 class PurchaseGuarantee(models.Model):
     _inherit = "purchase.guarantee"
 
+    state = fields.Selection(
+        selection_add=[("received", "Received"), ("returned", "Returned")],
+        ondelete={"received": "set default", "returned": "set default"},
+    )
+
     disbursement_request_ids = fields.One2many(
         comodel_name="disbursement.request",
         inverse_name="guarantee_id",
@@ -13,24 +18,31 @@ class PurchaseGuarantee(models.Model):
     disbursement_request_count = fields.Integer(
         compute="_compute_disbursement_request",
     )
-    is_disbursement_refund_allowed = fields.Boolean(
-        compute="_compute_disbursement_request",
+    hide_create_payment_button = fields.Boolean(
+        compute="_compute_hide_create_payment_button",
     )
     hide_create_disbursement_button = fields.Boolean(
         compute="_compute_hide_create_disbursement_button",
     )
 
-    @api.depends("disbursement_request_ids", "amount", "amount_returned")
+    @api.depends("disbursement_request_ids")
     def _compute_disbursement_request(self):
         for rec in self:
             rec.disbursement_request_count = len(rec.disbursement_request_ids)
-            rec.is_disbursement_refund_allowed = (rec.amount - rec.amount_returned) > 0
 
-    @api.depends("state", "is_disbursement_refund_allowed")
+    @api.depends("state", "payment_count")
+    def _compute_hide_create_payment_button(self):
+        for rec in self:
+            rec.hide_create_payment_button = (
+                rec.state != "lock" or rec.payment_count > 0
+            )
+
+    @api.depends("state", "amount", "amount_returned")
     def _compute_hide_create_disbursement_button(self):
         for rec in self:
             rec.hide_create_disbursement_button = (
-                rec.state != "lock" or not rec.is_disbursement_refund_allowed
+                rec.state != "received"
+                or (rec.amount - rec.amount_returned) <= 0
             )
 
     def _prepare_disbursement_request_vals(self):
@@ -55,8 +67,17 @@ class PurchaseGuarantee(models.Model):
 
     def action_create_disbursement_refund(self):
         self.ensure_one()
+        if self.state != "received":
+            raise UserError(
+                _("สามารถคืนเงินหลักประกันได้เฉพาะเมื่อรับเงินเสร็จสิ้นแล้วเท่านั้น")
+            )
         if self.amount - self.amount_returned <= 0:
             raise UserError(_("ไม่มียอดเงินหลักประกันคงเหลือที่จะคืน"))
+        if not self.guarantee_method_id.account_id:
+            raise UserError(
+                _("กรุณาตั้งค่าบัญชีในประเภทหลักประกัน '%s' ก่อน")
+                % self.guarantee_method_id.name
+            )
         disbursement = self.env["disbursement.request"].create(
             self._prepare_disbursement_request_vals()
         )

--- a/purchase_guarantee_disbursement/models/purchase_guarantee.py
+++ b/purchase_guarantee_disbursement/models/purchase_guarantee.py
@@ -1,0 +1,90 @@
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class PurchaseGuarantee(models.Model):
+    _inherit = "purchase.guarantee"
+
+    disbursement_request_ids = fields.One2many(
+        comodel_name="disbursement.request",
+        inverse_name="guarantee_id",
+        string="Disbursement Requests",
+    )
+    disbursement_request_count = fields.Integer(
+        compute="_compute_disbursement_request",
+    )
+    is_disbursement_refund_allowed = fields.Boolean(
+        compute="_compute_disbursement_request",
+    )
+    hide_create_disbursement_button = fields.Boolean(
+        compute="_compute_hide_create_disbursement_button",
+    )
+
+    @api.depends("disbursement_request_ids", "amount", "amount_returned")
+    def _compute_disbursement_request(self):
+        for rec in self:
+            rec.disbursement_request_count = len(rec.disbursement_request_ids)
+            rec.is_disbursement_refund_allowed = (rec.amount - rec.amount_returned) > 0
+
+    @api.depends("state", "is_disbursement_refund_allowed")
+    def _compute_hide_create_disbursement_button(self):
+        for rec in self:
+            rec.hide_create_disbursement_button = (
+                rec.state != "lock" or not rec.is_disbursement_refund_allowed
+            )
+
+    def _prepare_disbursement_request_vals(self):
+        self.ensure_one()
+        return {
+            "guarantee_id": self.id,
+            "partner_id": self.partner_id.id,
+            "ref": self.name,
+            "analytic_distribution": self.analytic_distribution,
+            "line_ids": [
+                Command.create(
+                    {
+                        "name": _("คืนเงินหลักประกัน - %s") % self.guarantee_method_id.name,
+                        "account_id": self.guarantee_method_id.account_id.id,
+                        "quantity": 1.0,
+                        "price_unit": self.amount - self.amount_returned,
+                        "analytic_distribution": self.analytic_distribution,
+                    }
+                )
+            ],
+        }
+
+    def action_create_disbursement_refund(self):
+        self.ensure_one()
+        if self.amount - self.amount_returned <= 0:
+            raise UserError(_("ไม่มียอดเงินหลักประกันคงเหลือที่จะคืน"))
+        disbursement = self.env["disbursement.request"].create(
+            self._prepare_disbursement_request_vals()
+        )
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "disbursement.request",
+            "res_id": disbursement.id,
+            "view_mode": "form",
+            "target": "current",
+        }
+
+    def action_view_disbursement_requests(self):
+        self.ensure_one()
+        requests = self.disbursement_request_ids
+        if len(requests) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "name": _("Disbursement Request"),
+                "res_model": "disbursement.request",
+                "res_id": requests.id,
+                "view_mode": "form",
+                "target": "current",
+            }
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Disbursement Requests"),
+            "res_model": "disbursement.request",
+            "view_mode": "tree,form",
+            "domain": [("id", "in", requests.ids)],
+            "target": "current",
+        }

--- a/purchase_guarantee_disbursement/security/ir.model.access.csv
+++ b/purchase_guarantee_disbursement/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_disbursement_request_purchase_guarantee_user,disbursement.request.purchase.guarantee.user,disbursement.model_disbursement_request,purchase.group_purchase_user,1,1,0,0
+access_disbursement_request_line_purchase_guarantee_user,disbursement.request.line.purchase.guarantee.user,disbursement.model_disbursement_request_line,purchase.group_purchase_user,1,1,0,0

--- a/purchase_guarantee_disbursement/views/disbursement_request_views.xml
+++ b/purchase_guarantee_disbursement/views/disbursement_request_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_disbursement_request_form" model="ir.ui.view">
+        <field name="name">disbursement.request.form.guarantee</field>
+        <field name="model">disbursement.request</field>
+        <field
+            name="inherit_id"
+            ref="disbursement.view_disbursement_request_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='state']" position="after">
+                <field name="guarantee_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_view_purchase_guarantee"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-shield"
+                    string="Purchase Guarantee"
+                    attrs="{'invisible': [('guarantee_id', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_guarantee_disbursement/views/purchase_guarantee_views.xml
+++ b/purchase_guarantee_disbursement/views/purchase_guarantee_views.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_guarantee_form" model="ir.ui.view">
+        <field name="name">purchase.guarantee.form.disbursement</field>
+        <field name="model">purchase.guarantee</field>
+        <field
+            name="inherit_id"
+            ref="purchase_guarantee_kmitl.view_purchase_guarantee_form"
+        />
+        <field name="arch" type="xml">
+            <!-- Hidden fields -->
+            <xpath expr="//div[@name='button_box']" position="before">
+                <field name="hide_create_disbursement_button" invisible="1"/>
+            </xpath>
+
+            <!-- Refund button in header -->
+            <xpath expr="//button[@name='button_lock']" position="after">
+                <button
+                    name="action_create_disbursement_refund"
+                    string="คืนเงินหลักประกัน"
+                    type="object"
+                    class="oe_highlight"
+                    attrs="{'invisible': [('hide_create_disbursement_button', '=', True)]}"
+                />
+            </xpath>
+
+            <!-- Smart button -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_view_disbursement_requests"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-exchange"
+                    attrs="{'invisible': [('disbursement_request_count', '=', 0)]}"
+                >
+                    <field
+                        name="disbursement_request_count"
+                        widget="statinfo"
+                        string="Disbursement"
+                    />
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/purchase_guarantee_disbursement/views/purchase_guarantee_views.xml
+++ b/purchase_guarantee_disbursement/views/purchase_guarantee_views.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- Inherit KMITL guarantee form: statusbar + disbursement button -->
     <record id="view_purchase_guarantee_form" model="ir.ui.view">
         <field name="name">purchase.guarantee.form.disbursement</field>
         <field name="model">purchase.guarantee</field>
@@ -10,7 +11,13 @@
         <field name="arch" type="xml">
             <!-- Hidden fields -->
             <xpath expr="//div[@name='button_box']" position="before">
+                <field name="hide_create_payment_button" invisible="1"/>
                 <field name="hide_create_disbursement_button" invisible="1"/>
+            </xpath>
+
+            <!-- Update statusbar to show all 4 states -->
+            <xpath expr="//field[@name='state'][@widget='statusbar']" position="attributes">
+                <attribute name="statusbar_visible">draft,lock,received,returned</attribute>
             </xpath>
 
             <!-- Refund button in header -->
@@ -24,7 +31,7 @@
                 />
             </xpath>
 
-            <!-- Smart button -->
+            <!-- Disbursement smart button -->
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button
                     name="action_view_disbursement_requests"
@@ -39,6 +46,21 @@
                         string="Disbursement"
                     />
                 </button>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Inherit payment view: control payment button visibility -->
+    <record id="view_purchase_guarantee_form_payment" model="ir.ui.view">
+        <field name="name">purchase.guarantee.form.disbursement.payment</field>
+        <field name="model">purchase.guarantee</field>
+        <field
+            name="inherit_id"
+            ref="purchase_guarantee_account_payment.view_purchase_guarantee_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_create_payment']" position="attributes">
+                <attribute name="attrs">{'invisible': [('hide_create_payment_button', '=', True)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Add new module `purchase_guarantee_disbursement` with full guarantee lifecycle: **draft → lock → received → returned**
- **Receipt control**: Limit to 1 payment per guarantee; "สร้างใบส่งเงิน" button hidden after payment created
- **Auto state transitions**: `lock → received` when payment posted, `received → returned` when refund bill posted (via `account.move._post()` override)
- **Refund via disbursement**: "คืนเงินหลักประกัน" button only visible after receipt completed (`state == received`), creates pre-filled disbursement request with partner, amount, account, and analytic dimensions
- **Bill linking**: Disbursement-created bills auto-linked to `guarantee.bill_ids` for `amount_returned` tracking
- Depends on `purchase_guarantee_account_payment` and `disbursement`

## Test plan
- [ ] Create guarantee → Lock → verify only "สร้างใบส่งเงิน" visible, "คืนเงินหลักประกัน" hidden
- [ ] Create payment → Post payment → verify state auto-transitions to "received"
- [ ] Verify second payment cannot be created (button hidden)
- [ ] Verify "คืนเงินหลักประกัน" now visible
- [ ] Create disbursement → Submit → Validate → Create Bill → Post bill
- [ ] Verify state auto-transitions to "returned"
- [ ] Verify statusbar shows all 4 states correctly
- [ ] Verify smart buttons navigate correctly both directions