### PR TITLE
[16.0][ADD] purchase_guarantee_operating_unit: add OU support

### DIFF
--- a/purchase_guarantee_operating_unit/__init__.py
+++ b/purchase_guarantee_operating_unit/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_guarantee_operating_unit/__manifest__.py
+++ b/purchase_guarantee_operating_unit/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Purchase Guarantee with Operating Units",
+    "version": "16.0.1.0.0",
+    "category": "KMITL",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "operating_unit",
+        "purchase_guarantee_account_payment",
+        "purchase_operating_unit",
+        "purchase_request_operating_unit",
+    ],
+    "data": [
+        "security/purchase_guarantee_security.xml",
+        "views/purchase_guarantee_views.xml",
+    ],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/purchase_guarantee_operating_unit/models/__init__.py
+++ b/purchase_guarantee_operating_unit/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import purchase_guarantee
+from . import purchase_order
+from . import purchase_request

--- a/purchase_guarantee_operating_unit/models/purchase_guarantee.py
+++ b/purchase_guarantee_operating_unit/models/purchase_guarantee.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class PurchaseGuarantee(models.Model):
+    _inherit = "purchase.guarantee"
+
+    operating_unit_id = fields.Many2one(
+        comodel_name="operating.unit",
+        string="Operating Unit",
+        default=lambda self: self.env["res.users"].operating_unit_default_get(),
+    )
+
+    def _prepare_account_payment_vals(self):
+        vals = super()._prepare_account_payment_vals()
+        vals["operating_unit_id"] = self.operating_unit_id.id
+        return vals

--- a/purchase_guarantee_operating_unit/models/purchase_order.py
+++ b/purchase_guarantee_operating_unit/models/purchase_order.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def action_view_purchase_guarantee(self):
+        action = super().action_view_purchase_guarantee()
+        action["context"]["default_operating_unit_id"] = self.operating_unit_id.id
+        return action

--- a/purchase_guarantee_operating_unit/models/purchase_request.py
+++ b/purchase_guarantee_operating_unit/models/purchase_request.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class PurchaseRequest(models.Model):
+    _inherit = "purchase.request"
+
+    def action_view_purchase_guarantee(self):
+        action = super().action_view_purchase_guarantee()
+        action["context"]["default_operating_unit_id"] = self.operating_unit_id.id
+        return action

--- a/purchase_guarantee_operating_unit/security/purchase_guarantee_security.xml
+++ b/purchase_guarantee_operating_unit/security/purchase_guarantee_security.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_rule_purchase_guarantee_operating_units" model="ir.rule">
+        <field name="name">Purchase Guarantee Operating Unit</field>
+        <field name="model_id" ref="l10n_th_gov_purchase_guarantee.model_purchase_guarantee"/>
+        <field
+            name="domain_force"
+        >['|', ('operating_unit_id','=',False), ('operating_unit_id','in',user.operating_unit_ids.ids)]
+        </field>
+        <field name="global" eval="True"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+        <field name="perm_create" eval="0"/>
+    </record>
+</odoo>

--- a/purchase_guarantee_operating_unit/views/purchase_guarantee_views.xml
+++ b/purchase_guarantee_operating_unit/views/purchase_guarantee_views.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Form view: add operating_unit_id after analytic_distribution -->
+    <record id="view_purchase_guarantee_form_operating_unit" model="ir.ui.view">
+        <field name="name">view.purchase.guarantee.form.operating_unit</field>
+        <field name="model">purchase.guarantee</field>
+        <field name="inherit_id" ref="l10n_th_gov_purchase_guarantee.view_purchase_guarantee_form"/>
+        <field name="arch" type="xml">
+            <field name="date_return" position="before">
+                <field
+                    name="operating_unit_id"
+                    widget="selection"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </field>
+        </field>
+    </record>
+
+    <!-- Tree view: add optional operating_unit_id column -->
+    <record id="view_purchase_guarantee_tree_operating_unit" model="ir.ui.view">
+        <field name="name">view.purchase.guarantee.tree.operating_unit</field>
+        <field name="model">purchase.guarantee</field>
+        <field name="inherit_id" ref="l10n_th_gov_purchase_guarantee.view_purchase_guarantee_tree"/>
+        <field name="arch" type="xml">
+            <field name="document_ref" position="after">
+                <field
+                    name="operating_unit_id"
+                    groups="operating_unit.group_multi_operating_unit"
+                    optional="hide"
+                />
+            </field>
+        </field>
+    </record>
+
+    <!-- Search view: add group by operating unit -->
+    <record id="purchase_guarantee_group_by_ou" model="ir.ui.view">
+        <field name="name">purchase.guarantee.group.by.ou</field>
+        <field name="model">purchase.guarantee</field>
+        <field name="inherit_id" ref="l10n_th_gov_purchase_guarantee.purchase_guarantee_search_view"/>
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator/>
+                <filter
+                    string="Operating Unit"
+                    name="operating_unit_grouped"
+                    domain="[]"
+                    context="{'group_by':'operating_unit_id'}"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </filter>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Adds operating unit support to purchase guarantees with automatic propagation from source documents (PO/PR) and payment creation. Includes security rules restricting access by user's assigned operating units.

Changes:
- Add operating_unit_id field to purchase.guarantee with user default
- Auto-populate from purchase order/request via context when creating guarantees  
- Pass operating_unit_id through to account.payment creation
- IR rule restricts read access by operating unit
- UI fields on form/tree/search views (gated by multi-OU group)