### PR TITLE
[16.0][IMP] disbursement, account_payment_budget: make budget_account_id optional

### DIFF
--- a/account_payment_budget/views/account_payment_views.xml
+++ b/account_payment_budget/views/account_payment_views.xml
@@ -22,7 +22,7 @@
                                 <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
                                 <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
                                 <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="budget_account_id" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                                <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
                             </group>
                         </group>
                     </page>

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -82,7 +82,7 @@
                             <field name="department_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
                             <field name="fund_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
                             <field name="activity_analytic_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
-                            <field name="budget_account_id" required="1" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
+                            <field name="budget_account_id" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', 'in', ['submitted', 'validated', 'cancel'])]}" />
                             <field name="analytic_distribution" invisible="1"/>
                         </group>
                     </group>


### PR DESCRIPTION
## Summary
Make `budget_account_id` optional in disbursement and account payment views by removing `required="1"` attributes. 

This aligns with the broader effort from PR #582 to allow operations without mandatory budget account selection when a budget commitment is not explicitly set. Users can now create disbursements and payments without pre-selecting a budget account if they prefer to track only analytic dimensions.

## Changes
- `disbursement/views/disbursement_request_views.xml`: Remove `required="1"` from budget_account_id field
- `account_payment_budget/views/account_payment_views.xml`: Remove `required="1"` from budget_account_id field