### PR TITLE
[16.0][FIX] purchase_order_disbursement: remove unnecessary create button restriction

### DIFF
--- a/purchase_order_disbursement/views/disbursement_request_views.xml
+++ b/purchase_order_disbursement/views/disbursement_request_views.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
   <odoo>
 
-    <!-- View disbursement.request tree -->
-    <record id="view_disbursement_request_tree" model="ir.ui.view">
-        <field name="name">view.disbursement.request.tree</field>
-        <field name="model">disbursement.request</field>
-        <field name="inherit_id" ref="disbursement.view_disbursement_request_tree"/>
-        <field name="arch" type="xml">
-            <xpath expr="//tree" position="attributes">
-                <attribute name="create">0</attribute>
-            </xpath>
-        </field>
-    </record>
-
     <!-- View disbursement.request form -->
     <record id="view_disbursement_request_form" model="ir.ui.view">
         <field name="name">view.disbursement.request.form</field>


### PR DESCRIPTION
Removes the inherited tree view record that was setting create="0" on the disbursement request tree. This restriction was unnecessary and prevented users from creating disbursement requests directly from the tree view.