### PR TITLE
[16.0][IMP] account_move_kmitl: default analytic distribution to move lines

### DIFF
--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -170,3 +170,11 @@ class AccountMove(models.Model):
             self.line_ids.update(
                 {"analytic_distribution": self.analytic_distribution}
             )
+
+    @api.onchange("line_ids")
+    def _onchange_line_ids_analytic_distribution(self):
+        """Auto-fill analytic distribution on new lines from header."""
+        if self.analytic_distribution:
+            for line in self.line_ids:
+                if not line.analytic_distribution:
+                    line.analytic_distribution = self.analytic_distribution

--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -154,8 +154,19 @@ class AccountMove(models.Model):
             if analytic_accounts:
                 self.analytic_distribution = analytic_accounts
 
+    def _inverse_analytic_distribution(self):
+        """Propagate analytic distribution to convenience fields and lines."""
+        super()._inverse_analytic_distribution()
+        for move in self:
+            if move.analytic_distribution:
+                move.line_ids.write(
+                    {"analytic_distribution": move.analytic_distribution}
+                )
+
     @api.onchange("analytic_distribution")
     def _onchange_analytic_distribution(self):
-        """When analytic_distribution changes, propagate to all move lines."""
+        """When change analytic distribution, propagate to all move lines."""
         if self.analytic_distribution:
-            self.line_ids.update({"analytic_distribution": self.analytic_distribution})
+            self.line_ids.update(
+                {"analytic_distribution": self.analytic_distribution}
+            )

--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -171,10 +171,3 @@ class AccountMove(models.Model):
                 {"analytic_distribution": self.analytic_distribution}
             )
 
-    @api.onchange("line_ids")
-    def _onchange_line_ids_analytic_distribution(self):
-        """Auto-fill analytic distribution on new lines from header."""
-        if self.analytic_distribution:
-            for line in self.line_ids:
-                if not line.analytic_distribution:
-                    line.analytic_distribution = self.analytic_distribution

--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -153,3 +153,9 @@ class AccountMove(models.Model):
                 self.source_analytic_id = commitment.source_analytic_id
             if analytic_accounts:
                 self.analytic_distribution = analytic_accounts
+
+    @api.onchange("analytic_distribution")
+    def _onchange_analytic_distribution(self):
+        """When analytic_distribution changes, propagate to all move lines."""
+        if self.analytic_distribution:
+            self.line_ids.update({"analytic_distribution": self.analytic_distribution})

--- a/account_move_kmitl/views/account_move_views.xml
+++ b/account_move_kmitl/views/account_move_views.xml
@@ -24,32 +24,56 @@
                 <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': ['|', ('state', '!=', 'submitted'), ('validation_status', 'in', ['validated', 'rejected', 'pending'])]}" />
             </xpath>
 
-            <!-- Budget tab -->
-            <xpath expr="//notebook" position="inside">
-                <page string="Budget" name="budget">
-                    <group string="Budget">
-                        <group name="budget_info">
-                            <field name="budget_commitment_id" attrs="{'readonly': [('state', '=', 'posted')]}"/>
-                            <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
-                            <field name="analytic_distribution" invisible="1"/>
-                        </group>
-                        <group name="analytic_dimensions">
-                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                            <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                        </group>
+            <!-- Pass analytic distribution as default to new lines -->
+            <xpath expr="//field[@name='invoice_line_ids']" position="attributes">
+                <attribute name="context">{
+                    'default_move_type': context.get('default_move_type'),
+                    'journal_id': journal_id,
+                    'default_partner_id': commercial_partner_id,
+                    'default_currency_id': currency_id or company_currency_id,
+                    'default_display_type': 'product',
+                    'quick_encoding_vals': quick_encoding_vals,
+                    'default_analytic_distribution': analytic_distribution,
+                }</attribute>
+            </xpath>
+            <xpath expr="//page[@id='aml_tab']//field[@name='line_ids']" position="attributes">
+                <attribute name="context">{
+                    'default_move_type': context.get('default_move_type'),
+                    'line_ids': line_ids,
+                    'journal_id': journal_id,
+                    'default_partner_id': commercial_partner_id,
+                    'default_currency_id': currency_id or company_currency_id,
+                    'kanban_view_ref': 'account.account_move_line_view_kanban_mobile',
+                    'default_analytic_distribution': analytic_distribution,
+                }</attribute>
+            </xpath>
+
+            <!-- Budget fields on main form (before notebook) -->
+            <xpath expr="//notebook" position="before">
+                <group string="Budget">
+                    <group name="budget_info">
+                        <field name="budget_commitment_id" attrs="{'readonly': [('state', '=', 'posted')]}"/>
+                        <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
+                        <field name="analytic_distribution" invisible="1"/>
                     </group>
-                    <div class="oe_button_box" name="button_box_budget">
-                        <button name="action_view_budget_commitment" type="object" class="oe_stat_button" icon="fa-calculator" attrs="{'invisible': [('budget_commitment_id', '=', False)]}">
-                            <div class="o_field_widget o_stat_info">
-                                <span class="o_stat_text">View</span>
-                                <span class="o_stat_text">Budget Commitment</span>
-                            </div>
-                        </button>
+                    <group name="analytic_dimensions">
+                        <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                        <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                        <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                        <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                        <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                    </group>
+                </group>
+            </xpath>
+
+            <!-- Budget commitment button in header button box -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_budget_commitment" type="object" class="oe_stat_button" icon="fa-calculator" attrs="{'invisible': [('budget_commitment_id', '=', False)]}">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">View</span>
+                        <span class="o_stat_text">Budget Commitment</span>
                     </div>
-                </page>
+                </button>
             </xpath>
 
         </field>


### PR DESCRIPTION
## Summary
- เพิ่ม `_onchange_analytic_distribution` บน `account.move` เพื่อ propagate analytic_distribution (4 มิติ: activities, departments, funds, sources) จาก header ลงไปยังทุก `account.move.line`
- ใช้ pattern เดียวกับ disbursement, purchase_budget, purchase_request_budget

## Test plan
- [ ] สร้าง journal entry → ตั้ง 4 มิติใน Budget tab → เพิ่ม line → ตรวจว่า line มี analytic_distribution ตาม header
- [ ] เลือก budget_commitment_id → ตรวจว่า lines ได้รับ analytic_distribution จาก commitment
- [ ] แก้ไข dimension field บน header → ตรวจว่า lines อัปเดตตาม