### PR TITLE
[16.0][IMP] disbursement, partner_type_aginix: default WHT from partner type

### DIFF
--- a/disbursement/__manifest__.py
+++ b/disbursement/__manifest__.py
@@ -13,6 +13,7 @@
         "base_exception",
         "l10n_th_account_tax",
         "base_fontawesome",
+        "partner_type_aginix",
     ],
     "data": [
         "security/security.xml",

--- a/disbursement/models/disbursement_request_line.py
+++ b/disbursement/models/disbursement_request_line.py
@@ -172,17 +172,10 @@ class DisbursementRequestLine(models.Model):
     # -------------------------------------------------------------------------
     # WHT methods
     # -------------------------------------------------------------------------
-    @api.depends("product_id", "request_id.partner_id")
+    @api.depends("request_id.partner_id.partner_type_id.wht_tax_id")
     def _compute_wht_tax_id(self):
         for line in self:
-            if line.product_id:
-                partner = line.request_id.partner_id
-                if partner and partner.company_type == "company":
-                    line.wht_tax_id = line.product_id.supplier_company_wht_tax_id
-                else:
-                    line.wht_tax_id = line.product_id.supplier_wht_tax_id
-            else:
-                line.wht_tax_id = False
+            line.wht_tax_id = line.request_id.partner_id.partner_type_id.wht_tax_id
 
     # -------------------------------------------------------------------------
     # Exception methods

--- a/partner_type_aginix/__manifest__.py
+++ b/partner_type_aginix/__manifest__.py
@@ -6,7 +6,7 @@
     'author': 'Aginix Technologies',
     'website': 'https://github.com/aginix/kmitl',
     'category': 'KMITL',
-    'depends': ['account', 'purchase'],
+    'depends': ['account', 'purchase', 'l10n_th_account_tax'],
     "data": [
         "data/partner_type_data.xml",
         "security/ir.model.access.csv",

--- a/partner_type_aginix/models/res_partner_type.py
+++ b/partner_type_aginix/models/res_partner_type.py
@@ -44,6 +44,13 @@ class ResPartnerType(models.Model):
         help='This account will be used instead of the default one as the payable account for the partner',
     )
 
+    wht_tax_id = fields.Many2one(
+        comodel_name="account.withholding.tax",
+        string="WHT",
+        company_dependent=True,
+        tracking=True,
+    )
+
     partner_ids = fields.One2many(
         comodel_name='res.partner',
         inverse_name='partner_type_id',

--- a/partner_type_aginix/views/res_partner_type_views.xml
+++ b/partner_type_aginix/views/res_partner_type_views.xml
@@ -34,6 +34,7 @@
                         <group>
                             <field name="property_account_receivable_id"/>
                             <field name="property_account_payable_id"/>
+                            <field name="wht_tax_id"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
## Summary
- เพิ่ม field `wht_tax_id` บน `res.partner.type` เพื่อให้ตั้งค่า WHT ตามประเภท partner ได้
- เปลี่ยน logic ใน `disbursement.request.line` ให้ใช้ WHT จาก partner type แทน product
- เพิ่ม dependency: `partner_type_aginix` → `l10n_th_account_tax`, `disbursement` → `partner_type_aginix`

## Post-deployment
ต้องตั้งค่า WHT ใน Partner Type (Purchase > Configuration > Partner Type):
| Partner Type | WHT |
|---|---|
| บริษัท | ภาษี หัก ณ ที่จ่ายนิติบุคคลจากหน่วยงานเอกชน |
| บุคลากรภายใน | ภาษี หัก ณ ที่จ่ายบุคคลธรรมดา |
| นักศึกษา | (ว่าง) |
| อื่น ๆ | (ว่าง) |

## Test plan
- [ ] Upgrade modules: `partner_type_aginix`, `disbursement`
- [ ] ตั้งค่า WHT ใน Partner Type ตามตาราง
- [ ] สร้าง DB กับ partner ประเภทบริษัท → line ต้อง auto-fill WHT นิติบุคคล
- [ ] สร้าง DB กับ partner ประเภทบุคลากร → line ต้อง auto-fill WHT บุคคลธรรมดา
- [ ] สร้าง DB กับ partner ประเภทนักศึกษา → ไม่มี WHT
- [ ] ทดสอบ override WHT ใน line ได้ด้วยมือ
- [ ] ทดสอบสร้าง bill จาก DB แล้ว WHT ส่งต่อถูกต้อง