### PR TITLE
[16.0][IMP] account_payment_kmitl: consolidate form view layout

### DIFF
--- a/account_payment_kmitl/__manifest__.py
+++ b/account_payment_kmitl/__manifest__.py
@@ -13,6 +13,7 @@
         "account_move_kmitl",
         "account_fiscal_year_enhance",
         "budget",
+        "l10n_th_account_tax",
         "l10n_th_bank_payment_export",
         "l10n_th_bank_payment_export_format",
         "thai_date_utils",

--- a/account_payment_kmitl/views/account_payment_views.xml
+++ b/account_payment_kmitl/views/account_payment_views.xml
@@ -44,25 +44,72 @@
             <xpath expr="//field[@name='payment_type']" position="after">
                 <field name="kmitl_payment_type_id" domain="[('direction', '=', payment_type)]"/></xpath>
 
-            <!-- Add Budget tab -->
-            <xpath expr="//sheet" position="inside">
-                <notebook>
-                    <page string="Budget" name="budget" attrs="{'invisible': [('payment_type', '!=', 'outbound')]}">
-                        <group string="Budget">
-                            <group name="budget_info">
-                                <field name="budget_commitment_id" attrs="{'readonly': [('state', '!=', 'draft')]}" />
-                                <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
-                            </group>
-                            <group name="analytic_dimensions">
-                                <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                            </group>
+        </field>
+    </record>
+
+    <!-- Consolidate notebook layout: Budget + Tax Invoice + WHT Moves in single notebook -->
+    <record id="view_account_payment_form_layout" model="ir.ui.view">
+        <field name="name">account.payment.form.layout.kmitl</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="l10n_th_account_tax.view_account_payment_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Remove notebook-level invisible so it always shows -->
+            <xpath expr="//page[@name='tax_invoice']/parent::notebook" position="attributes">
+                <attribute name="attrs"/>
+            </xpath>
+
+            <!-- Move visibility to the Tax Invoice page itself -->
+            <xpath expr="//page[@name='tax_invoice']" position="attributes">
+                <attribute name="attrs">{'invisible': [('tax_invoice_ids', '=', [])]}</attribute>
+            </xpath>
+
+            <!-- Remove standalone Withholding Moves group -->
+            <xpath expr="//group[@id='wht_move']" position="replace"/>
+
+            <!-- Add Budget page before Tax Invoice -->
+            <xpath expr="//page[@name='tax_invoice']" position="before">
+                <page string="Budget" name="budget" attrs="{'invisible': [('payment_type', '!=', 'outbound')]}">
+                    <group string="Budget">
+                        <group name="budget_info">
+                            <field name="budget_commitment_id" attrs="{'readonly': [('state', '!=', 'draft')]}" />
+                            <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
                         </group>
-                    </page>
-                </notebook>
+                        <group name="analytic_dimensions">
+                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+
+            <!-- Add Withholding Moves as a page after Tax Invoice -->
+            <xpath expr="//page[@name='tax_invoice']" position="after">
+                <page string="Withholding Moves" name="wht_moves" attrs="{'invisible': ['|', ('wht_move_ids', '=', []), ('payment_type', '!=', 'outbound')]}">
+                    <field
+                        name="wht_move_ids"
+                        nolabel="1"
+                        colspan="2"
+                    >
+                        <tree editable="bottom" create="0" delete="0">
+                            <field name="date" invisible="1" />
+                            <field name="calendar_year" invisible="1" />
+                            <field name="partner_id" readonly="1" />
+                            <field name="wht_cert_income_type" />
+                            <field
+                                name="wht_cert_income_desc"
+                                optional="show"
+                                style="white-space: normal;"
+                            />
+                            <field name="amount_income" />
+                            <field name="amount_wht" />
+                            <field name="is_pit" />
+                        </tree>
+                    </field>
+                </page>
             </xpath>
 
         </field>


### PR DESCRIPTION
## Summary

Consolidate account.payment form view layout by unifying Budget, Tax Invoice, and Withholding Moves sections into a single notebook. This fixes form layout fragmentation caused by l10n_th_account_tax and account_payment_kmitl independently adding content.

**Changes:**
- Add l10n_th_account_tax as dependency
- Move Budget tab into the l10n_th_account_tax notebook (before Tax Invoice page)
- Convert standalone Withholding Moves group into a notebook page
- Apply visibility conditions per-page instead of notebook-level (notebook always visible, individual pages control visibility)
- Result: Single unified notebook with Budget | Tax Invoice | Withholding Moves tabs

**Form behavior:**
- Outbound payments: Budget, Tax Invoice (if data exists), Withholding Moves (if data exists) tabs visible
- Inbound payments: Only Tax Invoice tab visible (if data exists)
- All existing functionality (Submit, Reset to Draft, statusbar, onchange, readonly conditions) preserved

## Test plan

- [ ] Open account.payment form (inbound and outbound) 
- [ ] Verify single notebook with no duplicate tab bars
- [ ] Confirm Budget tab visible only for outbound payments
- [ ] Confirm Tax Invoice tab visible only when tax_invoice_ids exist
- [ ] Confirm Withholding Moves tab visible only for outbound with wht_move_ids
- [ ] Verify Submit/Reset to Draft buttons work correctly
- [ ] Verify Budget onchange and readonly conditions still function