### PR TITLE
[16.0][FIX] purchase_guarantee_account_payment: preserve analytic dimensions on payment

### DIFF
--- a/purchase_guarantee_account_payment/models/purchase_guarantee.py
+++ b/purchase_guarantee_account_payment/models/purchase_guarantee.py
@@ -61,6 +61,17 @@ class PurchaseGuarantee(models.Model):
 
         payment = self.env["account.payment"].create(vals)
 
+        # Re-apply analytic distribution after creation.
+        # During _inherits creation, AnalyticDistributionMixin's compute
+        # resets analytic_distribution before lines are generated.
+        if self.analytic_distribution:
+            payment.move_id.write(
+                {"analytic_distribution": self.analytic_distribution}
+            )
+            payment.move_id.line_ids.write(
+                {"analytic_distribution": self.analytic_distribution}
+            )
+
         return {
             "type": "ir.actions.act_window",
             "res_model": "account.payment",


### PR DESCRIPTION
## Summary
- เวลาที่ purchase_guarantee สร้าง account_payment แล้ว 4 มิติ (activity, department, fund, source) หายไป
- สาเหตุ: ระหว่าง `_inherits` creation, `AnalyticDistributionMixin` compute จะ reset `analytic_distribution` ก่อนที่ move lines จะถูกสร้าง
- แก้โดย re-apply `analytic_distribution` ไปที่ move และ move lines หลัง payment creation

## Test plan
- [ ] เปิด purchase guarantee ที่มี analytic_distribution (จาก PO/PR lines ที่มี 4 มิติ)
- [ ] กด "สร้างใบส่งเงิน"
- [ ] ตรวจสอบว่า journal entry ของ payment มี:
  - `analytic_distribution` บน move header
  - 4 convenience fields (activity, department, fund, source) ถูกต้อง
  - `analytic_distribution` บน move lines ทั้ง 2 บรรทัด (liquidity + counterpart)