### PR TITLE
[16.0][IMP] purchase_request: add chatter notifications on PO creation

### DIFF
--- a/purchase_request_approval/models/purchase_request.py
+++ b/purchase_request_approval/models/purchase_request.py
@@ -187,7 +187,33 @@ class PurchaseRequest(models.Model):
             .create({"supplier_id": self.partner_id.id})
         )
         wizard.make_purchase_order()
+        approval = self.request_approval_ids[:1]
+        if approval:
+            purchase_orders = wizard.item_ids.mapped("line_id.purchase_lines.order_id")
+            self._post_chatter_messages_approval_po(approval, purchase_orders)
         return wizard
+
+    def _post_chatter_messages_approval_po(self, approval, purchase_orders):
+        if not purchase_orders:
+            return
+        pa_link = "/web#id=%d&model=purchase.request.approval&view_type=form" % approval.id
+        for po in purchase_orders:
+            po.message_post(
+                body=_(
+                    'Created from Purchase Request Approval'
+                    ' <a href="%(link)s" target="_blank">%(name)s</a>.'
+                ) % {"link": pa_link, "name": approval.name},
+                subtype_xmlid="mail.mt_note",
+            )
+        po_items = "".join(
+            '<li><a href="/web#id=%d&model=purchase.order&view_type=form" target="_blank">%s</a></li>'
+            % (po.id, po.name)
+            for po in purchase_orders
+        )
+        approval.message_post(
+            body=_("Purchase Order created:<ul>%s</ul>") % po_items,
+            subtype_xmlid="mail.mt_note",
+        )
 
     @api.depends(
         "state",

--- a/purchase_request_kmitl/wizards/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_kmitl/wizards/purchase_request_line_make_purchase_order.py
@@ -30,7 +30,33 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
                 ) % line.display_name)
 
         res = super().make_purchase_order()
+        self._post_chatter_messages_after_po_creation()
         return res
+
+    def _post_chatter_messages_after_po_creation(self):
+        purchase_orders = self.item_ids.mapped("line_id.purchase_lines.order_id")
+        purchase_requests = self.item_ids.mapped("line_id.request_id")
+        if not purchase_orders or not purchase_requests:
+            return
+        for po in purchase_orders:
+            pr_items = "".join(
+                '<li><a href="%s" target="_blank">%s</a></li>' % (pr._get_record_url(), pr.name)
+                for pr in purchase_requests
+            )
+            po.message_post(
+                body=_("Created from Purchase Request:<ul>%s</ul>") % pr_items,
+                subtype_xmlid="mail.mt_note",
+            )
+        for pr in purchase_requests:
+            po_items = "".join(
+                '<li><a href="/web#id=%d&model=purchase.order&view_type=form" target="_blank">%s</a></li>'
+                % (po.id, po.name)
+                for po in purchase_orders
+            )
+            pr.message_post(
+                body=_("Purchase Order created:<ul>%s</ul>") % po_items,
+                subtype_xmlid="mail.mt_note",
+            )
 
 
 class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):


### PR DESCRIPTION
## Summary
- When a PO is created from a Purchase Request via wizard, chatter notes are posted to both the PO (linking back to the source PR) and the PR (linking to the new PO).
- When the PO is created via the Purchase Request Approval flow, additional notes are posted to the PO (linking to the PA) and the PA (linking to the new PO).

## Test plan
- [ ] Create a PO from a PR via the wizard → verify chatter messages on both PO and PR with correct links
- [ ] Create a PO via `approval_make_purchase_order` → verify chatter messages on PO, PR, and PA with correct links