### PR TITLE
[16.0][IMP] disbursement: payment pipeline tracking

### DIFF
--- a/purchase_order_disbursement/__manifest__.py
+++ b/purchase_order_disbursement/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    'depends': ['purchase', 'disbursement', 'purchase_order_payment_type'],
+    'depends': ['purchase', 'disbursement', 'purchase_order_payment_type', 'account_payment_kmitl'],
     "data": [
         "security/ir.model.access.csv",
         "views/disbursement_request_views.xml",

--- a/purchase_order_disbursement/models/disbursement_request.py
+++ b/purchase_order_disbursement/models/disbursement_request.py
@@ -20,6 +20,29 @@ class DisbursementRequest(models.Model):
         tracking=True,
     )
 
+    # --- Pipeline: Payment tracking ---
+    payment_ids = fields.Many2many(
+        comodel_name="account.payment",
+        compute="_compute_payment_ids",
+        string="Payments",
+    )
+    payment_count = fields.Integer(
+        compute="_compute_payment_ids",
+        string="Payment Count",
+    )
+    bill_payment_state = fields.Selection(
+        related="bill_id.payment_state",
+        string="Bill Payment Status",
+    )
+    bill_amount_residual = fields.Monetary(
+        related="bill_id.amount_residual",
+        string="Amount Due",
+        currency_field="currency_id",
+    )
+    hide_register_payment_button = fields.Boolean(
+        compute="_compute_hide_register_payment_button",
+    )
+
     @api.depends("reference")
     def _compute_reference_fields(self):
         super()._compute_reference_fields()
@@ -40,6 +63,30 @@ class DisbursementRequest(models.Model):
                         rec.analytic_distribution = line.analytic_distribution
                         break
 
+    @api.depends("bill_id")
+    def _compute_payment_ids(self):
+        Payment = self.env["account.payment"]
+        for rec in self:
+            payments = Payment
+            if rec.bill_id:
+                # Reconciled payments (posted & matched)
+                payments |= rec.bill_id._get_reconciled_payments()
+                # Draft/submitted payments awaiting posting (KMITL flow)
+                payments |= Payment.search([
+                    ("to_reconcile_payment_line_ids.move_id", "=", rec.bill_id.id),
+                ])
+            rec.payment_ids = payments
+            rec.payment_count = len(payments)
+
+    @api.depends("bill_id", "bill_id.state", "bill_id.payment_state")
+    def _compute_hide_register_payment_button(self):
+        for rec in self:
+            rec.hide_register_payment_button = not (
+                rec.bill_id
+                and rec.bill_id.state == "posted"
+                and rec.bill_id.payment_state in ("not_paid", "partial")
+            )
+
     def action_view_purchase_order(self):
         self.ensure_one()
         if not self.purchase_id:
@@ -52,4 +99,45 @@ class DisbursementRequest(models.Model):
             'res_id': self.purchase_id.id,
             'view_mode': 'form',
             'target': 'current',
+        }
+
+    def action_register_payment(self):
+        """Open payment wizard for the linked bill."""
+        self.ensure_one()
+        if not self.bill_id:
+            raise UserError(_("No bill linked. Create a bill first."))
+        if self.bill_id.state != "posted":
+            raise UserError(_("The bill must be posted before registering a payment."))
+        return {
+            "name": _("Register Payment"),
+            "res_model": "account.payment.register",
+            "view_mode": "form",
+            "context": {
+                "active_model": "account.move",
+                "active_ids": [self.bill_id.id],
+                "dont_redirect_to_payments": True,
+            },
+            "target": "new",
+            "type": "ir.actions.act_window",
+        }
+
+    def action_view_payments(self):
+        """Open related payment(s)."""
+        self.ensure_one()
+        if self.payment_count == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "name": _("Payment"),
+                "res_model": "account.payment",
+                "res_id": self.payment_ids.id,
+                "view_mode": "form",
+                "target": "current",
+            }
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Payments"),
+            "res_model": "account.payment",
+            "domain": [("id", "in", self.payment_ids.ids)],
+            "view_mode": "tree,form",
+            "target": "current",
         }

--- a/purchase_order_disbursement/views/disbursement_request_views.xml
+++ b/purchase_order_disbursement/views/disbursement_request_views.xml
@@ -9,7 +9,20 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='reference_model']" position="after">
                 <field name="purchase_id" invisible="1"/>
+                <field name="hide_register_payment_button" invisible="1"/>
             </xpath>
+
+            <!-- Register Payment button in header -->
+            <xpath expr="//button[@name='action_cancel']" position="after">
+                <button name="action_register_payment"
+                        string="Register Payment"
+                        type="object"
+                        class="oe_highlight"
+                        attrs="{'invisible': [('hide_register_payment_button', '=', True)]}"
+                        groups="account.group_account_invoice"/>
+            </xpath>
+
+            <!-- Smart buttons -->
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button name="action_view_purchase_order"
                         type="object"
@@ -18,6 +31,35 @@
                         string="Purchase Order"
                         attrs="{'invisible': [('reference_model', '!=', 'purchase.order')]}">
                 </button>
+                <button name="action_view_payments"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-money"
+                        attrs="{'invisible': [('payment_count', '=', 0)]}">
+                    <field name="payment_count" widget="statinfo" string="Payments"/>
+                </button>
+            </xpath>
+
+            <!-- Pipeline notebook page -->
+            <xpath expr="//notebook" position="inside">
+                <page string="Pipeline" name="pipeline">
+                    <group>
+                        <group string="Vendor Bill">
+                            <field name="bill_id" readonly="1"/>
+                            <field name="bill_payment_state" widget="badge"
+                                decoration-danger="bill_payment_state == 'not_paid'"
+                                decoration-warning="bill_payment_state == 'partial'"
+                                decoration-success="bill_payment_state == 'paid'"
+                                attrs="{'invisible': [('bill_id', '=', False)]}"/>
+                            <field name="bill_amount_residual"
+                                attrs="{'invisible': [('bill_id', '=', False)]}"/>
+                        </group>
+                        <group string="Payments">
+                            <field name="payment_ids" widget="many2many_tags"
+                                attrs="{'invisible': [('payment_count', '=', 0)]}"/>
+                        </group>
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Redesign disbursement workflow with full approval pipeline: `draft → submitted → sent → validated → approved → in_progress → done`
- Add `action_send` (head of dept signs), `action_approve` (director approves + budget commitment), and `action_done` (auto when bill paid)
- Budget commitment is created at approval step via `_action_approve_budget()`
- Bill creation advances state to `in_progress`, auto-detects `done` when bill `payment_state == 'paid'`
- Register Payment button available directly from disbursement form in `in_progress` state
- Cancel releases budget commitment and cancels draft bills

## Test plan
- [ ] Create disbursement request and walk through full pipeline: draft → submitted → sent → validated → approved → in_progress → done
- [ ] Verify budget is committed at approval step
- [ ] Verify bill creation sets state to `in_progress`
- [ ] Verify paying the bill auto-sets state to `done`
- [ ] Verify cancel releases budget commitment
- [ ] Verify reset to draft only works from submitted/sent/cancel states