### PR TITLE
[16.0][IMP] budget_appropriation: add budget summary fields by expense type

### DIFF
--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -209,6 +209,47 @@ class BudgetAppropriation(models.Model):
         digits="Budget Precision",
     )
 
+    # Budget summary by expense type
+    BUDGET_SUMMARY_CODES = {
+        "reserve_fund_amount": "07020",
+        "personnel_expense_amount": "51000",
+        "operating_expense_amount": "52000",
+        "capital_expenditure_amount": "53000",
+        "subsidy_amount": "54000",
+        "other_expenditure_amount": "55000",
+    }
+
+    reserve_fund_amount = fields.Float(
+        string="งบกองทุนสำรอง",
+        compute="_compute_budget_summary_amounts",
+        digits="Budget Precision",
+    )
+    personnel_expense_amount = fields.Float(
+        string="งบบุคลากร",
+        compute="_compute_budget_summary_amounts",
+        digits="Budget Precision",
+    )
+    operating_expense_amount = fields.Float(
+        string="งบดำเนินงาน",
+        compute="_compute_budget_summary_amounts",
+        digits="Budget Precision",
+    )
+    capital_expenditure_amount = fields.Float(
+        string="งบลงทุน",
+        compute="_compute_budget_summary_amounts",
+        digits="Budget Precision",
+    )
+    subsidy_amount = fields.Float(
+        string="งบเงินอุดหนุน",
+        compute="_compute_budget_summary_amounts",
+        digits="Budget Precision",
+    )
+    other_expenditure_amount = fields.Float(
+        string="งบรายจ่ายอื่น",
+        compute="_compute_budget_summary_amounts",
+        digits="Budget Precision",
+    )
+
     # Link to created budget move
     budget_move_id = fields.Many2one(
         comodel_name="budget.move",
@@ -257,6 +298,29 @@ class BudgetAppropriation(models.Model):
             appropriation.amount_total = amount_total
             appropriation.amount_deduct = amount_deduct
             appropriation.amount_net = amount_total - amount_deduct
+
+    @api.depends("line_ids.balance", "line_ids.account_id")
+    def _compute_budget_summary_amounts(self):
+        # Build account_id -> field_name mapping (shared across all records)
+        account_field_map = {}
+        BudgetAccount = self.env["budget.account"]
+        for field_name, code in self.BUDGET_SUMMARY_CODES.items():
+            parent = BudgetAccount.search([("code", "=", code)], limit=1)
+            if parent:
+                descendants = BudgetAccount.search(
+                    [("parent_path", "like", f"{parent.parent_path}%")]
+                )
+                for acc_id in descendants.ids:
+                    account_field_map[acc_id] = field_name
+
+        for record in self:
+            totals = dict.fromkeys(self.BUDGET_SUMMARY_CODES, 0.0)
+            for line in record.line_ids:
+                field_name = account_field_map.get(line.account_id.id)
+                if field_name:
+                    totals[field_name] += line.balance
+            for field_name, amount in totals.items():
+                record[field_name] = amount
 
     @api.depends("state", "date")
     def _compute_name(self):

--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -2,6 +2,7 @@ import logging
 
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
 
@@ -301,17 +302,25 @@ class BudgetAppropriation(models.Model):
 
     @api.depends("line_ids.balance", "line_ids.account_id")
     def _compute_budget_summary_amounts(self):
-        # Build account_id -> field_name mapping (shared across all records)
-        account_field_map = {}
+        # Build account_id -> field_name mapping in 2 queries instead of 12
         BudgetAccount = self.env["budget.account"]
-        for field_name, code in self.BUDGET_SUMMARY_CODES.items():
-            parent = BudgetAccount.search([("code", "=", code)], limit=1)
-            if parent:
-                descendants = BudgetAccount.search(
-                    [("parent_path", "like", f"{parent.parent_path}%")]
-                )
-                for acc_id in descendants.ids:
-                    account_field_map[acc_id] = field_name
+        code_to_field = {v: k for k, v in self.BUDGET_SUMMARY_CODES.items()}
+        parents = BudgetAccount.search(
+            [("code", "in", list(code_to_field.keys()))]
+        )
+        account_field_map = {}
+        if parents:
+            domain = expression.OR(
+                [("parent_path", "=like", f"{p.parent_path}%")]
+                for p in parents
+            )
+            descendants = BudgetAccount.search(domain)
+            # Map each descendant back to the parent code's field name
+            for desc in descendants:
+                for parent in parents:
+                    if desc.parent_path.startswith(parent.parent_path):
+                        account_field_map[desc.id] = code_to_field[parent.code]
+                        break
 
         for record in self:
             totals = dict.fromkeys(self.BUDGET_SUMMARY_CODES, 0.0)

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -120,6 +120,14 @@
                                     <field style="text-decoration-line: underline;" name="amount_deduct" string="หัก" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
                                     <field style="text-decoration-line: underline; text-decoration-style: double;" name="amount_net" string="รายรับสุทธิ" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
                                 </group>
+                                <group string="สรุปตามประเภทงบ" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                                    <field name="reserve_fund_amount" />
+                                    <field name="personnel_expense_amount" />
+                                    <field name="operating_expense_amount" />
+                                    <field name="capital_expenditure_amount" />
+                                    <field name="subsidy_amount" />
+                                    <field name="other_expenditure_amount" />
+                                </group>
                             </group>
                         </page>
                         <page string="Preview" name="preview" invisible="1" attrs="{'invisible': [('id', '=', False)]}">

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -113,20 +113,20 @@
                                 </field>
                             </group>
                             <group>
-                                <group class="oe_subtotal_footer oe_right">
-                                    <label for="amount_total" string="รายรับรวม" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
-                                    <label for="amount_total" string="รายจ่ายรวม" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                                    <field nolabel="1" name="amount_total" />
-                                    <field style="text-decoration-line: underline;" name="amount_deduct" string="หัก" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
-                                    <field style="text-decoration-line: underline; text-decoration-style: double;" name="amount_net" string="รายรับสุทธิ" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
-                                </group>
-                                <group string="สรุปตามประเภทงบ" attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                                <group attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
                                     <field name="reserve_fund_amount" />
                                     <field name="personnel_expense_amount" />
                                     <field name="operating_expense_amount" />
                                     <field name="capital_expenditure_amount" />
                                     <field name="subsidy_amount" />
                                     <field name="other_expenditure_amount" />
+                                </group>
+                                <group class="oe_subtotal_footer oe_right">
+                                    <label for="amount_total" string="รายรับรวม" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
+                                    <label for="amount_total" string="รายจ่ายรวม" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                                    <field nolabel="1" name="amount_total" />
+                                    <field style="text-decoration-line: underline;" name="amount_deduct" string="หัก" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
+                                    <field style="text-decoration-line: underline; text-decoration-style: double;" name="amount_net" string="รายรับสุทธิ" attrs="{'invisible': [('budget_type', '!=', 'revenue')]}" />
                                 </group>
                             </group>
                         </page>

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -229,6 +229,38 @@ class BudgetAppropriationCompilation(models.Model):
         compute="_compute_totals",
     )
 
+    # Budget summary by expense type (aggregated from appropriations)
+    reserve_fund_amount = fields.Monetary(
+        string="งบกองทุนสำรอง",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    personnel_expense_amount = fields.Monetary(
+        string="งบบุคลากร",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    operating_expense_amount = fields.Monetary(
+        string="งบดำเนินงาน",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    capital_expenditure_amount = fields.Monetary(
+        string="งบลงทุน",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    subsidy_amount = fields.Monetary(
+        string="งบเงินอุดหนุน",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    other_expenditure_amount = fields.Monetary(
+        string="งบรายจ่ายอื่น",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+
     education_impact_line_ids = fields.One2many(
         "budget.appropriation.compilation.impact",
         "compilation_id",
@@ -334,6 +366,30 @@ class BudgetAppropriationCompilation(models.Model):
                 + record.external_funding_amount
             )
             record.fixed_expense_percentage = (record.fixed_expense_total * 100) / record.revenue_net
+
+    BUDGET_SUMMARY_FIELDS = [
+        "reserve_fund_amount",
+        "personnel_expense_amount",
+        "operating_expense_amount",
+        "capital_expenditure_amount",
+        "subsidy_amount",
+        "other_expenditure_amount",
+    ]
+
+    @api.depends(
+        "expense_appropriation_ids.reserve_fund_amount",
+        "expense_appropriation_ids.personnel_expense_amount",
+        "expense_appropriation_ids.operating_expense_amount",
+        "expense_appropriation_ids.capital_expenditure_amount",
+        "expense_appropriation_ids.subsidy_amount",
+        "expense_appropriation_ids.other_expenditure_amount",
+    )
+    def _compute_budget_summary_amounts(self):
+        for record in self:
+            for field_name in self.BUDGET_SUMMARY_FIELDS:
+                record[field_name] = sum(
+                    record.expense_appropriation_ids.mapped(field_name)
+                )
 
     @api.depends(
         "education_impact_line_ids.project_okr_amount",

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -365,7 +365,7 @@ class BudgetAppropriationCompilation(models.Model):
                 + record.recurrent_budget_amount
                 + record.external_funding_amount
             )
-            record.fixed_expense_percentage = (record.fixed_expense_total * 100) / record.revenue_net
+            record.fixed_expense_percentage = (record.fixed_expense_total * 100) / record.revenue_net if record.revenue_net else 0.0
 
     BUDGET_SUMMARY_FIELDS = [
         "reserve_fund_amount",

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -154,7 +154,7 @@
                                     <field name="amount_net" sum="รวม" />
                                 </tree>
                             </field>
-                            <group string="สรุปตามประเภทงบ">
+                            <group class="oe_subtotal_footer oe_right" string="สรุปตามประเภทงบ">
                               <field name="reserve_fund_amount" />
                               <field name="personnel_expense_amount" />
                               <field name="operating_expense_amount" />

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -104,6 +104,13 @@
                             <field name="master_summary_id" />
                             <field name="amount_revenue_total" />
                             <field name="amount_expense_total" />
+                            <separator string="สรุปตามประเภทงบ" colspan="2" />
+                            <field name="reserve_fund_amount" />
+                            <field name="personnel_expense_amount" />
+                            <field name="operating_expense_amount" />
+                            <field name="capital_expenditure_amount" />
+                            <field name="subsidy_amount" />
+                            <field name="other_expenditure_amount" />
                         </group>
                     </group>
                     <notebook>

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -104,13 +104,7 @@
                             <field name="master_summary_id" />
                             <field name="amount_revenue_total" />
                             <field name="amount_expense_total" />
-                            <separator string="สรุปตามประเภทงบ" colspan="2" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                            <field name="reserve_fund_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                            <field name="personnel_expense_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                            <field name="operating_expense_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                            <field name="capital_expenditure_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                            <field name="subsidy_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
-                            <field name="other_expenditure_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+
                         </group>
                     </group>
                     <notebook>
@@ -160,6 +154,15 @@
                                     <field name="amount_net" sum="รวม" />
                                 </tree>
                             </field>
+                            <group string="สรุปตามประเภทงบ">
+                              <field name="reserve_fund_amount" />
+                              <field name="personnel_expense_amount" />
+                              <field name="operating_expense_amount" />
+                              <field name="capital_expenditure_amount" />
+                              <field name="subsidy_amount" />
+                              <field name="other_expenditure_amount" />
+                              <field style="text-decoration-line: underline; text-decoration-style: double;" name="amount_expense_total" />
+                            </group>
                         </page>
                         <page string="รายงาน F23-W" name="f23w_report" attrs="{'invisible': [('use_f23', '=', False)]}">
                             <style>

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -104,13 +104,13 @@
                             <field name="master_summary_id" />
                             <field name="amount_revenue_total" />
                             <field name="amount_expense_total" />
-                            <separator string="สรุปตามประเภทงบ" colspan="2" />
-                            <field name="reserve_fund_amount" />
-                            <field name="personnel_expense_amount" />
-                            <field name="operating_expense_amount" />
-                            <field name="capital_expenditure_amount" />
-                            <field name="subsidy_amount" />
-                            <field name="other_expenditure_amount" />
+                            <separator string="สรุปตามประเภทงบ" colspan="2" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                            <field name="reserve_fund_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                            <field name="personnel_expense_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                            <field name="operating_expense_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                            <field name="capital_expenditure_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                            <field name="subsidy_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
+                            <field name="other_expenditure_amount" attrs="{'invisible': [('budget_type', '!=', 'expense')]}" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
## Summary
- Add 6 non-stored computed fields to `budget.appropriation` summarizing line amounts by expense category: งบกองทุนสำรอง (07020), งบบุคลากร (51000), งบดำเนินงาน (52000), งบลงทุน (53000), งบเงินอุดหนุน (54000), งบรายจ่ายอื่น (55000)
- Uses hierarchical `parent_path` matching with `=like` and batched queries (2 instead of 12) via `expression.OR`
- Add same 6 summary fields to `budget.appropriation.compilation`, aggregated from linked expense appropriations
- Display fields in form views for both models

## Test plan
- [ ] Verify summary fields compute correctly on `budget.appropriation` form
- [ ] Confirm child account balances roll up to parent category totals
- [ ] Verify compilation summary fields aggregate from linked expense appropriations