### PR TITLE
[16.0][FIX] account_move_kmitl: remove auto budget commitment consume

### DIFF
--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -110,13 +110,11 @@ class AccountMove(models.Model):
             )
 
     def _post(self, soft=True):
-        """Validate budget, consume commitment, and auto-fill tax invoices."""
+        """Validate budget and auto-fill tax invoices."""
         for move in self:
             payment = move.payment_id
             if payment and payment.payment_type == "outbound":
                 move._check_analytic_distribution_complete()
-                if move.budget_commitment_id:
-                    move._consume_commitment(amount=payment.amount)
         res = super()._post(soft=soft)
         self._auto_fill_tax_invoice()
         return res


### PR DESCRIPTION
## Summary
- Remove automatic `_consume_commitment()` call from `account.move._post()` so budget commitment is no longer auto-consumed when posting outbound payment moves.
- Budget commitment fields, mixin inheritance, onchange, and view action remain intact for manual use.

## Test plan
- [ ] Post an outbound payment move with a linked budget commitment — verify no auto-consume occurs
- [ ] Verify budget commitment fields and onchange still work correctly on account.move form