### PR TITLE
[16.0][IMP] budget: improve transfer form view and Thai localization

### DIFF
--- a/budget/models/budget_transfer.py
+++ b/budget/models/budget_transfer.py
@@ -34,7 +34,7 @@ class BudgetTransfer(models.Model):
     """
 
     _name = "budget.transfer"
-    _description = "Budget Transfer"
+    _description = "โอนเปลี่ยนแปลงงบประมาณ"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "date desc, name desc, id desc"
     _rec_names_search = ["name", "ref"]
@@ -49,7 +49,7 @@ class BudgetTransfer(models.Model):
 
     # Basic Information
     name = fields.Char(
-        string="Transfer Number",
+        string="เลขที่เอกสาร",
         compute="_compute_name",
         readonly=False,
         store=True,
@@ -60,7 +60,7 @@ class BudgetTransfer(models.Model):
     )
 
     ref = fields.Char(
-        string="Reference",
+        string="อ้างอิง",
         copy=False,
         tracking=True,
         readonly=False,
@@ -68,7 +68,7 @@ class BudgetTransfer(models.Model):
     )
 
     date = fields.Date(
-        string="Transfer Date",
+        string="วันที่",
         index=True,
         default=lambda self: fields.Date.context_today(self),
         required=True,
@@ -80,14 +80,14 @@ class BudgetTransfer(models.Model):
 
     state = fields.Selection(
         selection=[
-            ("draft", "Draft"),
-            ("submitted", "Submitted"),
-            ("approved", "Approved"),
-            ("posted", "Posted"),
-            ("rejected", "Rejected"),
-            ("cancelled", "Cancelled"),
+            ("draft", "ฉบับร่าง"),
+            ("submitted", "ส่งขออนุมัติ"),
+            ("approved", "อนุมัติแล้ว"),
+            ("posted", "ประกาศแล้ว"),
+            ("rejected", "ไม่อนุมัติ"),
+            ("cancelled", "ยกเลิก"),
         ],
-        string="Status",
+        string="สถานะ",
         required=True,
         readonly=True,
         copy=False,
@@ -100,7 +100,7 @@ class BudgetTransfer(models.Model):
         selection=[
             ("entry", "ทั่วไป"),
         ],
-        string="Transfer Type",
+        string="ประเภทการโอน",
         required=True,
         default="entry",
         readonly=True,
@@ -108,7 +108,7 @@ class BudgetTransfer(models.Model):
     )
 
     amount = fields.Float(
-        string="Transfer Amount",
+        string="จำนวนเงินรวม",
         compute="_compute_amount",
         store=True,
         digits="Budget Precision",
@@ -117,18 +117,18 @@ class BudgetTransfer(models.Model):
     )
 
     reason = fields.Text(
-        string="Transfer Reason",
+        string="เหตุผลในการโอน",
         required=True,
         readonly=False,
         states=READONLY_STATES,
         tracking=True,
-        help="Please provide detailed justification for this budget transfer",
+        help="กรุณาระบุเหตุผลในการโอนเปลี่ยนแปลงงบประมาณ",
     )
 
     # Company and Currency
     company_id = fields.Many2one(
         comodel_name="res.company",
-        string="Company",
+        string="หน่วยงาน",
         default=lambda self: self.env.company,
         required=True,
         tracking=True,
@@ -136,7 +136,7 @@ class BudgetTransfer(models.Model):
 
     currency_id = fields.Many2one(
         "res.currency",
-        string="Currency",
+        string="สกุลเงิน",
         default=lambda self: self.env.company.currency_id,
         tracking=True,
         store=True,
@@ -146,7 +146,7 @@ class BudgetTransfer(models.Model):
     # Fiscal Year
     account_fiscal_year_id = fields.Many2one(
         comodel_name="account.fiscal.year",
-        string="Fiscal Year",
+        string="ปีงบประมาณ",
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
@@ -178,7 +178,7 @@ class BudgetTransfer(models.Model):
 
     # User Management
     user_id = fields.Many2one(
-        string="Requested by",
+        string="ผู้ขอโอน",
         comodel_name="res.users",
         copy=False,
         tracking=True,
@@ -190,7 +190,7 @@ class BudgetTransfer(models.Model):
 
     # Approval Fields
     approver_id = fields.Many2one(
-        string="Approved by",
+        string="ผู้อนุมัติ",
         comodel_name="res.users",
         copy=False,
         tracking=True,
@@ -198,14 +198,14 @@ class BudgetTransfer(models.Model):
     )
 
     approval_date = fields.Datetime(
-        string="Approval Date",
+        string="วันที่อนุมัติ",
         copy=False,
         tracking=True,
         readonly=True,
     )
 
     rejection_reason = fields.Text(
-        string="Rejection Reason",
+        string="เหตุผลที่ไม่อนุมัติ",
         readonly=True,
         tracking=True,
     )
@@ -214,7 +214,7 @@ class BudgetTransfer(models.Model):
     line_ids = fields.One2many(
         comodel_name="budget.transfer.line",
         inverse_name="transfer_id",
-        string="Transfer Lines",
+        string="รายการโอน",
         copy=True,
         tracking=True,
         readonly=False,
@@ -225,7 +225,7 @@ class BudgetTransfer(models.Model):
     from_line_ids = fields.One2many(
         comodel_name="budget.transfer.line",
         inverse_name="transfer_id",
-        string="Transfer FROM Lines",
+        string="รายการโอนออก",
         domain=[("transfer_direction", "=", "from")],
         context={"default_transfer_direction": "from"},
         copy=False,
@@ -236,7 +236,7 @@ class BudgetTransfer(models.Model):
     to_line_ids = fields.One2many(
         comodel_name="budget.transfer.line",
         inverse_name="transfer_id",
-        string="Transfer TO Lines",
+        string="รายการโอนเข้า",
         domain=[("transfer_direction", "=", "to")],
         context={"default_transfer_direction": "to"},
         copy=False,
@@ -248,9 +248,9 @@ class BudgetTransfer(models.Model):
     budget_move_ids = fields.One2many(
         comodel_name="budget.move",
         inverse_name="transfer_id",
-        string="Generated Budget Moves",
+        string="รายการเคลื่อนไหวงบประมาณ",
         readonly=True,
-        help="Budget moves created when this transfer is posted",
+        help="รายการเคลื่อนไหวงบประมาณที่สร้างเมื่อโอนสำเร็จ",
     )
 
     # Button Visibility
@@ -774,7 +774,7 @@ class BudgetTransfer(models.Model):
     def _open_rejection_wizard(self):
         """Open wizard for rejection reason"""
         return {
-            "name": _("Reject Budget Transfer"),
+            "name": _("ไม่อนุมัติการโอนเปลี่ยนแปลง"),
             "type": "ir.actions.act_window",
             "res_model": "budget.transfer.reject.wizard",
             "view_mode": "form",

--- a/budget/models/budget_transfer_line.py
+++ b/budget/models/budget_transfer_line.py
@@ -11,7 +11,7 @@ class BudgetTransferLine(models.Model):
     """
 
     _name = "budget.transfer.line"
-    _description = "Budget Transfer Line"
+    _description = "รายการโอนเปลี่ยนแปลงงบประมาณ"
     _order = "transfer_id, sequence, id"
 
     # Basic Fields
@@ -30,10 +30,10 @@ class BudgetTransferLine(models.Model):
 
     transfer_direction = fields.Selection(
         selection=[
-            ("from", "Transfer From (Source)"),
-            ("to", "Transfer To (Destination)"),
+            ("from", "โอนออก (ต้นทาง)"),
+            ("to", "โอนเข้า (ปลายทาง)"),
         ],
-        string="Direction",
+        string="ประเภท",
         required=True,
         default="from",
         help="Direction of this transfer line"
@@ -100,8 +100,8 @@ class BudgetTransferLine(models.Model):
 
     # Description
     description = fields.Char(
-        string="Description",
-        help="Description for this transfer line"
+        string="หมายเหตุ",
+        help="หมายเหตุเพิ่มเติมสำหรับรายการนี้"
     )
 
     # Company and Currency (inherited from transfer)
@@ -125,7 +125,7 @@ class BudgetTransferLine(models.Model):
     )
 
     budget_sufficient = fields.Boolean(
-        string="Budget Sufficient",
+        string="งบเพียงพอ",
         compute="_compute_available_budget",
         help="True if available budget is sufficient for this transfer"
     )

--- a/budget/models/budget_transfer_reject_wizard.py
+++ b/budget/models/budget_transfer_reject_wizard.py
@@ -8,19 +8,19 @@ class BudgetTransferRejectWizard(models.TransientModel):
     """
     
     _name = "budget.transfer.reject.wizard"
-    _description = "Budget Transfer Rejection Wizard"
-    
+    _description = "ไม่อนุมัติการโอนเปลี่ยนแปลงงบประมาณ"
+
     transfer_id = fields.Many2one(
         comodel_name="budget.transfer",
-        string="Budget Transfer",
+        string="รายการโอน",
         required=True,
         readonly=True,
     )
-    
+
     rejection_reason = fields.Text(
-        string="Rejection Reason",
+        string="เหตุผลที่ไม่อนุมัติ",
         required=True,
-        help="Please provide detailed reason for rejecting this budget transfer"
+        help="กรุณาระบุเหตุผลในการไม่อนุมัติรายการโอนเปลี่ยนแปลงนี้"
     )
     
     def action_reject(self):

--- a/budget/views/budget_transfer_views.xml
+++ b/budget/views/budget_transfer_views.xml
@@ -6,138 +6,147 @@
         <field name="name">budget.transfer.form</field>
         <field name="model">budget.transfer</field>
         <field name="arch" type="xml">
-            <form string="Budget Transfer">
+            <form string="โอนเปลี่ยนแปลงงบประมาณ">
                 <header>
-                    <button name="action_submit" type="object" string="Submit for Approval" class="btn-primary" attrs="{'invisible': [('show_submit_button', '=', False)]}"/>
-                    <button name="action_approve" type="object" string="Approve" class="btn-success" attrs="{'invisible': [('show_approve_button', '=', False)]}"/>
-                    <button name="action_reject" type="object" string="Reject" class="btn-warning" attrs="{'invisible': [('show_reject_button', '=', False)]}"/>
-                    <button name="action_post" type="object" string="Post Transfer" class="btn-primary" attrs="{'invisible': [('show_post_button', '=', False)]}"/>
-                    <button name="action_cancel" type="object" string="Cancel" attrs="{'invisible': [('show_cancel_button', '=', False)]}"/>
-                    <button name="action_reset_to_draft" type="object" string="Reset to Draft" attrs="{'invisible': [('show_reset_button', '=', False)]}"/>
+                    <button name="action_submit" type="object" string="ส่งขออนุมัติ" class="oe_highlight" attrs="{'invisible': [('show_submit_button', '=', False)]}"/>
+                    <button name="action_approve" type="object" string="อนุมัติ" class="btn-success" attrs="{'invisible': [('show_approve_button', '=', False)]}"/>
+                    <button name="action_reject" type="object" string="ไม่อนุมัติ" class="btn-warning" attrs="{'invisible': [('show_reject_button', '=', False)]}"/>
+                    <button name="action_post" type="object" string="ประกาศ" class="oe_highlight" attrs="{'invisible': [('show_post_button', '=', False)]}"/>
+                    <button name="action_cancel" type="object" string="ยกเลิก" attrs="{'invisible': [('show_cancel_button', '=', False)]}" confirm="ยืนยันที่จะยกเลิกรายการโอนเปลี่ยนแปลงนี้?"/>
+                    <button name="action_reset_to_draft" type="object" string="กลับเป็นฉบับร่าง" attrs="{'invisible': [('show_reset_button', '=', False)]}"/>
 
                     <field name="state" widget="statusbar" statusbar_visible="draft,submitted,approved,posted"/>
                 </header>
 
                 <sheet>
+                    <!-- Hidden fields for computations -->
+                    <field name="show_submit_button" invisible="1"/>
+                    <field name="show_approve_button" invisible="1"/>
+                    <field name="show_reject_button" invisible="1"/>
+                    <field name="show_post_button" invisible="1"/>
+                    <field name="show_cancel_button" invisible="1"/>
+                    <field name="show_reset_button" invisible="1"/>
+                    <field name="has_sufficient_budget" invisible="1"/>
                     <div class="oe_button_box" name="button_box">
                         <button name="%(action_budget_move)d" type="action" class="oe_stat_button" icon="fa-exchange" attrs="{'invisible': [('budget_move_ids', '=', [])]}" context="{'search_default_transfer_id': id}">
-                            <field name="budget_move_ids" widget="statinfo" string="Budget Moves"/>
+                            <field name="budget_move_ids" widget="statinfo" string="รายการเคลื่อนไหว"/>
                         </button>
                     </div>
 
                     <div class="oe_title">
+                        <label for="name" string="เลขที่เอกสาร"/>
                         <h1>
-                            <field name="name" class="o_text_overflow" readonly="1"/>
+                            <field name="name" class="o_text_overflow" readonly="1" placeholder="ฉบับร่าง"/>
                         </h1>
                     </div>
 
                     <group>
-                        <group name="transfer_info">
-                            <field name="date" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
-                            <field name="transfer_type"/>
-                            <field name="department_analytic_id" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
-                            <field name="source_analytic_id" attrs="{'readonly': [('state', 'not in', ['draft'])]}"/>
+                        <group name="transfer_info" string="ข้อมูลการโอน">
+                            <field name="date"/>
+                            <field name="ref" placeholder="อ้างอิง..."/>
+                            <field name="department_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                            <field name="source_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
                         </group>
-                        <group name="meta_info">
-                            <field name="user_id"/>
-                            <field name="account_fiscal_year_id"/>
+                        <group name="meta_info" string="ข้อมูลเพิ่มเติม">
+                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="account_fiscal_year_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                            <field name="transfer_type"/>
                             <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="approver_id" attrs="{'invisible': [('approver_id', '=', False)]}"/>
-                            <field name="approval_date" attrs="{'invisible': [('approval_date', '=', False)]}"/>
                         </group>
                     </group>
 
-                    <!-- Budget Validation Alert -->
-                    <div class="alert alert-warning" role="alert" attrs="{'invisible': [('has_sufficient_budget', '=', True)]}" style="margin: 10px 0;">
-                        <strong>Budget Validation Warning:</strong>
+                    <!-- Budget Validation Alert - only show when there are lines -->
+                    <div class="alert alert-warning mb-0" role="alert" attrs="{'invisible': ['|', ('has_sufficient_budget', '=', True), ('line_ids', '=', [])]}">
+                        <i class="fa fa-exclamation-triangle"/> <strong>งบประมาณไม่เพียงพอ:</strong>
                         <field name="budget_validation_message" nolabel="1"/>
                     </div>
 
-                    <div class="alert alert-success" role="alert" attrs="{'invisible': [('has_sufficient_budget', '=', False)]}" style="margin: 10px 0;">
-                        <strong>✅ Budget Validation Passed</strong>
+                    <div class="alert alert-success mb-0" role="alert" attrs="{'invisible': ['|', ('has_sufficient_budget', '=', False), ('line_ids', '=', [])]}">
+                        <i class="fa fa-check-circle"/> <strong>งบประมาณเพียงพอ</strong>
                     </div>
 
-                    <group name="transfer_reason" colspan="8">
-                        <field name="reason" placeholder="Please provide detailed justification for this budget transfer..." attrs="{'readonly': [('state', 'not in', ['draft'])]}" colspan="2"/>
+                    <separator/>
+                    <group name="transfer_reason">
+                        <field name="reason" nolabel="1" placeholder="กรุณาระบุเหตุผลในการโอนเปลี่ยนแปลงงบประมาณ..." colspan="2"/>
                     </group>
 
                     <!-- Transfer Lines -->
                     <notebook>
-                        <page name="transfer_lines" string="Transfer Details">
+                        <page name="transfer_lines" string="รายละเอียดการโอน">
+                            <!-- Draft mode: separate FROM/TO sections -->
                             <group attrs="{'invisible': [('state', 'not in', ['draft'])]}">
-                                <separator string="Transfer FROM (Source)" />
-                                <field name="from_line_ids" nolabel="1" colspan="2" attrs="{'readonly': [('state', 'not in', ['draft'])]}">
-                                    <tree decoration-info="1" create="1" delete="1">
+                                <separator string="โอนออก (ต้นทาง)"/>
+                                <field name="from_line_ids" nolabel="1" colspan="2">
+                                    <tree editable="bottom" decoration-danger="budget_sufficient == False">
                                         <field name="sequence" widget="handle"/>
-                                        <field name="budget_account_id" required="1"/>
-                                        <field name="activity_analytic_id"/>
-                                        <field name="fund_analytic_id"/>
+                                        <field name="budget_account_id" required="1" options="{'no_create': True, 'no_create_edit': True}"/>
+                                        <field name="activity_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                                        <field name="fund_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
                                         <field name="department_analytic_id" invisible="1"/>
                                         <field name="source_analytic_id" invisible="1"/>
-                                        <field name="amount" widget="monetary" sum="Total Source"/>
-                                        <field name="available_budget" widget="monetary"/>
-                                        <field name="budget_sufficient" widget="boolean_toggle"/>
-                                        <field name="description" invisible="1" />
+                                        <field name="amount" widget="monetary" sum="รวมโอนออก"/>
+                                        <field name="available_budget" widget="monetary" string="คงเหลือ"/>
+                                        <field name="budget_sufficient" widget="boolean" string="เพียงพอ"/>
+                                        <field name="description" optional="hide"/>
                                         <field name="currency_id" invisible="1"/>
                                     </tree>
                                 </field>
-                                <separator string="Transfer TO (Destination)" />
-                                <field name="to_line_ids" nolabel="1" colspan="2" attrs="{'readonly': [('state', 'not in', ['draft'])]}">
-                                    <tree decoration-success="1" create="1" delete="1">
+                                <separator string="โอนเข้า (ปลายทาง)"/>
+                                <field name="to_line_ids" nolabel="1" colspan="2">
+                                    <tree editable="bottom">
                                         <field name="sequence" widget="handle"/>
-                                        <field name="budget_account_id" required="1"/>
-                                        <field name="activity_analytic_id"/>
-                                        <field name="fund_analytic_id"/>
-                                        <field name="department_analytic_id"/>
+                                        <field name="budget_account_id" required="1" options="{'no_create': True, 'no_create_edit': True}"/>
+                                        <field name="activity_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                                        <field name="fund_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                                        <field name="department_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
                                         <field name="source_analytic_id" invisible="1"/>
-                                        <field name="amount" widget="monetary" sum="Total Destination"/>
-                                        <field name="description" invisible="1" />
+                                        <field name="amount" widget="monetary" sum="รวมโอนเข้า"/>
+                                        <field name="description" optional="hide"/>
                                         <field name="currency_id" invisible="1"/>
                                     </tree>
                                 </field>
                             </group>
 
-                            <!-- All Lines View (when not in draft) -->
-                            <separator string="Transfer Lines Summary" attrs="{'invisible': [('state', 'in', ['draft'])]}"/>
+                            <!-- Non-draft: combined summary view -->
                             <field name="line_ids" nolabel="1" readonly="1" attrs="{'invisible': [('state', 'in', ['draft'])]}">
                                 <tree decoration-info="transfer_direction == 'from'" decoration-success="transfer_direction == 'to'">
-                                    <field name="transfer_direction"/>
+                                    <field name="transfer_direction" string="ประเภท"/>
                                     <field name="budget_account_id"/>
                                     <field name="activity_analytic_id"/>
                                     <field name="fund_analytic_id"/>
-                                    <field name="amount" widget="monetary" sum="Total"/>
-                                    <field name="available_budget" widget="monetary" attrs="{'column_invisible': [('transfer_direction', '!=', 'from')]}"/>
-                                    <field name="description"/>
+                                    <field name="department_analytic_id" optional="hide"/>
+                                    <field name="amount" widget="monetary" sum="รวม"/>
+                                    <field name="available_budget" widget="monetary" string="คงเหลือ"/>
+                                    <field name="description" optional="hide"/>
                                     <field name="currency_id" invisible="1"/>
                                 </tree>
                             </field>
                         </page>
 
-                        <page name="approval_info" string="Approval Information" attrs="{'invisible': [('state', 'in', ['draft'])]}">
+                        <page name="approval_info" string="การอนุมัติ" attrs="{'invisible': [('state', 'in', ['draft'])]}">
                             <group>
-                                <field name="rejection_reason" attrs="{'invisible': [('state', '!=', 'rejected')]}"/>
+                                <group string="ข้อมูลผู้อนุมัติ">
+                                    <field name="approver_id" widget="many2one_avatar_user"/>
+                                    <field name="approval_date"/>
+                                </group>
+                                <group string="เหตุผลการไม่อนุมัติ" attrs="{'invisible': [('state', '!=', 'rejected')]}">
+                                    <field name="rejection_reason" nolabel="1"/>
+                                </group>
                             </group>
                         </page>
 
-                        <page name="generated_moves" string="Generated Budget Moves" attrs="{'invisible': [('budget_move_ids', '=', [])]}">
+                        <page name="generated_moves" string="รายการเคลื่อนไหวงบประมาณ" attrs="{'invisible': [('budget_move_ids', '=', [])]}">
                             <field name="budget_move_ids" nolabel="1" readonly="1">
                                 <tree>
                                     <field name="name"/>
                                     <field name="date"/>
                                     <field name="move_type"/>
                                     <field name="total_amount" widget="monetary"/>
-                                    <field name="state"/>
+                                    <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'review'" decoration-success="state == 'posted'"/>
                                 </tree>
                             </field>
-                        </page>
-
-                        <page name="extra" string="Extra Info">
-                            <group>
-                                <group></group>
-                                <group></group>
-                            </group>
                         </page>
                     </notebook>
                 </sheet>
@@ -148,15 +157,6 @@
                     <field name="activity_ids"/>
                     <field name="message_ids"/>
                 </div>
-
-                <!-- Hidden fields for computations -->
-                <field name="show_submit_button" invisible="1"/>
-                <field name="show_approve_button" invisible="1"/>
-                <field name="show_reject_button" invisible="1"/>
-                <field name="show_post_button" invisible="1"/>
-                <field name="show_cancel_button" invisible="1"/>
-                <field name="show_reset_button" invisible="1"/>
-                <field name="has_sufficient_budget" invisible="1"/>
             </form>
         </field>
     </record>
@@ -166,14 +166,15 @@
         <field name="name">budget.transfer.tree</field>
         <field name="model">budget.transfer</field>
         <field name="arch" type="xml">
-            <tree string="Budget Transfers" decoration-info="state == 'draft'" decoration-warning="state == 'submitted'" decoration-success="state == 'posted'">
-                <field name="name"/>
+            <tree string="รายการโอนเปลี่ยนแปลงงบประมาณ" decoration-info="state == 'draft'" decoration-warning="state == 'submitted'" decoration-success="state == 'posted'">
+                <field name="name" string="เลขที่"/>
                 <field name="date"/>
-                <field name="user_id"/>
-                <field name="transfer_type"/>
-                <field name="amount" widget="monetary" sum="Total"/>
+                <field name="department_analytic_id" optional="show"/>
+                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="transfer_type" optional="hide"/>
+                <field name="amount" widget="monetary" sum="รวม"/>
                 <field name="currency_id" invisible="1"/>
-                <field name="approver_id"/>
+                <field name="approver_id" widget="many2one_avatar_user" optional="show"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'submitted'" decoration-success="state in ['approved', 'posted']" decoration-danger="state in ['rejected', 'cancelled']"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
@@ -185,28 +186,30 @@
         <field name="name">budget.transfer.search</field>
         <field name="model">budget.transfer</field>
         <field name="arch" type="xml">
-            <search string="Search Budget Transfers">
-                <field name="name" string="Transfer Number"/>
-                <field name="user_id" string="Requested by"/>
-                <field name="approver_id" string="Approved by"/>
-                <field name="reason" string="Reason"/>
+            <search string="ค้นหารายการโอน">
+                <field name="name" string="เลขที่เอกสาร"/>
+                <field name="user_id" string="ผู้ขอโอน"/>
+                <field name="approver_id" string="ผู้อนุมัติ"/>
+                <field name="department_analytic_id" string="ส่วนงาน"/>
+                <field name="reason" string="เหตุผล"/>
 
-                <filter name="my_transfers" string="My Transfers" domain="[('user_id', '=', uid)]"/>
-                <filter name="pending_approval" string="Pending Approval" domain="[('state', '=', 'submitted')]"/>
-                <filter name="approved" string="Approved" domain="[('state', '=', 'approved')]"/>
-                <filter name="posted" string="Posted" domain="[('state', '=', 'posted')]"/>
+                <filter name="my_transfers" string="ของฉัน" domain="[('user_id', '=', uid)]"/>
+                <filter name="pending_approval" string="รออนุมัติ" domain="[('state', '=', 'submitted')]"/>
+                <filter name="approved" string="อนุมัติแล้ว" domain="[('state', '=', 'approved')]"/>
+                <filter name="posted" string="ประกาศแล้ว" domain="[('state', '=', 'posted')]"/>
 
                 <separator/>
-                <filter name="this_month" string="This Month" domain="[('date', '>=', (context_today() - relativedelta(day=1)).strftime('%Y-%m-%d')),
+                <filter name="this_month" string="เดือนนี้" domain="[('date', '>=', (context_today() - relativedelta(day=1)).strftime('%Y-%m-%d')),
                                 ('date', '&lt;', (context_today() + relativedelta(months=1, day=1)).strftime('%Y-%m-%d'))]"/>
-                <filter name="this_year" string="This Year" domain="[('date', '>=', (context_today() - relativedelta(month=1, day=1)).strftime('%Y-%m-%d')),
+                <filter name="this_year" string="ปีนี้" domain="[('date', '>=', (context_today() - relativedelta(month=1, day=1)).strftime('%Y-%m-%d')),
                                 ('date', '&lt;', (context_today() + relativedelta(years=1, month=1, day=1)).strftime('%Y-%m-%d'))]"/>
 
-                <group expand="0" string="Group By">
-                    <filter name="group_by_state" string="Status" domain="[]" context="{'group_by': 'state'}"/>
-                    <filter name="group_by_user" string="Requested by" domain="[]" context="{'group_by': 'user_id'}"/>
-                    <filter name="group_by_type" string="Transfer Type" domain="[]" context="{'group_by': 'transfer_type'}"/>
-                    <filter name="group_by_date" string="Date" domain="[]" context="{'group_by': 'date'}"/>
+                <group expand="0" string="จัดกลุ่มตาม">
+                    <filter name="group_by_state" string="สถานะ" domain="[]" context="{'group_by': 'state'}"/>
+                    <filter name="group_by_user" string="ผู้ขอโอน" domain="[]" context="{'group_by': 'user_id'}"/>
+                    <filter name="group_by_department" string="ส่วนงาน" domain="[]" context="{'group_by': 'department_analytic_id'}"/>
+                    <filter name="group_by_type" string="ประเภทการโอน" domain="[]" context="{'group_by': 'transfer_type'}"/>
+                    <filter name="group_by_date" string="วันที่" domain="[]" context="{'group_by': 'date'}"/>
                 </group>
             </search>
         </field>
@@ -248,25 +251,25 @@
                                             <field name="amount" widget="monetary"/>
                                         </span>
                                     </div>
-                                    <div class="col-6 text-right">
+                                    <div class="col-6 text-end">
                                         <field name="date"/>
                                     </div>
                                 </div>
                                 <div class="row mt-2">
                                     <div class="col-12">
-                                        <strong>Requested by:</strong>
+                                        <strong>ผู้ขอโอน:</strong>
                                         <field name="user_id"/>
                                     </div>
                                 </div>
                                 <div class="row" t-if="record.approver_id.raw_value">
                                     <div class="col-12">
-                                        <strong>Approver:</strong>
+                                        <strong>ผู้อนุมัติ:</strong>
                                         <field name="approver_id"/>
                                     </div>
                                 </div>
-                                <div class="row mt-2">
-                                    <div class="col-12">
-                                        <field name="reason" widget="text" class="text-muted"/>
+                                <div class="row mt-2" t-if="record.reason.raw_value">
+                                    <div class="col-12 text-muted">
+                                        <field name="reason"/>
                                     </div>
                                 </div>
                             </div>
@@ -282,70 +285,69 @@
         <field name="name">budget.transfer.line.form</field>
         <field name="model">budget.transfer.line</field>
         <field name="arch" type="xml">
-            <form string="Transfer Line" create="true" edit="true" delete="true">
-                <sheet>
-
-                    <group>
-                        <field name="transfer_direction" widget="radio" options="{'horizontal': true}" attrs="{'readonly': [('id', '!=', False)]}"/>
-                        <field name="activity_analytic_id" options="{'no_create': True, 'no_open': True}" required="1"/>
-                        <field name="fund_analytic_id" options="{'no_create': True, 'no_open': True}" required="1"/>
-                        <field name="department_analytic_id" attrs="{'invisible': [('transfer_direction', '=', 'from')]}" options="{'no_create': True, 'no_open': True}" required="1"/>
-                        <field name="budget_account_id" required="1"/>
-                        <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}" required="1"/>
-                    </group>
-
-                    <!-- Budget validation info for FROM lines only -->
-                    <div class="alert alert-info" role="alert" attrs="{'invisible': [('transfer_direction', '!=', 'from')]}" style="margin: 10px 0;">
-                        <strong>💰 Budget Availability Check</strong>
-                        <div class="row mt-2">
-                            <div class="col-6">
-                                <strong>Available Budget:</strong>
-                                <field name="available_budget" widget="monetary" nolabel="1" readonly="1"/>
-                            </div>
-                            <div class="col-6">
-                                <strong>Sufficient:</strong>
-                                <field name="budget_sufficient" widget="boolean_toggle" nolabel="1" readonly="1"/>
-                            </div>
-                        </div>
-                    </div>
-
-                    <group name="description" string="Description" colspan="8">
-                        <field name="description" placeholder="Optional description for this transfer line..." nolabel="1" colspan="2" />
-                    </group>
-                </sheet>
-
-                <!-- All other fields explicitly hidden -->
+            <form string="รายการโอน">
+                <!-- Hidden fields -->
                 <field name="transfer_id" invisible="1"/>
                 <field name="sequence" invisible="1"/>
                 <field name="currency_id" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="analytic_distribution" invisible="1"/>
                 <field name="source_analytic_id" invisible="1"/>
+
+                <sheet>
+                    <group>
+                        <field name="transfer_direction" widget="radio" options="{'horizontal': true}" attrs="{'readonly': [('id', '!=', False)]}"/>
+                        <field name="activity_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}" required="1"/>
+                        <field name="fund_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}" required="1"/>
+                        <field name="department_analytic_id" attrs="{'invisible': [('transfer_direction', '=', 'from')]}" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}" required="1"/>
+                        <field name="budget_account_id" options="{'no_create': True, 'no_create_edit': True}" required="1"/>
+                        <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}" required="1"/>
+                    </group>
+
+                    <!-- Budget validation info for FROM lines only -->
+                    <div class="alert alert-info mb-0" role="alert" attrs="{'invisible': [('transfer_direction', '!=', 'from')]}">
+                        <i class="fa fa-info-circle"/> <strong>ตรวจสอบงบประมาณ</strong>
+                        <div class="row mt-2">
+                            <div class="col-6">
+                                <strong>งบประมาณคงเหลือ:</strong>
+                                <field name="available_budget" widget="monetary" nolabel="1" readonly="1"/>
+                            </div>
+                            <div class="col-6">
+                                <strong>เพียงพอ:</strong>
+                                <field name="budget_sufficient" widget="boolean" nolabel="1" readonly="1"/>
+                            </div>
+                        </div>
+                    </div>
+
+                    <group name="description" string="หมายเหตุ">
+                        <field name="description" placeholder="หมายเหตุเพิ่มเติม (ไม่บังคับ)..." nolabel="1" colspan="2"/>
+                    </group>
+                </sheet>
             </form>
         </field>
     </record>
 
     <!-- Budget Transfer Actions -->
     <record id="action_budget_transfer" model="ir.actions.act_window">
-        <field name="name">Budget Transfers</field>
+        <field name="name">โอนเปลี่ยนแปลงงบประมาณ</field>
         <field name="res_model">budget.transfer</field>
         <field name="view_mode">tree,form,kanban</field>
         <field name="search_view_id" ref="view_budget_transfer_search"/>
         <field name="context">{}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-                Create your first budget transfer!
+                สร้างรายการโอนเปลี่ยนแปลงงบประมาณรายการแรก
             </p>
             <p>
-                Budget transfers allow you to move allocated budget amounts between accounts
-                with proper approval workflow and budget availability checking.
+                โอนเปลี่ยนแปลงงบประมาณใช้สำหรับย้ายงบประมาณจากรหัสงบประมาณหนึ่งไปยังอีกรหัสหนึ่ง
+                โดยผ่านขั้นตอนการอนุมัติและการตรวจสอบงบประมาณคงเหลือ
             </p>
         </field>
     </record>
 
     <!-- My Transfers Action -->
     <record id="action_my_budget_transfers" model="ir.actions.act_window">
-        <field name="name">My Budget Transfers</field>
+        <field name="name">รายการโอนของฉัน</field>
         <field name="res_model">budget.transfer</field>
         <field name="view_mode">tree,form,kanban</field>
         <field name="domain">[('user_id', '=', uid)]</field>
@@ -354,7 +356,7 @@
 
     <!-- Pending Approvals Action -->
     <record id="action_budget_transfers_pending" model="ir.actions.act_window">
-        <field name="name">Pending Approvals</field>
+        <field name="name">รออนุมัติ</field>
         <field name="res_model">budget.transfer</field>
         <field name="view_mode">tree,form,kanban</field>
         <field name="domain">[('state', '=', 'submitted')]</field>

--- a/budget/views/budget_transfer_views.xml
+++ b/budget/views/budget_transfer_views.xml
@@ -79,7 +79,7 @@
                             <group attrs="{'invisible': [('state', 'not in', ['draft'])]}">
                                 <separator string="โอนออก (ต้นทาง)"/>
                                 <field name="from_line_ids" nolabel="1" colspan="2">
-                                    <tree editable="bottom" decoration-danger="budget_sufficient == False">
+                                    <tree decoration-danger="budget_sufficient == False">
                                         <field name="sequence" widget="handle"/>
                                         <field name="budget_account_id" required="1" options="{'no_create': True, 'no_create_edit': True}"/>
                                         <field name="activity_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
@@ -95,7 +95,7 @@
                                 </field>
                                 <separator string="โอนเข้า (ปลายทาง)"/>
                                 <field name="to_line_ids" nolabel="1" colspan="2">
-                                    <tree editable="bottom">
+                                    <tree>
                                         <field name="sequence" widget="handle"/>
                                         <field name="budget_account_id" required="1" options="{'no_create': True, 'no_create_edit': True}"/>
                                         <field name="activity_analytic_id" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>


### PR DESCRIPTION
## Summary
- ปรับปรุง form view ของ `budget.transfer` ให้ดีขึ้น: เพิ่ม field `ref`, ย้าย approver info ไปแท็บ "การอนุมัติ", ลบแท็บ "Extra Info" ที่ว่างเปล่า
- เปลี่ยน label ทุก field, button, filter, action, และ selection เป็นภาษาไทย ทั้งใน Python model และ XML views
- ปรับ UX: ใช้ `editable="bottom"` สำหรับ tree, เพิ่ม `no_create`/`no_create_edit` options, เพิ่ม confirm dialog บนปุ่มยกเลิก, ใช้ `decoration-danger` เมื่องบไม่เพียงพอ
- ลบ redundant XML `attrs` readonly ที่ซ้ำกับ Python `states=READONLY_STATES`
- เพิ่ม `department_analytic_id` ใน tree view และ search view สำหรับ group by

## Test plan
- [ ] เปิด form view ของ budget.transfer ตรวจสอบว่า label แสดงภาษาไทยถูกต้อง
- [ ] ทดสอบสร้าง/แก้ไข/ส่งอนุมัติ transfer ว่า readonly states ทำงานถูกต้อง
- [ ] ตรวจสอบ tree view, kanban view, search filters ว่าแสดงภาษาไทย
- [ ] ทดสอบ inline edit ในตาราง from/to lines ว่าทำงานได้