### PR TITLE
[ADD] skills: add grill-me skill

### DIFF
--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.claude/skills/grill-me
+++ b/.claude/skills/grill-me
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-me

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "f343ef02aa0ada0f8b13a77b6db7fb6a11f88d8067128215585500ef4fd3b5e0"
+    },
     "odoo-development": {
       "source": "mindrally/skills",
       "sourceType": "github",


### PR DESCRIPTION
## Summary
- Add the grill-me skill for stress-testing plans and designs
- Includes skill definition, symlink, and lock file entry

## Test plan
- [ ] Verify the grill-me skill is available via `/grill-me`