### PR TITLE
[16.0][FIX] purchase_work_acceptance_portal: fix crash when WA has no purchase_id

### DIFF
--- a/purchase_work_acceptance_portal/models/work_acceptance.py
+++ b/purchase_work_acceptance_portal/models/work_acceptance.py
@@ -20,7 +20,7 @@ class WorkAcceptance(models.Model):
         for wa in self:
             if not wa.work_acceptance_committee_ids:
                 continue
-            order_url = wa.purchase_id.get_portal_link()
+            order_url = wa.purchase_id.get_portal_link() if wa.purchase_id else ""
             wa_url = wa.get_portal_link()
             for committee in wa.work_acceptance_committee_ids:
                 committee.get_portal_link()
@@ -28,7 +28,7 @@ class WorkAcceptance(models.Model):
                 if not user:
                     continue
                 wa_link = f"{wa_url}&committee_token={committee.access_token}"
-                order_link = f"{order_url}&wa_token={wa.access_token}"
+                order_link = f"{order_url}&wa_token={wa.access_token}" if order_url else ""
                 Inbox = self.env["work.acceptance.inbox"].sudo()
                 existing = Inbox.search(
                     [("user_id", "=", user.id), ("work_acceptance_id", "=", wa.id)],

--- a/purchase_work_acceptance_portal/static/src/xml/wa_systray.xml
+++ b/purchase_work_acceptance_portal/static/src/xml/wa_systray.xml
@@ -34,7 +34,7 @@
                             <div class="o_wa_systray_item px-2 py-2 border-bottom">
                                 <div class="fw-bold small" t-esc="item.name"/>
                                 <div><a t-att-href="item.wa_url" target="_blank">กรุณาตรวจรับพัสดุ</a></div>
-                                <div><a t-att-href="item.order_url" target="_blank">เอกสารสัญญา</a></div>
+                                <div t-if="item.order_url"><a t-att-href="item.order_url" target="_blank">เอกสารสัญญา</a></div>
                             </div>
                         </t>
                     </div>

--- a/purchase_work_acceptance_portal/views/work_acceptance_portal_template.xml
+++ b/purchase_work_acceptance_portal/views/work_acceptance_portal_template.xml
@@ -207,7 +207,7 @@
                                                     <t t-esc="work_acceptance.name" />
                                                 </td>
                                             </tr>
-                                            <tr t-if="wa_committee">
+                                            <tr t-if="wa_committee and work_acceptance.purchase_id">
                                                 <th class="ps-0 pb-0">
                                                     สัญญา/ใบสั่งซื้อ/จ้าง
                                                 </th>


### PR DESCRIPTION
## Summary
- WA created from Purchase Request Approval (ไม่ผ่าน PO) crashes on "ส่งคำขออนุมัติ" because `purchase_id` is empty
- Guard `get_portal_link()` call in `request_validation()` to handle empty `purchase_id`
- Hide "เอกสารสัญญา" link in systray when no PO is linked
- Hide "สัญญา/ใบสั่งซื้อ/จ้าง" row in portal template when no PO is linked

## Test plan
- [x] Create WA from Purchase Request Approval (no PO) → click "ส่งคำขออนุมัติ" → should succeed
- [x] Check systray notification → WA link shown, no "เอกสารสัญญา" link
- [x] Open WA portal page → no "สัญญา/ใบสั่งซื้อ/จ้าง" row
- [x] Create WA from PO → verify all links still work normally