### PR TITLE
[16.0][FIX] purchase_contract_kmitl: fix duplicate exceptions and redundant code

### DIFF
--- a/purchase_contract_kmitl/data/purchase_exception.xml
+++ b/purchase_contract_kmitl/data/purchase_exception.xml
@@ -27,7 +27,7 @@ if not self.contract_type_id:
         <field name="model">purchase.order</field>
         <field name="exception_type">by_py_code</field>
         <field name="code">
-if self.fines_rate &lt; 0:
+if self.fines_rate &lt;= 0:
     failed = True
         </field>
     </record>
@@ -39,28 +39,6 @@ if self.fines_rate &lt; 0:
         <field name="exception_type">by_py_code</field>
         <field name="code">
 if self.work_start &lt; self.date_order_date:
-    failed = True
-        </field>
-    </record>
-
-    <record id="purchase_order_work_start_must_be_valid_exception" model="exception.rule">
-        <field name="name">วันที่เริ่มงาน ต้องไม่เริ่มก่อนวันที่เริ่มสัญญา</field>
-        <field name="description">ประเภทสัญญางานก่อสร้าง</field>
-        <field name="model">purchase.order</field>
-        <field name="exception_type">by_py_code</field>
-        <field name="code">
-if self.work_start &lt; self.date_order_date:
-    failed = True
-        </field>
-    </record>
-
-    <record id="purchase_order_contract_name_requried_exception" model="exception.rule">
-        <field name="name">จำเป็นต้องมีชื่อสัญญา/ใบสั่งซื้อ/จ้าง</field>
-        <field name="description">ประเภทสัญญางานก่อสร้าง</field>
-        <field name="model">purchase.order</field>
-        <field name="exception_type">by_py_code</field>
-        <field name="code">
-if not self.contract_name:
     failed = True
         </field>
     </record>

--- a/purchase_contract_kmitl/models/purchase_order.py
+++ b/purchase_contract_kmitl/models/purchase_order.py
@@ -175,7 +175,5 @@ class PurchaseOrder(models.Model):
 
     def action_view_wa(self):
         result = super().action_view_wa()
-        purchase_requests = self.order_line.mapped("purchase_request_lines.request_id")
-        lines = self._get_committee_line(purchase_requests)
         result["context"]["default_date_due"] = self.work_end
         return result


### PR DESCRIPTION
## Summary
- Remove duplicate XML ID `purchase_order_work_start_must_be_valid_exception` (defined twice, second overwrites first)
- Remove redundant `purchase_order_contract_name_requried_exception` rule (duplicate of existing `purchase_order_contract_name_exception`)
- Fix `fines_rate` validation: change `< 0` to `<= 0` to require positive fines rate
- Remove redundant `_get_committee_line()` call in `action_view_wa()` (already handled by parent in `purchase_work_acceptance_kmitl`)

## Test plan
- [ ] Confirm PO with missing contract name → should show 1 exception (not 2)
- [ ] Confirm PO with fines_rate = 0 → should trigger exception
- [ ] Create Work Acceptance from PO → should still pass `default_date_due` correctly
- [ ] Confirm PO with work_start < date_order_date → should show 1 exception (not 2)