### PR TITLE
[16.0][IMP] agx_sarabun: redesign for full-featured correspondence system

### DIFF
--- a/agx_sarabun/__manifest__.py
+++ b/agx_sarabun/__manifest__.py
@@ -15,6 +15,7 @@
         "data/sarabun_sequence.xml",
         "data/sarabun_document_type.xml",
         "data/sarabun_role.xml",
+        "data/sarabun_email_templates.xml",
         "report/paperformat.xml",
         "report/report_sarabun.xml",
         # Wizard
@@ -28,6 +29,7 @@
         "views/sarabun_document_recipient_views.xml",
         "views/sarabun_document_sequence_views.xml",
         "views/sarabun_role_views.xml",
+        "views/res_users_views.xml",
         "views/hr_department_views.xml",
         "views/sarabun_menus.xml",
     ],

--- a/agx_sarabun/data/sarabun_email_templates.xml
+++ b/agx_sarabun/data/sarabun_email_templates.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- New Document Notification -->
+    <record id="email_template_sarabun_new_document" model="mail.template">
+        <field name="name">Sarabun: New Document</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">New Sarabun Document: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #875A7B; color: white; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">New Document Received</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>You have received a new document requiring your attention.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">From:</td><td>{{ object.sender_display or object.sender_user_id.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Date:</td><td>{{ object.date }}</td></tr>
+        </table>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #875A7B; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Action Taken Notification -->
+    <record id="email_template_sarabun_action_taken" model="mail.template">
+        <field name="name">Sarabun: Action Taken</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">Action Taken on: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #28A745; color: white; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">Action Taken</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>An action has been taken on a document.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+        </table>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #28A745; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Forwarded (CC) Notification -->
+    <record id="email_template_sarabun_forwarded" model="mail.template">
+        <field name="name">Sarabun: Document Forwarded</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">Document Forwarded to You: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #17A2B8; color: white; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">Document Forwarded (CC)</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>A document has been forwarded to you for your information.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">From:</td><td>{{ object.sender_display or object.sender_user_id.name }}</td></tr>
+        </table>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #17A2B8; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Delegated Notification -->
+    <record id="email_template_sarabun_delegated" model="mail.template">
+        <field name="name">Sarabun: Action Delegated</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">Action Delegated to You: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #FFC107; color: #333; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">Action Delegated to You</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>An action on a document has been delegated to you.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">From:</td><td>{{ object.sender_display or object.sender_user_id.name }}</td></tr>
+        </table>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #FFC107; color: #333; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Dispatched Notification -->
+    <record id="email_template_sarabun_dispatched" model="mail.template">
+        <field name="name">Sarabun: Document Dispatched</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">Document Dispatched to You: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #6F42C1; color: white; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">Document Dispatched</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>A document has been dispatched to you by the central correspondence office.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">From:</td><td>{{ object.sender_display or object.sender_user_id.name }}</td></tr>
+        </table>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #6F42C1; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Rejected Notification -->
+    <record id="email_template_sarabun_rejected" model="mail.template">
+        <field name="name">Sarabun: Document Rejected</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">Document Rejected: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #DC3545; color: white; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">Document Rejected</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>Your document has been rejected.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+        </table>
+        <p>You can edit the document and resubmit it for routing.</p>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #DC3545; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Completed Notification -->
+    <record id="email_template_sarabun_completed" model="mail.template">
+        <field name="name">Sarabun: Routing Completed</field>
+        <field name="model_id" ref="agx_sarabun.model_sarabun_document"/>
+        <field name="subject">Routing Completed: {{ object.subject or object.name }}</field>
+        <field name="email_from">{{ (user.email_formatted or user.company_id.email_formatted or '') }}</field>
+        <field name="body_html" type="html">
+<table style="width: 100%; max-width: 600px; margin: 0 auto; font-family: Arial, sans-serif; font-size: 13px;">
+    <tr><td style="background-color: #28A745; color: white; padding: 15px; text-align: center; border-radius: 4px 4px 0 0;">
+        <h2 style="margin: 0;">Routing Completed</h2>
+    </td></tr>
+    <tr><td style="padding: 20px; border: 1px solid #dee2e6;">
+        <p>All routing steps for your document have been completed.</p>
+        <table style="width: 100%; margin: 10px 0;">
+            <tr><td style="padding: 5px 10px; font-weight: bold; width: 130px;">Document No.:</td><td>{{ object.name }}</td></tr>
+            <tr><td style="padding: 5px 10px; font-weight: bold;">Subject:</td><td>{{ object.subject }}</td></tr>
+        </table>
+        <p style="text-align: center; margin-top: 20px;">
+            <a href="{{ object.get_base_url() }}/web#id={{ object.id }}&amp;model=sarabun.document&amp;view_type=form"
+               style="background-color: #28A745; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                View Document
+            </a>
+        </p>
+    </td></tr>
+</table>
+        </field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+</odoo>

--- a/agx_sarabun/models/hr_department.py
+++ b/agx_sarabun/models/hr_department.py
@@ -14,3 +14,9 @@ class HrDepartment(models.Model):
         help="Users who can receive and process sarabun documents for this department. "
         "If not set, the department manager will receive documents.",
     )
+    use_central_correspondence = fields.Boolean(
+        string="Use Central Correspondence (สารบรรณกลาง)",
+        default=False,
+        help="When enabled, all incoming documents for this department "
+        "are first routed to sarabun officers (clerks) for dispatch.",
+    )

--- a/agx_sarabun/models/res_users.py
+++ b/agx_sarabun/models/res_users.py
@@ -1,9 +1,19 @@
 # -*- coding: utf-8 -*-
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ResUsers(models.Model):
     _inherit = "res.users"
+
+    sarabun_email_notification = fields.Boolean(
+        string="Sarabun Email Notifications",
+        default=True,
+        help="Receive email notifications for sarabun document events",
+    )
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ["sarabun_email_notification"]
 
     @api.model
     def get_sarabun_inbox_count(self):

--- a/agx_sarabun/models/res_users.py
+++ b/agx_sarabun/models/res_users.py
@@ -26,7 +26,7 @@ class ResUsers(models.Model):
         entries = Inbox.search([
             ("user_id", "=", self.env.user.id),
             ("is_read", "=", False),
-            ("document_id.state", "=", "sent"),
+            ("document_id.state", "in", ["sent", "completed"]),
         ], order="create_date desc")
 
         # Deduplicate by document

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 READONLY_STATES = {
     "sent": [("readonly", True)],
     "completed": [("readonly", True)],
+    "rejected": [("readonly", True)],
     "cancelled": [("readonly", True)],
 }
 
@@ -190,6 +191,7 @@ class SarabunDocument(models.Model):
             ("draft", "Draft"),
             ("sent", "Sent"),
             ("completed", "Completed"),
+            ("rejected", "Rejected"),
             ("cancelled", "Cancelled"),
         ],
         string="Status",
@@ -198,6 +200,11 @@ class SarabunDocument(models.Model):
         copy=False,
         tracking=True,
         default="draft",
+    )
+    resubmit_count = fields.Integer(
+        string="Resubmit Count",
+        default=0,
+        readonly=True,
     )
 
     # === Routing ===
@@ -360,6 +367,8 @@ class SarabunDocument(models.Model):
                 done = len(
                     record.recipient_ids.filtered(
                         lambda r: r.state in ("acknowledged", "approved")
+                        and not r.is_cc
+                        and not r.is_delegated
                     )
                 )
                 record.routing_progress = (done / total) * 100
@@ -370,11 +379,17 @@ class SarabunDocument(models.Model):
     def _compute_routing_counts(self):
         for record in self:
             record.pending_routing_count = len(
-                record.recipient_ids.filtered(lambda r: r.state == "new")
+                record.recipient_ids.filtered(
+                    lambda r: r.state == "new"
+                    and not r.is_cc
+                    and not r.is_delegated
+                )
             )
             record.completed_routing_count = len(
                 record.recipient_ids.filtered(
                     lambda r: r.state in ("acknowledged", "approved")
+                    and not r.is_cc
+                    and not r.is_delegated
                 )
             )
 
@@ -382,7 +397,9 @@ class SarabunDocument(models.Model):
     def _compute_current_user_recipient(self):
         for record in self:
             recipient = False
-            for r in record.recipient_ids.filtered(lambda x: x.state == "new"):
+            for r in record.recipient_ids.filtered(
+                lambda x: x.state == "new" and not x.is_cc
+            ):
                 if r._can_user_access():
                     recipient = r
                     break
@@ -444,6 +461,8 @@ class SarabunDocument(models.Model):
                         tmpl_line.department_id.id if tmpl_line.department_id else False
                     ),
                     "role_id": tmpl_line.role_id.id if tmpl_line.role_id else False,
+                    "required": tmpl_line.required,
+                    "on_complete_method": tmpl_line.on_complete_method,
                 }
                 lines.append((0, 0, line_vals))
             self.routing_line_ids = lines
@@ -513,6 +532,25 @@ class SarabunDocument(models.Model):
                 message_type="notification",
             )
 
+    def action_resubmit(self):
+        """Reset rejected document to draft for editing and re-sending."""
+        for document in self:
+            if document.state != "rejected":
+                raise UserError(_("Only rejected documents can be resubmitted."))
+            if document.sender_user_id != self.env.user:
+                raise UserError(
+                    _("Only the sender can resubmit a document.")
+                )
+            # Detach old recipients from routing lines so routing starts fresh
+            document.recipient_ids.write({"routing_line_id": False})
+            document.resubmit_count += 1
+            document.state = "draft"
+            document.message_post(
+                body=_("Document reset for resubmission (attempt %s).")
+                % document.resubmit_count,
+                message_type="notification",
+            )
+
     def action_cancel(self):
         """Cancel draft document - like email, once sent cannot be cancelled"""
         for document in self:
@@ -545,6 +583,33 @@ class SarabunDocument(models.Model):
         if not self.current_user_recipient_id:
             raise UserError(_("No pending action for you."))
         return self.current_user_recipient_id.action_reject()
+
+    def action_forward_cc(self):
+        """Open forward CC wizard. Available to sender and any recipient."""
+        self.ensure_one()
+        if self.state not in ("sent", "completed"):
+            raise UserError(_("Can only forward sent or completed documents."))
+        is_sender = self.sender_user_id == self.env.user
+        is_recipient = any(r._can_user_access() for r in self.recipient_ids)
+        if not is_sender and not is_recipient:
+            raise UserError(
+                _("Only the sender or a recipient can forward this document.")
+            )
+        return {
+            "name": _("Forward Document (CC)"),
+            "type": "ir.actions.act_window",
+            "res_model": "sarabun.forward.cc.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_document_id": self.id},
+        }
+
+    def action_delegate_current(self):
+        """Delegate current user's pending action."""
+        self.ensure_one()
+        if not self.current_user_recipient_id:
+            raise UserError(_("No pending action for you."))
+        return self.current_user_recipient_id.action_delegate()
 
     def action_view_origin(self):
         """View origin record"""
@@ -651,6 +716,8 @@ class SarabunDocument(models.Model):
                 "user_id": tmpl_line.user_id.id if tmpl_line.user_id else False,
                 "department_id": tmpl_line.department_id.id if tmpl_line.department_id else False,
                 "role_id": tmpl_line.role_id.id if tmpl_line.role_id else False,
+                "required": tmpl_line.required,
+                "on_complete_method": tmpl_line.on_complete_method,
             }
             lines.append((0, 0, line_vals))
         # Clear existing and set new
@@ -716,7 +783,10 @@ class SarabunDocument(models.Model):
             return
 
         # Find which routing lines already have recipients
-        existing_line_ids = self.recipient_ids.mapped("routing_line_id").ids
+        # Exclude CC and delegated recipients from this check
+        existing_line_ids = self.recipient_ids.filtered(
+            lambda r: r.routing_line_id and not r.is_cc and not r.is_delegated
+        ).mapped("routing_line_id").ids
 
         # Find next routing line that doesn't have a recipient yet
         next_line = self.routing_line_ids.filtered(
@@ -738,6 +808,9 @@ class SarabunDocument(models.Model):
                 "role_id": next_line.role_id.id if next_line.role_id else False,
                 "state": "new",
             })
+            # Check central correspondence interception
+            if self._should_intercept_central_correspondence(new_recipient):
+                new_recipient.write({"needs_dispatch": True})
             new_recipient._send_notification()
         else:
             # No more routing lines - check if completed
@@ -750,17 +823,21 @@ class SarabunDocument(models.Model):
         if self.state != "sent":
             return
 
-        # Check for rejected recipients
-        rejected = self.recipient_ids.filtered(lambda r: r.state == "rejected")
+        # Check for rejected recipients (only routing recipients)
+        rejected = self.recipient_ids.filtered(
+            lambda r: r.state == "rejected" and r.routing_line_id
+        )
         if rejected:
-            # Document stays in sent state, origin notified
+            self.state = "rejected"
+            self._on_routing_rejected(rejected[0])
             return
 
         # Check if all routing lines have been processed
-        # (recipient exists and state is not 'new')
         all_lines_count = len(self.routing_line_ids)
         completed_count = len(self.recipient_ids.filtered(
             lambda r: r.state in ("acknowledged", "approved")
+            and not r.is_cc
+            and not r.is_delegated
         ))
 
         if completed_count >= all_lines_count:
@@ -797,6 +874,12 @@ class SarabunDocument(models.Model):
             message_type="notification",
         )
 
+        # Email sender about completion
+        self._send_sarabun_email(
+            self.sender_user_id,
+            "agx_sarabun.email_template_sarabun_completed",
+        )
+
         # Callback to origin record if exists
         # Use sudo() because the approver may not have access to the origin record
         if self.origin_model and self.origin_res_id:
@@ -820,6 +903,12 @@ class SarabunDocument(models.Model):
             body=_("Document rejected by %s. Reason: %s")
             % (recipient.actioned_by.name, recipient.comment or _("No reason")),
             message_type="notification",
+        )
+
+        # Email sender about rejection
+        self._send_sarabun_email(
+            self.sender_user_id,
+            "agx_sarabun.email_template_sarabun_rejected",
         )
 
         # Callback to origin record if exists
@@ -857,6 +946,73 @@ class SarabunDocument(models.Model):
                     self.origin_model, self.origin_res_id, e
                 )
 
+    def _should_intercept_central_correspondence(self, recipient):
+        """Check if recipient's department uses central correspondence."""
+        dept = False
+        if recipient.recipient_type == "department" and recipient.department_id:
+            dept = recipient.department_id
+        elif recipient.recipient_type == "user" and recipient.user_id:
+            emp = recipient.user_id.employee_id
+            if emp and emp.department_id:
+                dept = emp.department_id
+        elif recipient.recipient_type == "role" and recipient.role_id:
+            role_users = recipient.role_id.get_users_for_document(self)
+            for user in role_users:
+                if user.employee_id and user.employee_id.department_id:
+                    dept = user.employee_id.department_id
+                    break
+        return bool(
+            dept and dept.use_central_correspondence and dept.sarabun_officer_ids
+        )
+
+    def _execute_step_hook(self, routing_line):
+        """Execute callback method on origin record when routing step completes."""
+        self.ensure_one()
+        method_name = routing_line.on_complete_method
+        if not method_name:
+            return
+        if not method_name.startswith("_on_sarabun_step_"):
+            raise UserError(
+                _("Invalid callback method name '%s'. "
+                  "Must start with '_on_sarabun_step_'.")
+                % method_name
+            )
+        if not self.origin_model or not self.origin_res_id:
+            return
+        try:
+            origin_record = self.env[self.origin_model].sudo().browse(
+                self.origin_res_id
+            )
+            if origin_record.exists() and hasattr(origin_record, method_name):
+                getattr(origin_record, method_name)(self, routing_line)
+        except UserError:
+            raise
+        except Exception as e:
+            _logger.exception(
+                "Error executing step hook %s on %s (id=%s): %s",
+                method_name, self.origin_model, self.origin_res_id, e,
+            )
+            raise
+
+    def _send_sarabun_email(self, users, template_xmlid, extra_values=None):
+        """Send email notification to users who have email notifications enabled."""
+        self.ensure_one()
+        users_to_email = users.filtered(
+            lambda u: u.sarabun_email_notification and u.email
+        )
+        if not users_to_email:
+            return
+        template = self.env.ref(template_xmlid, raise_if_not_found=False)
+        if not template:
+            return
+        for user in users_to_email:
+            template.with_context(
+                recipient_user=user,
+                **(extra_values or {}),
+            ).send_mail(self.id, force_send=False, email_values={
+                "email_to": user.email,
+            })
+
     # === Constraints ===
     @api.constrains("routing_line_ids")
     def _check_routing_lines(self):
@@ -867,6 +1023,21 @@ class SarabunDocument(models.Model):
             if len(approve_lines) > 1:
                 # Allow multiple approvers but warn via tracking
                 pass
+
+    @api.constrains("routing_line_ids", "route_template_id")
+    def _check_required_routing_lines(self):
+        """Prevent deletion of required routing lines from template."""
+        for doc in self.filtered("route_template_id"):
+            required_count = len(
+                doc.route_template_id.line_ids.filtered("required")
+            )
+            existing_required = len(
+                doc.routing_line_ids.filtered("required")
+            )
+            if existing_required < required_count:
+                raise ValidationError(
+                    _("Cannot remove required routing steps from the template.")
+                )
 
     # === Portal ===
     def _compute_access_url(self):

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -228,6 +228,11 @@ class SarabunDocument(models.Model):
         string="Recipients",
         readonly=True,
     )
+    inbox_ids = fields.One2many(
+        comodel_name="sarabun.inbox",
+        inverse_name="document_id",
+        string="Inbox Entries",
+    )
 
     # === Computed Routing Status ===
     routing_progress = fields.Float(

--- a/agx_sarabun/models/sarabun_document.py
+++ b/agx_sarabun/models/sarabun_document.py
@@ -259,6 +259,9 @@ class SarabunDocument(models.Model):
     current_user_can_approve = fields.Boolean(
         compute="_compute_current_user_recipient",
     )
+    is_current_user_sender = fields.Boolean(
+        compute="_compute_is_current_user_sender",
+    )
     report_preview_url = fields.Char(
         compute="_compute_report_preview_url",
     )
@@ -409,6 +412,13 @@ class SarabunDocument(models.Model):
             )
             record.current_user_can_approve = (
                 bool(recipient) and recipient.routing_type == "approve"
+            )
+
+    @api.depends("sender_user_id")
+    def _compute_is_current_user_sender(self):
+        for record in self:
+            record.is_current_user_sender = (
+                record.sender_user_id == self.env.user
             )
 
     def _compute_current_user_inbox_is_read(self):

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -477,7 +477,10 @@ class SarabunDocumentRecipient(models.Model):
                 ("user_id", "=", user.id),
                 ("document_id", "=", self.document_id.id),
             ], limit=1)
-            if not existing:
+            if existing:
+                if existing.is_read:
+                    existing.write({"is_read": False})
+            else:
                 Inbox.create({
                     "user_id": user.id,
                     "document_id": self.document_id.id,

--- a/agx_sarabun/models/sarabun_document_recipient.py
+++ b/agx_sarabun/models/sarabun_document_recipient.py
@@ -121,6 +121,67 @@ class SarabunDocumentRecipient(models.Model):
         readonly=True,
     )
 
+    # === CC Forward ===
+    is_cc = fields.Boolean(
+        string="CC (Read Only)",
+        default=False,
+        help="CC recipients have read-only access, cannot take routing actions",
+    )
+    forwarded_by_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Forwarded By",
+        readonly=True,
+    )
+    forwarded_by_recipient_id = fields.Many2one(
+        comodel_name="sarabun.document.recipient",
+        string="Forwarded From",
+        readonly=True,
+    )
+    forward_comment = fields.Text(
+        string="Forward Comment",
+    )
+
+    # === Delegation ===
+    is_delegated = fields.Boolean(
+        string="Delegated",
+        default=False,
+        help="This recipient was created via delegation",
+    )
+    delegated_by_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Delegated By",
+        readonly=True,
+    )
+    delegated_by_recipient_id = fields.Many2one(
+        comodel_name="sarabun.document.recipient",
+        string="Delegated From",
+        readonly=True,
+    )
+    delegation_chain_ids = fields.One2many(
+        comodel_name="sarabun.document.recipient",
+        inverse_name="delegated_by_recipient_id",
+        string="Delegated To",
+    )
+
+    # === Central Correspondence Dispatch ===
+    needs_dispatch = fields.Boolean(
+        string="Needs Dispatch",
+        default=False,
+        help="Pending dispatch by central correspondence clerk",
+    )
+    dispatched_by_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Dispatched By",
+        readonly=True,
+    )
+    dispatched_date = fields.Datetime(
+        string="Dispatched Date",
+        readonly=True,
+    )
+    dispatch_note = fields.Text(
+        string="Dispatch Note",
+    )
+
     # === Notifications ===
     is_notified = fields.Boolean(
         string="Notified",
@@ -231,6 +292,13 @@ class SarabunDocumentRecipient(models.Model):
         # Trigger callback on origin
         self.document_id._trigger_origin_action_callback(self, "acknowledge")
 
+        # Execute step hook on origin record
+        if self.routing_line_id:
+            self.document_id._execute_step_hook(self.routing_line_id)
+
+        # Resolve delegation chain
+        self._resolve_delegation_chain()
+
         # Activate next recipient
         self.document_id._activate_next_recipient()
 
@@ -266,6 +334,13 @@ class SarabunDocumentRecipient(models.Model):
 
         # Trigger callback on origin
         self.document_id._trigger_origin_action_callback(self, "approve")
+
+        # Execute step hook on origin record
+        if self.routing_line_id:
+            self.document_id._execute_step_hook(self.routing_line_id)
+
+        # Resolve delegation chain
+        self._resolve_delegation_chain()
 
         # Activate next recipient
         self.document_id._activate_next_recipient()
@@ -329,25 +404,61 @@ class SarabunDocumentRecipient(models.Model):
         if self.document_id.state != "sent":
             raise UserError(_("Document is not in sent state."))
 
-        can_action = False
+        if self.is_cc:
+            raise UserError(_("CC recipients cannot take routing actions."))
 
-        if self.recipient_type == "user":
-            can_action = self.user_id == self.env.user
-        elif self.recipient_type == "department":
-            if self.department_id:
-                # Check if user is a sarabun officer
-                if self.env.user in self.department_id.sarabun_officer_ids:
+        if self.needs_dispatch:
+            raise UserError(
+                _("This document must be dispatched by the "
+                  "correspondence office first.")
+            )
+
+        can_action = self._can_user_access()
+
+        # Walk delegation chain — delegator can act on delegated recipient
+        if not can_action and self.delegated_by_recipient_id:
+            parent = self.delegated_by_recipient_id
+            while parent:
+                if parent._can_user_access():
                     can_action = True
-                # Or if user is manager of department
-                elif self.department_id.manager_id:
-                    can_action = self.department_id.manager_id.user_id == self.env.user
-        elif self.recipient_type == "role":
-            if self.role_id:
-                role_users = self.role_id.get_users_for_document(self.document_id)
-                can_action = self.env.user in role_users
+                    break
+                parent = parent.delegated_by_recipient_id
 
         if not can_action:
             raise UserError(_("You are not authorized to perform this action."))
+
+    def _get_users_to_notify(self):
+        """Get users who should receive notification for this recipient."""
+        self.ensure_one()
+        # If needs dispatch, notify clerks instead of actual recipient
+        if self.needs_dispatch:
+            dept = self._get_recipient_department()
+            if dept and dept.sarabun_officer_ids:
+                return dept.sarabun_officer_ids
+            # Fallback: no clerks, clear dispatch flag and notify normally
+            self.needs_dispatch = False
+
+        if self.recipient_type == "user":
+            return self.user_id or self.env["res.users"]
+        elif self.recipient_type == "department" and self.department_id:
+            if self.department_id.sarabun_officer_ids:
+                return self.department_id.sarabun_officer_ids
+            elif self.department_id.manager_id:
+                return self.department_id.manager_id.user_id
+        elif self.recipient_type == "role" and self.role_id:
+            return self.role_id.get_users_for_document(self.document_id)
+        return self.env["res.users"]
+
+    def _get_recipient_department(self):
+        """Get the department associated with this recipient."""
+        self.ensure_one()
+        if self.recipient_type == "department" and self.department_id:
+            return self.department_id
+        if self.recipient_type == "user" and self.user_id:
+            emp = self.user_id.employee_id
+            if emp and emp.department_id:
+                return emp.department_id
+        return False
 
     def _send_notification(self):
         """Send activity notification to recipient"""
@@ -356,19 +467,7 @@ class SarabunDocumentRecipient(models.Model):
         if self.is_notified:
             return
 
-        users_to_notify = self.env["res.users"]
-
-        if self.recipient_type == "user":
-            users_to_notify = self.user_id
-        elif self.recipient_type == "department" and self.department_id:
-            # Send to all sarabun officers
-            if self.department_id.sarabun_officer_ids:
-                users_to_notify = self.department_id.sarabun_officer_ids
-            # Fallback to department manager
-            elif self.department_id.manager_id:
-                users_to_notify = self.department_id.manager_id.user_id
-        elif self.recipient_type == "role" and self.role_id:
-            users_to_notify = self.role_id.get_users_for_document(self.document_id)
+        users_to_notify = self._get_users_to_notify()
 
         # Create per-user inbox records (one per document per user)
         Inbox = self.env["sarabun.inbox"].sudo()
@@ -396,6 +495,12 @@ class SarabunDocumentRecipient(models.Model):
                     'document_id': self.document_id.id,
                 }
             )
+
+        # Send email notification
+        self.document_id._send_sarabun_email(
+            users_to_notify,
+            "agx_sarabun.email_template_sarabun_new_document",
+        )
 
         self.write({
             "is_notified": True,
@@ -443,6 +548,13 @@ class SarabunDocumentRecipient(models.Model):
         if user is None:
             user = self.env.user
 
+        # Central correspondence clerk access
+        if self.needs_dispatch:
+            dept = self._get_recipient_department()
+            if dept and user in dept.sarabun_officer_ids:
+                return True
+            return False
+
         if self.recipient_type == "user":
             return self.user_id == user
         elif self.recipient_type == "department" and self.department_id:
@@ -456,3 +568,85 @@ class SarabunDocumentRecipient(models.Model):
             return user in role_users
 
         return False
+
+    # === Delegation ===
+    def action_delegate(self):
+        """Open delegation wizard."""
+        self.ensure_one()
+        if self.state != "new":
+            raise UserError(_("Can only delegate pending actions."))
+        if self.is_cc:
+            raise UserError(_("CC recipients cannot delegate."))
+        if not self._can_user_access():
+            raise UserError(
+                _("You are not authorized to delegate this action.")
+            )
+        return {
+            "name": _("Delegate Action"),
+            "type": "ir.actions.act_window",
+            "res_model": "sarabun.delegate.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_recipient_id": self.id},
+        }
+
+    def _resolve_delegation_chain(self):
+        """When one recipient in a chain acts, resolve all others."""
+        if not self.delegated_by_recipient_id and not self.delegation_chain_ids:
+            return
+        # Find root of delegation chain
+        root = self
+        while root.delegated_by_recipient_id:
+            root = root.delegated_by_recipient_id
+        # Collect all in chain
+        all_in_chain = self._collect_delegation_chain(root)
+        # Mark siblings as resolved
+        siblings = all_in_chain.filtered(
+            lambda r: r.id != self.id and r.state == "new"
+        )
+        now = fields.Datetime.now()
+        for sibling in siblings:
+            sibling.write({
+                "state": self.state,
+                "actioned_by": self.env.user.id,
+                "actioned_date": now,
+                "comment": _("Resolved: action taken by %s")
+                % self.env.user.name,
+            })
+        # Notify all users in chain (except actor)
+        users_to_notify = self.env["res.users"]
+        for r in all_in_chain.filtered(lambda r: r.id != self.id):
+            if r.user_id:
+                users_to_notify |= r.user_id
+        if users_to_notify:
+            self.document_id._send_sarabun_email(
+                users_to_notify,
+                "agx_sarabun.email_template_sarabun_action_taken",
+            )
+
+    def _collect_delegation_chain(self, root):
+        """Recursively collect all recipients in a delegation chain."""
+        result = root
+        for child in root.delegation_chain_ids:
+            result |= self._collect_delegation_chain(child)
+        return result
+
+    # === Central Correspondence Dispatch ===
+    def action_dispatch(self):
+        """Open dispatch wizard for central correspondence clerk."""
+        self.ensure_one()
+        if not self.needs_dispatch:
+            raise UserError(_("This recipient does not need dispatch."))
+        dept = self._get_recipient_department()
+        if not dept or self.env.user not in dept.sarabun_officer_ids:
+            raise UserError(
+                _("Only sarabun officers can dispatch documents.")
+            )
+        return {
+            "name": _("Dispatch Document"),
+            "type": "ir.actions.act_window",
+            "res_model": "sarabun.dispatch.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_recipient_id": self.id},
+        }

--- a/agx_sarabun/models/sarabun_route_template.py
+++ b/agx_sarabun/models/sarabun_route_template.py
@@ -142,3 +142,14 @@ class SarabunRouteTemplateLine(models.Model):
         string="Role/Position",
         help="Select a role/position for routing",
     )
+    required = fields.Boolean(
+        string="Required",
+        default=False,
+        help="If checked, this step cannot be removed by users when customizing the route",
+    )
+    on_complete_method = fields.Char(
+        string="On Complete Callback",
+        help="Method name to call on origin record when this step completes. "
+             "Must start with '_on_sarabun_step_'. "
+             "Example: _on_sarabun_step_dept_approved",
+    )

--- a/agx_sarabun/models/sarabun_routing_line.py
+++ b/agx_sarabun/models/sarabun_routing_line.py
@@ -69,6 +69,16 @@ class SarabunRoutingLine(models.Model):
         string="Role/Position",
         help="Select a role/position for routing",
     )
+    required = fields.Boolean(
+        string="Required",
+        default=False,
+        readonly=True,
+        help="Step originated from a required template step and cannot be removed",
+    )
+    on_complete_method = fields.Char(
+        string="On Complete Callback",
+        help="Method name called on origin record when step completes",
+    )
     recipient_name = fields.Char(
         string="Recipient",
         compute="_compute_recipient_name",

--- a/agx_sarabun/security/ir.model.access.csv
+++ b/agx_sarabun/security/ir.model.access.csv
@@ -12,7 +12,9 @@ access_sarabun_route_template_line_manager,sarabun.route.template.line.manager,m
 access_sarabun_reference_user,sarabun.reference.user,model_sarabun_reference,group_sarabun_user,1,1,1,0
 access_sarabun_reference_manager,sarabun.reference.manager,model_sarabun_reference,group_sarabun_manager,1,1,1,1
 access_sarabun_routing_reject_wizard,sarabun.routing.reject.wizard,model_sarabun_routing_reject_wizard,group_sarabun_user,1,1,1,1
-access_sarabun_routing_forward_wizard,sarabun.routing.forward.wizard,model_sarabun_routing_forward_wizard,group_sarabun_user,1,1,1,1
+access_sarabun_forward_cc_wizard,sarabun.forward.cc.wizard,model_sarabun_forward_cc_wizard,group_sarabun_user,1,1,1,1
+access_sarabun_delegate_wizard,sarabun.delegate.wizard,model_sarabun_delegate_wizard,group_sarabun_user,1,1,1,1
+access_sarabun_dispatch_wizard,sarabun.dispatch.wizard,model_sarabun_dispatch_wizard,group_sarabun_user,1,1,1,1
 access_sarabun_department_lookup_wizard,sarabun.department.lookup.wizard,model_sarabun_department_lookup_wizard,group_sarabun_user,1,1,1,1
 access_sarabun_document_sequence_user,sarabun.document.sequence.user,model_sarabun_document_sequence,group_sarabun_user,1,0,0,0
 access_sarabun_document_sequence_manager,sarabun.document.sequence.manager,model_sarabun_document_sequence,group_sarabun_manager,1,1,1,1

--- a/agx_sarabun/security/security.xml
+++ b/agx_sarabun/security/security.xml
@@ -51,6 +51,18 @@
             <field name="perm_unlink" eval="False"/>
         </record>
 
+        <!-- Users can read documents where they have inbox entries -->
+        <record id="sarabun_document_inbox_rule" model="ir.rule">
+            <field name="name">Sarabun Document: Inbox Access</field>
+            <field name="model_id" ref="model_sarabun_document"/>
+            <field name="groups" eval="[(4, ref('group_sarabun_user'))]"/>
+            <field name="domain_force">[('inbox_ids.user_id', '=', user.id)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
         <!-- Users can read documents where they have activities assigned -->
         <record id="sarabun_document_activity_rule" model="ir.rule">
             <field name="name">Sarabun Document: Activity Access</field>

--- a/agx_sarabun/views/hr_department_views.xml
+++ b/agx_sarabun/views/hr_department_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='manager_id']" position="after">
                 <field name="sarabun_officer_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                <field name="use_central_correspondence"/>
             </xpath>
         </field>
     </record>

--- a/agx_sarabun/views/res_users_views.xml
+++ b/agx_sarabun/views/res_users_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_users_view_form_inherit_sarabun" model="ir.ui.view">
+        <field name="name">res.users.form.inherit.sarabun</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='notification_type']" position="after">
+                <field name="sarabun_email_notification"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/agx_sarabun/views/sarabun_document_recipient_views.xml
+++ b/agx_sarabun/views/sarabun_document_recipient_views.xml
@@ -15,8 +15,10 @@
                 <field name="read_date" optional="show"/>
                 <field name="signed_as_text" optional="show"/>
                 <field name="actioned_date" optional="hide"/>
-                <field name="is_cc" invisible="1"/>
-                <field name="is_delegated" invisible="1"/>
+                <field name="is_cc" widget="boolean_toggle" readonly="1" optional="show" string="CC"/>
+                <field name="is_delegated" widget="boolean_toggle" readonly="1" optional="show" string="Delegated"/>
+                <field name="forwarded_by_user_id" optional="hide" string="Forwarded By"/>
+                <field name="delegated_by_user_id" optional="hide" string="Delegated By"/>
                 <field name="needs_dispatch" invisible="1"/>
                 <button name="action_dispatch" string="Dispatch" type="object" icon="fa-paper-plane" attrs="{'invisible': [('needs_dispatch', '!=', True)]}"/>
                 <button name="action_acknowledge" string="Acknowledge" type="object" icon="fa-check" attrs="{'invisible': ['|', '|', '|', ('state', '!=', 'new'), ('routing_type', '=', 'approve'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
@@ -62,6 +64,25 @@
                     </group>
                     <group attrs="{'invisible': [('comment', '=', False)]}">
                         <field name="comment" readonly="1"/>
+                    </group>
+                    <group string="Forward (CC) Information"
+                           attrs="{'invisible': [('is_cc', '=', False)]}">
+                        <field name="forwarded_by_user_id" readonly="1"/>
+                        <field name="forward_comment" readonly="1"
+                               attrs="{'invisible': [('forward_comment', '=', False)]}"/>
+                    </group>
+                    <group string="Delegation Information"
+                           attrs="{'invisible': [('is_delegated', '=', False)]}">
+                        <field name="is_delegated" invisible="1"/>
+                        <field name="delegated_by_user_id" readonly="1"/>
+                        <field name="delegated_by_recipient_id" readonly="1"/>
+                    </group>
+                    <group string="Dispatch Information"
+                           attrs="{'invisible': [('dispatched_by_user_id', '=', False)]}">
+                        <field name="dispatched_by_user_id" readonly="1"/>
+                        <field name="dispatched_date" readonly="1"/>
+                        <field name="dispatch_note" readonly="1"
+                               attrs="{'invisible': [('dispatch_note', '=', False)]}"/>
                     </group>
                 </sheet>
                 <div class="oe_chatter">

--- a/agx_sarabun/views/sarabun_document_recipient_views.xml
+++ b/agx_sarabun/views/sarabun_document_recipient_views.xml
@@ -15,9 +15,13 @@
                 <field name="read_date" optional="show"/>
                 <field name="signed_as_text" optional="show"/>
                 <field name="actioned_date" optional="hide"/>
-                <button name="action_acknowledge" string="Acknowledge" type="object" icon="fa-check" attrs="{'invisible': ['|', ('state', '!=', 'new'), ('routing_type', '=', 'approve')]}"/>
-                <button name="action_approve" string="Approve" type="object" icon="fa-thumbs-up" class="text-success" attrs="{'invisible': ['|', ('state', '!=', 'new'), ('routing_type', '!=', 'approve')]}"/>
-                <button name="action_reject" string="Reject" type="object" icon="fa-thumbs-down" class="text-danger" attrs="{'invisible': [('state', '!=', 'new')]}"/>
+                <field name="is_cc" invisible="1"/>
+                <field name="is_delegated" invisible="1"/>
+                <field name="needs_dispatch" invisible="1"/>
+                <button name="action_dispatch" string="Dispatch" type="object" icon="fa-paper-plane" attrs="{'invisible': [('needs_dispatch', '!=', True)]}"/>
+                <button name="action_acknowledge" string="Acknowledge" type="object" icon="fa-check" attrs="{'invisible': ['|', '|', '|', ('state', '!=', 'new'), ('routing_type', '=', 'approve'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
+                <button name="action_approve" string="Approve" type="object" icon="fa-thumbs-up" class="text-success" attrs="{'invisible': ['|', '|', '|', ('state', '!=', 'new'), ('routing_type', '!=', 'approve'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
+                <button name="action_reject" string="Reject" type="object" icon="fa-thumbs-down" class="text-danger" attrs="{'invisible': ['|', '|', ('state', '!=', 'new'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
             </tree>
         </field>
     </record>
@@ -29,9 +33,13 @@
         <field name="arch" type="xml">
             <form string="Document Recipient">
                 <header>
-                    <button name="action_acknowledge" string="Acknowledge" type="object" class="btn-primary" attrs="{'invisible': ['|', ('state', '!=', 'new'), ('routing_type', '=', 'approve')]}"/>
-                    <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': ['|', ('state', '!=', 'new'), ('routing_type', '!=', 'approve')]}"/>
-                    <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': [('state', '!=', 'new')]}"/>
+                    <field name="is_cc" invisible="1"/>
+                    <field name="needs_dispatch" invisible="1"/>
+                    <button name="action_dispatch" string="Dispatch" type="object" class="btn-primary" icon="fa-paper-plane" attrs="{'invisible': [('needs_dispatch', '!=', True)]}"/>
+                    <button name="action_acknowledge" string="Acknowledge" type="object" class="btn-primary" attrs="{'invisible': ['|', '|', '|', ('state', '!=', 'new'), ('routing_type', '=', 'approve'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
+                    <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': ['|', '|', '|', ('state', '!=', 'new'), ('routing_type', '!=', 'approve'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
+                    <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': ['|', '|', ('state', '!=', 'new'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
+                    <button name="action_delegate" string="Delegate" type="object" class="btn-secondary" icon="fa-user-plus" attrs="{'invisible': ['|', '|', ('state', '!=', 'new'), ('is_cc', '=', True), ('needs_dispatch', '=', True)]}"/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -416,7 +416,7 @@
         <field name="name">Incoming Documents</field>
         <field name="res_model">sarabun.document</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="domain">['|', ('routing_line_ids.user_id', '=', uid), ('recipient_ids.user_id', '=', uid)]</field>
+        <field name="domain">['|', '|', ('routing_line_ids.user_id', '=', uid), ('recipient_ids.user_id', '=', uid), ('inbox_ids.user_id', '=', uid)]</field>
         <field name="context">{'create': False}</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'tree', 'view_id': ref('sarabun_document_view_tree_incoming')}),

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -175,6 +175,27 @@
                             <group attrs="{'invisible': [('state', 'not in', ['sent', 'completed'])]}">
                                 <field name="routing_progress" widget="progressbar"/>
                             </group>
+                            <!-- CC & Delegated Recipients -->
+                            <group string="CC &amp; Delegated Recipients"
+                                   attrs="{'invisible': [('state', 'not in', ['sent', 'completed'])]}">
+                                <field name="recipient_ids" nolabel="1"
+                                       domain="['|', ('is_cc', '=', True), ('is_delegated', '=', True)]"
+                                       readonly="1">
+                                    <tree decoration-info="is_cc == True"
+                                          decoration-warning="is_delegated == True">
+                                        <field name="is_cc" invisible="1"/>
+                                        <field name="is_delegated" invisible="1"/>
+                                        <field name="recipient_name"/>
+                                        <field name="routing_type"/>
+                                        <field name="forwarded_by_user_id" string="Forwarded By"/>
+                                        <field name="delegated_by_user_id" string="Delegated By"/>
+                                        <field name="state" widget="badge"
+                                               decoration-info="state == 'new'"
+                                               decoration-success="state in ('acknowledged', 'approved')"/>
+                                        <field name="create_date" string="Date"/>
+                                    </tree>
+                                </field>
+                            </group>
                         </page>
 
                         <page string="References" name="references">
@@ -395,7 +416,7 @@
         <field name="name">Incoming Documents</field>
         <field name="res_model">sarabun.document</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="domain">[('routing_line_ids.user_id', '=', uid)]</field>
+        <field name="domain">['|', ('routing_line_ids.user_id', '=', uid), ('recipient_ids.user_id', '=', uid)]</field>
         <field name="context">{'create': False}</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'tree', 'view_id': ref('sarabun_document_view_tree_incoming')}),

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -5,7 +5,7 @@
         <field name="name">sarabun.document.view.tree</field>
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
-            <tree string="Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-muted="state == 'cancelled'">
+            <tree string="Documents" decoration-info="state == 'draft'" decoration-warning="state == 'sent'" decoration-success="state == 'completed'" decoration-danger="state == 'rejected'" decoration-muted="state == 'cancelled'">
                 <field name="urgency" optional="hide"/>
                 <field name="recipient" string="To"/>
                 <field name="name"/>
@@ -72,10 +72,13 @@
                     <button name="action_approve" string="Approve" type="object" class="btn-success" attrs="{'invisible': [('current_user_can_approve', '=', False)]}"/>
                     <button name="action_reject" string="Reject" type="object" class="btn-danger" attrs="{'invisible': ['|', ('current_user_recipient_id', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_print_report" string="Print" type="object" icon="fa-print" attrs="{'invisible': [('state', '=', 'draft')]}"/>
+                    <button name="action_forward_cc" string="Forward (CC)" type="object" class="btn-secondary" icon="fa-share" attrs="{'invisible': [('state', 'not in', ['sent', 'completed'])]}"/>
+                    <button name="action_delegate_current" string="Delegate" type="object" class="btn-secondary" icon="fa-user-plus" attrs="{'invisible': [('current_user_recipient_id', '=', False)]}"/>
                     <button name="action_mark_inbox_read" string="Mark as Read" type="object" class="btn-secondary" icon="fa-envelope-open" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', True), ('state', '!=', 'sent')]}"/>
                     <button name="action_mark_inbox_unread" string="Mark as Unread" type="object" class="btn-secondary" icon="fa-envelope" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed"/>
+                    <button name="action_resubmit" string="Edit &amp; Resubmit" type="object" class="btn-warning" icon="fa-refresh" attrs="{'invisible': ['|', ('state', '!=', 'rejected'), ('sender_user_id', '!=', uid)]}"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed,rejected"/>
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -163,6 +166,8 @@
                                     <field name="department_text" attrs="{'invisible': [('recipient_type', '!=', 'department')]}"/>
                                     <field name="department_id" attrs="{'invisible': [('recipient_type', '!=', 'department')]}" optional="hide" string="Route To (System)"/>
                                     <field name="role_id" attrs="{'invisible': [('recipient_type', '!=', 'role')], 'required': [('recipient_type', '=', 'role')]}"/>
+                                    <field name="required" invisible="1"/>
+                                    <field name="on_complete_method" optional="hide"/>
                                     <field name="recipient_state" widget="badge" attrs="{'invisible': [('parent.state', '=', 'draft')]}" decoration-muted="recipient_state == 'waiting'" decoration-info="recipient_state == 'new'" decoration-success="recipient_state in ('acknowledged', 'approved')" decoration-danger="recipient_state == 'rejected'"/>
                                 </tree>
                             </field>
@@ -218,6 +223,8 @@
                     <field name="current_user_can_approve" invisible="1"/>
                     <field name="has_delegated_report" invisible="1"/>
                     <field name="current_user_inbox_is_read" invisible="1"/>
+                    <field name="sender_user_id" invisible="1"/>
+                    <field name="resubmit_count" invisible="1"/>
                 </sheet>
                 <!-- Attachment preview -->
                 <div class="o_attachment_preview"
@@ -252,6 +259,7 @@
                 <filter string="Sent" name="sent" domain="[('state', '=', 'sent')]"/>
                 <filter string="Completed" name="completed" domain="[('state', '=', 'completed')]"/>
                 <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancelled')]"/>
+                <filter string="Rejected" name="rejected" domain="[('state', '=', 'rejected')]"/>
                 <separator/>
                 <filter string="Urgent" name="urgent" domain="[('urgency', 'in', ['urgent', 'very_urgent', 'immediate'])]"/>
                 <separator/>

--- a/agx_sarabun/views/sarabun_document_views.xml
+++ b/agx_sarabun/views/sarabun_document_views.xml
@@ -65,6 +65,7 @@
         <field name="model">sarabun.document</field>
         <field name="arch" type="xml">
             <form string="Document">
+                <field name="is_current_user_sender" invisible="1"/>
                 <header>
                     <button name="action_send" string="Send" type="object" class="btn-primary" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <!-- Action buttons for recipient -->
@@ -77,7 +78,7 @@
                     <button name="action_mark_inbox_read" string="Mark as Read" type="object" class="btn-secondary" icon="fa-envelope-open" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', True), ('state', '!=', 'sent')]}"/>
                     <button name="action_mark_inbox_unread" string="Mark as Unread" type="object" class="btn-secondary" icon="fa-envelope" attrs="{'invisible': ['|', ('current_user_inbox_is_read', '=', False), ('state', '!=', 'sent')]}"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
-                    <button name="action_resubmit" string="Edit &amp; Resubmit" type="object" class="btn-warning" icon="fa-refresh" attrs="{'invisible': ['|', ('state', '!=', 'rejected'), ('sender_user_id', '!=', uid)]}"/>
+                    <button name="action_resubmit" string="Edit &amp; Resubmit" type="object" class="btn-warning" icon="fa-refresh" attrs="{'invisible': ['|', ('state', '!=', 'rejected'), ('is_current_user_sender', '=', False)]}"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,completed,rejected"/>
                 </header>
                 <sheet>

--- a/agx_sarabun/views/sarabun_route_template_views.xml
+++ b/agx_sarabun/views/sarabun_route_template_views.xml
@@ -48,6 +48,8 @@
                                     <field name="user_id" attrs="{'invisible': [('recipient_type', '!=', 'user')], 'required': [('recipient_type', '=', 'user')]}"/>
                                     <field name="department_id" attrs="{'invisible': [('recipient_type', '!=', 'department')], 'required': [('recipient_type', '=', 'department')]}"/>
                                     <field name="role_id" attrs="{'invisible': [('recipient_type', '!=', 'role')], 'required': [('recipient_type', '=', 'role')]}"/>
+                                    <field name="required" widget="boolean_toggle"/>
+                                    <field name="on_complete_method" optional="hide"/>
                                 </tree>
                             </field>
                         </page>

--- a/agx_sarabun/wizard/__init__.py
+++ b/agx_sarabun/wizard/__init__.py
@@ -2,3 +2,6 @@
 from . import sarabun_routing_wizard
 from . import sarabun_signing_wizard
 from . import sarabun_route_selection_wizard
+from . import sarabun_forward_cc_wizard
+from . import sarabun_delegate_wizard
+from . import sarabun_dispatch_wizard

--- a/agx_sarabun/wizard/sarabun_delegate_wizard.py
+++ b/agx_sarabun/wizard/sarabun_delegate_wizard.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from odoo import _, fields, models
+
+
+class SarabunDelegateWizard(models.TransientModel):
+    _name = "sarabun.delegate.wizard"
+    _description = "Delegate Action Wizard"
+
+    recipient_id = fields.Many2one(
+        comodel_name="sarabun.document.recipient",
+        string="Recipient",
+        required=True,
+    )
+    delegate_to_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Delegate To",
+        required=True,
+    )
+    comment = fields.Text(string="Comment")
+
+    def action_delegate(self):
+        """Create delegated recipient."""
+        self.ensure_one()
+        original = self.recipient_id
+        Recipient = self.env["sarabun.document.recipient"].sudo()
+        delegate = Recipient.create({
+            "document_id": original.document_id.id,
+            "routing_line_id": (
+                original.routing_line_id.id if original.routing_line_id else False
+            ),
+            "sequence": original.sequence,
+            "routing_type": original.routing_type,
+            "recipient_type": "user",
+            "user_id": self.delegate_to_user_id.id,
+            "state": "new",
+            "is_delegated": True,
+            "delegated_by_user_id": self.env.user.id,
+            "delegated_by_recipient_id": original.id,
+        })
+        delegate._send_notification()
+
+        # Email delegate about delegation
+        original.document_id._send_sarabun_email(
+            self.delegate_to_user_id,
+            "agx_sarabun.email_template_sarabun_delegated",
+        )
+
+        original.document_id.message_post(
+            body=_("%s delegated action to %s")
+            % (self.env.user.name, self.delegate_to_user_id.name),
+            message_type="notification",
+        )
+        return {"type": "ir.actions.act_window_close"}

--- a/agx_sarabun/wizard/sarabun_delegate_wizard.py
+++ b/agx_sarabun/wizard/sarabun_delegate_wizard.py
@@ -45,9 +45,18 @@ class SarabunDelegateWizard(models.TransientModel):
             "agx_sarabun.email_template_sarabun_delegated",
         )
 
+        routing_type_label = dict(
+            original._fields["routing_type"].selection
+        ).get(original.routing_type, "")
+        body = _("%s delegated %s action to %s") % (
+            self.env.user.name,
+            routing_type_label,
+            self.delegate_to_user_id.name,
+        )
+        if self.comment:
+            body += "<br/>" + _("Comment: %s") % self.comment
         original.document_id.message_post(
-            body=_("%s delegated action to %s")
-            % (self.env.user.name, self.delegate_to_user_id.name),
+            body=body,
             message_type="notification",
         )
         return {"type": "ir.actions.act_window_close"}

--- a/agx_sarabun/wizard/sarabun_dispatch_wizard.py
+++ b/agx_sarabun/wizard/sarabun_dispatch_wizard.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class SarabunDispatchWizard(models.TransientModel):
+    _name = "sarabun.dispatch.wizard"
+    _description = "Dispatch Document Wizard"
+
+    recipient_id = fields.Many2one(
+        comodel_name="sarabun.document.recipient",
+        string="Recipient",
+        required=True,
+    )
+    dispatch_to_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Dispatch To (Optional)",
+        help="Optionally specify exact user. "
+        "If blank, original recipient target is used.",
+    )
+    note = fields.Text(string="Dispatch Note")
+
+    def action_dispatch(self):
+        """Dispatch document to actual recipient."""
+        self.ensure_one()
+        recipient = self.recipient_id
+        if not recipient.needs_dispatch:
+            raise UserError(_("This recipient does not need dispatch."))
+
+        vals = {
+            "needs_dispatch": False,
+            "dispatched_by_user_id": self.env.user.id,
+            "dispatched_date": fields.Datetime.now(),
+            "dispatch_note": self.note,
+            "is_notified": False,  # Reset so it re-notifies actual recipient
+        }
+        if self.dispatch_to_user_id:
+            vals.update({
+                "recipient_type": "user",
+                "user_id": self.dispatch_to_user_id.id,
+            })
+        recipient.write(vals)
+        recipient._send_notification()
+
+        # Email dispatched recipient
+        recipient.document_id._send_sarabun_email(
+            recipient._get_users_to_notify(),
+            "agx_sarabun.email_template_sarabun_dispatched",
+        )
+
+        recipient.document_id.message_post(
+            body=_("Document dispatched by %s (Central Correspondence)%s")
+            % (
+                self.env.user.name,
+                _(" to %s") % self.dispatch_to_user_id.name
+                if self.dispatch_to_user_id
+                else "",
+            ),
+            message_type="notification",
+        )
+        return {"type": "ir.actions.act_window_close"}

--- a/agx_sarabun/wizard/sarabun_forward_cc_wizard.py
+++ b/agx_sarabun/wizard/sarabun_forward_cc_wizard.py
@@ -83,4 +83,19 @@ class SarabunForwardCCWizard(models.TransientModel):
             recipient = Recipient.create(vals)
             recipient._send_notification()
 
+        # Audit trail
+        if self.recipient_type == "user":
+            target_names = ", ".join(self.user_ids.mapped("name"))
+        elif self.recipient_type == "department":
+            target_names = self.department_id.name
+        else:
+            target_names = self.role_id.name
+        body = _("%s forwarded document (CC) to: %s") % (
+            self.env.user.name,
+            target_names,
+        )
+        if self.comment:
+            body += "<br/>" + _("Comment: %s") % self.comment
+        self.document_id.message_post(body=body, message_type="notification")
+
         return {"type": "ir.actions.act_window_close"}

--- a/agx_sarabun/wizard/sarabun_forward_cc_wizard.py
+++ b/agx_sarabun/wizard/sarabun_forward_cc_wizard.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class SarabunForwardCCWizard(models.TransientModel):
+    _name = "sarabun.forward.cc.wizard"
+    _description = "Forward Document CC Wizard"
+
+    document_id = fields.Many2one(
+        comodel_name="sarabun.document",
+        string="Document",
+        required=True,
+    )
+    recipient_type = fields.Selection(
+        selection=[
+            ("user", "User"),
+            ("department", "Department"),
+            ("role", "Role/Position"),
+        ],
+        string="Forward To",
+        required=True,
+        default="user",
+    )
+    user_ids = fields.Many2many(
+        comodel_name="res.users",
+        string="Users",
+    )
+    department_id = fields.Many2one(
+        comodel_name="hr.department",
+        string="Department",
+    )
+    role_id = fields.Many2one(
+        comodel_name="sarabun.role",
+        string="Role/Position",
+    )
+    comment = fields.Text(string="Comment")
+
+    def action_forward_cc(self):
+        """Create CC recipient records."""
+        self.ensure_one()
+        if self.recipient_type == "user" and not self.user_ids:
+            raise UserError(_("Please select at least one user to forward to."))
+        if self.recipient_type == "department" and not self.department_id:
+            raise UserError(_("Please select a department to forward to."))
+        if self.recipient_type == "role" and not self.role_id:
+            raise UserError(_("Please select a role to forward to."))
+
+        Recipient = self.env["sarabun.document.recipient"].sudo()
+        base_vals = {
+            "document_id": self.document_id.id,
+            "is_cc": True,
+            "forwarded_by_user_id": self.env.user.id,
+            "forward_comment": self.comment,
+            "routing_type": "acknowledge",
+            "state": "new",
+        }
+
+        if self.recipient_type == "user":
+            for user in self.user_ids:
+                vals = dict(
+                    base_vals,
+                    recipient_type="user",
+                    user_id=user.id,
+                )
+                recipient = Recipient.create(vals)
+                recipient._send_notification()
+        elif self.recipient_type == "department":
+            vals = dict(
+                base_vals,
+                recipient_type="department",
+                department_id=self.department_id.id,
+                department_text=self.department_id.name,
+            )
+            recipient = Recipient.create(vals)
+            recipient._send_notification()
+        elif self.recipient_type == "role":
+            vals = dict(
+                base_vals,
+                recipient_type="role",
+                role_id=self.role_id.id,
+            )
+            recipient = Recipient.create(vals)
+            recipient._send_notification()
+
+        return {"type": "ir.actions.act_window_close"}

--- a/agx_sarabun/wizard/sarabun_routing_wizard.py
+++ b/agx_sarabun/wizard/sarabun_routing_wizard.py
@@ -27,52 +27,6 @@ class SarabunRoutingRejectWizard(models.TransientModel):
         return {"type": "ir.actions.act_window_close"}
 
 
-class SarabunRoutingForwardWizard(models.TransientModel):
-    _name = "sarabun.routing.forward.wizard"
-    _description = "Forward Document Wizard"
-
-    routing_line_id = fields.Many2one(
-        comodel_name="sarabun.routing.line",
-        string="Routing Line",
-        required=True,
-    )
-    forward_type = fields.Selection(
-        selection=[
-            ("user", "User"),
-            ("department", "Department"),
-        ],
-        string="Forward To",
-        required=True,
-        default="user",
-    )
-    forward_to_user_id = fields.Many2one(
-        comodel_name="res.users",
-        string="User",
-    )
-    forward_to_department_id = fields.Many2one(
-        comodel_name="hr.department",
-        string="Department",
-    )
-    comment = fields.Text(
-        string="Comment",
-    )
-
-    def action_forward(self):
-        """Confirm forward"""
-        self.ensure_one()
-        if self.forward_type == "user" and not self.forward_to_user_id:
-            raise UserError(_("Please select a user to forward to."))
-        if self.forward_type == "department" and not self.forward_to_department_id:
-            raise UserError(_("Please select a department to forward to."))
-
-        self.routing_line_id.action_do_forward(
-            forward_to_user_id=self.forward_to_user_id.id if self.forward_to_user_id else False,
-            forward_to_department_id=self.forward_to_department_id.id if self.forward_to_department_id else False,
-            comment=self.comment,
-        )
-        return {"type": "ir.actions.act_window_close"}
-
-
 class SarabunDepartmentLookupWizard(models.TransientModel):
     """Wizard to search and select department, then insert text into target field"""
 

--- a/agx_sarabun/wizard/sarabun_routing_wizard_views.xml
+++ b/agx_sarabun/wizard/sarabun_routing_wizard_views.xml
@@ -18,25 +18,68 @@
         </field>
     </record>
 
-    <!-- Forward Wizard Form -->
-    <record id="sarabun_routing_forward_wizard_view_form" model="ir.ui.view">
-        <field name="name">sarabun.routing.forward.wizard.form</field>
-        <field name="model">sarabun.routing.forward.wizard</field>
+    <!-- Forward CC Wizard Form -->
+    <record id="sarabun_forward_cc_wizard_view_form" model="ir.ui.view">
+        <field name="name">sarabun.forward.cc.wizard.form</field>
+        <field name="model">sarabun.forward.cc.wizard</field>
         <field name="arch" type="xml">
-            <form string="Forward Document">
+            <form string="Forward Document (CC)">
                 <group>
-                    <field name="routing_line_id" invisible="1"/>
-                    <field name="forward_type" widget="radio"/>
+                    <field name="document_id" invisible="1"/>
+                    <field name="recipient_type" widget="radio"/>
                 </group>
                 <group>
-                    <field name="forward_to_user_id" attrs="{'invisible': [('forward_type', '!=', 'user')], 'required': [('forward_type', '=', 'user')]}"/>
-                    <field name="forward_to_department_id" attrs="{'invisible': [('forward_type', '!=', 'department')], 'required': [('forward_type', '=', 'department')]}"/>
+                    <field name="user_ids" widget="many2many_tags" attrs="{'invisible': [('recipient_type', '!=', 'user')], 'required': [('recipient_type', '=', 'user')]}" options="{'no_create': True}"/>
+                    <field name="department_id" attrs="{'invisible': [('recipient_type', '!=', 'department')], 'required': [('recipient_type', '=', 'department')]}" options="{'no_create': True}"/>
+                    <field name="role_id" attrs="{'invisible': [('recipient_type', '!=', 'role')], 'required': [('recipient_type', '=', 'role')]}" options="{'no_create': True}"/>
                 </group>
                 <group>
                     <field name="comment" placeholder="Optional comment..."/>
                 </group>
                 <footer>
-                    <button name="action_forward" string="Forward" type="object" class="btn-primary"/>
+                    <button name="action_forward_cc" string="Forward" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <!-- Delegate Action Wizard Form -->
+    <record id="sarabun_delegate_wizard_view_form" model="ir.ui.view">
+        <field name="name">sarabun.delegate.wizard.form</field>
+        <field name="model">sarabun.delegate.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Delegate Action">
+                <group>
+                    <field name="recipient_id" invisible="1"/>
+                    <field name="delegate_to_user_id" options="{'no_create': True}"/>
+                </group>
+                <group>
+                    <field name="comment" placeholder="Optional comment..."/>
+                </group>
+                <footer>
+                    <button name="action_delegate" string="Delegate" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <!-- Dispatch Wizard Form -->
+    <record id="sarabun_dispatch_wizard_view_form" model="ir.ui.view">
+        <field name="name">sarabun.dispatch.wizard.form</field>
+        <field name="model">sarabun.dispatch.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Dispatch Document">
+                <group>
+                    <field name="recipient_id" invisible="1"/>
+                    <field name="dispatch_to_user_id" options="{'no_create': True}"/>
+                </group>
+                <group>
+                    <field name="note" placeholder="Optional dispatch note..."/>
+                </group>
+                <footer>
+                    <button name="action_dispatch" string="Dispatch" type="object" class="btn-primary"/>
                     <button string="Cancel" class="btn-secondary" special="cancel"/>
                 </footer>
             </form>


### PR DESCRIPTION
## Summary

- **Forward CC**: sender/recipients can forward documents as read-only CC to users, departments, or roles with chain forwarding
- **Delegation**: unlimited re-delegation where both delegator and delegate can action (first wins), with full chain notification
- **Programmable step hooks**: `on_complete_method` callback on routing steps for consuming modules to hook into specific workflow stages
- **Template customization**: `required` flag on template steps preventing user deletion while allowing reorder/add
- **Central correspondence office (สารบรรณกลาง)**: per-department dispatch model where clerks intercept all incoming documents before forwarding to actual recipients
- **Rejection + resubmit**: new `rejected` state with sender able to edit and resubmit (full routing reset)
- **Email notifications**: per-user preference (default on) with 7 mail templates for all document events

## Test plan

- [ ] Send document, forward CC to user B → B sees in inbox but has NO action buttons, routing progress excludes CC
- [ ] Send to A, A delegates to B → both can action, whoever acts first resolves the chain with notification
- [ ] Create route template with `on_complete_method="_on_sarabun_step_test"` → verify callback fires on step completion, error rolls back
- [ ] Create template with required steps → user cannot delete required steps from routing
- [ ] Enable central correspondence on department → all documents intercepted by clerks, dispatch to actual recipient
- [ ] Reject document at step 2 → state=rejected, sender edits and resubmits → routing restarts from step 1
- [ ] Toggle email notification preference → verify emails sent/not sent accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)