### PR TITLE
[16.0][IMP] budget_appropriation: sort activity tiers 1-2 by priority code

### DIFF
--- a/budget_appropriation/utils/tree_builder.py
+++ b/budget_appropriation/utils/tree_builder.py
@@ -183,8 +183,16 @@ class TreeNode:
 
         # Add children if requested
         if include_children and self.children:
-            # Sort children by code (simple alphabetical for non-root levels)
-            sorted_children = sorted(self.children, key=lambda c: c.code)
+            if self.node_type == 'activity' and self.level == 1:
+                # Second tier activity: priority sort (09, 06 first)
+                priority_codes = ['09', '06']
+                sorted_children = sorted(self.children, key=lambda c: (
+                    (priority_codes.index(c.code[:2]), c.code)
+                    if len(c.code) >= 2 and c.code[:2] in priority_codes
+                    else (len(priority_codes), c.code)
+                ))
+            else:
+                sorted_children = sorted(self.children, key=lambda c: c.code)
             data['children'] = [
                 child.to_dict(include_children=True)
                 for child in sorted_children
@@ -547,7 +555,15 @@ class BudgetTreeExporter:
                 'note': node.metadata.get('note', ''),
             })
 
-            sorted_children = sorted(node.children, key=lambda c: c.code)
+            if node.node_type == 'activity' and node.level == 1:
+                priority_codes = ['09', '06']
+                sorted_children = sorted(node.children, key=lambda c: (
+                    (priority_codes.index(c.code[:2]), c.code)
+                    if len(c.code) >= 2 and c.code[:2] in priority_codes
+                    else (len(priority_codes), c.code)
+                ))
+            else:
+                sorted_children = sorted(node.children, key=lambda c: c.code)
             for child in sorted_children:
                 if node.node_type == 'account':
                     traverse(child, indent + 1)


### PR DESCRIPTION
## Summary
- Apply priority sorting (09 first, 06 second, then others by code) to the **second tier** of activity dimensions in F5 report, matching the existing first-tier behavior
- Affects both hierarchical (`to_dict`) and flat (`to_flat_list`) export paths in `tree_builder.py`
- Tiers 3+ continue to sort by code normally

## Test plan
- [x] Print F5 report for an appropriation with both 09-prefixed and 06-prefixed activities
- [x] Verify tier 1: 09 appears before 06
- [x] Verify tier 2: 09xxx codes appear before 06xxx codes
- [x] Verify tier 3+: sorted by code normally