### PR TITLE
[16.0][IMP] budget_appropriation_summary: add department domain filter to compilation

### DIFF
--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -117,6 +117,9 @@
                                     '|',
                                         ('source_analytic_id', '=', source_analytic_id),
                                         ('source_analytic_id', '=', False),
+                                    '|',
+                                        ('department_analytic_id', '=', department_analytic_id),
+                                        ('department_analytic_id.parent_id', '=', department_analytic_id),
                                 ]"
                                 attrs="{'readonly': ['|', '|', ('account_fiscal_year_id', '=', False), ('source_analytic_id', '=', False), ('department_analytic_id', '=', False)]}"
                                 context="{'can_edit': False}"
@@ -142,6 +145,9 @@
                                     '|',
                                         ('source_analytic_id', '=', source_analytic_id),
                                         ('source_analytic_id', '=', False),
+                                    '|',
+                                        ('department_analytic_id', '=', department_analytic_id),
+                                        ('department_analytic_id.parent_id', '=', department_analytic_id),
                                 ]"
                                 attrs="{'readonly': ['|', '|', ('account_fiscal_year_id', '=', False), ('source_analytic_id', '=', False), ('department_analytic_id', '=', False)]}"
                             >


### PR DESCRIPTION
## Summary
- Add department domain filter on revenue and expense appropriation many2many fields in the compilation form view
- When adding appropriations to a compilation, only appropriations whose `department_analytic_id` matches the compilation's department or whose department is a direct child of the compilation's department are now visible
- Applies to both revenue (`revenue_appropriation_ids`) and expense (`expense_appropriation_ids`) tabs