### PR TITLE
[16.0][IMP] budget_appropriation: add delete confirmation for lines

### DIFF
--- a/budget_appropriation/static/src/components/budget_appropriation_line/budget_appropriation_line.esm.js
+++ b/budget_appropriation/static/src/components/budget_appropriation_line/budget_appropriation_line.esm.js
@@ -2,11 +2,29 @@
 
 import {ListRenderer} from "@web/views/list/list_renderer";
 import {X2ManyField} from "@web/views/fields/x2many/x2many_field";
+import {ConfirmationDialog} from "@web/core/confirmation_dialog/confirmation_dialog";
+import {useService} from "@web/core/utils/hooks";
 import {registry} from "@web/core/registry";
 
 export class BudgetAppropriationLineRenderer extends ListRenderer {
     setup() {
         super.setup();
+        this.dialog = useService("dialog");
+    }
+
+    onDeleteRecord(record) {
+        const accountName = record.data.account_id
+            ? record.data.account_id[1]
+            : "";
+        const balance = record.data.balance || 0;
+        const balanceFormatted = balance.toLocaleString("th-TH", {
+            minimumFractionDigits: 2,
+        });
+        this.dialog.add(ConfirmationDialog, {
+            title: "ยืนยันการลบรายการ",
+            body: `คุณต้องการลบรายการ "${accountName}" จำนวนเงิน ${balanceFormatted} บาท ใช่หรือไม่?`,
+            confirm: () => super.onDeleteRecord(record),
+        });
     }
 }
 BudgetAppropriationLineRenderer.template =

--- a/budget_appropriation/static/src/components/budget_appropriation_line/budget_appropriation_line.esm.js
+++ b/budget_appropriation/static/src/components/budget_appropriation_line/budget_appropriation_line.esm.js
@@ -24,6 +24,8 @@ export class BudgetAppropriationLineRenderer extends ListRenderer {
             title: "ยืนยันการลบรายการ",
             body: `คุณต้องการลบรายการ "${accountName}" จำนวนเงิน ${balanceFormatted} บาท ใช่หรือไม่?`,
             confirm: () => super.onDeleteRecord(record),
+            cancel: () => {},
+            cancelLabel: "ยกเลิก",
         });
     }
 }


### PR DESCRIPTION
## Summary
- Add a confirmation dialog when deleting `budget.appropriation.line` rows from the appropriation form
- Displays the budget account name and amount in the dialog so users can verify which line they are about to delete
- Prevents accidental data loss on large appropriation documents where mis-clicks are hard to track

## Test plan
- [ ] Open a `budget.appropriation` form with multiple lines
- [ ] Click the trash icon on a line → confirmation dialog should appear with account name and amount
- [ ] Click Cancel → line should NOT be deleted
- [ ] Click Ok → line should be deleted as normal
- [ ] Verify the same behavior works on deduct lines (revenue budget type)