### PR TITLE
[16.0][IMP] account_analytic_kmitl: add cross-dimension relations

### DIFF
--- a/account_analytic_kmitl/__manifest__.py
+++ b/account_analytic_kmitl/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Account Analytic",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.1.0",
     "summary": """ KMITL Account Analytic""",
     "category": "KMITL/Accounting",
     "author": "Aginix Technologies",
@@ -13,6 +13,7 @@
     "data": [
         "data/account.analytic.plan.xml",
         "data/account.analytic.account.xml",
+        "views/account_analytic_account_views.xml",
     ],
     "auto_install": False,
     "license": "AGPL-3",

--- a/account_analytic_kmitl/models/__init__.py
+++ b/account_analytic_kmitl/models/__init__.py
@@ -1,1 +1,2 @@
+from . import account_analytic_account
 from . import analytic_mixin

--- a/account_analytic_kmitl/models/account_analytic_account.py
+++ b/account_analytic_kmitl/models/account_analytic_account.py
@@ -18,3 +18,17 @@ class AccountAnalyticAccount(models.Model):
             )
         ],
     )
+    fund_analytic_ids = fields.Many2many(
+        comodel_name="account.analytic.account",
+        relation="account_analytic_fund_rel",
+        column1="src_id",
+        column2="fund_id",
+        string="Funds",
+        domain=lambda self: [
+            (
+                "plan_id",
+                "=",
+                self.env.ref("account_analytic_kmitl.analytic_plan_funds").id,
+            )
+        ],
+    )

--- a/account_analytic_kmitl/models/account_analytic_account.py
+++ b/account_analytic_kmitl/models/account_analytic_account.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = "account.analytic.account"
+
+    related_analytic_ids = fields.Many2many(
+        comodel_name="account.analytic.account",
+        relation="account_analytic_related_rel",
+        column1="src_id",
+        column2="dest_id",
+        string="Related Analytic Accounts",
+    )

--- a/account_analytic_kmitl/models/account_analytic_account.py
+++ b/account_analytic_kmitl/models/account_analytic_account.py
@@ -4,10 +4,11 @@ from odoo import fields, models
 class AccountAnalyticAccount(models.Model):
     _inherit = "account.analytic.account"
 
-    related_analytic_ids = fields.Many2many(
+    department_analytic_ids = fields.Many2many(
         comodel_name="account.analytic.account",
-        relation="account_analytic_related_rel",
+        relation="account_analytic_department_rel",
         column1="src_id",
-        column2="dest_id",
-        string="Related Analytic Accounts",
+        column2="department_id",
+        string="Departments",
+        domain="[('plan_id', '=', %(account_analytic_kmitl.analytic_plan_departments)d)]",
     )

--- a/account_analytic_kmitl/models/account_analytic_account.py
+++ b/account_analytic_kmitl/models/account_analytic_account.py
@@ -10,5 +10,11 @@ class AccountAnalyticAccount(models.Model):
         column1="src_id",
         column2="department_id",
         string="Departments",
-        domain="[('plan_id', '=', %(account_analytic_kmitl.analytic_plan_departments)d)]",
+        domain=lambda self: [
+            (
+                "plan_id",
+                "=",
+                self.env.ref("account_analytic_kmitl.analytic_plan_departments").id,
+            )
+        ],
     )

--- a/account_analytic_kmitl/views/account_analytic_account_views.xml
+++ b/account_analytic_kmitl/views/account_analytic_account_views.xml
@@ -7,12 +7,20 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
-                <group string="Departments">
+                <group string="Related Analytic Accounts">
                     <field
                         name="department_analytic_ids"
                         widget="many2many_tags"
                         nolabel="1"
                         colspan="2"
+                        attrs="{'invisible': [('plan_id', '=', %(account_analytic_kmitl.analytic_plan_departments)d)]}"
+                    />
+                    <field
+                        name="fund_analytic_ids"
+                        widget="many2many_tags"
+                        nolabel="1"
+                        colspan="2"
+                        attrs="{'invisible': [('plan_id', '=', %(account_analytic_kmitl.analytic_plan_funds)d)]}"
                     />
                 </group>
             </xpath>

--- a/account_analytic_kmitl/views/account_analytic_account_views.xml
+++ b/account_analytic_kmitl/views/account_analytic_account_views.xml
@@ -7,9 +7,9 @@
         <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
-                <group string="Related Analytic Accounts">
+                <group string="Departments">
                     <field
-                        name="related_analytic_ids"
+                        name="department_analytic_ids"
                         widget="many2many_tags"
                         nolabel="1"
                     />

--- a/account_analytic_kmitl/views/account_analytic_account_views.xml
+++ b/account_analytic_kmitl/views/account_analytic_account_views.xml
@@ -11,15 +11,11 @@
                     <field
                         name="department_analytic_ids"
                         widget="many2many_tags"
-                        nolabel="1"
-                        colspan="2"
                         attrs="{'invisible': [('plan_id', '=', %(account_analytic_kmitl.analytic_plan_departments)d)]}"
                     />
                     <field
                         name="fund_analytic_ids"
                         widget="many2many_tags"
-                        nolabel="1"
-                        colspan="2"
                         attrs="{'invisible': [('plan_id', '=', %(account_analytic_kmitl.analytic_plan_funds)d)]}"
                     />
                 </group>

--- a/account_analytic_kmitl/views/account_analytic_account_views.xml
+++ b/account_analytic_kmitl/views/account_analytic_account_views.xml
@@ -12,6 +12,7 @@
                         name="department_analytic_ids"
                         widget="many2many_tags"
                         nolabel="1"
+                        colspan="2"
                     />
                 </group>
             </xpath>

--- a/account_analytic_kmitl/views/account_analytic_account_views.xml
+++ b/account_analytic_kmitl/views/account_analytic_account_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_analytic_account_form" model="ir.ui.view">
+        <field name="name">account.analytic.account.form.inherit.kmitl</field>
+        <field name="model">account.analytic.account</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="inside">
+                <group string="Related Analytic Accounts">
+                    <field
+                        name="related_analytic_ids"
+                        widget="many2many_tags"
+                        nolabel="1"
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/budget_appropriation/__manifest__.py
+++ b/budget_appropriation/__manifest__.py
@@ -8,7 +8,6 @@
     "depends": [
         "budget",
         "account_analytic_kmitl",
-        "account_analytic_public",
         "mail",
         "hr",
         "portal",

--- a/budget_appropriation/models/budget_appropriation_line.py
+++ b/budget_appropriation/models/budget_appropriation_line.py
@@ -121,7 +121,9 @@ class BudgetAppropriationLine(models.Model):
     activity_analytic_id = fields.Many2one(
         "account.analytic.account",
         string="กิจกรรม",
-        domain=[("root_plan_id.code", "=", "activities")],
+        domain="[('root_plan_id.code', '=', 'activities'),"
+        " '|', ('department_analytic_ids', '=', False),"
+        " ('department_analytic_ids', 'in', [department_analytic_id])]",
         tracking=True,
         auto_join=True,
     )

--- a/budget_appropriation/models/budget_appropriation_line.py
+++ b/budget_appropriation/models/budget_appropriation_line.py
@@ -101,7 +101,7 @@ class BudgetAppropriationLine(models.Model):
     )
 
     deduct_analytic_id = fields.Many2one(
-        "account.analytic.account.public",
+        "account.analytic.account",
         compute="_compute_account_id",
         string="หักให้หน่วยงาน",
         compute_sudo=True,

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -204,7 +204,7 @@
                         <field name="activity_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" required="1" />
                         <field name="fund_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' required="1" />
                         <field name="account_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" required="1" />
-                        <field name="deduct_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" attrs="{'invisible': [('deduct', '!=', True)]}" />
+                        <field name="deduct_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" attrs="{'invisible': [('deduct', '!=', True)], 'required': [('deduct', '=', True)]}" />
                         <field name="balance" required="1" />
                     </group>
                     <notebook>

--- a/web_widget_helper_text/static/src/components/helper_text/helper_text.js
+++ b/web_widget_helper_text/static/src/components/helper_text/helper_text.js
@@ -21,6 +21,7 @@ HelperText.supportedTypes = ["many2one"];
 HelperText.props = {
     ...Many2OneField.props,
     helperText: {type: String, optional: true},
+    "*": true,
 };
 
 HelperText.extractProps = ({attrs, field}) => {


### PR DESCRIPTION
## Summary
- Add `related_analytic_ids` Many2many self-referential field on `account.analytic.account` to support cross-dimension relationships (e.g. activity → department)
- Decouple `budget_appropriation` from `account_analytic_public` by changing `deduct_analytic_id` to point to `account.analytic.account` directly
- `account_analytic_public` is now deprecated — to be uninstalled and removed in a future release

## Release Notes
- Uninstall `account_analytic_public` module (deprecated)
- Later: uninstall `analytic_operating_unit`, `analytic_operating_unit_access_all`, `analytic_operating_unit_tree`
- Update `account_analytic_kmitl` and `budget_appropriation`