### PR TITLE
[16.0][ADD] kmitl_demo: เพิ่ม master data end-to-end purchase request ถึง purchase order

### DIFF
--- a/kmitl_demo/__manifest__.py
+++ b/kmitl_demo/__manifest__.py
@@ -23,6 +23,8 @@
         "purchase_request_budget",
         "purchase_request_price_tax_included",
         "purchase_request_approval_kmitl",
+        "purchase_request_approval",
+        "purchase_request_sarabun",
         "operating_unit_kmitl",
         "analytic_operating_unit",
         "account_analytic_kmitl",

--- a/kmitl_demo/hooks.py
+++ b/kmitl_demo/hooks.py
@@ -45,15 +45,151 @@ def uninstall_hook(cr, registry):
 
 # === End-to-end purchase demo data ===
 
+# 10 test cases covering all payment types, procurement types, methods, EGP/non-EGP
+E2E_CASES = [
+    # Group A: fund_0200 + source_2 + activity_06
+    {
+        "title": "[E2E] ซื้อวัสดุสำนักงาน (จ่ายตรง)",
+        "description": "จัดซื้อวัสดุสำนักงาน เฉพาะเจาะจง จ่ายตรง",
+        "price_unit": 45_000,
+        "payment_type": "direct",
+        "proc_type": "purchase_request_kmitl.procurement_type_004",
+        "proc_method": "purchase_request_kmitl.procurement_specific",
+        "vendor": "kmitl_demo.vendor_demo_004",
+        "fund": "account_analytic_kmitl.fund_0200",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_06",
+    },
+    {
+        "title": "[E2E] เช่าเครื่องถ่ายเอกสาร (ยืมเงิน)",
+        "description": "เช่าเครื่องถ่ายเอกสาร เฉพาะเจาะจง ยืมเงิน",
+        "price_unit": 72_000,
+        "payment_type": "loan",
+        "proc_type": "purchase_request_kmitl.procurement_type_005",
+        "proc_method": "purchase_request_kmitl.procurement_specific",
+        "vendor": "kmitl_demo.vendor_demo_005",
+        "fund": "account_analytic_kmitl.fund_0200",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_06",
+    },
+    {
+        "title": "[E2E] จ้างปรับปรุงห้องปฏิบัติการ (EGP, E-bidding)",
+        "description": "จ้างก่อสร้างปรับปรุงห้องปฏิบัติการ E-bidding EGP",
+        "price_unit": 2_500_000,
+        "payment_type": "loan",
+        "proc_type": "purchase_request_kmitl.procurement_type_006",
+        "proc_method": "purchase_request_kmitl.procurement_bidding",
+        "vendor": "kmitl_demo.vendor_demo_006",
+        "fund": "account_analytic_kmitl.fund_0200",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_06",
+    },
+    # Group B: fund_0100 + source_1 + activity_09
+    {
+        "title": "[E2E] ซื้อครุภัณฑ์คอมพิวเตอร์ (งบแผ่นดิน, คัดเลือก)",
+        "description": "จัดซื้อครุภัณฑ์คอมพิวเตอร์ งบแผ่นดิน คัดเลือก EGP",
+        "price_unit": 800_000,
+        "payment_type": "direct",
+        "proc_type": "purchase_request_kmitl.procurement_type_004",
+        "proc_method": "purchase_request_kmitl.procurement_select",
+        "vendor": "kmitl_demo.vendor_demo_002",
+        "fund": "account_analytic_kmitl.fund_0100",
+        "source": "account_analytic_kmitl.source_1",
+        "activity": "account_analytic_kmitl.activity_09",
+    },
+    {
+        "title": "[E2E] จ้างเหมาบริการทำความสะอาด (งบแผ่นดิน)",
+        "description": "จ้างทำของ/จ้างเหมาบริการ งบแผ่นดิน เฉพาะเจาะจง ใกล้ EGP",
+        "price_unit": 95_000,
+        "payment_type": "direct",
+        "proc_type": "purchase_request_kmitl.procurement_type_007",
+        "proc_method": "purchase_request_kmitl.procurement_specific",
+        "vendor": "kmitl_demo.vendor_demo_015",
+        "fund": "account_analytic_kmitl.fund_0100",
+        "source": "account_analytic_kmitl.source_1",
+        "activity": "account_analytic_kmitl.activity_09",
+    },
+    {
+        "title": "[E2E] ซื้อเครื่องมือวิทยาศาสตร์ (งบแผ่นดิน, ประกาศทั่วไป)",
+        "description": "จัดซื้อเครื่องมือวิทยาศาสตร์ งบแผ่นดิน ประกาศเชิญชวนทั่วไป EGP",
+        "price_unit": 3_200_000,
+        "payment_type": "loan",
+        "proc_type": "purchase_request_kmitl.procurement_type_004",
+        "proc_method": "purchase_request_kmitl.procurement_general",
+        "vendor": "kmitl_demo.vendor_demo_008",
+        "fund": "account_analytic_kmitl.fund_0100",
+        "source": "account_analytic_kmitl.source_1",
+        "activity": "account_analytic_kmitl.activity_09",
+    },
+    # Group C: fund_0300 + source_2 + activity_00
+    {
+        "title": "[E2E] จ้างที่ปรึกษาวิจัย (กองทุนวิจัย, จ่ายล่วงหน้า)",
+        "description": "จ้างทำของ/จ้างเหมาบริการที่ปรึกษาวิจัย กองทุนวิจัย จ่ายล่วงหน้า",
+        "price_unit": 85_000,
+        "payment_type": "prepaid",
+        "proc_type": "purchase_request_kmitl.procurement_type_007",
+        "proc_method": "purchase_request_kmitl.procurement_specific",
+        "vendor": "kmitl_demo.vendor_demo_013",
+        "fund": "account_analytic_kmitl.fund_0300",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_00",
+    },
+    {
+        "title": "[E2E] ซื้ออุปกรณ์ห้องปฏิบัติการ (กองทุนวิจัย, EGP)",
+        "description": "จัดซื้ออุปกรณ์ห้องปฏิบัติการ กองทุนวิจัย EGP จ่ายล่วงหน้า",
+        "price_unit": 450_000,
+        "payment_type": "prepaid",
+        "proc_type": "purchase_request_kmitl.procurement_type_004",
+        "proc_method": "purchase_request_kmitl.procurement_specific",
+        "vendor": "kmitl_demo.vendor_demo_009",
+        "fund": "account_analytic_kmitl.fund_0300",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_00",
+    },
+    # Group D: fund_0400 + source_2 + activity_06
+    {
+        "title": "[E2E] เช่าเครื่องมือวัด (กองทุนบริการวิชาการ)",
+        "description": "เช่าเครื่องมือวัด กองทุนบริการวิชาการ ยืมเงิน",
+        "price_unit": 65_000,
+        "payment_type": "loan",
+        "proc_type": "purchase_request_kmitl.procurement_type_005",
+        "proc_method": "purchase_request_kmitl.procurement_specific",
+        "vendor": "kmitl_demo.vendor_demo_017",
+        "fund": "account_analytic_kmitl.fund_0400",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_06",
+    },
+    {
+        "title": "[E2E] จ้างก่อสร้างห้องเรียนอัจฉริยะ (EGP, E-bidding)",
+        "description": "จ้างก่อสร้างห้องเรียนอัจฉริยะ กองทุนบริการวิชาการ E-bidding EGP",
+        "price_unit": 5_000_000,
+        "payment_type": "direct",
+        "proc_type": "purchase_request_kmitl.procurement_type_006",
+        "proc_method": "purchase_request_kmitl.procurement_bidding",
+        "vendor": "kmitl_demo.vendor_demo_007",
+        "fund": "account_analytic_kmitl.fund_0400",
+        "source": "account_analytic_kmitl.source_2",
+        "activity": "account_analytic_kmitl.activity_06",
+    },
+]
+
+# Budget appropriation groups: (activity, fund, source, amount)
+BUDGET_GROUPS = [
+    ("account_analytic_kmitl.activity_06", "account_analytic_kmitl.fund_0200",
+     "account_analytic_kmitl.source_2", 3_000_000),
+    ("account_analytic_kmitl.activity_09", "account_analytic_kmitl.fund_0100",
+     "account_analytic_kmitl.source_1", 5_000_000),
+    ("account_analytic_kmitl.activity_00", "account_analytic_kmitl.fund_0300",
+     "account_analytic_kmitl.source_2", 1_000_000),
+    ("account_analytic_kmitl.activity_06", "account_analytic_kmitl.fund_0400",
+     "account_analytic_kmitl.source_2", 6_000_000),
+]
+
 
 def _create_budget_appropriation(
     env, budget_account, activity, dept, fund, source, fiscal_year, amount
 ):
     """Create and post a budget appropriation move."""
-    analytic_distribution = {
-        str(activity.id): 100,
-        str(fund.id): 100,
-    }
     move = env["budget.move"].create(
         {
             "move_type": "appropriation",
@@ -68,7 +204,10 @@ def _create_budget_appropriation(
                         "debit": amount,
                         "balance": amount,
                         "fund_analytic_id": fund.id,
-                        "analytic_distribution": analytic_distribution,
+                        "analytic_distribution": {
+                            str(activity.id): 100,
+                            str(fund.id): 100,
+                        },
                     }
                 )
             ],
@@ -101,12 +240,11 @@ def _process_sarabun_approve(env, origin_record, admin_user, department):
     # Send document
     doc.action_send()
 
-    # Approve as admin (must switch to admin user since post_init runs as SUPERUSER_ID)
-    admin_env = env(user=admin_user)
-    doc_as_admin = doc.with_env(admin_env)
+    # Approve as admin (switch user since post_init runs as SUPERUSER_ID)
+    doc_as_admin = doc.with_user(admin_user)
     recipient = doc_as_admin.recipient_ids.filtered(lambda r: r.state == "new")
-    role = admin_env.ref("agx_sarabun.role_system_admin")
-    recipient.action_do_approve(signed_as_role_id=role.id)
+    role = env.ref("agx_sarabun.role_system_admin")
+    recipient.with_user(admin_user).action_do_approve(signed_as_role_id=role.id)
 
     _logger.info(
         "Sarabun %s completed for %s,%s",
@@ -117,38 +255,30 @@ def _process_sarabun_approve(env, origin_record, admin_user, department):
     return doc
 
 
-def _create_pr_with_line(
-    env,
-    title,
-    description,
-    price_unit,
-    payment_type,
-    admin_user,
-    fiscal_year,
-    budget_account,
-    activity,
-    dept,
-    fund,
-    source,
-    vendor,
-    department,
-    procurement_type,
-    procurement_method,
-    employees,
-):
+def _create_pr_with_line(env, case, admin_user, fiscal_year, budget_account,
+                         dept, department, operating_unit, admin_employee,
+                         supervisor_employee):
     """Create a purchase request with line and committees."""
+    activity = env.ref(case["activity"])
+    fund = env.ref(case["fund"])
+    source = env.ref(case["source"])
+    vendor = env.ref(case["vendor"])
+    procurement_type = env.ref(case["proc_type"])
+    procurement_method = env.ref(case["proc_method"])
+
     pr = env["purchase.request"].create(
         {
-            "title": title,
-            "description": description,
+            "title": case["title"],
+            "description": case["description"],
             "account_fiscal_year_id": fiscal_year.id,
             "procurement_type_id": procurement_type.id,
             "procurement_method_id": procurement_method.id,
-            "payment_type": payment_type,
+            "payment_type": case["payment_type"],
             "requested_by": admin_user.id,
             "partner_id": vendor.id,
             "user_id": admin_user.id,
             "department_id": department.id,
+            "operating_unit_id": operating_unit.id,
             "budget_account_id": budget_account.id,
             "activity_analytic_id": activity.id,
             "department_analytic_id": dept.id,
@@ -157,7 +287,7 @@ def _create_pr_with_line(
         }
     )
 
-    # Create PR line (like _onchange_budget_account_id does)
+    # Create PR line
     product = budget_account.product_id
     env["purchase.request.line"].create(
         {
@@ -165,88 +295,82 @@ def _create_pr_with_line(
             "product_id": product.id,
             "name": product.display_name,
             "product_uom_id": product.uom_id.id,
-            "price_unit": price_unit,
+            "price_unit": case["price_unit"],
             "product_qty": 1.0,
         }
     )
 
-    # Add work acceptance committees
-    for i, (emp, role) in enumerate(
-        [
-            (employees[0], "chairman"),
-            (employees[1], "committee"),
-            (employees[2], "committee"),
-        ]
-    ):
-        env["procurement.committee"].create(
-            {
-                "request_id": pr.id,
-                "employee_id": emp.id,
-                "committee_type": "work_acceptance",
-                "approve_role": role,
-                "name": emp.name,
-                "phone": emp.work_phone or "",
-            }
-        )
+    # Work acceptance committee: admin as sole chairman
+    env["procurement.committee"].create(
+        {
+            "request_id": pr.id,
+            "employee_id": admin_employee.id,
+            "committee_type": "work_acceptance",
+            "approve_role": "chairman",
+            "name": admin_employee.name,
+            "phone": admin_employee.work_phone or "",
+        }
+    )
+
+    # Work supervisor: separate employee (constraint forbids same as work_acceptance)
+    env["procurement.committee"].create(
+        {
+            "request_id": pr.id,
+            "employee_id": supervisor_employee.id,
+            "committee_type": "work_supervisor",
+            "approve_role": "chairman",
+            "name": supervisor_employee.name,
+            "phone": supervisor_employee.work_phone or "",
+        }
+    )
 
     # Ignore exceptions and verify
     pr.action_ignore_exceptions()
     pr.button_to_verify()
 
-    _logger.info("PR %s created (title=%s, amount=%s)", pr.name, title, price_unit)
+    _logger.info(
+        "PR %s created (title=%s, amount=%s)",
+        pr.name, case["title"], case["price_unit"],
+    )
     return pr
 
 
 def _run_non_egp_flow(env, pr, admin_user, department):
     """Run non-EGP flow: PR → Sarabun → PA → Sarabun → PO."""
-    # Reserve budget → moves to to_approve
     pr.action_reserve_budget()
     _logger.info("PR %s budget reserved, state=%s", pr.name, pr.state)
 
-    # Sarabun approve → moves to approved
     _process_sarabun_approve(env, pr, admin_user, department)
     _logger.info("PR %s sarabun approved, state=%s", pr.name, pr.state)
 
-    # Create PA
     pr.button_create_approval()
     pa = pr.request_approval_ids[0]
     _logger.info("PA %s created, state=%s", pa.name, pa.state)
 
-    # Validate PA
     pa.button_validate()
     _logger.info("PA %s validated, state=%s", pa.name, pa.state)
 
-    # Sarabun approve PA → moves to approved
     _process_sarabun_approve(env, pa, admin_user, department)
     _logger.info("PA %s sarabun approved, state=%s", pa.name, pa.state)
 
-    # Create PO from approval
     pr.approval_make_purchase_order()
-    _logger.info(
-        "PR %s PO created, purchase_count=%s", pr.name, pr.purchase_count
-    )
+    _logger.info("PR %s PO created, purchase_count=%s", pr.name, pr.purchase_count)
 
 
 def _run_egp_flow(env, pr, admin_user, department):
     """Run EGP flow: PR → Sarabun → egp_in_progress → PO (no PA)."""
-    # Reserve budget → moves to to_approve
     pr.action_reserve_budget()
     _logger.info("PR %s budget reserved, state=%s", pr.name, pr.state)
 
-    # Sarabun approve → moves to approved, egp_status set to "waiting"
     _process_sarabun_approve(env, pr, admin_user, department)
     _logger.info(
         "PR %s sarabun approved, state=%s, egp_status=%s",
-        pr.name,
-        pr.state,
-        pr.egp_status,
+        pr.name, pr.state, pr.egp_status,
     )
 
-    # Move EGP to in_progress
     pr.action_egp_in_progress()
     _logger.info("PR %s egp_status=%s", pr.name, pr.egp_status)
 
-    # Create PO via wizard (same pattern as _create_purchase_order_from_approval)
     wizard = (
         env["purchase.request.line.make.purchase.order"]
         .with_context(
@@ -257,88 +381,59 @@ def _run_egp_flow(env, pr, admin_user, department):
         .create({"supplier_id": pr.partner_id.id})
     )
     wizard.make_purchase_order()
-    _logger.info(
-        "PR %s EGP PO created, purchase_count=%s", pr.name, pr.purchase_count
-    )
+    _logger.info("PR %s EGP PO created, purchase_count=%s", pr.name, pr.purchase_count)
 
 
 def _create_e2e_purchase_demo(env):
-    """Create 3 end-to-end PR → PO demo records."""
-    _logger.info("Creating end-to-end purchase demo data...")
+    """Create 10 end-to-end PR → PO demo records."""
+    _logger.info("Creating end-to-end purchase demo data (10 cases)...")
 
-    # Resolve references
+    # Resolve shared references
     admin = env.ref("base.user_admin")
     fiscal_year = env.ref("kmitl_demo.account_fiscal_year_y2569")
     budget_account = env.ref("budget.budget_account_5101020008")
-    activity = env.ref("account_analytic_kmitl.activity_06")
     dept = env.ref("account_analytic_kmitl.dept_01")
-    fund = env.ref("account_analytic_kmitl.fund_0200")
-    source = env.ref("account_analytic_kmitl.source_2")
-    vendor = env.ref("kmitl_demo.vendor_demo_014")
     department = env.ref("kmitl_demo.01")
-    procurement_type = env.ref("purchase_request_kmitl.procurement_type_006")
-    procurement_method = env.ref("purchase_request_kmitl.procurement_general")
-    employees = [
-        env.ref("kmitl_demo.employee_demo_005"),
-        env.ref("kmitl_demo.employee_demo_007"),
-        env.ref("kmitl_demo.employee_demo_008"),
-    ]
+    operating_unit = env.ref("operating_unit_kmitl.operating_unit_01")
 
-    # Shared PR creation kwargs
-    shared = dict(
-        admin_user=admin,
-        fiscal_year=fiscal_year,
-        budget_account=budget_account,
-        activity=activity,
-        dept=dept,
-        fund=fund,
-        source=source,
-        vendor=vendor,
-        department=department,
-        procurement_type=procurement_type,
-        procurement_method=procurement_method,
-        employees=employees,
+    # Admin employee for work_acceptance committee
+    admin_employee = env["hr.employee"].search(
+        [("user_id", "=", admin.id)], limit=1
     )
+    # Separate employee for work_supervisor (constraint forbids same as work_acceptance)
+    supervisor_employee = env.ref("kmitl_demo.employee_demo_008")
 
-    # Step A: Create budget appropriation (20M to cover all cases)
-    _create_budget_appropriation(
-        env, budget_account, activity, dept, fund, source, fiscal_year, 20_000_000
-    )
+    # Create budget appropriations for each financial dimension group
+    for activity_ref, fund_ref, source_ref, amount in BUDGET_GROUPS:
+        _create_budget_appropriation(
+            env,
+            budget_account,
+            env.ref(activity_ref),
+            dept,
+            env.ref(fund_ref),
+            env.ref(source_ref),
+            fiscal_year,
+            amount,
+        )
 
-    # Step B: Case 1 — Non-EGP Direct Payment (50K)
-    _logger.info("=== Case 1: Non-EGP Direct 50K ===")
-    pr1 = _create_pr_with_line(
-        env,
-        title="[E2E] จัดซื้อวัสดุสำนักงาน",
-        description="จัดซื้อวัสดุสำนักงานสำหรับทดสอบระบบ (direct payment)",
-        price_unit=50000,
-        payment_type="direct",
-        **shared,
-    )
-    _run_non_egp_flow(env, pr1, admin, department)
+    # Process each case
+    for i, case in enumerate(E2E_CASES, 1):
+        _logger.info("=== Case %d: %s ===", i, case["title"])
+        pr = _create_pr_with_line(
+            env, case,
+            admin_user=admin,
+            fiscal_year=fiscal_year,
+            budget_account=budget_account,
+            dept=dept,
+            department=department,
+            operating_unit=operating_unit,
+            admin_employee=admin_employee,
+            supervisor_employee=supervisor_employee,
+        )
 
-    # Step C: Case 2 — Non-EGP Loan Payment (80K)
-    _logger.info("=== Case 2: Non-EGP Loan 80K ===")
-    pr2 = _create_pr_with_line(
-        env,
-        title="[E2E] จัดจ้างซ่อมแซมอุปกรณ์",
-        description="จัดจ้างซ่อมแซมอุปกรณ์สำหรับทดสอบระบบ (loan payment)",
-        price_unit=80000,
-        payment_type="loan",
-        **shared,
-    )
-    _run_non_egp_flow(env, pr2, admin, department)
+        if pr.is_egp:
+            _run_egp_flow(env, pr, admin, department)
+        else:
+            _run_non_egp_flow(env, pr, admin, department)
 
-    # Step D: Case 3 — EGP (5M)
-    _logger.info("=== Case 3: EGP 5M ===")
-    pr3 = _create_pr_with_line(
-        env,
-        title="[E2E] จัดซื้อครุภัณฑ์คอมพิวเตอร์",
-        description="จัดซื้อครุภัณฑ์คอมพิวเตอร์สำหรับทดสอบระบบ (EGP >100K)",
-        price_unit=5_000_000,
-        payment_type="loan",
-        **shared,
-    )
-    _run_egp_flow(env, pr3, admin, department)
-
-    _logger.info("End-to-end purchase demo data created successfully!")
+    _logger.info("End-to-end purchase demo data created successfully! (10 cases)")

--- a/kmitl_demo/hooks.py
+++ b/kmitl_demo/hooks.py
@@ -101,9 +101,11 @@ def _process_sarabun_approve(env, origin_record, admin_user, department):
     # Send document
     doc.action_send()
 
-    # Approve as admin
-    recipient = doc.recipient_ids.filtered(lambda r: r.state == "new")
-    role = env.ref("agx_sarabun.role_system_admin")
+    # Approve as admin (must switch to admin user since post_init runs as SUPERUSER_ID)
+    admin_env = env(user=admin_user)
+    doc_as_admin = doc.with_env(admin_env)
+    recipient = doc_as_admin.recipient_ids.filtered(lambda r: r.state == "new")
+    role = admin_env.ref("agx_sarabun.role_system_admin")
     recipient.action_do_approve(signed_as_role_id=role.id)
 
     _logger.info(

--- a/kmitl_demo/hooks.py
+++ b/kmitl_demo/hooks.py
@@ -97,8 +97,6 @@ def _process_sarabun_approve(env, origin_record, admin_user, department):
 
     # Set required fields
     doc.recipient = "ผู้บริหาร"
-    if not doc.sender_department_id:
-        doc.sender_department_id = department.id
 
     # Send document
     doc.action_send()

--- a/kmitl_demo/hooks.py
+++ b/kmitl_demo/hooks.py
@@ -1,9 +1,12 @@
+import logging
+
 from odoo import SUPERUSER_ID, api
 from odoo.fields import Command
 
+_logger = logging.getLogger(__name__)
+
 
 def post_init(cr, registry):
-    # This is a placeholder for the post-init method.
     env = api.Environment(cr, SUPERUSER_ID, {})
 
     # Install the Thai language pack
@@ -23,9 +26,11 @@ def post_init(cr, registry):
     users = env["res.users"].search([])
     users.lang = "th_TH"
 
+    # Create end-to-end purchase request → purchase order demo data
+    _create_e2e_purchase_demo(env)
+
 
 def uninstall_hook(cr, registry):
-    # This is a placeholder for the uninstall method.
     env = api.Environment(cr, SUPERUSER_ID, {})
 
     default_lang = env["ir.default"].browse([1])
@@ -36,3 +41,304 @@ def uninstall_hook(cr, registry):
 
     rl = env["res.lang"].search([("code", "=", "th_TH")])
     rl.active = False
+
+
+# === End-to-end purchase demo data ===
+
+
+def _create_budget_appropriation(
+    env, budget_account, activity, dept, fund, source, fiscal_year, amount
+):
+    """Create and post a budget appropriation move."""
+    analytic_distribution = {
+        str(activity.id): 100,
+        str(fund.id): 100,
+    }
+    move = env["budget.move"].create(
+        {
+            "move_type": "appropriation",
+            "budget_type": "expense",
+            "account_fiscal_year_id": fiscal_year.id,
+            "department_analytic_id": dept.id,
+            "source_analytic_id": source.id,
+            "line_ids": [
+                Command.create(
+                    {
+                        "account_id": budget_account.id,
+                        "debit": amount,
+                        "balance": amount,
+                        "fund_analytic_id": fund.id,
+                        "analytic_distribution": analytic_distribution,
+                    }
+                )
+            ],
+        }
+    )
+    move.action_post()
+    _logger.info("Budget appropriation %s posted (amount=%s)", move.name, amount)
+    return move
+
+
+def _process_sarabun_approve(env, origin_record, admin_user, department):
+    """Drive sarabun document from creation through approval."""
+    result = origin_record.action_submit_to_sarabun()
+    doc = env["sarabun.document"].browse(result.get("res_id"))
+
+    # Add routing line: admin as approver
+    env["sarabun.routing.line"].create(
+        {
+            "document_id": doc.id,
+            "sequence": 100,
+            "routing_type": "approve",
+            "recipient_type": "user",
+            "user_id": admin_user.id,
+        }
+    )
+
+    # Set required fields
+    doc.recipient = "ผู้บริหาร"
+    if not doc.sender_department_id:
+        doc.sender_department_id = department.id
+
+    # Send document
+    doc.action_send()
+
+    # Approve as admin
+    recipient = doc.recipient_ids.filtered(lambda r: r.state == "new")
+    role = env.ref("agx_sarabun.role_system_admin")
+    recipient.action_do_approve(signed_as_role_id=role.id)
+
+    _logger.info(
+        "Sarabun %s completed for %s,%s",
+        doc.name,
+        origin_record._name,
+        origin_record.id,
+    )
+    return doc
+
+
+def _create_pr_with_line(
+    env,
+    title,
+    description,
+    price_unit,
+    payment_type,
+    admin_user,
+    fiscal_year,
+    budget_account,
+    activity,
+    dept,
+    fund,
+    source,
+    vendor,
+    department,
+    procurement_type,
+    procurement_method,
+    employees,
+):
+    """Create a purchase request with line and committees."""
+    pr = env["purchase.request"].create(
+        {
+            "title": title,
+            "description": description,
+            "account_fiscal_year_id": fiscal_year.id,
+            "procurement_type_id": procurement_type.id,
+            "procurement_method_id": procurement_method.id,
+            "payment_type": payment_type,
+            "requested_by": admin_user.id,
+            "partner_id": vendor.id,
+            "user_id": admin_user.id,
+            "department_id": department.id,
+            "budget_account_id": budget_account.id,
+            "activity_analytic_id": activity.id,
+            "department_analytic_id": dept.id,
+            "fund_analytic_id": fund.id,
+            "source_analytic_id": source.id,
+        }
+    )
+
+    # Create PR line (like _onchange_budget_account_id does)
+    product = budget_account.product_id
+    env["purchase.request.line"].create(
+        {
+            "request_id": pr.id,
+            "product_id": product.id,
+            "name": product.display_name,
+            "product_uom_id": product.uom_id.id,
+            "price_unit": price_unit,
+            "product_qty": 1.0,
+        }
+    )
+
+    # Add work acceptance committees
+    for i, (emp, role) in enumerate(
+        [
+            (employees[0], "chairman"),
+            (employees[1], "committee"),
+            (employees[2], "committee"),
+        ]
+    ):
+        env["procurement.committee"].create(
+            {
+                "request_id": pr.id,
+                "employee_id": emp.id,
+                "committee_type": "work_acceptance",
+                "approve_role": role,
+                "name": emp.name,
+                "phone": emp.work_phone or "",
+            }
+        )
+
+    # Ignore exceptions and verify
+    pr.action_ignore_exceptions()
+    pr.button_to_verify()
+
+    _logger.info("PR %s created (title=%s, amount=%s)", pr.name, title, price_unit)
+    return pr
+
+
+def _run_non_egp_flow(env, pr, admin_user, department):
+    """Run non-EGP flow: PR → Sarabun → PA → Sarabun → PO."""
+    # Reserve budget → moves to to_approve
+    pr.action_reserve_budget()
+    _logger.info("PR %s budget reserved, state=%s", pr.name, pr.state)
+
+    # Sarabun approve → moves to approved
+    _process_sarabun_approve(env, pr, admin_user, department)
+    _logger.info("PR %s sarabun approved, state=%s", pr.name, pr.state)
+
+    # Create PA
+    pr.button_create_approval()
+    pa = pr.request_approval_ids[0]
+    _logger.info("PA %s created, state=%s", pa.name, pa.state)
+
+    # Validate PA
+    pa.button_validate()
+    _logger.info("PA %s validated, state=%s", pa.name, pa.state)
+
+    # Sarabun approve PA → moves to approved
+    _process_sarabun_approve(env, pa, admin_user, department)
+    _logger.info("PA %s sarabun approved, state=%s", pa.name, pa.state)
+
+    # Create PO from approval
+    pr.approval_make_purchase_order()
+    _logger.info(
+        "PR %s PO created, purchase_count=%s", pr.name, pr.purchase_count
+    )
+
+
+def _run_egp_flow(env, pr, admin_user, department):
+    """Run EGP flow: PR → Sarabun → egp_in_progress → PO (no PA)."""
+    # Reserve budget → moves to to_approve
+    pr.action_reserve_budget()
+    _logger.info("PR %s budget reserved, state=%s", pr.name, pr.state)
+
+    # Sarabun approve → moves to approved, egp_status set to "waiting"
+    _process_sarabun_approve(env, pr, admin_user, department)
+    _logger.info(
+        "PR %s sarabun approved, state=%s, egp_status=%s",
+        pr.name,
+        pr.state,
+        pr.egp_status,
+    )
+
+    # Move EGP to in_progress
+    pr.action_egp_in_progress()
+    _logger.info("PR %s egp_status=%s", pr.name, pr.egp_status)
+
+    # Create PO via wizard (same pattern as _create_purchase_order_from_approval)
+    wizard = (
+        env["purchase.request.line.make.purchase.order"]
+        .with_context(
+            active_model="purchase.request",
+            active_ids=pr.ids,
+            active_id=pr.id,
+        )
+        .create({"supplier_id": pr.partner_id.id})
+    )
+    wizard.make_purchase_order()
+    _logger.info(
+        "PR %s EGP PO created, purchase_count=%s", pr.name, pr.purchase_count
+    )
+
+
+def _create_e2e_purchase_demo(env):
+    """Create 3 end-to-end PR → PO demo records."""
+    _logger.info("Creating end-to-end purchase demo data...")
+
+    # Resolve references
+    admin = env.ref("base.user_admin")
+    fiscal_year = env.ref("kmitl_demo.account_fiscal_year_y2569")
+    budget_account = env.ref("budget.budget_account_5101020008")
+    activity = env.ref("account_analytic_kmitl.activity_06")
+    dept = env.ref("account_analytic_kmitl.dept_01")
+    fund = env.ref("account_analytic_kmitl.fund_0200")
+    source = env.ref("account_analytic_kmitl.source_2")
+    vendor = env.ref("kmitl_demo.vendor_demo_014")
+    department = env.ref("kmitl_demo.01")
+    procurement_type = env.ref("purchase_request_kmitl.procurement_type_006")
+    procurement_method = env.ref("purchase_request_kmitl.procurement_general")
+    employees = [
+        env.ref("kmitl_demo.employee_demo_005"),
+        env.ref("kmitl_demo.employee_demo_007"),
+        env.ref("kmitl_demo.employee_demo_008"),
+    ]
+
+    # Shared PR creation kwargs
+    shared = dict(
+        admin_user=admin,
+        fiscal_year=fiscal_year,
+        budget_account=budget_account,
+        activity=activity,
+        dept=dept,
+        fund=fund,
+        source=source,
+        vendor=vendor,
+        department=department,
+        procurement_type=procurement_type,
+        procurement_method=procurement_method,
+        employees=employees,
+    )
+
+    # Step A: Create budget appropriation (20M to cover all cases)
+    _create_budget_appropriation(
+        env, budget_account, activity, dept, fund, source, fiscal_year, 20_000_000
+    )
+
+    # Step B: Case 1 — Non-EGP Direct Payment (50K)
+    _logger.info("=== Case 1: Non-EGP Direct 50K ===")
+    pr1 = _create_pr_with_line(
+        env,
+        title="[E2E] จัดซื้อวัสดุสำนักงาน",
+        description="จัดซื้อวัสดุสำนักงานสำหรับทดสอบระบบ (direct payment)",
+        price_unit=50000,
+        payment_type="direct",
+        **shared,
+    )
+    _run_non_egp_flow(env, pr1, admin, department)
+
+    # Step C: Case 2 — Non-EGP Loan Payment (80K)
+    _logger.info("=== Case 2: Non-EGP Loan 80K ===")
+    pr2 = _create_pr_with_line(
+        env,
+        title="[E2E] จัดจ้างซ่อมแซมอุปกรณ์",
+        description="จัดจ้างซ่อมแซมอุปกรณ์สำหรับทดสอบระบบ (loan payment)",
+        price_unit=80000,
+        payment_type="loan",
+        **shared,
+    )
+    _run_non_egp_flow(env, pr2, admin, department)
+
+    # Step D: Case 3 — EGP (5M)
+    _logger.info("=== Case 3: EGP 5M ===")
+    pr3 = _create_pr_with_line(
+        env,
+        title="[E2E] จัดซื้อครุภัณฑ์คอมพิวเตอร์",
+        description="จัดซื้อครุภัณฑ์คอมพิวเตอร์สำหรับทดสอบระบบ (EGP >100K)",
+        price_unit=5_000_000,
+        payment_type="loan",
+        **shared,
+    )
+    _run_egp_flow(env, pr3, admin, department)
+
+    _logger.info("End-to-end purchase demo data created successfully!")

--- a/purchase_request_approval/models/purchase_request_approval.py
+++ b/purchase_request_approval/models/purchase_request_approval.py
@@ -286,6 +286,8 @@ class PurchaseRequestApproval(models.Model):
         self.ensure_one()
         vals = super()._prepare_sarabun_document_vals()
         vals["subject"] = self.title or self.name
+        if self.requesting_department_id:
+            vals["sender_department_id"] = self.requesting_department_id.id
         return vals
 
     def action_submit_to_sarabun(self):

--- a/purchase_request_sarabun/models/purchase_request.py
+++ b/purchase_request_sarabun/models/purchase_request.py
@@ -44,6 +44,8 @@ class PurchaseRequest(models.Model):
         self.ensure_one()
         vals = super()._prepare_sarabun_document_vals()
         vals["subject"] = self.title
+        if self.department_id:
+            vals["sender_department_id"] = self.department_id.id
         return vals
 
     def _on_sarabun_completed(self, document):


### PR DESCRIPTION
## สรุปการเปลี่ยนแปลง

เพิ่ม Python script ใน `kmitl_demo/hooks.py` (post_init hook) สำหรับสร้างข้อมูล master data ที่ทำงาน end-to-end ตั้งแต่ `purchase.request` จนถึง `purchase.order` โดยอัตโนมัติเมื่อติดตั้ง module

### ปัญหาที่แก้
- การทดสอบ flow จัดซื้อจัดจ้างต้องกรอกฟอร์มหลายขั้นตอนทุกครั้ง (PR → สารบรรณ → PA → สารบรรณ → PO) ซึ่งเสียเวลามากและเหนื่อย
- ข้อมูลทดสอบเดิม ไม่ครอบคลุม case ต่างๆ (payment type, procurement type/method, EGP, funds, sources)

---

## ขยายจาก 3 → 10 เคสทดสอบ

สร้างข้อมูล **10 เคส** ครอบคลุมทุก combination ของ:

### Payment Types (3 แบบ)
- `direct` — จ่ายตรง (4 เคส)
- `loan` — ยืมเงิน (4 เคส)
- `prepaid` — จ่ายล่วงหน้า (2 เคส)

### Procurement Types (4 แบบ)
- `004` — ซื้อ (4 เคส)
- `005` — เช่า (2 เคส)
- `006` — จ้างก่อสร้าง (2 เคส)
- `007` — จ้างทำของ/จ้างเหมาบริการ (2 เคส)

### Procurement Methods (4 แบบ)
- เฉพาะเจาะจง (6 เคส)
- E-bidding (2 เคส)
- คัดเลือก (1 เคส)
- ประกาศเชิญชวนทั่วไป (1 เคส)

### EGP Distribution
- Non-EGP (≤100K): 5 เคส
- EGP (>100K): 5 เคส

### Financial Dimensions
- **กองทุน**: fund_0200 (Education), fund_0100 (General), fund_0300 (Research), fund_0400 (Academic Service)
- **แหล่งเงิน**: source_1 (งบแผ่นดิน), source_2 (เงินรายได้)
- **ด้าน/กิจกรรม**: activity_06, activity_09, activity_00
- **ผู้ขาย**: 7 บริษัท (vendor_demo_002, 004-009) + 3 บุคคลธรรมชาติ (vendor_demo_013, 015, 017)

---

## 10 เคสโดยละเอียด

| # | ชื่อ | จำนวน | จ่าย | ประเภท | วิธี | EGP? | กองทุน |
|---|------|-------|------|--------|------|------|--------|
| 1 | ซื้อวัสดุสำนักงาน | 45K | direct | 004 | specific | No | 0200 |
| 2 | เช่าเครื่องถ่ายเอกสาร | 72K | loan | 005 | specific | No | 0200 |
| 3 | จ้างปรับปรุงห้องปฏิบัติการ | 2.5M | loan | 006 | bidding | Yes | 0200 |
| 4 | ซื้อครุภัณฑ์คอมพิวเตอร์ (งบแผ่นดิน) | 800K | direct | 004 | select | Yes | 0100 |
| 5 | จ้างเหมาบริการทำความสะอาด | 95K | direct | 007 | specific | No | 0100 |
| 6 | ซื้อเครื่องมือวิทยาศาสตร์ | 3.2M | loan | 004 | general | Yes | 0100 |
| 7 | จ้างที่ปรึกษาวิจัย | 85K | prepaid | 007 | specific | No | 0300 |
| 8 | ซื้ออุปกรณ์ห้องปฏิบัติการ | 450K | prepaid | 004 | specific | Yes | 0300 |
| 9 | เช่าเครื่องมือวัด (บริการวิชาการ) | 65K | loan | 005 | specific | No | 0400 |
| 10 | จ้างก่อสร้างห้องเรียนอัจฉริยะ | 5M | direct | 006 | bidding | Yes | 0400 |

---

## Bug Fixes ที่ทำ

### 1. SUPERUSER_ID Authorization Error
**ปัญหา**: `post_init` รันเป็น uid=1 (OdooBot) แต่ sarabun routing line มี user_id=admin(uid=2) → ล้มเหลวการ check `self.user_id == self.env.user`

**แก้ไข**: ใช้ `with_user(admin_user)` ก่อนเรียก `action_do_approve()`

### 2. Operating Unit
**ปัญหา**: ไม่ได้ set บน PR → ค่า default ไม่ถูกต้อง

**แก้ไข**: เพิ่ม `operating_unit_id = operating_unit_kmitl.operating_unit_01` (คณะวิศวกรรมศาสตร์) ลงใน PR create

### 3. Committee Structure
**ปัญหา**: ต้องการ admin เป็นกรรมการตรวจรับเพียงคนเดียว

**แก้ไข**: 
- Work Acceptance: admin เป็น chairman (1 คน)
- Work Supervisor: employee อื่น เป็น chairman (constraint ห้ามซ้ำ type)

### 4. Dependency Issues
**ปัญหา**: ขาด `purchase_request_approval` และ `purchase_request_sarabun` ใน manifest depends

**แก้ไข**: เพิ่มลงใน kmitl_demo __manifest__.py

### 5. sender_department_id NotNullViolation
**แก้ไข**: เพิ่ม `sender_department_id` ใน `_prepare_sarabun_document_vals` ของ PR และ PA

---

## Files Modified
- `kmitl_demo/hooks.py` — Rewrite `_create_e2e_purchase_demo()` with 10 cases + bug fixes
- `kmitl_demo/__manifest__.py` — Add `purchase_request_approval`, `purchase_request_sarabun` ✅
- `purchase_request_sarabun/models/purchase_request.py` — Add `sender_department_id` fix ✅
- `purchase_request_approval/models/purchase_request_approval.py` — Add `sender_department_id` fix ✅

---

## วิธีทดสอบ
1. ติดตั้ง/อัปเดต module `kmitl_demo`
2. ตรวจสอบ log → ข้อมูลการสร้างทั้ง 10 เคส
3. ค้นหา `purchase.request` ด้วยชื่อ `[E2E]` → พบ 10 records
4. ตรวจสอบ:
   - Non-EGP cases (1,2,5,7,9): มี `purchase.request.approval` ที่ state=approved
   - ทั้ง 10 เคส: มี `purchase.order` ที่ลิ้งค์มา
   - ทั้ง 10 เคส: มี `budget.commitment` + sarabun documents ที่ state=completed
   - Operating unit = คณะวิศวกรรมศาสตร์