### PR TITLE
[16.0][IMP] budget_appropriation_summary: add is_ma and is_investment flags

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -12,6 +12,7 @@
         "security/ir.model.access.csv",
         "views/budget_appropriation_compilation_views.xml",
         "views/budget_appropriation_line_views.xml",
+        "views/budget_appropriation_views.xml",
         "views/budget_appropriation_master_summary_views.xml",
         "views/menu.xml",
         "views/wizard_master_summary_done_views.xml",

--- a/budget_appropriation_summary/models/budget_appropriation.py
+++ b/budget_appropriation_summary/models/budget_appropriation.py
@@ -66,6 +66,32 @@ class BudgetAppropriation(models.Model):
         compute="_compute_totals",
     )
 
+    recurrent_line_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_flag_line_ids",
+        store=False,
+        readonly=True,
+    )
+    ma_line_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_flag_line_ids",
+        store=False,
+        readonly=True,
+    )
+    investment_line_ids = fields.One2many(
+        "budget.appropriation.line",
+        compute="_compute_flag_line_ids",
+        store=False,
+        readonly=True,
+    )
+
+    @api.depends("line_ids.is_recurrent", "line_ids.is_ma", "line_ids.is_investment")
+    def _compute_flag_line_ids(self):
+        for record in self:
+            record.recurrent_line_ids = record.line_ids.filtered("is_recurrent")
+            record.ma_line_ids = record.line_ids.filtered("is_ma")
+            record.investment_line_ids = record.line_ids.filtered("is_investment")
+
     # ชดใช้เงินคงคลัง
     TREASURY_REPLENISHMENT_CODES = ["0702000001", "5108000038"]
     DEDUCTED_RESERVE_CODES = ["0702000002", "0702000003"]

--- a/budget_appropriation_summary/models/budget_appropriation.py
+++ b/budget_appropriation_summary/models/budget_appropriation.py
@@ -70,24 +70,7 @@ class BudgetAppropriation(models.Model):
     TREASURY_REPLENISHMENT_CODES = ["0702000001", "5108000038"]
     DEDUCTED_RESERVE_CODES = ["0702000002", "0702000003"]
 
-    # งบลงทุน
-    CAPITAL_BUDGET_CODES = [
-        "5411000001",
-        "5411000002",
-        "5411000003",
-        "5411000009",
-        "5104030207",
-        "5104030208",
-        "5104030209",
-    ]
-
-    # ค่าดูแลและบำรุงรักษา
-    MAINTENANCE_CODES = ["5104010204", "5104010205", "5104010206"]
-
-    # งบประจำ
-    RECURRENT_BUDGET_CODES = ["5104010203"]
-
-    @api.depends("line_ids.code", "line_ids.balance")
+    @api.depends("line_ids.code", "line_ids.balance", "line_ids.is_recurrent", "line_ids.is_ma", "line_ids.is_investment")
     def _compute_totals(self):
         for record in self:
             line_ids = record.line_ids
@@ -102,14 +85,10 @@ class BudgetAppropriation(models.Model):
                 ).mapped("balance")
             )
             record.maintenance_amount = sum(
-                line_ids.filtered(
-                    lambda x: x.account_id.code in self.MAINTENANCE_CODES
-                ).mapped("balance")
+                line_ids.filtered(lambda x: x.is_ma).mapped("balance")
             )
             record.capital_budget_amount = sum(
-                line_ids.filtered(
-                    lambda x: x.account_id.code in self.CAPITAL_BUDGET_CODES
-                ).mapped("balance")
+                line_ids.filtered(lambda x: x.is_investment).mapped("balance")
             )
             record.recurrent_budget_amount = sum(
                 line_ids.filtered(lambda x: x.is_recurrent).mapped("balance")

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -318,15 +318,15 @@ class BudgetAppropriationCompilation(models.Model):
     social_mgt_percentage = fields.Float(compute="_compute_impact_totals", store=False)
 
     @api.depends(
-        "revenue_appropriation_ids.treasury_replenishment_amount",
-        "revenue_appropriation_ids.deducted_reserve_amount",
-        "revenue_appropriation_ids.maintenance_amount",
-        "revenue_appropriation_ids.capital_budget_amount",
-        "revenue_appropriation_ids.recurrent_budget_amount",
-        "revenue_appropriation_ids.external_funding_amount",
+        "expense_appropriation_ids.treasury_replenishment_amount",
+        "expense_appropriation_ids.deducted_reserve_amount",
+        "expense_appropriation_ids.maintenance_amount",
+        "expense_appropriation_ids.capital_budget_amount",
+        "expense_appropriation_ids.recurrent_budget_amount",
+        "expense_appropriation_ids.external_funding_amount",
+        "expense_appropriation_ids.code_0702000002",
+        "expense_appropriation_ids.code_0702000003",
         "revenue_appropriation_ids.amount_net",
-        "revenue_appropriation_ids.code_0702000002",
-        "revenue_appropriation_ids.code_0702000003",
     )
     def _compute_totals(self):
         for record in self:

--- a/budget_appropriation_summary/models/budget_appropriation_line.py
+++ b/budget_appropriation_summary/models/budget_appropriation_line.py
@@ -11,3 +11,5 @@ class BudgetAppropriationLine(models.Model):
     _inherit = 'budget.appropriation.line'
 
     is_recurrent = fields.Boolean("เป็นงบประจำ", default=False, help="หากติ๊กเลือก, ระบบจะดึงจำนวนเงินไปรวมเป็นงบประจำ")
+    is_ma = fields.Boolean("เป็นงบค่าดูแลและบำรุงรักษา", default=False, help="หากติ๊กเลือก, ระบบจะดึงจำนวนเงินไปรวมเป็นงบค่าดูแลและบำรุงรักษา")
+    is_investment = fields.Boolean("เป็นงบลงทุน", default=False, help="หากติ๊กเลือก, ระบบจะดึงจำนวนเงินไปรวมเป็นงบลงทุน")

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -183,8 +183,8 @@
                                     <field name="code_0702000002" />
                                     <field name="code_0702000003" />
                                     <field name="treasury_replenishment_amount" help="คำนวณจากรหัสงบประมาณ (0702000001, 5108000038)" />
-                                    <field name="maintenance_amount" help="คำนวณจากรหัสงบประมาณ (5104010204, 5104010205, 5104010206)" />
-                                    <field name="capital_budget_amount" help="คำนวณจากรหัสงบประมาณ (5411000001, 5411000002, 5411000003, 5411000009, 5104030207, 5104030208, 5104030209)" />
+                                    <field name="maintenance_amount" help="คำนวณจากรายการที่ติ๊กเลือก เป็นงบค่าดูแลและบำรุงรักษา" />
+                                    <field name="capital_budget_amount" help="คำนวณจากรายการที่ติ๊กเลือก เป็นงบลงทุน" />
                                     <field name="recurrent_budget_amount" />
                                     <field name="external_funding_amount" />
                                 </group>

--- a/budget_appropriation_summary/views/budget_appropriation_line_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_line_views.xml
@@ -9,6 +9,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='balance']" position="after">
                 <field name="is_recurrent" />
+                <field name="is_ma" />
+                <field name="is_investment" />
             </xpath>
         </field>
     </record>

--- a/budget_appropriation_summary/views/budget_appropriation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_views.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_budget_appropriation_form_summary" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.form.summary</field>
+        <field name="model">budget.appropriation</field>
+        <field name="inherit_id" ref="budget_appropriation.view_budget_appropriation_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='line_ids']" position="after">
+                <page name="recurrent_lines" string="งบประจำ"
+                      attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="recurrent_line_ids" readonly="1" nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="id" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="fund_analytic_id" string="กองทุน" />
+                            <field name="balance" string="จำนวนเงิน" sum="รวม" />
+                        </tree>
+                    </field>
+                </page>
+                <page name="ma_lines" string="งบค่าดูแลและบำรุงรักษา"
+                      attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="ma_line_ids" readonly="1" nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="id" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="fund_analytic_id" string="กองทุน" />
+                            <field name="balance" string="จำนวนเงิน" sum="รวม" />
+                        </tree>
+                    </field>
+                </page>
+                <page name="investment_lines" string="งบลงทุน"
+                      attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
+                    <field name="investment_line_ids" readonly="1" nolabel="1">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="id" />
+                            <field name="account_id" string="รหัสงบประมาณ" />
+                            <field name="activity_analytic_id" string="กิจกรรม" />
+                            <field name="fund_analytic_id" string="กองทุน" />
+                            <field name="balance" string="จำนวนเงิน" sum="รวม" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary
- Add `is_ma` and `is_investment` Boolean fields on `budget.appropriation.line` for manual classification of maintenance (MA) and investment budget lines, matching the existing `is_recurrent` pattern
- Replace hardcoded account code matching (`MAINTENANCE_CODES`, `CAPITAL_BUDGET_CODES`) with flag-based computation in `_compute_totals`
- Remove dead code constants (`RECURRENT_BUDGET_CODES`, `MAINTENANCE_CODES`, `CAPITAL_BUDGET_CODES`)
- Fix missing `@api.depends` triggers for `is_recurrent`, `is_ma`, `is_investment`
- Update stale help text in compilation views to reflect the new flag-based approach