### PR TITLE
[16.0][IMP] budget_appropriation: show line IDs on portal expense report

### DIFF
--- a/budget_appropriation/utils/tree_builder.py
+++ b/budget_appropriation/utils/tree_builder.py
@@ -553,6 +553,7 @@ class BudgetTreeExporter:
                 'line_count': node.metadata.get('line_count', 0),
                 'description': node.metadata.get('description', ''),
                 'note': node.metadata.get('note', ''),
+                'line_ids': node.metadata.get('line_ids', []),
             })
 
             if node.node_type == 'activity' and node.level == 1:

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -77,6 +77,7 @@
                             <group>
                                 <field nolabel="1" colspan="2" name="line_ids" style="max-width: 100%; display: block;" attrs="{'readonly': [('state', 'in', ['review', 'posted', 'cancel'])]}" widget="budget_appropriation_line">
                                     <tree limit="1000">
+                                        <field name="id" readonly="1" optional="show" />
                                         <field name="appropriation_id" invisible="1" />
                                         <field name="description" invisible="1" />
                                         <field name="budget_type" invisible="1" />
@@ -96,6 +97,7 @@
                                 <separator string="หัก" />
                                 <field nolabel="1" colspan="2" name="deduct_line_ids" style="max-width: 100%; display: block;" attrs="{'readonly': [('state', 'in', ['review', 'posted', 'cancel'])]}" widget="budget_appropriation_line" context="{'default_deduct': True}">
                                     <tree limit="1000">
+                                        <field name="id" readonly="1" optional="show" />
                                         <field name="appropriation_id" invisible="1" />
                                         <field name="description" invisible="1" />
                                         <field name="budget_type" invisible="1" />

--- a/budget_appropriation/views/templates.xml
+++ b/budget_appropriation/views/templates.xml
@@ -216,12 +216,20 @@
                                             <tr t-att-data-row-id="line['code'] or line['name']"
                                                 t-att-data-row-indent="line['indent']"
                                                 t-att-data-row-amount="line['amount_total']"
-                                                t-att-data-has-children="'1' if line.get('has_children') else '0'">
+                                                t-att-data-has-children="'1' if line.get('has_children') else '0'"
+                                                t-att-data-line-ids="','.join(str(i) for i in line.get('line_ids', []))">
                                                 <td>
                                                     <div t-attf-style="padding-left: #{16 * line['indent']}px;">
                                                         <span t-attf-class="{{'fw-bolder' if line['indent'] == 0 else ''}}">
                                                             <t t-out="line['name']" />
                                                         </span>
+                                                        <t t-if="line.get('line_ids')">
+                                                            <span class="budget-line-ids text-black-50 ms-1" style="font-size: 0.75em;">
+                                                                <t t-foreach="line['line_ids']" t-as="lid">
+                                                                    <span class="badge text-bg-light border me-1">#<t t-out="lid" /></span>
+                                                                </t>
+                                                            </span>
+                                                        </t>
 
                                                         <div t-if="line['note'] or line.get('description')" class="text-black-50 fs-6 budget-note-content" style="display:none; padding-left: 16px;">
                                                             <div t-if="line['note']" style="white-space: pre-wrap;" t-out="line['note']"></div>
@@ -269,6 +277,10 @@
                             return row.cells[0].querySelector('.budget-note-content');
                         }
 
+                        function getLineIdsContainer(row) {
+                            return row.cells[0].querySelector('.budget-line-ids');
+                        }
+
                         function applyMerge(tbody) {
                             // Reset: restore originals and show all rows
                             Array.from(tbody.rows).forEach(function (row) {
@@ -281,6 +293,11 @@
                                 if (nc &amp;&amp; nc.dataset.originalNotes !== undefined) {
                                     nc.innerHTML = nc.dataset.originalNotes;
                                     delete nc.dataset.originalNotes;
+                                }
+                                var lc = getLineIdsContainer(row);
+                                if (lc &amp;&amp; lc.dataset.originalIds !== undefined) {
+                                    lc.innerHTML = lc.dataset.originalIds;
+                                    delete lc.dataset.originalIds;
                                 }
                             });
 
@@ -329,6 +346,22 @@
                                         });
                                     }
 
+                                    // Aggregate line IDs from dupes
+                                    var lc = getLineIdsContainer(row);
+                                    if (lc) {
+                                        if (lc.dataset.originalIds === undefined) {
+                                            lc.dataset.originalIds = lc.innerHTML;
+                                        }
+                                        dupes.forEach(function (d) {
+                                            var dlc = getLineIdsContainer(d);
+                                            if (dlc) {
+                                                Array.from(dlc.children).forEach(function (child) {
+                                                    lc.appendChild(child.cloneNode(true));
+                                                });
+                                            }
+                                        });
+                                    }
+
                                     dupes.forEach(function (d) { d.style.display = 'none'; });
                                     i += dupes.length;
                                 }
@@ -346,6 +379,11 @@
                                 if (nc &amp;&amp; nc.dataset.originalNotes !== undefined) {
                                     nc.innerHTML = nc.dataset.originalNotes;
                                     delete nc.dataset.originalNotes;
+                                }
+                                var lc = getLineIdsContainer(row);
+                                if (lc &amp;&amp; lc.dataset.originalIds !== undefined) {
+                                    lc.innerHTML = lc.dataset.originalIds;
+                                    delete lc.dataset.originalIds;
                                 }
                             });
                         }
@@ -433,12 +471,20 @@
                                     <tr t-att-data-row-id="line['code'] or line['name']"
                                         t-att-data-row-indent="line['indent']"
                                         t-att-data-row-amount="line['amount_total']"
-                                        t-att-data-has-children="'1' if line.get('has_children') else '0'">
+                                        t-att-data-has-children="'1' if line.get('has_children') else '0'"
+                                        t-att-data-line-ids="','.join(str(i) for i in line.get('line_ids', []))">
                                         <td>
                                             <div t-attf-style="padding-left: #{16 * line['indent']}px;">
                                                 <span t-attf-class="{{'fw-bolder' if line['indent'] == 0 else ''}}">
                                                     <t t-out="line['name']" />
                                                 </span>
+                                                <t t-if="line.get('line_ids')">
+                                                    <span class="budget-line-ids text-black-50 ms-1" style="font-size: 0.75em;">
+                                                        <t t-foreach="line['line_ids']" t-as="lid">
+                                                            <span class="badge text-bg-light border me-1">#<t t-out="lid" /></span>
+                                                        </t>
+                                                    </span>
+                                                </t>
 
                                                 <div t-if="line['note'] or line.get('description')" class="text-black-50 fs-6 budget-note-content" style="display:none; padding-left: 16px;">
                                                     <div t-if="line['note']" style="white-space: pre-wrap;" t-out="line['note']"></div>
@@ -484,6 +530,10 @@
                             return row.cells[0].querySelector('.budget-note-content');
                         }
 
+                        function getLineIdsContainer(row) {
+                            return row.cells[0].querySelector('.budget-line-ids');
+                        }
+
                         function applyMerge(tbody) {
                             Array.from(tbody.rows).forEach(function (row) {
                                 row.style.display = '';
@@ -495,6 +545,11 @@
                                 if (nc &amp;&amp; nc.dataset.originalNotes !== undefined) {
                                     nc.innerHTML = nc.dataset.originalNotes;
                                     delete nc.dataset.originalNotes;
+                                }
+                                var lc = getLineIdsContainer(row);
+                                if (lc &amp;&amp; lc.dataset.originalIds !== undefined) {
+                                    lc.innerHTML = lc.dataset.originalIds;
+                                    delete lc.dataset.originalIds;
                                 }
                             });
 
@@ -542,6 +597,22 @@
                                         });
                                     }
 
+                                    // Aggregate line IDs from dupes
+                                    var lc = getLineIdsContainer(row);
+                                    if (lc) {
+                                        if (lc.dataset.originalIds === undefined) {
+                                            lc.dataset.originalIds = lc.innerHTML;
+                                        }
+                                        dupes.forEach(function (d) {
+                                            var dlc = getLineIdsContainer(d);
+                                            if (dlc) {
+                                                Array.from(dlc.children).forEach(function (child) {
+                                                    lc.appendChild(child.cloneNode(true));
+                                                });
+                                            }
+                                        });
+                                    }
+
                                     dupes.forEach(function (d) { d.style.display = 'none'; });
                                     i += dupes.length;
                                 }
@@ -559,6 +630,11 @@
                                 if (nc &amp;&amp; nc.dataset.originalNotes !== undefined) {
                                     nc.innerHTML = nc.dataset.originalNotes;
                                     delete nc.dataset.originalNotes;
+                                }
+                                var lc = getLineIdsContainer(row);
+                                if (lc &amp;&amp; lc.dataset.originalIds !== undefined) {
+                                    lc.innerHTML = lc.dataset.originalIds;
+                                    delete lc.dataset.originalIds;
                                 }
                             });
                         }


### PR DESCRIPTION
## Summary
- แสดง `budget.appropriation.line` ID บนรายงาน F5 (รายจ่าย) ในหน้า portal เพื่อให้ผู้ใช้สามารถ trace รายการกลับไปแก้ไขในแบบฟอร์มได้โดยตรง
- เพิ่มคอลัมน์ ID ใน backend tree view ของ line_ids และ deduct_line_ids (optional column)
- รองรับการรวม line IDs เมื่อแถวถูก merge ในโหมดย่อรหัสงบประมาณ และคืนค่าเดิมเมื่อสลับเป็นโหมดแจกแจง

## Test plan
- [ ] เปิดรายงาน F5 รายจ่ายบน portal → ตรวจสอบว่ามี badge `#ID` แสดงข้างชื่อรายการ leaf
- [ ] สลับ checkbox "แสดงแจกแจงรหัสงบประมาณ" → merged rows ควรแสดง IDs รวม, itemized rows แสดง ID เดี่ยว
- [ ] ตรวจสอบ expense_content template (iframe) ทำงานเหมือนกัน
- [ ] เปิด budget appropriation form → คอลัมน์ ID แสดงใน tree view ของ line_ids