### PR TITLE
[16.0][ADD] budget_appropriation_tracking: track line changes on chatter

### DIFF
--- a/budget_appropriation_tracking/__init__.py
+++ b/budget_appropriation_tracking/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/budget_appropriation_tracking/__manifest__.py
+++ b/budget_appropriation_tracking/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Budget Appropriation Tracking",
+    "version": "16.0.1.0.0",
+    "summary": "Track line changes on budget appropriation chatter",
+    "category": "KMITL/Budgeting",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/AginixTechnologies/kmitl",
+    "depends": ["budget_appropriation"],
+    "data": [],
+    "installable": True,
+    "auto_install": False,
+    "license": "AGPL-3",
+}

--- a/budget_appropriation_tracking/i18n/th.po
+++ b/budget_appropriation_tracking/i18n/th.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* budget_appropriation_tracking
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-03 13:30+0000\n"
+"PO-Revision-Date: 2026-04-03 13:30+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: budget_appropriation_tracking
+#. odoo-python
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#, python-format
+msgid "%(label)s %(desc)s updated: %(changes)s"
+msgstr "%(label)s %(desc)s แก้ไข: %(changes)s"
+
+#. module: budget_appropriation_tracking
+#. odoo-python
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#, python-format
+msgid "%(label)s added: %(desc)s"
+msgstr "เพิ่ม%(label)s: %(desc)s"
+
+#. module: budget_appropriation_tracking
+#. odoo-python
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#, python-format
+msgid "%(label)s removed: %(desc)s"
+msgstr "ลบ%(label)s: %(desc)s"
+
+#. module: budget_appropriation_tracking
+#. odoo-python
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#, python-format
+msgid "(empty)"
+msgstr "(ว่าง)"
+
+#. module: budget_appropriation_tracking
+#: model:ir.model,name:budget_appropriation_tracking.model_budget_appropriation
+msgid "Budget Appropriation"
+msgstr "จัดสรรงบประมาณ"
+
+#. module: budget_appropriation_tracking
+#. odoo-python
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#, python-format
+msgid "Deduct Line"
+msgstr "รายการหัก"
+
+#. module: budget_appropriation_tracking
+#. odoo-python
+#: code:addons/budget_appropriation_tracking/models/budget_appropriation.py:0
+#, python-format
+msgid "Line"
+msgstr "รายการ"

--- a/budget_appropriation_tracking/models/__init__.py
+++ b/budget_appropriation_tracking/models/__init__.py
@@ -1,0 +1,1 @@
+from . import budget_appropriation

--- a/budget_appropriation_tracking/models/budget_appropriation.py
+++ b/budget_appropriation_tracking/models/budget_appropriation.py
@@ -1,0 +1,141 @@
+from markupsafe import Markup, escape
+
+from odoo import _, models
+
+# Fields on budget.appropriation.line to track for value changes
+_TRACKED_FIELDS = {
+    "account_id": "รหัสงบประมาณ",
+    "description": "รายละเอียด",
+    "balance": "จำนวนเงิน",
+    "note": "หมายเหตุ",
+    "activity_analytic_id": "กิจกรรม",
+    "fund_analytic_id": "กองทุน",
+}
+_M2O_FIELDS = {"account_id", "activity_analytic_id", "fund_analytic_id"}
+
+
+class BudgetAppropriation(models.Model):
+    _inherit = "budget.appropriation"
+
+    def write(self, vals):
+        track = not self.env.context.get("tracking_disable") and (
+            "line_ids" in vals or "deduct_line_ids" in vals
+        )
+
+        snapshots = {}
+        if track:
+            for rec in self:
+                snapshots[rec.id] = rec._snapshot_appropriation_lines()
+
+        result = super().write(vals)
+
+        if track:
+            for rec in self:
+                old_snap = snapshots.get(rec.id)
+                if old_snap is not None:
+                    new_snap = rec._snapshot_appropriation_lines()
+                    body = rec._build_line_tracking_body(old_snap, new_snap)
+                    if body:
+                        rec._message_log(body=body)
+
+        return result
+
+    # -- snapshot --
+
+    def _snapshot_appropriation_lines(self):
+        """Capture current state of all lines for before/after comparison."""
+        snapshot = {}
+        for line in self.line_ids | self.deduct_line_ids:
+            data = {
+                "deduct": line.deduct,
+                "code": line.code or "",
+                "name": line.name or "",
+            }
+            for fname in _TRACKED_FIELDS:
+                val = line[fname]
+                if fname in _M2O_FIELDS:
+                    data[fname] = val.id if val else False
+                    data[f"{fname}_display"] = val.display_name if val else ""
+                elif fname == "balance":
+                    data[fname] = val or 0.0
+                else:
+                    data[fname] = val or ""
+            snapshot[line.id] = data
+        return snapshot
+
+    # -- message building --
+
+    def _build_line_tracking_body(self, old_snap, new_snap):
+        """Build a single HTML message describing all line changes."""
+        old_ids = set(old_snap)
+        new_ids = set(new_snap)
+
+        parts = []
+
+        # Created lines
+        for lid in sorted(new_ids - old_ids):
+            d = new_snap[lid]
+            label = self._line_label(d)
+            parts.append(_("%(label)s added: %(desc)s", label=label, desc=self._fmt_line(d)))
+
+        # Updated lines
+        for lid in sorted(old_ids & new_ids):
+            changes = self._diff_line(old_snap[lid], new_snap[lid])
+            if changes:
+                d = new_snap[lid]
+                label = self._line_label(d)
+                parts.append(
+                    _(
+                        "%(label)s %(desc)s updated: %(changes)s",
+                        label=label,
+                        desc=self._fmt_line(d),
+                        changes=changes,
+                    )
+                )
+
+        # Deleted lines
+        for lid in sorted(old_ids - new_ids):
+            d = old_snap[lid]
+            label = self._line_label(d)
+            parts.append(_("%(label)s removed: %(desc)s", label=label, desc=self._fmt_line(d)))
+
+        if not parts:
+            return False
+
+        items = Markup("").join(Markup("<li>%s</li>") % escape(str(p)) for p in parts)
+        return Markup("<ul>%s</ul>") % items
+
+    # -- formatting helpers --
+
+    @staticmethod
+    def _line_label(data):
+        return _("Deduct Line") if data["deduct"] else _("Line")
+
+    @staticmethod
+    def _fmt_line(data):
+        parts = [p for p in (data.get("code"), data.get("name")) if p]
+        desc = " ".join(parts)
+        balance = data.get("balance")
+        if balance:
+            desc += " - {:,.2f}".format(balance)
+        return desc
+
+    @staticmethod
+    def _diff_line(old, new):
+        changes = []
+        for fname, label in _TRACKED_FIELDS.items():
+            old_val = old.get(fname)
+            new_val = new.get(fname)
+            if old_val != new_val:
+                old_disp = _fmt_field(fname, old)
+                new_disp = _fmt_field(fname, new)
+                changes.append("{}: {} → {}".format(label, old_disp, new_disp))
+        return ", ".join(changes)
+
+
+def _fmt_field(fname, data):
+    if fname == "balance":
+        return "{:,.2f}".format(data.get(fname, 0))
+    if fname in _M2O_FIELDS:
+        return data.get(f"{fname}_display") or _("(empty)")
+    return data.get(fname) or _("(empty)")


### PR DESCRIPTION
## Summary

New module that tracks changes to `line_ids` and `deduct_line_ids` on `budget.appropriation`. Overrides `write()` to snapshot lines before/after save, then posts a single consolidated message listing all created, updated, and deleted lines with field-level diffs.

## Changes
- Detects added, updated (with old → new values), and removed lines
- Distinguishes regular lines vs deduct lines in messages
- Respects `tracking_disable` context flag
- Tracks: รหัสงบประมาณ, รายละเอียด, จำนวนเงิน, หมายเหตุ, กิจกรรม, กองทุน