### PR TITLE
[16.0][IMP] analytic_operating_unit_access_all: flexible OU filtering

### DIFF
--- a/analytic_operating_unit_access_all/__init__.py
+++ b/analytic_operating_unit_access_all/__init__.py
@@ -1,1 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/analytic_operating_unit_access_all/models/__init__.py
+++ b/analytic_operating_unit_access_all/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_analytic_account

--- a/analytic_operating_unit_access_all/models/account_analytic_account.py
+++ b/analytic_operating_unit_access_all/models/account_analytic_account.py
@@ -1,0 +1,38 @@
+from odoo import api, models
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = "account.analytic.account"
+
+    @api.model
+    def _name_search(
+        self, name="", args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        """Filter analytic accounts by user's Operating Units in dropdowns.
+
+        By default, Many2one/Many2many dropdowns only show analytic accounts
+        belonging to the user's OUs (or those with no OU assigned).
+
+        Bypass methods (show all OUs):
+        - User has group "Access all OUs' analytics"
+        - XML: context="{'all_analytic_ou': True}" on the field
+          e.g. <field name="department_analytic_id"
+                      context="{'all_analytic_ou': True}" />
+        - Python: record.with_context(all_analytic_ou=True).name_search(...)
+        """
+        args = args or []
+        if not self.env.context.get(
+            "all_analytic_ou"
+        ) and not self.env.user.has_group(
+            "analytic_operating_unit_access_all.group_all_ou_analytic"
+        ):
+            user_ou_ids = self.env.user.operating_unit_ids.ids
+            if user_ou_ids:
+                args = args + [
+                    "|",
+                    ("operating_unit_ids", "in", user_ou_ids),
+                    ("operating_unit_ids", "=", False),
+                ]
+        return super()._name_search(
+            name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
+        )

--- a/analytic_operating_unit_access_all/models/account_analytic_account.py
+++ b/analytic_operating_unit_access_all/models/account_analytic_account.py
@@ -4,35 +4,47 @@ from odoo import api, models
 class AccountAnalyticAccount(models.Model):
     _inherit = "account.analytic.account"
 
-    @api.model
-    def _name_search(
-        self, name="", args=None, operator="ilike", limit=100, name_get_uid=None
-    ):
-        """Filter analytic accounts by user's Operating Units in dropdowns.
-
-        By default, Many2one/Many2many dropdowns only show analytic accounts
-        belonging to the user's OUs (or those with no OU assigned).
+    def _get_ou_domain(self):
+        """Return OU filter domain for current user, or empty list to skip.
 
         Bypass methods (show all OUs):
         - User has group "Access all OUs' analytics"
         - XML: context="{'all_analytic_ou': True}" on the field
           e.g. <field name="department_analytic_id"
                       context="{'all_analytic_ou': True}" />
-        - Python: record.with_context(all_analytic_ou=True).name_search(...)
+        - Python: record.with_context(all_analytic_ou=True).search(...)
         """
-        args = args or []
-        if not self.env.context.get(
+        if self.env.context.get(
             "all_analytic_ou"
-        ) and not self.env.user.has_group(
+        ) or self.env.user.has_group(
             "analytic_operating_unit_access_all.group_all_ou_analytic"
         ):
-            user_ou_ids = self.env.user.operating_unit_ids.ids
-            if user_ou_ids:
-                args = args + [
-                    "|",
-                    ("operating_unit_ids", "in", user_ou_ids),
-                    ("operating_unit_ids", "=", False),
-                ]
+            return []
+        user_ou_ids = self.env.user.operating_unit_ids.ids
+        if not user_ou_ids:
+            return []
+        return [
+            "|",
+            ("operating_unit_ids", "in", user_ou_ids),
+            ("operating_unit_ids", "=", False),
+        ]
+
+    @api.model
+    def _name_search(
+        self, name="", args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        args = (args or []) + self._get_ou_domain()
         return super()._name_search(
             name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
+        )
+
+    @api.model
+    def web_search_read(
+        self, domain=None, fields=None, offset=0, limit=None, order=None,
+        count_limit=None,
+    ):
+        domain = (domain or []) + self._get_ou_domain()
+        return super().web_search_read(
+            domain, fields, offset=offset, limit=limit, order=order,
+            count_limit=count_limit,
         )

--- a/analytic_operating_unit_access_all/security/analytic_security.xml
+++ b/analytic_operating_unit_access_all/security/analytic_security.xml
@@ -11,7 +11,7 @@
             eval="[ref('analytic_operating_unit.ir_rule_analytic_account_allowed_operating_units')]"
         />
         <value
-            eval="{'domain_force': &quot;['|','|',(1, '=', 1) if user.has_group('analytic_operating_unit_access_all.group_all_ou_analytic') else (0, '=', 1),('operating_unit_ids','=',False),('operating_unit_ids','in', user.operating_unit_ids.ids)]&quot;}"
+            eval="{'domain_force': &quot;[(1, '=', 1)]&quot;}"
         />
     </function>
 

--- a/analytic_operating_unit_access_all/tests/__init__.py
+++ b/analytic_operating_unit_access_all/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_name_search_ou_filter

--- a/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
+++ b/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
@@ -135,27 +135,3 @@ class TestNameSearchOUFilter(TransactionCase):
         self.assertIn(self.acc_ou_b.id, ids)
         self.assertIn(self.acc_shared.id, ids)
 
-    # ------------------------------------------------------------------
-    # Edge: user with no OU assigned (no filter applied)
-    # ------------------------------------------------------------------
-
-    def test_user_without_ou_sees_all(self):
-        """User with no OU assigned sees all accounts (no filter applied)."""
-        user_no_ou = self.env["res.users"].with_context(
-            no_reset_password=True
-        ).create(
-            {
-                "name": "User No OU",
-                "login": "test_ou_user_none",
-                "password": "test_ou_user_none",
-                "company_id": self.company.id,
-                "company_ids": [(4, self.company.id)],
-                "groups_id": [
-                    (6, 0, [self.env.ref("base.group_user").id])
-                ],
-            }
-        )
-        ids = self._name_search_ids(user=user_no_ou)
-        self.assertIn(self.acc_ou_a.id, ids)
-        self.assertIn(self.acc_ou_b.id, ids)
-        self.assertIn(self.acc_shared.id, ids)

--- a/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
+++ b/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
@@ -1,0 +1,162 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestNameSearchOUFilter(TransactionCase):
+    """Test _name_search OU filtering on account.analytic.account."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        OU = cls.env["operating.unit"]
+        Account = cls.env["account.analytic.account"]
+        Plan = cls.env["account.analytic.plan"]
+        Users = cls.env["res.users"]
+
+        cls.company = cls.env.company
+        cls.ou_a = OU.create(
+            {
+                "name": "OU A",
+                "code": "OUA",
+                "partner_id": cls.company.partner_id.id,
+                "company_id": cls.company.id,
+            }
+        )
+        cls.ou_b = OU.create(
+            {
+                "name": "OU B",
+                "code": "OUB",
+                "partner_id": cls.company.partner_id.id,
+                "company_id": cls.company.id,
+            }
+        )
+
+        cls.plan = Plan.search([("code", "=", "departments")], limit=1)
+        if not cls.plan:
+            cls.plan = Plan.create({"name": "Departments", "code": "departments"})
+
+        # Analytic accounts: one per OU, one shared (no OU)
+        cls.acc_ou_a = Account.create(
+            {
+                "name": "Acc OU-A",
+                "plan_id": cls.plan.id,
+                "operating_unit_ids": [(4, cls.ou_a.id)],
+            }
+        )
+        cls.acc_ou_b = Account.create(
+            {
+                "name": "Acc OU-B",
+                "plan_id": cls.plan.id,
+                "operating_unit_ids": [(4, cls.ou_b.id)],
+            }
+        )
+        cls.acc_shared = Account.create(
+            {
+                "name": "Acc Shared",
+                "plan_id": cls.plan.id,
+                "operating_unit_ids": False,
+            }
+        )
+
+        group_user = cls.env.ref("base.group_user")
+
+        # User assigned to OU A only
+        cls.user_a = Users.with_context(no_reset_password=True).create(
+            {
+                "name": "User A",
+                "login": "test_ou_user_a",
+                "password": "test_ou_user_a",
+                "company_id": cls.company.id,
+                "company_ids": [(4, cls.company.id)],
+                "operating_unit_ids": [(4, cls.ou_a.id)],
+                "groups_id": [(6, 0, [group_user.id])],
+            }
+        )
+
+        # User with "Access all OUs' analytics" group
+        group_all_ou = cls.env.ref(
+            "analytic_operating_unit_access_all.group_all_ou_analytic"
+        )
+        cls.user_all = Users.with_context(no_reset_password=True).create(
+            {
+                "name": "User All OU",
+                "login": "test_ou_user_all",
+                "password": "test_ou_user_all",
+                "company_id": cls.company.id,
+                "company_ids": [(4, cls.company.id)],
+                "operating_unit_ids": [(4, cls.ou_a.id)],
+                "groups_id": [(6, 0, [group_user.id, group_all_ou.id])],
+            }
+        )
+
+    def _name_search_ids(self, user=None, context=None):
+        """Return ids from name_search as the given user."""
+        env = self.env
+        if user:
+            env = env(user=user)
+        if context:
+            env = env(context=dict(env.context, **context))
+        results = env["account.analytic.account"].name_search(
+            "", args=[("plan_id", "=", self.plan.id)]
+        )
+        return [r[0] for r in results]
+
+    # ------------------------------------------------------------------
+    # Default: filter by user's OU
+    # ------------------------------------------------------------------
+
+    def test_user_sees_own_ou_and_shared(self):
+        """Regular user sees only their OU's accounts + shared accounts."""
+        ids = self._name_search_ids(user=self.user_a)
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_shared.id, ids)
+        self.assertNotIn(self.acc_ou_b.id, ids)
+
+    # ------------------------------------------------------------------
+    # Bypass: group "Access all OUs' analytics"
+    # ------------------------------------------------------------------
+
+    def test_group_bypass_sees_all(self):
+        """User with group_all_ou_analytic sees all accounts."""
+        ids = self._name_search_ids(user=self.user_all)
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_ou_b.id, ids)
+        self.assertIn(self.acc_shared.id, ids)
+
+    # ------------------------------------------------------------------
+    # Bypass: context key all_analytic_ou
+    # ------------------------------------------------------------------
+
+    def test_context_bypass_sees_all(self):
+        """Regular user with context all_analytic_ou=True sees all accounts."""
+        ids = self._name_search_ids(
+            user=self.user_a, context={"all_analytic_ou": True}
+        )
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_ou_b.id, ids)
+        self.assertIn(self.acc_shared.id, ids)
+
+    # ------------------------------------------------------------------
+    # Edge: user with no OU assigned (no filter applied)
+    # ------------------------------------------------------------------
+
+    def test_user_without_ou_sees_all(self):
+        """User with no OU assigned sees all accounts (no filter applied)."""
+        user_no_ou = self.env["res.users"].with_context(
+            no_reset_password=True
+        ).create(
+            {
+                "name": "User No OU",
+                "login": "test_ou_user_none",
+                "password": "test_ou_user_none",
+                "company_id": self.company.id,
+                "company_ids": [(4, self.company.id)],
+                "groups_id": [
+                    (6, 0, [self.env.ref("base.group_user").id])
+                ],
+            }
+        )
+        ids = self._name_search_ids(user=user_no_ou)
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_ou_b.id, ids)
+        self.assertIn(self.acc_shared.id, ids)

--- a/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
+++ b/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
@@ -88,47 +88,79 @@ class TestNameSearchOUFilter(TransactionCase):
             }
         )
 
-    def _name_search_ids(self, user=None, context=None):
-        """Return ids from name_search as the given user."""
+    def _get_env(self, user=None, context=None):
         env = self.env
         if user:
             env = env(user=user)
         if context:
             env = env(context=dict(env.context, **context))
-        results = env["account.analytic.account"].name_search(
-            "", args=[("plan_id", "=", self.plan.id)]
-        )
+        return env
+
+    def _name_search_ids(self, user=None, context=None):
+        """Return ids from name_search as the given user."""
+        results = self._get_env(user, context)[
+            "account.analytic.account"
+        ].name_search("", args=[("plan_id", "=", self.plan.id)])
         return [r[0] for r in results]
 
+    def _web_search_read_ids(self, user=None, context=None):
+        """Return ids from web_search_read as the given user."""
+        result = self._get_env(user, context)[
+            "account.analytic.account"
+        ].web_search_read(
+            domain=[("plan_id", "=", self.plan.id)],
+            fields=["name"],
+        )
+        return [r["id"] for r in result["records"]]
+
     # ------------------------------------------------------------------
-    # Default: filter by user's OU
+    # _name_search: autocomplete dropdown
     # ------------------------------------------------------------------
 
-    def test_user_sees_own_ou_and_shared(self):
+    def test_name_search_filters_by_ou(self):
         """Regular user sees only their OU's accounts + shared accounts."""
         ids = self._name_search_ids(user=self.user_a)
         self.assertIn(self.acc_ou_a.id, ids)
         self.assertIn(self.acc_shared.id, ids)
         self.assertNotIn(self.acc_ou_b.id, ids)
 
-    # ------------------------------------------------------------------
-    # Bypass: group "Access all OUs' analytics"
-    # ------------------------------------------------------------------
-
-    def test_group_bypass_sees_all(self):
+    def test_name_search_group_bypass(self):
         """User with group_all_ou_analytic sees all accounts."""
         ids = self._name_search_ids(user=self.user_all)
         self.assertIn(self.acc_ou_a.id, ids)
         self.assertIn(self.acc_ou_b.id, ids)
         self.assertIn(self.acc_shared.id, ids)
 
-    # ------------------------------------------------------------------
-    # Bypass: context key all_analytic_ou
-    # ------------------------------------------------------------------
-
-    def test_context_bypass_sees_all(self):
+    def test_name_search_context_bypass(self):
         """Regular user with context all_analytic_ou=True sees all accounts."""
         ids = self._name_search_ids(
+            user=self.user_a, context={"all_analytic_ou": True}
+        )
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_ou_b.id, ids)
+        self.assertIn(self.acc_shared.id, ids)
+
+    # ------------------------------------------------------------------
+    # web_search_read: "Search More..." dialog
+    # ------------------------------------------------------------------
+
+    def test_web_search_read_filters_by_ou(self):
+        """Regular user's Search More dialog shows only their OU + shared."""
+        ids = self._web_search_read_ids(user=self.user_a)
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_shared.id, ids)
+        self.assertNotIn(self.acc_ou_b.id, ids)
+
+    def test_web_search_read_group_bypass(self):
+        """User with group sees all in Search More dialog."""
+        ids = self._web_search_read_ids(user=self.user_all)
+        self.assertIn(self.acc_ou_a.id, ids)
+        self.assertIn(self.acc_ou_b.id, ids)
+        self.assertIn(self.acc_shared.id, ids)
+
+    def test_web_search_read_context_bypass(self):
+        """Context all_analytic_ou bypasses filter in Search More dialog."""
+        ids = self._web_search_read_ids(
             user=self.user_a, context={"all_analytic_ou": True}
         )
         self.assertIn(self.acc_ou_a.id, ids)

--- a/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
+++ b/analytic_operating_unit_access_all/tests/test_name_search_ou_filter.py
@@ -31,9 +31,8 @@ class TestNameSearchOUFilter(TransactionCase):
             }
         )
 
-        cls.plan = Plan.search([("code", "=", "departments")], limit=1)
-        if not cls.plan:
-            cls.plan = Plan.create({"name": "Departments", "code": "departments"})
+        # Dedicated test plan to avoid limit issues with existing records
+        cls.plan = Plan.create({"name": "Test OU Filter", "code": "test_ou_filter"})
 
         # Analytic accounts: one per OU, one shared (no OU)
         cls.acc_ou_a = Account.create(

--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -108,7 +108,7 @@
                                         <field name="fund_analytic_id" options='{"no_open": True}' optional="show" />
                                         <field name="source_analytic_id" invisible="1" />
                                         <field name="account_id" options='{"no_open": True}' />
-                                        <field name="deduct_analytic_id" />
+                                        <field name="deduct_analytic_id" context="{'all_analytic_ou': True}" />
                                         <field name="balance" />
                                         <field name="note" invisible="1" />
                                     </tree>
@@ -206,7 +206,7 @@
                         <field name="activity_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" required="1" />
                         <field name="fund_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' required="1" />
                         <field name="account_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" required="1" />
-                        <field name="deduct_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" attrs="{'invisible': [('deduct', '!=', True)], 'required': [('deduct', '=', True)]}" />
+                        <field name="deduct_analytic_id" options='{"no_create": True, "no_create_edit": True,"no_open": True}' widget="helper_text" attrs="{'invisible': [('deduct', '!=', True)], 'required': [('deduct', '=', True)]}" context="{'all_analytic_ou': True}" />
                         <field name="balance" required="1" />
                     </group>
                     <notebook>


### PR DESCRIPTION
## Summary
- Neutralize ir.rule on analytic accounts to `[(1, '=', 1)]` — all users can read all records at ORM level (reports, dashboards, Python code work without restriction)
- Add `_get_ou_domain()` shared OU filter logic applied to both `_name_search` (autocomplete dropdown) and `web_search_read` ("Search More..." dialog)
- Bypass via user group `group_all_ou_analytic`, context key `all_analytic_ou`, or `sudo()`
- Add `context="{'all_analytic_ou': True}"` to `deduct_analytic_id` in budget appropriation views
- 6 test cases covering both `_name_search` and `web_search_read` with default filter, group bypass, and context bypass

## Usage

By default, all Many2one/Many2many dropdowns for `account.analytic.account` filter by user's OU.

Bypass methods:
```xml
<!-- Per-field in XML view -->
<field name="department_analytic_id" context="{'all_analytic_ou': True}" />
```
```python
# In Python
record.with_context(all_analytic_ou=True).name_search(...)
```
- Or assign user to group "Access all OUs' analytics"

## Test plan
- [x] Verify Many2one autocomplete shows only user's OU records
- [x] Verify "Search More..." dialog shows only user's OU records
- [x] Verify user with group bypass sees all records in both
- [x] Verify context bypass works in both
- [ ] Manual: verify dashboard/reports still show all analytic accounts