### PR TITLE
[16.0][IMP] purchase_guarantee_kmitl: add no-expiry flag for due date

### DIFF
--- a/purchase_guarantee_expiration/views/view.xml
+++ b/purchase_guarantee_expiration/views/view.xml
@@ -6,7 +6,7 @@
         <field name="name">Guarantee Expire</field>
         <field name="res_model">purchase.guarantee</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('date_due_guarantee', '&lt;', (context_today() + relativedelta(days=30)))]</field>
+        <field name="domain">['|', ('date_due_guarantee', '&lt;', (context_today() + relativedelta(days=30))), ('date_due_guarantee', '=', False)]</field>
         <field name="context">{}</field>
     </record>
 

--- a/purchase_guarantee_kmitl/i18n/th.po
+++ b/purchase_guarantee_kmitl/i18n/th.po
@@ -1,513 +1,82 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_th_gov_purchase_guarantee
 # 	* purchase_guarantee_kmitl
-# 	* purchase_guarantee_lock (merged)
-# 	* purchase_guarantee_attachment (merged)
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-15 03:27+0000\n"
-"PO-Revision-Date: 2025-09-15 10:33+0700\n"
+"POT-Creation-Date: 2026-04-03 09:01+0000\n"
+"PO-Revision-Date: 2026-04-03 09:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.6\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
-#. module: l10n_th_gov_purchase_guarantee
-#. odoo-python
-#: code:addons/l10n_th_gov_purchase_guarantee/models/purchase_guarantee.py:0
-#, python-format
-msgid "%(ref)s must be in status: %(state)s"
+#. module: purchase_guarantee_kmitl
+#: model:exception.rule,description:purchase_guarantee_kmitl.po_exception_02
+msgid ""
+"\n"
+"            ใบสั่งซื้อ/จ้าง/สัญญา มูลค่ามากกว่า 500,000 บาท จะต้องบันทึกหลักประกันสัญญา\n"
+"        "
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__account_id
-msgid "Account"
+#. module: purchase_guarantee_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
+msgid "<span class=\"o_stat_text\">Purchase Order</span>"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_needaction
-msgid "Action Needed"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__active
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__active
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__active
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_search_view
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__active
 msgid "Active"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_ids
-msgid "Activities"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_exception_decoration
-msgid "Activity Exception Decoration"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_state
-msgid "Activity State"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_type_icon
-msgid "Activity Type Icon"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__amount
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__amount
 msgid "Amount"
 msgstr "มูลค่าหลักประกัน"
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__analytic_account_id
-msgid "Analytic Account"
-msgstr "บัญชีวิเคราะห์"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_method_form_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_method_search_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_search_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_type_form_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_type_search_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_guarantee_form
-msgid "Archived"
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__analytic_distribution
+msgid "Analytic"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_attachment_count
-msgid "Attachment Count"
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__analytic_distribution_search
+msgid "Analytic Distribution Search"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__bill_ids
-msgid "Bill Ref"
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__analytic_precision
+msgid "Analytic Precision"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.actions.act_window,name:l10n_th_gov_purchase_guarantee.action_open_guarantee_bills
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_guarantee_form
-msgid "Bills"
-msgstr ""
+#. module: purchase_guarantee_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
+msgid "Attachment"
+msgstr "เอกสารแนบ"
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__can_edit_guarantee_method
-msgid "Can Edit Guarantee Method"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__company_id
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__company_id
 msgid "Company"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__is_create_invoice
-msgid "Create Invoice ?"
+#. module: purchase_guarantee_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
+msgid "Description"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__create_uid
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__create_uid
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__create_uid
-msgid "Created by"
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__attachment_ids
+msgid "Document Attachments"
 msgstr ""
 
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__create_date
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__create_date
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__create_date
-msgid "Created on"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__currency_id
-msgid "Currency"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__default_for_model
-msgid "Default method for"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__display_name
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__display_name
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__display_name
-msgid "Display Name"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__document_ref
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__document_ref
 msgid "Document Ref"
 msgstr "ข้อมูลอ้างอิงเอกสารหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__domain_analytic_account_ids
-msgid "Domain Analytic Account"
-msgstr "กลุ่มบัญชีวิเคราะห์"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_guarantee_tree
-msgid "Due Date"
-msgstr "วันที่หมดอายุหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_follower_ids
-msgid "Followers"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_partner_ids
-msgid "Followers (Partners)"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_type_icon
-msgid "Font awesome icon e.g. fa-tasks"
-msgstr ""
-
-#. modules: l10n_th_gov_purchase_guarantee, purchase_guarantee_kmitl
-#: model:ir.actions.act_window,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_action
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_account_bank_statement_line__guarantee_ids
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_account_move__guarantee_ids
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_account_payment__guarantee_ids
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_order__purchase_guarantee_ids
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_requisition__purchase_guarantee_ids
-#: model:ir.ui.menu,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_config_menu
-#: model:ir.ui.menu,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_menu
-#: model:ir.ui.menu,name:purchase_guarantee_kmitl.kmitl_guarantee_purchase
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_search_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_order_form
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_requisition_form
-msgid "Guarantee"
-msgstr "หลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_order__purchase_guarantee_count
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_requisition__purchase_guarantee_count
-msgid "Guarantee Count"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__date_due_guarantee
-msgid "Guarantee Due Date"
-msgstr "วันที่หมดอายุหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.actions.act_window,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_method_action
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__guarantee_method_id
-#: model:ir.ui.menu,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_method_menu
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_method_form_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_method_search_view
-msgid "Guarantee Method"
-msgstr "ประเภทการค้ำประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__name
-msgid "Guarantee Number"
-msgstr "หมายเลขการรับประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__date_guarantee_receive
-msgid "Guarantee Receive Date"
-msgstr "วันที่รับหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.actions.act_window,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_type_action
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__guarantee_type_id
-#: model:ir.ui.menu,name:l10n_th_gov_purchase_guarantee.purchase_guarantee_type_menu
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_type_form_view
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_type_search_view
-msgid "Guarantee Type"
-msgstr "ประเภทหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__default_for_model
-msgid "Guarantee created from which document model, will use this method"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__has_message
-msgid "Has Message"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__id
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__id
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__id
-msgid "ID"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_exception_icon
-msgid "Icon"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_exception_icon
-msgid "Icon to indicate an exception activity."
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_needaction
-msgid "If checked, new messages require your attention."
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_has_error
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_has_sms_error
-msgid "If checked, some messages have a delivery error."
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__invoice_ids
-msgid "Invoice Ref"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.actions.act_window,name:l10n_th_gov_purchase_guarantee.action_open_guarantee_invoices
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_guarantee_form
-msgid "Invoices"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_is_follower
-msgid "Is Follower"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_account_move
-msgid "Journal Entry"
-msgstr "รายการบันทึกประจำวัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee____last_update
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method____last_update
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type____last_update
-msgid "Last Modified on"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__write_uid
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__write_uid
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__write_uid
-msgid "Last Updated by"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__write_date
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__write_date
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__write_date
-msgid "Last Updated on"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_main_attachment_id
-msgid "Main Attachment"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_has_error
-msgid "Message Delivery error"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_ids
-msgid "Messages"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__my_activity_date_deadline
-msgid "My Activity Deadline"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_method__name
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee_type__name
-msgid "Name"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_date_deadline
-msgid "Next Activity Deadline"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_summary
-msgid "Next Activity Summary"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_type_id
-msgid "Next Activity Type"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__note
-msgid "Note"
-msgstr "หมายเหตุ"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_needaction_counter
-msgid "Number of Actions"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_has_error_counter
-msgid "Number of errors"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_needaction_counter
-msgid "Number of messages requiring action"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_has_error_counter
-msgid "Number of messages with delivery error"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__partner_id
-msgid "Partner"
-msgstr "คู่ค้า"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields.selection,name:l10n_th_gov_purchase_guarantee.selection__purchase_guarantee__reference__purchase_requisition
-#: model:ir.model.fields.selection,name:l10n_th_gov_purchase_guarantee.selection__purchase_guarantee_method__default_for_model__purchase_requisition
-msgid "Purchase Agreement"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_guarantee_form
-msgid "Purchase Agreements"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_purchase_guarantee
-msgid "Purchase Guarantee"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_purchase_guarantee_method
-msgid "Purchase Guarantee Method"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_purchase_guarantee_type
-msgid "Purchase Guarantee Type"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_purchase_order
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__purchase_id
-#: model:ir.model.fields.selection,name:l10n_th_gov_purchase_guarantee.selection__purchase_guarantee__reference__purchase_order
-#: model:ir.model.fields.selection,name:l10n_th_gov_purchase_guarantee.selection__purchase_guarantee_method__default_for_model__purchase_order_po
-msgid "Purchase Order"
-msgstr "คำสั่งซื้อ"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_purchase_requisition
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__requisition_id
-msgid "Purchase Requisition"
-msgstr "ใบเบิกซื้อ"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.view_purchase_guarantee_tree
-msgid "Receive Date"
-msgstr "วันที่รับหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__amount_received
-msgid "Received"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__reference
-msgid "Reference"
-msgstr "อ้างอิงเลขที่คำขอซื้อ/จ้าง"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__reference_model
-msgid "Reference Model"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model,name:l10n_th_gov_purchase_guarantee.model_account_payment_register
-msgid "Register Payment"
-msgstr "ลงทะเบียนการชำระเงิน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields.selection,name:l10n_th_gov_purchase_guarantee.selection__purchase_guarantee_method__default_for_model__purchase_order_rfq
-msgid "Request for Quotation"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_user_id
-msgid "Responsible User"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__date_return
-msgid "Return Date"
-msgstr "วันที่คืนหลักประกัน"
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_account_bank_statement_line__return_guarantee_ids
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_account_move__return_guarantee_ids
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_account_payment__return_guarantee_ids
-msgid "Return Guarantee"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__amount_returned
-msgid "Returned"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__message_has_sms_error
-msgid "SMS Delivery error"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model_terms:ir.ui.view,arch_db:l10n_th_gov_purchase_guarantee.purchase_guarantee_search_view
-msgid "Show active taxes"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_state
-msgid ""
-"Status based on activities\n"
-"Overdue: Due date is already passed\n"
-"Today: Activity date is today\n"
-"Planned: Future activities."
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__activity_exception_decoration
-msgid "Type of the exception activity on record."
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,field_description:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__website_message_ids
-msgid "Website Messages"
-msgstr ""
-
-#. module: l10n_th_gov_purchase_guarantee
-#: model:ir.model.fields,help:l10n_th_gov_purchase_guarantee.field_purchase_guarantee__website_message_ids
-msgid "Website communication history"
-msgstr ""
 
 #. module: purchase_guarantee_kmitl
 #: model:ir.model.fields.selection,name:purchase_guarantee_kmitl.selection__purchase_guarantee__state__draft
@@ -516,10 +85,108 @@ msgid "Draft"
 msgstr "แบบร่าง"
 
 #. module: purchase_guarantee_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
+msgid "File Name"
+msgstr "ชื่อไฟล์"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.ui.menu,name:purchase_guarantee_kmitl.kmitl_guarantee_purchase
+msgid "Guarantee"
+msgstr "หลักประกัน"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__date_due_guarantee
+msgid "Guarantee Due Date"
+msgstr "วันที่หมดอายุหลักประกัน"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__guarantee_method_id
+msgid "Guarantee Method"
+msgstr "ประเภทการค้ำประกัน"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__date_guarantee_receive
+msgid "Guarantee Receive Date"
+msgstr "วันที่รับหลักประกัน"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__guarantee_type_id
+msgid "Guarantee Type"
+msgstr "ประเภทหลักประกัน"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__is_editable
+msgid "Is Editable"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__is_purchase_order
+msgid "Is Purchase Order"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
 #: model:ir.model.fields.selection,name:purchase_guarantee_kmitl.selection__purchase_guarantee__state__lock
 #: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
 msgid "Lock"
 msgstr "ล๊อค"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__is_no_expiry
+msgid "No Expiry"
+msgstr "ไม่มีวันหมดอายุ"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__note
+msgid "Note"
+msgstr "หมายเหตุ"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__partner_id
+msgid "Partner"
+msgstr "คู่ค้า"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model,name:purchase_guarantee_kmitl.model_purchase_guarantee
+msgid "Purchase Guarantee"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
+#. odoo-python
+#: code:addons/purchase_guarantee_kmitl/models/purchase_guarantee.py:0
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__purchase_id
+#, python-format
+msgid "Purchase Order"
+msgstr "คำสั่งซื้อ"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__requisition_id
+msgid "Purchase Requisition"
+msgstr "ใบเบิกซื้อ"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__amount_received
+msgid "Received"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__reference
+msgid "Reference"
+msgstr "อ้างอิงเลขที่คำขอซื้อ/จ้าง"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__reference_model
+msgid "Reference Model"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__date_return
+msgid "Return Date"
+msgstr "วันที่คืนหลักประกัน"
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__amount_returned
+msgid "Returned"
+msgstr ""
 
 #. module: purchase_guarantee_kmitl
 #: model:ir.model.fields,field_description:purchase_guarantee_kmitl.field_purchase_guarantee__state
@@ -527,11 +194,23 @@ msgid "Status"
 msgstr "สถานะ"
 
 #. module: purchase_guarantee_kmitl
-#: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
-msgid "Attachment"
-msgstr "เอกสารแนบ"
+#: model:ir.model.fields,help:purchase_guarantee_kmitl.field_purchase_guarantee__is_purchase_order
+msgid "True if reference is purchase.order"
+msgstr ""
 
 #. module: purchase_guarantee_kmitl
-#: model_terms:ir.ui.view,arch_db:purchase_guarantee_kmitl.view_purchase_guarantee_form
-msgid "File Name"
-msgstr "ชื่อไฟล์"
+#: model:exception.rule,name:purchase_guarantee_kmitl.po_exception_02
+msgid "มูลค่ามากกว่า 500,000 บาท จะต้องบันทึกหลักประกันสัญญา"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.actions.act_window,name:purchase_guarantee_kmitl.action_bid_guarantee
+#: model:ir.ui.menu,name:purchase_guarantee_kmitl.menu_bid_guarantee
+msgid "หลักประกันข้อเสนอ"
+msgstr ""
+
+#. module: purchase_guarantee_kmitl
+#: model:ir.actions.act_window,name:purchase_guarantee_kmitl.action_contract_guarantee
+#: model:ir.ui.menu,name:purchase_guarantee_kmitl.menu_contract_guarantee
+msgid "หลักประกันสัญญา"
+msgstr ""

--- a/purchase_guarantee_kmitl/models/purchase_guarantee.py
+++ b/purchase_guarantee_kmitl/models/purchase_guarantee.py
@@ -21,6 +21,11 @@ class PurchaseGuarantee(models.Model):
     document_ref = fields.Char(tracking=True)
     date_return = fields.Date(tracking=True)
     amount_returned = fields.Monetary(tracking=True)
+    is_no_expiry = fields.Boolean(
+        string="No Expiry",
+        store=False,
+        compute="_compute_is_no_expiry",
+    )
     date_due_guarantee = fields.Date(tracking=True)
     note = fields.Text(tracking=True)
     active = fields.Boolean(tracking=True)
@@ -54,6 +59,16 @@ class PurchaseGuarantee(models.Model):
         store=False,
         help="True if reference is purchase.order",
     )
+
+    @api.depends("date_due_guarantee")
+    def _compute_is_no_expiry(self):
+        for rec in self:
+            rec.is_no_expiry = not rec.date_due_guarantee
+
+    @api.onchange("is_no_expiry")
+    def _onchange_is_no_expiry(self):
+        if self.is_no_expiry:
+            self.date_due_guarantee = False
 
     @api.depends("state")
     def _compute_is_editable(self):

--- a/purchase_guarantee_kmitl/models/purchase_guarantee.py
+++ b/purchase_guarantee_kmitl/models/purchase_guarantee.py
@@ -25,6 +25,7 @@ class PurchaseGuarantee(models.Model):
         string="No Expiry",
         store=False,
         compute="_compute_is_no_expiry",
+        inverse="_inverse_is_no_expiry",
     )
     date_due_guarantee = fields.Date(tracking=True)
     note = fields.Text(tracking=True)
@@ -65,10 +66,10 @@ class PurchaseGuarantee(models.Model):
         for rec in self:
             rec.is_no_expiry = not rec.date_due_guarantee
 
-    @api.onchange("is_no_expiry")
-    def _onchange_is_no_expiry(self):
-        if self.is_no_expiry:
-            self.date_due_guarantee = False
+    def _inverse_is_no_expiry(self):
+        for rec in self:
+            if rec.is_no_expiry:
+                rec.date_due_guarantee = False
 
     @api.depends("state")
     def _compute_is_editable(self):

--- a/purchase_guarantee_kmitl/views/purchase_guarantee_views.xml
+++ b/purchase_guarantee_kmitl/views/purchase_guarantee_views.xml
@@ -124,6 +124,16 @@
                 </attribute>
             </xpath>
 
+            <!-- No expiry checkbox + due date attrs -->
+            <xpath expr="//field[@name='date_due_guarantee']" position="before">
+                <field name="is_no_expiry" />
+            </xpath>
+            <xpath expr="//field[@name='date_due_guarantee']" position="attributes">
+                <attribute name="attrs">
+                    {'invisible': [('is_no_expiry', '=', True)], 'required': [('is_no_expiry', '=', False)], 'readonly': [('is_editable', '=', False)]}
+                </attribute>
+            </xpath>
+
             <!-- Hide analytic field -->
             <xpath expr="//field[@name='analytic_distribution']" position="attributes">
                 <attribute name="groups">base.group_no_one</attribute>


### PR DESCRIPTION
## Summary
- Add computed `is_no_expiry` Boolean field (store=False) before `date_due_guarantee`
- When checked (True), the guarantee has no expiry and `date_due_guarantee` is cleared and hidden
- When unchecked (False), `date_due_guarantee` becomes required
- Respects existing lock/readonly state via `is_editable`

OK-286