### PR TITLE
[16.0][IMP] budget_appropriation_summary: increase tree view limits and improve search panel

### DIFF
--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -124,7 +124,7 @@
                                 attrs="{'readonly': ['|', '|', ('account_fiscal_year_id', '=', False), ('source_analytic_id', '=', False), ('department_analytic_id', '=', False)]}"
                                 context="{'can_edit': False}"
                             >
-                                <tree decoration-info="state == 'review'" decoration-danger="state == 'draft'" decoration-success="state == 'posted'" default_order="department_analytic_id, id">
+                                <tree decoration-info="state == 'review'" decoration-danger="state == 'draft'" decoration-success="state == 'posted'" default_order="department_analytic_id, id" limit="1000">
                                     <field name="state" widget="badge" decoration-info="state == 'review'" decoration-danger="state == 'draft'" decoration-success="state == 'posted'" />
                                     <field name="name" />
                                     <field name="date" invisible="1" />
@@ -151,7 +151,7 @@
                                 ]"
                                 attrs="{'readonly': ['|', '|', ('account_fiscal_year_id', '=', False), ('source_analytic_id', '=', False), ('department_analytic_id', '=', False)]}"
                             >
-                                <tree decoration-info="state == 'review'" decoration-danger="state == 'draft'" decoration-success="state == 'posted'" default_order="department_analytic_id, id">
+                                <tree decoration-info="state == 'review'" decoration-danger="state == 'draft'" decoration-success="state == 'posted'" default_order="department_analytic_id, id" limit="1000">
                                     <field name="state" widget="badge" decoration-info="state == 'review'" decoration-danger="state == 'draft'" decoration-success="state == 'posted'" />
                                     <field name="name" />
                                     <field name="date" invisible="1" />
@@ -383,6 +383,7 @@
                     />
                 </group>
                 <searchpanel>
+                    <field name="account_fiscal_year_id" icon="fa-calendar" enable_counters="1" />
                     <field name="department_analytic_id" icon="fa-users" select="multi" limit="0" />
                 </searchpanel>
             </search>
@@ -394,7 +395,7 @@
         <field name="name">รวมเล่มหน่วยงาน</field>
         <field name="res_model">budget.appropriation.compilation</field>
         <field name="view_mode">kanban,tree,form</field>
-        <field name="context">{'search_default_current_fiscal_year': 1, 'search_default_group_by_source': 1}</field>
+        <field name="context">{'search_default_group_by_source': 1}</field>
         <field
             name="search_view_id"
             ref="view_budget_appropriation_compilation_search"

--- a/budget_appropriation_summary/views/budget_appropriation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_views.xml
@@ -10,7 +10,7 @@
                 <page name="recurrent_lines" string="งบประจำ"
                       attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
                     <field name="recurrent_line_ids" readonly="1" nolabel="1">
-                        <tree create="false" edit="false" delete="false">
+                        <tree create="false" edit="false" delete="false" limit="1000">
                             <field name="id" />
                             <field name="account_id" string="รหัสงบประมาณ" />
                             <field name="activity_analytic_id" string="กิจกรรม" />
@@ -22,7 +22,7 @@
                 <page name="ma_lines" string="งบค่าดูแลและบำรุงรักษา"
                       attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
                     <field name="ma_line_ids" readonly="1" nolabel="1">
-                        <tree create="false" edit="false" delete="false">
+                        <tree create="false" edit="false" delete="false" limit="1000">
                             <field name="id" />
                             <field name="account_id" string="รหัสงบประมาณ" />
                             <field name="activity_analytic_id" string="กิจกรรม" />
@@ -34,7 +34,7 @@
                 <page name="investment_lines" string="งบลงทุน"
                       attrs="{'invisible': [('budget_type', '!=', 'expense')]}">
                     <field name="investment_line_ids" readonly="1" nolabel="1">
-                        <tree create="false" edit="false" delete="false">
+                        <tree create="false" edit="false" delete="false" limit="1000">
                             <field name="id" />
                             <field name="account_id" string="รหัสงบประมาณ" />
                             <field name="activity_analytic_id" string="กิจกรรม" />

--- a/procurement_plan_budget/views/budget_appropriation_compilation_views.xml
+++ b/procurement_plan_budget/views/budget_appropriation_compilation_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//notebook/page[@name='expense_appropriations']" position="after">
                 <page name="procurement_plan_summary" string="สรุปแผนจัดซื้อจัดจ้าง">
                     <field name="procurement_plan_line_ids" readonly="1" nolabel="1">
-                        <tree create="false" edit="false" delete="false">
+                        <tree create="false" edit="false" delete="false" limit="1000">
                             <field name="appropriation_id" string="ใบจัดสรรงบประมาณ" optional="hide" />
                             <field name="description" string="ชื่อรายการ" />
                             <field name="account_id" string="รหัสงบประมาณ" />


### PR DESCRIPTION
## Summary
- Increase tree view `limit` to 1000 on appropriation compilation and summary forms so all lines display without pagination
- Add fiscal year field to compilation search panel for easy filtering
- Remove default fiscal year filter from action context, letting users select via search panel instead
- Also applies the tree limit change to procurement plan summary in `procurement_plan_budget`

## Test plan
- [ ] Open budget appropriation compilation form and verify all lines show without pagination
- [ ] Verify fiscal year appears in the search panel sidebar
- [ ] Confirm compilation list view no longer auto-filters by current fiscal year

🤖 Generated with [Claude Code](https://claude.com/claude-code)