### PR TITLE
[16.0][FIX] budget_appropriation_summary: fix fixed_expense_total calculation

### DIFF
--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -357,14 +357,15 @@ class BudgetAppropriationCompilation(models.Model):
             record.code_0702000003 = sum(
                 record.expense_appropriation_ids.mapped("code_0702000003")
             )
-            record.fixed_expense_total = record.revenue_net - (
-                record.treasury_replenishment_amount
-                + record.deducted_reserve_amount
-                + record.maintenance_amount
-                + record.capital_budget_amount
-                + record.recurrent_budget_amount
-                + record.external_funding_amount
-            )
+            record.fixed_expense_total = sum([
+                record.treasury_replenishment_amount,
+                record.deducted_reserve_amount,
+                record.maintenance_amount,
+                record.capital_budget_amount,
+                record.recurrent_budget_amount,
+                record.external_funding_amount
+            ])
+
             record.fixed_expense_percentage = (record.fixed_expense_total * 100) / record.revenue_net if record.revenue_net else 0.0
 
     BUDGET_SUMMARY_FIELDS = [

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -39,19 +39,17 @@
                 </div>
                 <div class="report-body">
                     <table class="table table-sm table-borderless">
-                        <thead>
-                            <tr>
-                                <th colspan="4">
+                        <tbody>
+                            <tr class="fw-bold">
+                                <td class="text-start" colspan="4">
                                     <t t-out="o.department_analytic_id.name" />
                                     มีรายได้ทุกประเภทรวมกัน (หลังจากหัก 35% แล้ว)
-                                </th>
-                                <th class="text-end" style="width: 100pt;">
+                                </td>
+                                <td class="text-end" style="width: 100pt;">
                                     <t t-out="'{:,.0f}'.format(o.revenue_net)" />
                                     บาท
-                                </th>
+                                </td>
                             </tr>
-                        </thead>
-                        <tbody>
                             <tr class="fw-bold">
                                 <td colspan="5">(1) การจัดสรรตามประกาศสถาบันฯ</td>
                             </tr>


### PR DESCRIPTION
## Summary
- Fix `fixed_expense_total` computation which was incorrectly calculated as `revenue_net` minus expense components
- The correct formula is the sum of the expense components (treasury replenishment, deducted reserve, maintenance, capital budget, recurrent budget, external funding)

## Test plan
- [ ] Verify `fixed_expense_total` equals the sum of expense component fields
- [ ] Verify `fixed_expense_percentage` is correctly derived from the updated total