### PR TITLE
[16.0][IMP] budget_appropriation_summary: A4 paper layout and print button for F23W portal

### DIFF
--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -731,7 +731,7 @@ class BudgetAppropriationSummaryController(http.Controller):
 
         if report_type == "html":
             html = request.env["ir.actions.report"]._render_qweb_html(
-                report.id, [record.id]
+                report.id, [record.id], data={"title": record.name}
             )[0]
             return request.make_response(
                 html,
@@ -788,7 +788,11 @@ class BudgetAppropriationSummaryController(http.Controller):
             report_env = request.env["ir.actions.report"].with_context(
                 html_preview=True
             )
-            html = report_env._render_qweb_html(report.id, [record.id])[0]
+            html = report_env._render_qweb_html(
+                report.id,
+                [record.id],
+                data={"title": f"{record.name} - {report_name.upper()}"},
+            )[0]
             return request.make_response(
                 html,
                 headers=[

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -702,6 +702,135 @@ class BudgetAppropriationCompilation(models.Model):
             "total_management": total_management,
         }
 
+    _F23W_IMPACT_TYPES = [
+        ("education", "1) ด้านการศึกษา (Education)"),
+        ("academic", "2) ด้านการวิจัย (Academic)"),
+        ("industrial", "3) ด้านตอบโจทย์ภาคอุตสาหกรรม (Industrial)"),
+        ("social", "4) ด้านสังคม (Social)"),
+    ]
+
+    def get_f23w_report_data(self):
+        """Prepare F23W report rows for QWeb rendering.
+
+        Returns a flat list of row dicts with a ``type`` key that tells
+        the QWeb template how to render each row.
+        """
+        self.ensure_one()
+
+        # Pre-compute impact data and grand totals
+        impact_data = []
+        for itype, ilabel in self._F23W_IMPACT_TYPES:
+            data = self.get_impact_line_hierarchy(itype)
+            impact_data.append((itype, ilabel, data))
+
+        grand_okr = sum(d[2].get("total_project_okr", 0) for d in impact_data)
+        grand_mgmt = sum(d[2].get("total_management", 0) for d in impact_data)
+        grand_total = grand_okr + grand_mgmt
+        variable_pct = (
+            (grand_total * 100 / self.revenue_net) if self.revenue_net else 0
+        )
+
+        rows = []
+
+        # --- Section 1: Fixed expenses ---
+        rows.append({"type": "fixed_header"})
+        rows.append({"type": "data", "label": "1. หักสำรองจ่าย"})
+        rows.append({
+            "type": "data",
+            "label": "1.1 สำรองจ่ายร้อยละ 15",
+            "amount": self.code_0702000002,
+            "indent": True,
+        })
+        rows.append({
+            "type": "data",
+            "label": "1.2 สำรองจ่ายเกินกว่าร้อยละ 15",
+            "amount": self.code_0702000003,
+            "indent": True,
+        })
+        rows.append({
+            "type": "data",
+            "label": "2. ชดใช้เงินคงคลัง (ถ้ามี)",
+            "amount": self.treasury_replenishment_amount,
+        })
+        rows.append({
+            "type": "data_multiline",
+            "label": "3. ค่าดูแลและบำรุงรักษา",
+            "label2": "(Preventive Maintenance บำรุงรักษาเชิงป้องกัน)",
+            "amount": self.maintenance_amount,
+        })
+        rows.append({
+            "type": "data",
+            "label": "4. งบลงทุน",
+            "amount": self.capital_budget_amount,
+        })
+        rows.append({
+            "type": "data",
+            "label": "5. งบประจำ",
+            "amount": self.recurrent_budget_amount,
+        })
+        rows.append({
+            "type": "data",
+            "label": "6. เงินสนับสนุนจากหน่วยงานภายนอก",
+            "amount": self.external_funding_amount,
+        })
+        rows.append({
+            "type": "fixed_total",
+            "pct": self.fixed_expense_percentage,
+            "amount": self.fixed_expense_total,
+        })
+
+        # --- Section 2: Impact types ---
+        rows.append({"type": "spacer"})
+        rows.append({
+            "type": "impact_section_header",
+            "pct": variable_pct,
+            "amount": grand_total,
+        })
+        rows.append({"type": "impact_column_header"})
+
+        for _itype, ilabel, idata in impact_data:
+            i_okr = idata.get("total_project_okr", 0)
+            i_mgmt = idata.get("total_management", 0)
+            i_total = i_okr + i_mgmt
+            rows.append({
+                "type": "impact_type_header",
+                "label": ilabel,
+                "pct": (i_total * 100 / grand_total) if grand_total else 0,
+                "okr_pct": (i_okr * 100 / grand_total) if grand_total else 0,
+                "mgmt_pct": (i_mgmt * 100 / grand_total) if grand_total else 0,
+                "amount": i_total,
+            })
+            for row in idata.get("rows", []):
+                rows.append({
+                    "type": "impact_row",
+                    "name": row.get("name", ""),
+                    "level": row.get("level", 0),
+                    "okr_amount": row.get("project_okr_amount", 0),
+                    "mgmt_amount": row.get("management_amount", 0),
+                })
+            rows.append({"type": "spacer"})
+
+        # --- Section 3: Grand totals ---
+        okr_pct = (grand_okr * 100 / grand_total) if grand_total else 0
+        mgmt_pct = (grand_mgmt * 100 / grand_total) if grand_total else 0
+        rows.append({
+            "type": "sub_totals",
+            "okr_pct": okr_pct,
+            "mgmt_pct": mgmt_pct,
+        })
+        rows.append({
+            "type": "grand_total_line",
+            "okr_amount": grand_okr,
+            "mgmt_amount": grand_mgmt,
+            "amount": grand_total,
+        })
+        rows.append({
+            "type": "grand_total",
+            "amount": self.fixed_expense_total + grand_total,
+        })
+
+        return rows
+
     def action_open_f23w_report(self):
         """Open F23W report in a new browser tab as HTML."""
         self.ensure_one()

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -31,39 +31,8 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
                     พิมพ์รายงาน
                 </button>
-                <script>
-                    (function () {
-                        function addPageBreaks() {
-                            var page = document.querySelector('.page');
-                            if (!page) return;
-                            var ruler = document.createElement('div');
-                            ruler.style.cssText = 'position:absolute;visibility:hidden;height:297mm;width:0;';
-                            document.body.appendChild(ruler);
-                            var ph = ruler.offsetHeight;
-                            document.body.removeChild(ruler);
-                            page.querySelectorAll('.page-break-line').forEach(function (e) { e.remove(); });
-                            var total = page.scrollHeight;
-                            for (var y = ph; y &lt; total; y += ph) {
-                                var line = document.createElement('div');
-                                line.className = 'page-break-line';
-                                line.style.top = y + 'px';
-                                var label = document.createElement('span');
-                                label.className = 'page-break-label';
-                                label.textContent = 'ตำแหน่งตัดหน้า';
-                                line.appendChild(label);
-                                page.appendChild(line);
-                            }
-                        }
-                        if (document.readyState === 'loading') {
-                            document.addEventListener('DOMContentLoaded', addPageBreaks);
-                        } else {
-                            addPageBreaks();
-                        }
-                        window.addEventListener('resize', addPageBreaks);
-                    })();
-                </script>
             </t>
-            <div class="page budget-compilation-f23w-report" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else 'false'">
+            <div class="page budget-compilation-f23w-report">
                 <div class="report-header">
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
                     <h4 class="pb-2">
@@ -172,7 +141,7 @@
                             <t t-set="grand_mgmt" t-value="sum(d.get('total_management', 0) for d in all_impacts)" />
                             <t t-set="grand_total" t-value="grand_okr + grand_mgmt" />
                             <t t-set="variable_pct" t-value="(grand_total * 100 / o.revenue_net) if o.revenue_net else 0" />
-                            <tr><td colspan="5"  /></tr>
+                            <tr><td colspan="5" class="pt-4" /></tr>
                             <tr class="fw-bold">
                                 <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
                                 <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(variable_pct)" /></td>
@@ -247,7 +216,7 @@
                                     </tr>
                                 </t>
                                 <tr>
-                                    <td colspan="5" style="height: 32pt; />
+                                    <td colspan="5" class="pt-4" />
                                 </tr>
                             </t>
                             <!-- Sub-totals row -->
@@ -301,31 +270,29 @@
                     position: relative;
                     width: 210mm;
                     min-height: 297mm;
-                    background: white !important;
+                    background-color: white !important;
+                    background-image: repeating-linear-gradient(
+                        to bottom,
+                        transparent,
+                        transparent calc(297mm - 1px),
+                        rgba(239, 68, 68, 0.35) calc(297mm - 1px),
+                        rgba(239, 68, 68, 0.35) 297mm
+                    ) !important;
                     margin: 40px auto;
                     padding: 15mm !important;
                     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
                     box-sizing: border-box;
                     border-radius: 2px;
                 }
-
-                .page-break-line {
+                .page::after {
+                    content: 'ตำแหน่งตัดหน้า';
                     position: absolute;
-                    left: -20px;
-                    right: -20px;
-                    height: 0;
-                    border-top: 1px dashed rgba(239, 68, 68, 0.45);
-                    pointer-events: none;
-                    z-index: 100;
-                }
-                .page-break-label {
-                    position: absolute;
-                    right: 0;
-                    top: -14px;
+                    top: calc(297mm - 10px);
+                    right: -90px;
                     font-size: 10px;
                     color: rgba(239, 68, 68, 0.6);
                     font-family: 'TH SarabunPSK', 'Sarabun', sans-serif;
-                    white-space: nowrap;
+                    pointer-events: none;
                 }
 
                 .f23w-print-btn {
@@ -368,9 +335,10 @@
                         padding: 15mm !important;
                         box-shadow: none;
                         border-radius: 0;
+                        background-image: none !important;
                     }
-                    .page-break-line {
-                        display: none !important;
+                    .page::after {
+                        display: none;
                     }
                     .f23w-print-btn {
                         display: none !important;

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -141,7 +141,7 @@
                             <t t-set="grand_mgmt" t-value="sum(d.get('total_management', 0) for d in all_impacts)" />
                             <t t-set="grand_total" t-value="grand_okr + grand_mgmt" />
                             <t t-set="variable_pct" t-value="(grand_total * 100 / o.revenue_net) if o.revenue_net else 0" />
-                            <tr><td colspan="5" class="pt-4" /></tr>
+                            <tr><td colspan="5" style="height: 24pt;" /></tr>
                             <tr class="fw-bold">
                                 <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
                                 <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(variable_pct)" /></td>
@@ -216,7 +216,7 @@
                                     </tr>
                                 </t>
                                 <tr>
-                                    <td colspan="5" class="pt-4" />
+                                    <td colspan="5" style="height: 24pt;" />
                                 </tr>
                             </t>
                             <!-- Sub-totals row -->

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -336,10 +336,12 @@
                     .f23w-print-btn {
                         display: none !important;
                     }
-                    *[contenteditable="false"] {
-                        cursor: not-allowed;
-                    }
-                }</style>
+                }
+
+                *[contenteditable="false"] {
+                    cursor: not-allowed;
+                }
+            </style>
         </t>
         <t t-else="">
             <style>

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -31,8 +31,39 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
                     พิมพ์รายงาน
                 </button>
+                <script>
+                    (function () {
+                        function addPageBreaks() {
+                            var page = document.querySelector('.page');
+                            if (!page) return;
+                            var ruler = document.createElement('div');
+                            ruler.style.cssText = 'position:absolute;visibility:hidden;height:297mm;width:0;';
+                            document.body.appendChild(ruler);
+                            var ph = ruler.offsetHeight;
+                            document.body.removeChild(ruler);
+                            page.querySelectorAll('.page-break-line').forEach(function (e) { e.remove(); });
+                            var total = page.scrollHeight;
+                            for (var y = ph; y &lt; total; y += ph) {
+                                var line = document.createElement('div');
+                                line.className = 'page-break-line';
+                                line.style.top = y + 'px';
+                                var label = document.createElement('span');
+                                label.className = 'page-break-label';
+                                label.textContent = 'ตำแหน่งตัดหน้า';
+                                line.appendChild(label);
+                                page.appendChild(line);
+                            }
+                        }
+                        if (document.readyState === 'loading') {
+                            document.addEventListener('DOMContentLoaded', addPageBreaks);
+                        } else {
+                            addPageBreaks();
+                        }
+                        window.addEventListener('resize', addPageBreaks);
+                    })();
+                </script>
             </t>
-            <div class="page budget-compilation-f23w-report">
+            <div class="page budget-compilation-f23w-report" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else 'false'">
                 <div class="report-header">
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
                     <h4 class="pb-2">
@@ -141,7 +172,7 @@
                             <t t-set="grand_mgmt" t-value="sum(d.get('total_management', 0) for d in all_impacts)" />
                             <t t-set="grand_total" t-value="grand_okr + grand_mgmt" />
                             <t t-set="variable_pct" t-value="(grand_total * 100 / o.revenue_net) if o.revenue_net else 0" />
-                            <tr><td colspan="5" class="pt-4" /></tr>
+                            <tr><td colspan="5"  /></tr>
                             <tr class="fw-bold">
                                 <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
                                 <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(variable_pct)" /></td>
@@ -216,7 +247,7 @@
                                     </tr>
                                 </t>
                                 <tr>
-                                    <td colspan="5" class="pt-4" />
+                                    <td colspan="5" style="height: 32pt; />
                                 </tr>
                             </t>
                             <!-- Sub-totals row -->
@@ -270,29 +301,31 @@
                     position: relative;
                     width: 210mm;
                     min-height: 297mm;
-                    background-color: white !important;
-                    background-image: repeating-linear-gradient(
-                        to bottom,
-                        transparent,
-                        transparent calc(297mm - 1px),
-                        rgba(239, 68, 68, 0.35) calc(297mm - 1px),
-                        rgba(239, 68, 68, 0.35) 297mm
-                    ) !important;
+                    background: white !important;
                     margin: 40px auto;
                     padding: 15mm !important;
                     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
                     box-sizing: border-box;
                     border-radius: 2px;
                 }
-                .page::after {
-                    content: 'ตำแหน่งตัดหน้า';
+
+                .page-break-line {
                     position: absolute;
-                    top: calc(297mm - 10px);
-                    right: -90px;
+                    left: -20px;
+                    right: -20px;
+                    height: 0;
+                    border-top: 1px dashed rgba(239, 68, 68, 0.45);
+                    pointer-events: none;
+                    z-index: 100;
+                }
+                .page-break-label {
+                    position: absolute;
+                    right: 0;
+                    top: -14px;
                     font-size: 10px;
                     color: rgba(239, 68, 68, 0.6);
                     font-family: 'TH SarabunPSK', 'Sarabun', sans-serif;
-                    pointer-events: none;
+                    white-space: nowrap;
                 }
 
                 .f23w-print-btn {
@@ -335,10 +368,9 @@
                         padding: 15mm !important;
                         box-shadow: none;
                         border-radius: 0;
-                        background-image: none !important;
                     }
-                    .page::after {
-                        display: none;
+                    .page-break-line {
+                        display: none !important;
                     }
                     .f23w-print-btn {
                         display: none !important;

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -267,14 +267,32 @@
                 }
 
                 .page {
+                    position: relative;
                     width: 210mm;
                     min-height: 297mm;
-                    background: white !important;
+                    background-color: white !important;
+                    background-image: repeating-linear-gradient(
+                        to bottom,
+                        transparent,
+                        transparent calc(297mm - 1px),
+                        rgba(239, 68, 68, 0.35) calc(297mm - 1px),
+                        rgba(239, 68, 68, 0.35) 297mm
+                    ) !important;
                     margin: 40px auto;
                     padding: 15mm !important;
                     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
                     box-sizing: border-box;
                     border-radius: 2px;
+                }
+                .page::after {
+                    content: 'ตำแหน่งตัดหน้า';
+                    position: absolute;
+                    top: calc(297mm - 10px);
+                    right: -90px;
+                    font-size: 10px;
+                    color: rgba(239, 68, 68, 0.6);
+                    font-family: 'TH SarabunPSK', 'Sarabun', sans-serif;
+                    pointer-events: none;
                 }
 
                 .f23w-print-btn {
@@ -299,17 +317,28 @@
                     background: #5a3a52;
                 }
 
+                @page {
+                    margin: 0;
+                    size: A4;
+                }
+
                 @media print {
                     html, body {
                         background: white !important;
+                        margin: 0;
+                        padding: 0;
                     }
                     .page {
                         width: auto;
                         min-height: auto;
                         margin: 0;
-                        padding: 0 !important;
+                        padding: 15mm !important;
                         box-shadow: none;
                         border-radius: 0;
+                        background-image: none !important;
+                    }
+                    .page::after {
+                        display: none;
                     }
                     .f23w-print-btn {
                         display: none !important;

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -26,6 +26,12 @@
     <template id="report_compilation_f23w_document">
         <t t-call="web.basic_layout">
             <t t-call="budget_appropriation_summary.report_compilation_f23w_styles" />
+            <t t-if="o.env.context.get('html_preview', False)">
+                <button class="f23w-print-btn" onclick="window.print()">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+                    พิมพ์รายงาน
+                </button>
+            </t>
             <div class="page budget-compilation-f23w-report">
                 <div class="report-header">
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
@@ -255,17 +261,59 @@
         <t t-set="is_html_preview" t-value="o.env.context.get('html_preview', False)" />
         <t t-if="is_html_preview">
             <style>html, body {
-                    background: #e0e0e0 !important;
+                    background: #e8e8e8 !important;
+                    margin: 0;
+                    padding: 0;
                 }
 
                 .page {
-                    width: 240mm;
+                    width: 210mm;
                     min-height: 297mm;
                     background: white !important;
-                    margin: 20px auto;
+                    margin: 40px auto;
                     padding: 15mm !important;
-                    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+                    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
                     box-sizing: border-box;
+                    border-radius: 2px;
+                }
+
+                .f23w-print-btn {
+                    position: fixed;
+                    top: 20px;
+                    right: 20px;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #714B67;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 14px;
+                    cursor: pointer;
+                    font-family: 'TH SarabunPSK', 'Sarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .f23w-print-btn:hover {
+                    background: #5a3a52;
+                }
+
+                @media print {
+                    html, body {
+                        background: white !important;
+                    }
+                    .page {
+                        width: auto;
+                        min-height: auto;
+                        margin: 0;
+                        padding: 0 !important;
+                        box-shadow: none;
+                        border-radius: 0;
+                    }
+                    .f23w-print-btn {
+                        display: none !important;
+                    }
                 }</style>
         </t>
         <t t-else="">

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -32,7 +32,7 @@
                     พิมพ์รายงาน
                 </button>
             </t>
-            <div class="page budget-compilation-f23w-report">
+            <div class="page budget-compilation-f23w-report" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
                 <div class="report-header">
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
                     <h4 class="pb-2">
@@ -293,6 +293,10 @@
                     color: rgba(239, 68, 68, 0.6);
                     font-family: 'TH SarabunPSK', 'Sarabun', sans-serif;
                     pointer-events: none;
+                }
+
+                [contenteditable]:focus {
+                    outline: none;
                 }
 
                 .f23w-print-btn {

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -34,7 +34,6 @@
             </t>
             <div class="page budget-compilation-f23w-report" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
                 <div class="report-header" contenteditable="false">
-                    <div class="f23w-page-label">F23-W-วง-002</div>
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
                     <h4 class="pb-2">
                         ประจำปีงบประมาณ พ.ศ.
@@ -248,12 +247,12 @@
                     background-image: repeating-linear-gradient(
                         to bottom,
                         transparent,
-                        transparent calc(297mm - 1px),
-                        rgba(239, 68, 68, 0.35) calc(297mm - 1px),
-                        rgba(239, 68, 68, 0.35) 297mm
+                        transparent calc(274mm - 1px),
+                        rgba(239, 68, 68, 0.35) calc(274mm - 1px),
+                        rgba(239, 68, 68, 0.35) 274mm
                     ) !important;
                     margin: 40px auto;
-                    padding: 15mm !important;
+                    padding: 25mm 8mm !important;
                     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
                     box-sizing: border-box;
                     border-radius: 2px;
@@ -261,7 +260,7 @@
                 .page::after {
                     content: 'ตำแหน่งตัดหน้า';
                     position: absolute;
-                    top: calc(297mm - 10px);
+                    top: calc(274mm - 10px);
                     right: -90px;
                     font-size: 10px;
                     color: rgba(239, 68, 68, 0.6);
@@ -304,12 +303,6 @@
                     background: #5a3a52;
                 }
 
-                @page {
-                    margin: 0 !important;
-                    padding: 8mm !important;
-                    size: A4;
-                }
-
                 @media print {
                     html, body {
                         background: white !important;
@@ -327,6 +320,11 @@
                     }
                     .page::after {
                         display: none;
+                    }
+                    @page {
+                        margin: 0 !important;
+                        padding: 24mm 8mm !important;
+                        size: A4;
                     }
                     .f23w-page-label {
                         position: fixed;
@@ -377,8 +375,6 @@
             .report-header {
                 position: relative;
                 text-align: center;
-                padding: 5px 0;
-                margin-bottom: 20px;
                 cursor: not-allowed;
             }</style>
     </template>

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -33,7 +33,8 @@
                 </button>
             </t>
             <div class="page budget-compilation-f23w-report" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-                <div class="report-header">
+                <div class="report-header" contenteditable="false">
+                    <div class="f23w-page-label">F23-W-วง-002</div>
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
                     <h4 class="pb-2">
                         ประจำปีงบประมาณ พ.ศ.
@@ -46,7 +47,7 @@
                 <div class="report-body">
                     <table class="table table-sm table-borderless">
                         <tbody>
-                            <tr class="fw-bold">
+                            <tr class="fw-bold" contenteditable="false">
                                 <td class="text-start" colspan="4">
                                     <t t-out="o.department_analytic_id.name" />
                                     มีรายได้ทุกประเภทรวมกัน (หลังจากหัก 35% แล้ว)
@@ -75,7 +76,7 @@
                                                 <t t-out="row['label']" />
                                             </t>
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" contenteditable="false">
                                             <t t-if="'amount' in row">
                                                 <t t-out="'{:,.0f}'.format(row['amount'])" />
                                                 บาท
@@ -91,7 +92,7 @@
                                             <br />
                                             <t t-out="row['label2']" />
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" contenteditable="false">
                                             <t t-out="'{:,.0f}'.format(row['amount'])" />
                                             บาท
                                         </td>
@@ -104,7 +105,7 @@
                                         <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(row['pct'])" /></td>
                                         <td />
                                         <td />
-                                        <td class="text-end" style="border-bottom: 3px double #000; border-top: 1px solid #000;">
+                                        <td class="text-end" style="border-bottom: 3px double #000; border-top: 1px solid #000;" contenteditable="false">
                                             <t t-out="'{:,.0f}'.format(row['amount'])" />
                                             บาท
                                         </td>
@@ -121,7 +122,7 @@
                                         <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(row['pct'])" /></td>
                                         <td />
                                         <td />
-                                        <td class="text-end">
+                                        <td class="text-end" contenteditable="false">
                                             <t t-out="'{:,.0f} บาท'.format(row['amount'])" />
                                         </td>
                                     </tr>
@@ -152,7 +153,7 @@
                                             ร้อยละ
                                             <t t-out="'{:,.2f}'.format(row['mgmt_pct'])" />
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" contenteditable="false">
                                             <t t-out="'{:,.0f} บาท'.format(row['amount'])" />
                                         </td>
                                     </tr>
@@ -165,17 +166,17 @@
                                                 <t t-out="row.get('name', '')" />
                                             </div>
                                         </td>
-                                        <td class="text-center">
+                                        <td class="text-center" contenteditable="false">
                                             <t t-if="row.get('okr_amount', 0) != 0">
                                                 <t t-out="'{:,.0f}'.format(row['okr_amount'])" />
                                             </t>
                                         </td>
-                                        <td class="text-center">
+                                        <td class="text-center" contenteditable="false">
                                             <t t-if="row.get('mgmt_amount', 0) != 0">
                                                 <t t-out="'{:,.0f}'.format(row['mgmt_amount'])" />
                                             </t>
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" contenteditable="false">
                                             <t t-set="row_total" t-value="row.get('okr_amount', 0) + row.get('mgmt_amount', 0)" />
                                             <t t-if="row_total != 0">
                                                 <t t-out="'{:,.0f} บาท'.format(row_total)" />
@@ -200,13 +201,13 @@
                                 <t t-elif="row.get('type') == 'grand_total_line'">
                                     <tr class="fw-bold">
                                         <td colspan="2">รวมจัดสรรทุกด้านร้อยละ 100</td>
-                                        <td class="text-center">
+                                        <td class="text-center" contenteditable="false">
                                             <t t-out="'{:,.0f}'.format(row['okr_amount'])" />
                                         </td>
-                                        <td class="text-center">
+                                        <td class="text-center" contenteditable="false">
                                             <t t-out="'{:,.0f}'.format(row['mgmt_amount'])" />
                                         </td>
-                                        <td class="text-end" style="border-bottom: 1px solid #000;">
+                                        <td class="text-end" style="border-bottom: 1px solid #000;" contenteditable="false">
                                             <t t-out="'{:,.0f}'.format(row['amount'])" />
                                             บาท
                                         </td>
@@ -216,7 +217,7 @@
                                 <t t-elif="row.get('type') == 'grand_total'">
                                     <tr class="fw-bold">
                                         <td colspan="4">รวมประมาณการรายจ่ายทั้งสิ้น (1)+(2)</td>
-                                        <td class="text-end" style="border-bottom: 3px double #000;">
+                                        <td class="text-end" style="border-bottom: 3px double #000;" contenteditable="false">
                                             <t t-out="'{:,.0f}'.format(row['amount'])" />
                                             บาท
                                         </td>
@@ -272,6 +273,15 @@
                     outline: none;
                 }
 
+                .f23w-page-label {
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    font-size: 10pt;
+                    color: #333;
+                    pointer-events: none;
+                }
+
                 .f23w-print-btn {
                     position: fixed;
                     top: 20px;
@@ -318,8 +328,16 @@
                     .page::after {
                         display: none;
                     }
+                    .f23w-page-label {
+                        position: fixed;
+                        top: 5mm;
+                        right: 5mm;
+                    }
                     .f23w-print-btn {
                         display: none !important;
+                    }
+                    *[contenteditable="false"] {
+                        cursor: not-allowed;
                     }
                 }</style>
         </t>
@@ -355,9 +373,11 @@
             }
 
             .report-header {
+                position: relative;
                 text-align: center;
                 padding: 5px 0;
                 margin-bottom: 20px;
+                cursor: not-allowed;
             }</style>
     </template>
     <!-- Main report template -->

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -56,141 +56,109 @@
                                     บาท
                                 </td>
                             </tr>
-                            <tr class="fw-bold">
-                                <td colspan="5">(1) การจัดสรรตามประกาศสถาบันฯ</td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">1. หักสำรองจ่าย</td>
-                                <td />
-                            </tr>
-                            <tr>
-                                <td colspan="4">
-                                    <div class="ps-4">1.1 สำรองจ่ายร้อยละ 15</div>
-                                </td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.code_0702000002)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">
-                                    <div class="ps-4">1.2 สำรองจ่ายเกินกว่าร้อยละ 15 </div>
-                                </td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.code_0702000003)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">2. ชดใช้เงินคงคลัง (ถ้ามี)</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.treasury_replenishment_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">
-                                    3. ค่าดูแลและบำรุงรักษา
-                                    <br />
-                                    (Preventive Maintenance บำรุงรักษาเชิงป้องกัน)
-                                </td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.maintenance_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">4. งบลงทุน</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.capital_budget_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">5. งบประจำ</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.recurrent_budget_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">6. เงินสนับสนุนจากหน่วยงานภายนอก</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.external_funding_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr class="fw-bold">
-                                <td>รวมประมาณการรายจ่ายคงที่</td>
-                                <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(o.fixed_expense_percentage)" /></td>
-                                <td />
-                                <td />
-                                <td class="text-end" style="border-bottom: 3px double #000; border-top: 1px solid #000;">
-                                    <t t-out="'{:,.0f}'.format(o.fixed_expense_total)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <!-- Compute impact data for all 4 types -->
-                            <t t-set="impact_types" t-value="[('education', '1) ด้านการศึกษา (Education)'),('academic', '2) ด้านการวิจัย (Academic)'),('industrial', '3) ด้านตอบโจทย์ภาคอุตสาหกรรม (Industrial)'),('social', '4) ด้านสังคม (Social)')]" />
-                            <t t-set="edu_data" t-value="o.get_impact_line_hierarchy('education')" />
-                            <t t-set="acad_data" t-value="o.get_impact_line_hierarchy('academic')" />
-                            <t t-set="ind_data" t-value="o.get_impact_line_hierarchy('industrial')" />
-                            <t t-set="soc_data" t-value="o.get_impact_line_hierarchy('social')" />
-                            <t t-set="all_impacts" t-value="[edu_data, acad_data, ind_data, soc_data]" />
-                            <t t-set="grand_okr" t-value="sum(d.get('total_project_okr', 0) for d in all_impacts)" />
-                            <t t-set="grand_mgmt" t-value="sum(d.get('total_management', 0) for d in all_impacts)" />
-                            <t t-set="grand_total" t-value="grand_okr + grand_mgmt" />
-                            <t t-set="variable_pct" t-value="(grand_total * 100 / o.revenue_net) if o.revenue_net else 0" />
-                            <tr><td colspan="5" style="height: 24pt;" /></tr>
-                            <tr class="fw-bold">
-                                <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
-                                <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(variable_pct)" /></td>
-                                <td />
-                                <td />
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f} บาท'.format(grand_total)" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td />
-                                <td class="text-center fw-medium">จุดเน้น</td>
-                                <td class="text-center fw-medium">จัดสรรโครงการ OKR</td>
-                                <td class="text-center fw-medium">ค่าใช้จ่ายบริหาร</td>
-                                <td />
-                            </tr>
-                            <!-- Impact type summary rows -->
-                            <t t-foreach="[('education', '1) ด้านการศึกษา (Education)', edu_data),                                            ('academic', '2) ด้านการวิจัย (Academic)', acad_data),                                            ('industrial', '3) ด้านตอบโจทย์ภาคอุตสาหกรรม (Industrial)', ind_data),                                            ('social', '4) ด้านสังคม (Social)', soc_data)]" t-as="impact">
-                                <t t-set="itype" t-value="impact[0]" />
-                                <t t-set="ilabel" t-value="impact[1]" />
-                                <t t-set="idata" t-value="impact[2]" />
-                                <t t-set="i_okr" t-value="idata.get('total_project_okr', 0)" />
-                                <t t-set="i_mgmt" t-value="idata.get('total_management', 0)" />
-                                <t t-set="i_total" t-value="i_okr + i_mgmt" />
-                                <t t-set="i_pct" t-value="(i_total * 100 / grand_total) if grand_total else 0" />
-                                <t t-set="i_okr_pct" t-value="(i_okr * 100 / grand_total) if grand_total else 0" />
-                                <t t-set="i_mgmt_pct" t-value="(i_mgmt * 100 / grand_total) if grand_total else 0" />
-                                <tr class="fw-bold">
-                                    <td>
-                                        <t t-out="ilabel" />
-                                    </td>
-                                    <td class="text-center" style="width: 70pt;">
-                                        ร้อยละ
-                                        <t t-out="'{:,.2f}'.format(i_pct)" />
-                                    </td>
-                                    <td class="text-center">
-                                        ร้อยละ
-                                        <t t-out="'{:,.2f}'.format(i_okr_pct)" />
-                                    </td>
-                                    <td class="text-center">
-                                        ร้อยละ
-                                        <t t-out="'{:,.2f}'.format(i_mgmt_pct)" />
-                                    </td>
-                                    <td class="text-end">
-                                        <t t-out="'{:,.0f} บาท'.format(i_total)" />
-                                    </td>
-                                </tr>
-                                <!-- Hierarchy rows for this impact type -->
-                                <t t-foreach="idata.get('rows', [])" t-as="row">
+                            <t t-set="report_rows" t-value="o.get_f23w_report_data()" />
+                            <t t-foreach="report_rows" t-as="row">
+                                <!-- Fixed header -->
+                                <t t-if="row.get('type') == 'fixed_header'">
+                                    <tr class="fw-bold">
+                                        <td colspan="5">(1) การจัดสรรตามประกาศสถาบันฯ</td>
+                                    </tr>
+                                </t>
+                                <!-- Data row -->
+                                <t t-elif="row.get('type') == 'data'">
+                                    <tr>
+                                        <td colspan="4">
+                                            <t t-if="row.get('indent')">
+                                                <div class="ps-4"><t t-out="row['label']" /></div>
+                                            </t>
+                                            <t t-else="">
+                                                <t t-out="row['label']" />
+                                            </t>
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="'amount' in row">
+                                                <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                                บาท
+                                            </t>
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Data multiline row -->
+                                <t t-elif="row.get('type') == 'data_multiline'">
+                                    <tr>
+                                        <td colspan="4">
+                                            <t t-out="row['label']" />
+                                            <br />
+                                            <t t-out="row['label2']" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                            บาท
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Fixed total -->
+                                <t t-elif="row.get('type') == 'fixed_total'">
+                                    <tr class="fw-bold">
+                                        <td>รวมประมาณการรายจ่ายคงที่</td>
+                                        <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(row['pct'])" /></td>
+                                        <td />
+                                        <td />
+                                        <td class="text-end" style="border-bottom: 3px double #000; border-top: 1px solid #000;">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                            บาท
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Spacer -->
+                                <t t-elif="row.get('type') == 'spacer'">
+                                    <tr><td colspan="5" style="height: 24pt;" /></tr>
+                                </t>
+                                <!-- Impact section header -->
+                                <t t-elif="row.get('type') == 'impact_section_header'">
+                                    <tr class="fw-bold">
+                                        <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
+                                        <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(row['pct'])" /></td>
+                                        <td />
+                                        <td />
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f} บาท'.format(row['amount'])" />
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Impact column header -->
+                                <t t-elif="row.get('type') == 'impact_column_header'">
+                                    <tr>
+                                        <td />
+                                        <td class="text-center fw-medium">จุดเน้น</td>
+                                        <td class="text-center fw-medium">จัดสรรโครงการ OKR</td>
+                                        <td class="text-center fw-medium">ค่าใช้จ่ายบริหาร</td>
+                                        <td />
+                                    </tr>
+                                </t>
+                                <!-- Impact type header -->
+                                <t t-elif="row.get('type') == 'impact_type_header'">
+                                    <tr class="fw-bold">
+                                        <td><t t-out="row['label']" /></td>
+                                        <td class="text-center" style="width: 70pt;">
+                                            ร้อยละ
+                                            <t t-out="'{:,.2f}'.format(row['pct'])" />
+                                        </td>
+                                        <td class="text-center">
+                                            ร้อยละ
+                                            <t t-out="'{:,.2f}'.format(row['okr_pct'])" />
+                                        </td>
+                                        <td class="text-center">
+                                            ร้อยละ
+                                            <t t-out="'{:,.2f}'.format(row['mgmt_pct'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f} บาท'.format(row['amount'])" />
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Impact hierarchy row -->
+                                <t t-elif="row.get('type') == 'impact_row'">
                                     <tr class="impact-hierarchy-row">
                                         <td colspan="2">
                                             <div t-att-style="'margin-left: ' + str(16 * (row.get('level', 0) + 1)) + 'px;'">
@@ -198,58 +166,63 @@
                                             </div>
                                         </td>
                                         <td class="text-center">
-                                            <t t-if="row.get('project_okr_amount', 0) != 0">
-                                                <t t-out="'{:,.0f}'.format(row['project_okr_amount'])" />
+                                            <t t-if="row.get('okr_amount', 0) != 0">
+                                                <t t-out="'{:,.0f}'.format(row['okr_amount'])" />
                                             </t>
                                         </td>
                                         <td class="text-center">
-                                            <t t-if="row.get('management_amount', 0) != 0">
-                                                <t t-out="'{:,.0f}'.format(row['management_amount'])" />
+                                            <t t-if="row.get('mgmt_amount', 0) != 0">
+                                                <t t-out="'{:,.0f}'.format(row['mgmt_amount'])" />
                                             </t>
                                         </td>
                                         <td class="text-end">
-                                            <t t-set="row_total" t-value="row.get('project_okr_amount', 0) + row.get('management_amount', 0)" />
+                                            <t t-set="row_total" t-value="row.get('okr_amount', 0) + row.get('mgmt_amount', 0)" />
                                             <t t-if="row_total != 0">
                                                 <t t-out="'{:,.0f} บาท'.format(row_total)" />
                                             </t>
                                         </td>
                                     </tr>
                                 </t>
-                                <tr>
-                                    <td colspan="5" style="height: 24pt;" />
-                                </tr>
+                                <!-- Sub totals -->
+                                <t t-elif="row.get('type') == 'sub_totals'">
+                                    <tr>
+                                        <td colspan="2" />
+                                        <td class="text-center">
+                                            ร้อยละ <t t-out="'{:,.2f}'.format(row['okr_pct'])" />
+                                        </td>
+                                        <td class="text-center">
+                                            ร้อยละ <t t-out="'{:,.2f}'.format(row['mgmt_pct'])" />
+                                        </td>
+                                        <td class="text-end" />
+                                    </tr>
+                                </t>
+                                <!-- Grand total line -->
+                                <t t-elif="row.get('type') == 'grand_total_line'">
+                                    <tr class="fw-bold">
+                                        <td colspan="2">รวมจัดสรรทุกด้านร้อยละ 100</td>
+                                        <td class="text-center">
+                                            <t t-out="'{:,.0f}'.format(row['okr_amount'])" />
+                                        </td>
+                                        <td class="text-center">
+                                            <t t-out="'{:,.0f}'.format(row['mgmt_amount'])" />
+                                        </td>
+                                        <td class="text-end" style="border-bottom: 1px solid #000;">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                            บาท
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Grand total -->
+                                <t t-elif="row.get('type') == 'grand_total'">
+                                    <tr class="fw-bold">
+                                        <td colspan="4">รวมประมาณการรายจ่ายทั้งสิ้น (1)+(2)</td>
+                                        <td class="text-end" style="border-bottom: 3px double #000;">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                            บาท
+                                        </td>
+                                    </tr>
+                                </t>
                             </t>
-                            <!-- Sub-totals row -->
-                            <tr>
-                                <td colspan="2" />
-                                <td class="text-center">
-                                    ร้อยละ <t t-out="'{:,.2f}'.format((grand_okr * 100 / grand_total) if grand_total else 0)" />
-                                </td>
-                                <td class="text-center">
-                                    ร้อยละ <t t-out="'{:,.2f}'.format((grand_mgmt * 100 / grand_total) if grand_total else 0)" />
-                                </td>
-                                <td class="text-end" />
-                            </tr>
-                            <tr class="fw-bold">
-                                <td colspan="2">รวมจัดสรรทุกด้านร้อยละ 100</td>
-                                <td class="text-center">
-                                    <t t-out="'{:,.0f}'.format(grand_okr)" />
-                                </td>
-                                <td class="text-center">
-                                    <t t-out="'{:,.0f}'.format(grand_mgmt)" />
-                                </td>
-                                <td class="text-end" style="border-bottom: 1px solid #000;">
-                                    <t t-out="'{:,.0f}'.format(grand_total)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr class="fw-bold">
-                                <td colspan="4">รวมประมาณการรายจ่ายทั้งสิ้น (1)+(2)</td>
-                                <td class="text-end" style="border-bottom: 3px double #000;">
-                                    <t t-out="'{:,.0f}'.format(o.fixed_expense_total + grand_total)" />
-                                    บาท
-                                </td>
-                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -144,11 +144,11 @@
                                             ร้อยละ
                                             <t t-out="'{:,.2f}'.format(row['pct'])" />
                                         </td>
-                                        <td class="text-center">
+                                        <td class="text-center" style="width: 70pt;">
                                             ร้อยละ
                                             <t t-out="'{:,.2f}'.format(row['okr_pct'])" />
                                         </td>
-                                        <td class="text-center">
+                                        <td class="text-center" style="width: 70pt;">
                                             ร้อยละ
                                             <t t-out="'{:,.2f}'.format(row['mgmt_pct'])" />
                                         </td>
@@ -295,7 +295,8 @@
                 }
 
                 @page {
-                    margin: 0;
+                    margin: 0 !important;
+                    padding: 8mm !important;
                     size: A4;
                 }
 
@@ -308,8 +309,8 @@
                     .page {
                         width: auto;
                         min-height: auto;
-                        margin: 0;
-                        padding: 15mm !important;
+                        margin: 0 !important;
+                        padding: 0 !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -70,18 +70,20 @@
                         />
                         <button
                             name="action_open_f23w_report"
-                            string="ดูรายงาน F23"
+                            string="รายงาน F23"
                             type="object"
                             class="oe_stat_button"
                             icon="fa-file-text-o"
+                            attrs="{'invisible': [('use_f23', '=', False)]}"
                         />
-                        <button
+                        <!-- <button
                             name="action_print_f23w_report"
                             string="พิมพ์ F23"
                             type="object"
                             class="oe_stat_button"
                             icon="fa-print"
-                        />
+                            attrs="{'invisible': [('use_f23', '=', False)]}"
+                        /> -->
                     </div>
                     <group>
                         <group>


### PR DESCRIPTION
## Summary
- Style the F23W HTML preview page to simulate A4 paper with realistic box shadow and proper 210mm width
- Add a fixed \"พิมพ์รายงาน\" print button that triggers browser's native print dialog (`window.print()`)
- Use `@media print` rules to hide the print button and paper simulation, printing only report content
- Add page break indicators with accurate positioning using JavaScript
- Add `contenteditable` support to F23W HTML preview for inline editing before printing
- Add page number labels and protect numeric cells from accidental editing
- Fix print margins across all pages for F23W
- Move F23W report rendering logic from QWeb to Python for better maintainability
- Set meaningful window/page title for HTML report responses (`record.name - REPORT_TYPE`)