### PR TITLE
[16.0][IMP] budget_appropriation_summary: Python-driven page breaks for F23W

### DIFF
--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -701,6 +701,202 @@ class BudgetAppropriationCompilation(models.Model):
             "total_management": total_management,
         }
 
+    _F23W_IMPACT_TYPES = [
+        ("education", "1) ด้านการศึกษา (Education)"),
+        ("academic", "2) ด้านการวิจัย (Academic)"),
+        ("industrial", "3) ด้านตอบโจทย์ภาคอุตสาหกรรม (Industrial)"),
+        ("social", "4) ด้านสังคม (Social)"),
+    ]
+
+    def get_f23w_paged_data(self):
+        """Prepare F23W report rows split into pages for controlled breaks.
+
+        Returns a list of pages, each page is a list of row dicts with a
+        ``type`` key that tells the QWeb template how to render it.
+        """
+        self.ensure_one()
+        first_page_cap = 30
+        other_page_cap = 38
+        min_last_page = 5
+
+        # Pre-compute impact data and grand totals
+        impact_data = []
+        for itype, ilabel in self._F23W_IMPACT_TYPES:
+            data = self.get_impact_line_hierarchy(itype)
+            impact_data.append((itype, ilabel, data))
+
+        grand_okr = sum(d[2].get("total_project_okr", 0) for d in impact_data)
+        grand_mgmt = sum(d[2].get("total_management", 0) for d in impact_data)
+        grand_total = grand_okr + grand_mgmt
+        variable_pct = (
+            (grand_total * 100 / self.revenue_net) if self.revenue_net else 0
+        )
+
+        rows = []
+
+        # --- Section 1: Fixed expenses ---
+        rows.append({"type": "fixed_header"})
+        rows.append({"type": "data", "label": "1. หักสำรองจ่าย"})
+        rows.append({
+            "type": "data",
+            "label": "1.1 สำรองจ่ายร้อยละ 15",
+            "amount": self.code_0702000002,
+            "indent": True,
+        })
+        rows.append({
+            "type": "data",
+            "label": "1.2 สำรองจ่ายเกินกว่าร้อยละ 15",
+            "amount": self.code_0702000003,
+            "indent": True,
+        })
+        rows.append({
+            "type": "data",
+            "label": "2. ชดใช้เงินคงคลัง (ถ้ามี)",
+            "amount": self.treasury_replenishment_amount,
+        })
+        rows.append({
+            "type": "data_multiline",
+            "label": "3. ค่าดูแลและบำรุงรักษา",
+            "label2": "(Preventive Maintenance บำรุงรักษาเชิงป้องกัน)",
+            "amount": self.maintenance_amount,
+            "height": 2,
+        })
+        rows.append({
+            "type": "data",
+            "label": "4. งบลงทุน",
+            "amount": self.capital_budget_amount,
+        })
+        rows.append({
+            "type": "data",
+            "label": "5. งบประจำ",
+            "amount": self.recurrent_budget_amount,
+        })
+        rows.append({
+            "type": "data",
+            "label": "6. เงินสนับสนุนจากหน่วยงานภายนอก",
+            "amount": self.external_funding_amount,
+        })
+        rows.append({
+            "type": "fixed_total",
+            "pct": self.fixed_expense_percentage,
+            "amount": self.fixed_expense_total,
+        })
+
+        # --- Section 2: Impact types ---
+        rows.append({"type": "spacer"})
+        rows.append({
+            "type": "impact_section_header",
+            "pct": variable_pct,
+            "amount": grand_total,
+        })
+        rows.append({"type": "impact_column_header"})
+
+        for _itype, ilabel, idata in impact_data:
+            i_okr = idata.get("total_project_okr", 0)
+            i_mgmt = idata.get("total_management", 0)
+            i_total = i_okr + i_mgmt
+            group = f"impact_{_itype}"
+            rows.append({
+                "type": "impact_type_header",
+                "group": group,
+                "label": ilabel,
+                "pct": (i_total * 100 / grand_total) if grand_total else 0,
+                "okr_pct": (i_okr * 100 / grand_total) if grand_total else 0,
+                "mgmt_pct": (i_mgmt * 100 / grand_total) if grand_total else 0,
+                "amount": i_total,
+            })
+            for row in idata.get("rows", []):
+                rows.append({
+                    "type": "impact_row",
+                    "group": group,
+                    "name": row.get("name", ""),
+                    "level": row.get("level", 0),
+                    "okr_amount": row.get("project_okr_amount", 0),
+                    "mgmt_amount": row.get("management_amount", 0),
+                })
+            rows.append({"type": "spacer"})
+
+        # --- Section 3: Grand totals ---
+        okr_pct = (grand_okr * 100 / grand_total) if grand_total else 0
+        mgmt_pct = (grand_mgmt * 100 / grand_total) if grand_total else 0
+        rows.append({
+            "type": "sub_totals",
+            "group": "totals",
+            "okr_pct": okr_pct,
+            "mgmt_pct": mgmt_pct,
+        })
+        rows.append({
+            "type": "grand_total_line",
+            "group": "totals",
+            "okr_amount": grand_okr,
+            "mgmt_amount": grand_mgmt,
+            "amount": grand_total,
+        })
+        rows.append({
+            "type": "grand_total",
+            "group": "totals",
+            "amount": self.fixed_expense_total + grand_total,
+        })
+
+        return self._split_rows_into_pages(
+            rows, first_page_cap, other_page_cap, min_last_page
+        )
+
+    @staticmethod
+    def _split_rows_into_pages(rows, first_cap, page_cap, min_last):
+        """Split rows into pages, keeping grouped rows together.
+
+        Rows with the same ``group`` key are treated as an indivisible block
+        and will not be split across pages (unless the block itself is larger
+        than a full page).
+        """
+
+        def _block_height(block):
+            return sum(r.get("height", 1) for r in block)
+
+        # Build blocks: contiguous rows sharing a group stay together.
+        blocks = []
+        for row in rows:
+            group = row.get("group")
+            if group and blocks and blocks[-1][0].get("group") == group:
+                blocks[-1].append(row)
+            else:
+                blocks.append([row])
+
+        pages = []
+        remaining = list(blocks)
+        cap = first_cap
+        while remaining:
+            page_blocks = []
+            units = 0
+            while remaining:
+                bh = _block_height(remaining[0])
+                if units + bh <= cap:
+                    page_blocks.append(remaining.pop(0))
+                    units += bh
+                elif not page_blocks:
+                    # Block larger than a full page; add anyway to progress.
+                    page_blocks.append(remaining.pop(0))
+                    break
+                else:
+                    break
+            # Ensure last page has enough content by giving back blocks.
+            if remaining:
+                remaining_units = sum(_block_height(b) for b in remaining)
+                if remaining_units < min_last:
+                    give_back_target = min_last - remaining_units
+                    given = 0
+                    while len(page_blocks) > 1 and given < give_back_target:
+                        block = page_blocks.pop()
+                        remaining.insert(0, block)
+                        given += _block_height(block)
+            if page_blocks:
+                pages.append(
+                    [row for block in page_blocks for row in block]
+                )
+            cap = page_cap
+        return pages
+
     def action_open_f23w_report(self):
         """Open F23W report in a new browser tab as HTML."""
         self.ensure_one()

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -26,230 +26,208 @@
     <template id="report_compilation_f23w_document">
         <t t-call="web.basic_layout">
             <t t-call="budget_appropriation_summary.report_compilation_f23w_styles" />
-            <div class="page budget-compilation-f23w-report">
-                <div class="report-header">
-                    <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
-                    <h4 class="pb-2">
-                        ประจำปีงบประมาณ พ.ศ.
-                        <t t-out="o.account_fiscal_year_id.name" />
-                    </h4>
-                    <h4 class="pb-2">
-                        <t t-out="o.department_analytic_id.name" />
-                    </h4>
-                </div>
-                <div class="report-body">
-                    <table class="table table-sm table-borderless">
-                        <thead>
-                            <tr>
-                                <th colspan="4">
-                                    <t t-out="o.department_analytic_id.name" />
-                                    มีรายได้ทุกประเภทรวมกัน (หลังจากหัก 35% แล้ว)
-                                </th>
-                                <th class="text-end" style="width: 100pt;">
-                                    <t t-out="'{:,.0f}'.format(o.revenue_net)" />
-                                    บาท
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr class="fw-bold">
-                                <td colspan="5">(1) การจัดสรรตามประกาศสถาบันฯ</td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">1. หักสำรองจ่าย</td>
-                                <td />
-                            </tr>
-                            <tr>
-                                <td colspan="4">
-                                    <div class="ps-4">1.1 สำรองจ่ายร้อยละ 15</div>
-                                </td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.code_0702000002)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">
-                                    <div class="ps-4">1.2 สำรองจ่ายเกินกว่าร้อยละ 15 </div>
-                                </td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.code_0702000003)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">2. ชดใช้เงินคงคลัง (ถ้ามี)</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.treasury_replenishment_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">
-                                    3. ค่าดูแลและบำรุงรักษา
-                                    <br />
-                                    (Preventive Maintenance บำรุงรักษาเชิงป้องกัน)
-                                </td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.maintenance_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">4. งบลงทุน</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.capital_budget_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">5. งบประจำ</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.recurrent_budget_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr>
-                                <td colspan="4">6. เงินสนับสนุนจากหน่วยงานภายนอก</td>
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f}'.format(o.external_funding_amount)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr class="fw-bold">
-                                <td>รวมประมาณการรายจ่ายคงที่</td>
-                                <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(o.fixed_expense_percentage)" /></td>
-                                <td />
-                                <td />
-                                <td class="text-end" style="border-bottom: 3px double #000; border-top: 1px solid #000;">
-                                    <t t-out="'{:,.0f}'.format(o.fixed_expense_total)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <!-- Compute impact data for all 4 types -->
-                            <t t-set="impact_types" t-value="[('education', '1) ด้านการศึกษา (Education)'),('academic', '2) ด้านการวิจัย (Academic)'),('industrial', '3) ด้านตอบโจทย์ภาคอุตสาหกรรม (Industrial)'),('social', '4) ด้านสังคม (Social)')]" />
-                            <t t-set="edu_data" t-value="o.get_impact_line_hierarchy('education')" />
-                            <t t-set="acad_data" t-value="o.get_impact_line_hierarchy('academic')" />
-                            <t t-set="ind_data" t-value="o.get_impact_line_hierarchy('industrial')" />
-                            <t t-set="soc_data" t-value="o.get_impact_line_hierarchy('social')" />
-                            <t t-set="all_impacts" t-value="[edu_data, acad_data, ind_data, soc_data]" />
-                            <t t-set="grand_okr" t-value="sum(d.get('total_project_okr', 0) for d in all_impacts)" />
-                            <t t-set="grand_mgmt" t-value="sum(d.get('total_management', 0) for d in all_impacts)" />
-                            <t t-set="grand_total" t-value="grand_okr + grand_mgmt" />
-                            <t t-set="variable_pct" t-value="(grand_total * 100 / o.revenue_net) if o.revenue_net else 0" />
-                            <tr><td colspan="5" class="pt-4" /></tr>
-                            <tr class="fw-bold">
-                                <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
-                                <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(variable_pct)" /></td>
-                                <td />
-                                <td />
-                                <td class="text-end">
-                                    <t t-out="'{:,.0f} บาท'.format(grand_total)" />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td />
-                                <td class="text-center fw-medium">จุดเน้น</td>
-                                <td class="text-center fw-medium">จัดสรรโครงการ OKR</td>
-                                <td class="text-center fw-medium">ค่าใช้จ่ายบริหาร</td>
-                                <td />
-                            </tr>
-                            <!-- Impact type summary rows -->
-                            <t t-foreach="[('education', '1) ด้านการศึกษา (Education)', edu_data),                                            ('academic', '2) ด้านการวิจัย (Academic)', acad_data),                                            ('industrial', '3) ด้านตอบโจทย์ภาคอุตสาหกรรม (Industrial)', ind_data),                                            ('social', '4) ด้านสังคม (Social)', soc_data)]" t-as="impact">
-                                <t t-set="itype" t-value="impact[0]" />
-                                <t t-set="ilabel" t-value="impact[1]" />
-                                <t t-set="idata" t-value="impact[2]" />
-                                <t t-set="i_okr" t-value="idata.get('total_project_okr', 0)" />
-                                <t t-set="i_mgmt" t-value="idata.get('total_management', 0)" />
-                                <t t-set="i_total" t-value="i_okr + i_mgmt" />
-                                <t t-set="i_pct" t-value="(i_total * 100 / grand_total) if grand_total else 0" />
-                                <t t-set="i_okr_pct" t-value="(i_okr * 100 / grand_total) if grand_total else 0" />
-                                <t t-set="i_mgmt_pct" t-value="(i_mgmt * 100 / grand_total) if grand_total else 0" />
-                                <tr class="fw-bold">
-                                    <td>
-                                        <t t-out="ilabel" />
-                                    </td>
-                                    <td class="text-center" style="width: 70pt;">
-                                        ร้อยละ
-                                        <t t-out="'{:,.2f}'.format(i_pct)" />
-                                    </td>
-                                    <td class="text-center">
-                                        ร้อยละ
-                                        <t t-out="'{:,.2f}'.format(i_okr_pct)" />
-                                    </td>
-                                    <td class="text-center">
-                                        ร้อยละ
-                                        <t t-out="'{:,.2f}'.format(i_mgmt_pct)" />
-                                    </td>
-                                    <td class="text-end">
-                                        <t t-out="'{:,.0f} บาท'.format(i_total)" />
-                                    </td>
-                                </tr>
-                                <!-- Hierarchy rows for this impact type -->
-                                <t t-foreach="idata.get('rows', [])" t-as="row">
-                                    <tr class="impact-hierarchy-row">
-                                        <td colspan="2">
-                                            <div t-att-style="'margin-left: ' + str(16 * (row.get('level', 0) + 1)) + 'px;'">
-                                                <t t-out="row.get('name', '')" />
-                                            </div>
-                                        </td>
-                                        <td class="text-center">
-                                            <t t-if="row.get('project_okr_amount', 0) != 0">
-                                                <t t-out="'{:,.0f}'.format(row['project_okr_amount'])" />
-                                            </t>
-                                        </td>
-                                        <td class="text-center">
-                                            <t t-if="row.get('management_amount', 0) != 0">
-                                                <t t-out="'{:,.0f}'.format(row['management_amount'])" />
-                                            </t>
-                                        </td>
-                                        <td class="text-end">
-                                            <t t-set="row_total" t-value="row.get('project_okr_amount', 0) + row.get('management_amount', 0)" />
-                                            <t t-if="row_total != 0">
-                                                <t t-out="'{:,.0f} บาท'.format(row_total)" />
-                                            </t>
-                                        </td>
-                                    </tr>
-                                </t>
+            <t t-set="pages" t-value="o.get_f23w_paged_data()" />
+            <t t-foreach="pages" t-as="page_rows">
+                <div class="page budget-compilation-f23w-report">
+                    <!-- Report header only on first page -->
+                    <t t-if="page_rows_index == 0">
+                        <div class="report-header">
+                            <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
+                            <h4 class="pb-2">
+                                ประจำปีงบประมาณ พ.ศ.
+                                <t t-out="o.account_fiscal_year_id.name" />
+                            </h4>
+                            <h4 class="pb-2">
+                                <t t-out="o.department_analytic_id.name" />
+                            </h4>
+                        </div>
+                    </t>
+                    <div class="report-body">
+                        <table class="table table-sm table-borderless">
+                            <thead>
                                 <tr>
-                                    <td colspan="5" class="pt-4" />
+                                    <th colspan="4">
+                                        <t t-out="o.department_analytic_id.name" />
+                                        มีรายได้ทุกประเภทรวมกัน (หลังจากหัก 35% แล้ว)
+                                    </th>
+                                    <th class="text-end" style="width: 100pt;">
+                                        <t t-out="'{:,.0f}'.format(o.revenue_net)" />
+                                        บาท
+                                    </th>
                                 </tr>
-                            </t>
-                            <!-- Sub-totals row -->
-                            <tr>
-                                <td colspan="2" />
-                                <td class="text-center">
-                                    ร้อยละ <t t-out="'{:,.2f}'.format((grand_okr * 100 / grand_total) if grand_total else 0)" />
-                                </td>
-                                <td class="text-center">
-                                    ร้อยละ <t t-out="'{:,.2f}'.format((grand_mgmt * 100 / grand_total) if grand_total else 0)" />
-                                </td>
-                                <td class="text-end" />
-                            </tr>
-                            <tr class="fw-bold">
-                                <td colspan="2">รวมจัดสรรทุกด้านร้อยละ 100</td>
-                                <td class="text-center">
-                                    <t t-out="'{:,.0f}'.format(grand_okr)" />
-                                </td>
-                                <td class="text-center">
-                                    <t t-out="'{:,.0f}'.format(grand_mgmt)" />
-                                </td>
-                                <td class="text-end" style="border-bottom: 1px solid #000;">
-                                    <t t-out="'{:,.0f}'.format(grand_total)" />
-                                    บาท
-                                </td>
-                            </tr>
-                            <tr class="fw-bold">
-                                <td colspan="4">รวมประมาณการรายจ่ายทั้งสิ้น (1)+(2)</td>
-                                <td class="text-end" style="border-bottom: 3px double #000;">
-                                    <t t-out="'{:,.0f}'.format(o.fixed_expense_total + grand_total)" />
-                                    บาท
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                <t t-foreach="page_rows" t-as="row">
+                                    <!-- Fixed header -->
+                                    <t t-if="row.get('type') == 'fixed_header'">
+                                        <tr class="fw-bold">
+                                            <td colspan="5">(1) การจัดสรรตามประกาศสถาบันฯ</td>
+                                        </tr>
+                                    </t>
+                                    <!-- Data row -->
+                                    <t t-elif="row.get('type') == 'data'">
+                                        <tr>
+                                            <td colspan="4">
+                                                <t t-if="row.get('indent')">
+                                                    <div class="ps-4"><t t-out="row['label']" /></div>
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-out="row['label']" />
+                                                </t>
+                                            </td>
+                                            <td class="text-end">
+                                                <t t-if="'amount' in row">
+                                                    <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                                    บาท
+                                                </t>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Data multiline row -->
+                                    <t t-elif="row.get('type') == 'data_multiline'">
+                                        <tr>
+                                            <td colspan="4">
+                                                <t t-out="row['label']" />
+                                                <br />
+                                                <t t-out="row['label2']" />
+                                            </td>
+                                            <td class="text-end">
+                                                <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                                บาท
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Fixed total -->
+                                    <t t-elif="row.get('type') == 'fixed_total'">
+                                        <tr class="fw-bold">
+                                            <td>รวมประมาณการรายจ่ายคงที่</td>
+                                            <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(row['pct'])" /></td>
+                                            <td />
+                                            <td />
+                                            <td class="text-end" style="border-bottom: 3px double #000; border-top: 1px solid #000;">
+                                                <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                                บาท
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Spacer -->
+                                    <t t-elif="row.get('type') == 'spacer'">
+                                        <tr><td colspan="5" class="pt-4" /></tr>
+                                    </t>
+                                    <!-- Impact section header -->
+                                    <t t-elif="row.get('type') == 'impact_section_header'">
+                                        <tr class="fw-bold">
+                                            <td>(2) การจัดสรรด้านต่าง ๆ ดังนี้</td>
+                                            <td class="text-center">ร้อยละ <t t-out="'{:,.2f}'.format(row['pct'])" /></td>
+                                            <td />
+                                            <td />
+                                            <td class="text-end">
+                                                <t t-out="'{:,.0f} บาท'.format(row['amount'])" />
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Impact column header -->
+                                    <t t-elif="row.get('type') == 'impact_column_header'">
+                                        <tr>
+                                            <td />
+                                            <td class="text-center fw-medium">จุดเน้น</td>
+                                            <td class="text-center fw-medium">จัดสรรโครงการ OKR</td>
+                                            <td class="text-center fw-medium">ค่าใช้จ่ายบริหาร</td>
+                                            <td />
+                                        </tr>
+                                    </t>
+                                    <!-- Impact type header -->
+                                    <t t-elif="row.get('type') == 'impact_type_header'">
+                                        <tr class="fw-bold">
+                                            <td><t t-out="row['label']" /></td>
+                                            <td class="text-center" style="width: 70pt;">
+                                                ร้อยละ
+                                                <t t-out="'{:,.2f}'.format(row['pct'])" />
+                                            </td>
+                                            <td class="text-center">
+                                                ร้อยละ
+                                                <t t-out="'{:,.2f}'.format(row['okr_pct'])" />
+                                            </td>
+                                            <td class="text-center">
+                                                ร้อยละ
+                                                <t t-out="'{:,.2f}'.format(row['mgmt_pct'])" />
+                                            </td>
+                                            <td class="text-end">
+                                                <t t-out="'{:,.0f} บาท'.format(row['amount'])" />
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Impact hierarchy row -->
+                                    <t t-elif="row.get('type') == 'impact_row'">
+                                        <tr class="impact-hierarchy-row">
+                                            <td colspan="2">
+                                                <div t-att-style="'margin-left: ' + str(16 * (row.get('level', 0) + 1)) + 'px;'">
+                                                    <t t-out="row.get('name', '')" />
+                                                </div>
+                                            </td>
+                                            <td class="text-center">
+                                                <t t-if="row.get('okr_amount', 0) != 0">
+                                                    <t t-out="'{:,.0f}'.format(row['okr_amount'])" />
+                                                </t>
+                                            </td>
+                                            <td class="text-center">
+                                                <t t-if="row.get('mgmt_amount', 0) != 0">
+                                                    <t t-out="'{:,.0f}'.format(row['mgmt_amount'])" />
+                                                </t>
+                                            </td>
+                                            <td class="text-end">
+                                                <t t-set="row_total" t-value="row.get('okr_amount', 0) + row.get('mgmt_amount', 0)" />
+                                                <t t-if="row_total != 0">
+                                                    <t t-out="'{:,.0f} บาท'.format(row_total)" />
+                                                </t>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Sub totals -->
+                                    <t t-elif="row.get('type') == 'sub_totals'">
+                                        <tr>
+                                            <td colspan="2" />
+                                            <td class="text-center">
+                                                ร้อยละ <t t-out="'{:,.2f}'.format(row['okr_pct'])" />
+                                            </td>
+                                            <td class="text-center">
+                                                ร้อยละ <t t-out="'{:,.2f}'.format(row['mgmt_pct'])" />
+                                            </td>
+                                            <td class="text-end" />
+                                        </tr>
+                                    </t>
+                                    <!-- Grand total line -->
+                                    <t t-elif="row.get('type') == 'grand_total_line'">
+                                        <tr class="fw-bold">
+                                            <td colspan="2">รวมจัดสรรทุกด้านร้อยละ 100</td>
+                                            <td class="text-center">
+                                                <t t-out="'{:,.0f}'.format(row['okr_amount'])" />
+                                            </td>
+                                            <td class="text-center">
+                                                <t t-out="'{:,.0f}'.format(row['mgmt_amount'])" />
+                                            </td>
+                                            <td class="text-end" style="border-bottom: 1px solid #000;">
+                                                <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                                บาท
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <!-- Grand total -->
+                                    <t t-elif="row.get('type') == 'grand_total'">
+                                        <tr class="fw-bold">
+                                            <td colspan="4">รวมประมาณการรายจ่ายทั้งสิ้น (1)+(2)</td>
+                                            <td class="text-end" style="border-bottom: 3px double #000;">
+                                                <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                                บาท
+                                            </td>
+                                        </tr>
+                                    </t>
+                                </t>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
-            </div>
+            </t>
         </t>
     </template>
     <!-- Styles template -->


### PR DESCRIPTION
## Summary

- Add `get_f23w_paged_data()` method that collects all F23W report rows into a flat list with type tags, then splits them into pages with controlled boundaries
- Group impact type sections (header + hierarchy rows) as indivisible blocks so they never split across pages
- Keep totals rows (sub-totals + grand total) together as a group
- Ensure the last page always has at least 5 rows to prevent orphaned content
- Refactor F23W QWeb template to iterate over computed pages, each with its own table and repeated thead

## Test plan

- [ ] Print F23W report with multiple impact types — verify no 1-2 row orphans on new pages
- [ ] Verify impact type sections stay together on one page (or move entirely to next page)
- [ ] Verify totals rows are never split across pages
- [ ] Verify thead repeats on every page
- [ ] Verify report header only appears on first page
- [ ] Test with minimal data (fits on 1 page) — no unnecessary page breaks
- [ ] Adjust `first_page_cap` / `other_page_cap` constants if row counts don't match actual rendering