### PR TITLE
[16.0][IMP] disbursement: rename action_send to action_sign

### DIFF
--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -554,8 +554,8 @@ msgstr "สามารถทำการ ยืนยัน คำขอเบ�
 #. odoo-python
 #: code:addons/disbursement/models/disbursement_request.py:0
 #, python-format
-msgid "Only submitted requests can be sent."
-msgstr "สามารถส่งได้เฉพาะคำขอเบิกที่อยู่ในสถานะ \"ส่งแล้ว\" เท่านั้น"
+msgid "Only submitted requests can be signed."
+msgstr "สามารถลงนามได้เฉพาะคำขอเบิกที่อยู่ในสถานะ \"ส่งแล้ว\" เท่านั้น"
 
 #. module: disbursement
 #. odoo-python
@@ -1059,8 +1059,8 @@ msgstr "บันทึกการจ่ายเงิน"
 
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
-msgid "Send"
-msgstr "ส่งให้หมวดตรวจ"
+msgid "Sign"
+msgstr "ลงนาม"
 
 #. module: disbursement
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__signed

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -769,11 +769,11 @@ class DisbursementRequest(models.Model):
             record.state = "submitted"
         return True
 
-    def action_send(self):
+    def action_sign(self):
         """Head of department signs and sends to inspector"""
         for record in self:
             if record.state != "submitted":
-                raise UserError(_("Only submitted requests can be sent."))
+                raise UserError(_("Only submitted requests can be signed."))
             record.state = "signed"
         return True
 

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -29,7 +29,7 @@
             <form string="Disbursement Request">
                 <header>
                     <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}" />
-                    <button name="action_send" string="Send" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'submitted')]}" groups="disbursement.group_disbursement_head" />
+                    <button name="action_sign" string="Sign" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'submitted')]}" groups="disbursement.group_disbursement_head" />
                     <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'signed')]}" confirm="Are you sure you want to validate this request?" groups="disbursement.group_disbursement_officer" />
                     <button name="action_approve" string="Approve" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'verified')]}" confirm="Are you sure you want to approve? This will reserve budget." groups="disbursement.group_disbursement_manager" />
                     <button name="action_create_bill" string="Create Bill" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'approved'), ('bill_count', '>', 0)]}" groups="disbursement.group_disbursement_officer" />

--- a/disbursement_sarabun/views/disbursement_request_views.xml
+++ b/disbursement_sarabun/views/disbursement_request_views.xml
@@ -12,7 +12,7 @@
             </xpath>
 
             <!-- Submit to Sarabun button: visible when submitted and no active Sarabun -->
-            <xpath expr="//button[@name='action_send']" position="before">
+            <xpath expr="//button[@name='action_sign']" position="before">
                 <button name="action_submit_to_sarabun"
                         string="Submit to Sarabun"
                         type="object"
@@ -22,7 +22,7 @@
             </xpath>
 
             <!-- Hide Send button when disbursement_sarabun is installed -->
-            <xpath expr="//button[@name='action_send']" position="attributes">
+            <xpath expr="//button[@name='action_sign']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
 


### PR DESCRIPTION
## Summary
- Rename `action_send` → `action_sign` on `disbursement.request` to align with the resulting state `"signed"` and match the naming pattern of other workflow methods (`action_submit`→submitted, `action_validate`→verified, `action_approve`→approved).
- Update button label from "Send" to "Sign" in the form view.
- Update xpath references in `disbursement_sarabun` views accordingly.