### PR TITLE
[16.0][IMP] budget_appropriation_summary: add per-department pages to F3W/F6W report

### DIFF
--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -778,7 +778,20 @@ class BudgetAppropriationSummaryController(http.Controller):
             "f23w": "budget_appropriation_summary.action_report_compilation_f23w",
         }
 
-        report_ref = report_map.get(report_name)
+        # Reports that belong to master summary, rendered via master_summary_id
+        master_summary_report_map = {
+            "f3w_f6w": "budget_appropriation_summary.action_report_f3w_f6w_revenue",
+        }
+
+        if report_name in master_summary_report_map:
+            render_record = record.master_summary_id
+            if not render_record:
+                return request.redirect("/web")
+            report_ref = master_summary_report_map[report_name]
+        else:
+            render_record = record
+            report_ref = report_map.get(report_name)
+
         if not report_ref:
             return request.redirect("/web")
 
@@ -790,7 +803,7 @@ class BudgetAppropriationSummaryController(http.Controller):
             )
             html = report_env._render_qweb_html(
                 report.id,
-                [record.id],
+                [render_record.id],
                 data={"title": f"{record.name} - {report_name.upper()}"},
             )[0]
             return request.make_response(
@@ -802,7 +815,7 @@ class BudgetAppropriationSummaryController(http.Controller):
             )
         elif report_type == "pdf":
             pdf_content, _ = request.env["ir.actions.report"]._render_qweb_pdf(
-                report.id, [record.id]
+                report.id, [render_record.id]
             )
             pdfhttpheaders = [
                 ("Content-Type", "application/pdf"),

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -831,6 +831,15 @@ class BudgetAppropriationCompilation(models.Model):
 
         return rows
 
+    def action_open_f3w_f6w_report(self):
+        """Open F3W/F6W revenue report in a new browser tab as HTML."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/budget_appropriation_summary/compilation/{self.id}/f3w_f6w/html",
+            "target": "new",
+        }
+
     def action_open_f23w_report(self):
         """Open F23W report in a new browser tab as HTML."""
         self.ensure_one()

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -104,6 +104,108 @@
                 </table>
             </div>
         </div>
+
+        <!-- Per-department detail pages -->
+        <t t-foreach="o.f4w_revenue_data['departments']" t-as="dept">
+            <div class="page f3w_f6w">
+                <t t-call="budget_appropriation_summary.report_f3w_f6w_revenue_dept_content" />
+            </div>
+        </t>
+    </template>
+
+    <!-- Per-department detail template for F3-W/F6-W -->
+    <template id="report_f3w_f6w_revenue_dept_content">
+        <t t-call="budget_appropriation_summary.report_council_header" />
+        <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <div>
+                สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย
+            </div>
+            <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
+            <div>
+                <t t-out="dept['name']" />
+            </div>
+            <div>จําแนกตามประเภทรายรับ ปีงบประมาณ พ.ศ.
+                <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
+                และ
+                <t t-out="o.account_fiscal_year_id.name" />
+            </div>
+        </div>
+        <div>
+            <table class="table table-sm table-bordered">
+                <thead>
+                    <tr>
+                        <th class="text-center" rowspan="2" style="width: 35%;">ประเภทรายรับ</th>
+                        <th class="text-center" colspan="2">ปีงบประมาณ
+                            <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
+                        </th>
+                        <th class="text-center" colspan="2">ปีงบประมาณ
+                            <t t-out="o.account_fiscal_year_id.name" />
+                        </th>
+                        <th class="text-center" colspan="2">+ เพิ่ม - ลด</th>
+                    </tr>
+                    <tr>
+                        <th class="text-center">เงินรายได้</th>
+                        <th class="text-center">%</th>
+                        <th class="text-center">เงินรายได้</th>
+                        <th class="text-center">%</th>
+                        <th class="text-center">เงินรายได้</th>
+                        <th class="text-center">%</th>
+                    </tr>
+                </thead>
+                <tbody class="category">
+                    <t t-foreach="dept['categories']" t-as="cat">
+                        <tr class="border-0">
+                            <td class="border-0 border-start">
+                                <t t-out="cat['name']" />
+                            </td>
+                            <td class="text-end border-bottom border-black">
+                                <t t-out="'{0:,.2f}'.format(cat['compare_amount'])" />
+                            </td>
+                            <td class="text-end border-bottom border-black">
+                                <t t-out="'{0:,.2f}'.format(cat['compare_percentage'])" />
+                            </td>
+                            <td class="text-end border-bottom border-black">
+                                <t t-out="'{0:,.2f}'.format(cat['amount'])" />
+                            </td>
+                            <td class="text-end border-bottom border-black">
+                                <t t-out="'{0:,.2f}'.format(cat['percentage'])" />
+                            </td>
+                            <td class="text-end border-bottom border-black">
+                                <t t-out="'{0:,.2f}'.format(cat['diff_amount'])" />
+                            </td>
+                            <td class="text-end border-bottom border-black">
+                                <t t-out="'{0:,.2f}'.format(cat['diff_percentage'])" />
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td class="text-center">
+                            <strong>รวมทั้งสิ้น</strong>
+                        </td>
+                        <td class="text-end" style="font-weight: bold;">
+                            <t t-out="'{0:,.2f}'.format(dept['compare_amount'])" />
+                        </td>
+                        <td class="text-end" style="font-weight: bold;">
+                            <t t-out="'{0:,.2f}'.format(100)" />
+                        </td>
+                        <td class="text-end" style="font-weight: bold;">
+                            <t t-out="'{0:,.2f}'.format(dept['amount'])" />
+                        </td>
+                        <td class="text-end" style="font-weight: bold;">
+                            <t t-out="'{0:,.2f}'.format(100)" />
+                        </td>
+                        <td class="text-end" style="font-weight: bold;">
+                            <t t-out="'{0:,.2f}'.format(dept['diff_amount'])" />
+                        </td>
+                        <td class="text-end" style="font-weight: bold;">
+                            <t t-out="'{0:,.2f}'.format(dept['diff_percentage'])" />
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
     </template>
 
     <!-- Main F3-W-วง-003 และ F6-W-วง-003 report template -->

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -69,6 +69,14 @@
                             attrs="{'invisible': [('expense_appropriation_ids', '=', [])]}"
                         />
                         <button
+                            name="action_open_f3w_f6w_report"
+                            string="รายงาน F3W/F6W"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                            attrs="{'invisible': [('master_summary_id', '=', False)]}"
+                        />
+                        <button
                             name="action_open_f23w_report"
                             string="รายงาน F23"
                             type="object"


### PR DESCRIPTION
## Summary
- Add per-department detail pages to the F3W/F6W revenue comparison report
- After the summary page (all departments), each department now gets its own page showing revenue category breakdown with year-over-year comparison
- Uses existing `f4w_revenue_data` which already provides per-department category data — no Python changes needed
- Follows the same overview + detail pattern used in compilation reports (F4, F5)

## Test plan
- [ ] Upgrade `budget_appropriation_summary` module
- [ ] Open a master summary record with comparison data set
- [ ] Print F3W/F6W report — verify summary page appears first, followed by one page per department
- [ ] Print master summary report — verify F3W/F6W section includes all pages
- [ ] Verify departments with zero amounts do not produce empty pages