### PR TITLE
[16.0][IMP] account_move_kmitl: auto-fill tax invoice before validation

### DIFF
--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -115,8 +115,8 @@ class AccountMove(models.Model):
             payment = move.payment_id
             if payment and payment.payment_type == "outbound":
                 move._check_analytic_distribution_complete()
-        res = super()._post(soft=soft)
         self._auto_fill_tax_invoice()
+        res = super()._post(soft=soft)
         return res
 
     def _auto_fill_tax_invoice(self):
@@ -126,7 +126,9 @@ class AccountMove(models.Model):
                 continue
             for tax_inv in move.tax_invoice_ids:
                 if not tax_inv.tax_invoice_number:
-                    tax_inv.tax_invoice_number = move.ref or move.name
+                    ref = move.ref or (move.name if move.name != "/" else False)
+                    if ref:
+                        tax_inv.tax_invoice_number = ref
                 if not tax_inv.tax_invoice_date:
                     tax_inv.tax_invoice_date = move.date
 


### PR DESCRIPTION
## Summary

Auto-fill tax invoice number and date before `super()._post()` so that `l10n_th_account_tax` validation passes without requiring manual input. Previously, `_auto_fill_tax_invoice()` ran after `super()._post()`, which was too late — the validation already raised an error for empty purchase tax invoice fields. Also improved the fallback logic to skip `"/"` as a meaningless tax invoice number.