### PR TITLE
[16.0][IMP] budget_appropriation_summary_f3: add F3-P report

### DIFF
--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -26,13 +26,13 @@
     <template id="report_compilation_f23w_document">
         <t t-call="web.basic_layout">
             <t t-call="budget_appropriation_summary.report_compilation_f23w_styles" />
-            <t t-if="o.env.context.get('html_preview', False)">
-                <button class="f23w-print-btn" onclick="window.print()">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
-                    พิมพ์รายงาน
-                </button>
-            </t>
             <div class="page budget-compilation-f23w-report" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+                <t t-if="o.env.context.get('html_preview', False)">
+                    <button class="f23w-print-btn" onclick="window.print()" contenteditable="false">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+                        พิมพ์รายงาน
+                    </button>
+                </t>
                 <div class="report-header" contenteditable="false">
                     <h4 class="pb-2">สรุปงบประมาณรายจ่าย</h4>
                     <h4 class="pb-2">
@@ -282,7 +282,7 @@
                 }
 
                 .f23w-print-btn {
-                    position: fixed;
+                    position: absolute;
                     top: 20px;
                     right: 20px;
                     z-index: 1000;

--- a/budget_appropriation_summary_f3/__init__.py
+++ b/budget_appropriation_summary_f3/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import controllers
+from . import models

--- a/budget_appropriation_summary_f3/__manifest__.py
+++ b/budget_appropriation_summary_f3/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Budget Appropriation Summary F3P",
+    "summary": "รายงาน F3-P สรุปประมาณการรายรับ-รายจ่าย ประจำหน่วยงาน",
+    "author": "",
+    "website": "",
+    "category": "Accounting",
+    "depends": [
+        "budget_appropriation_summary",
+        "account_analytic_kmitl",
+    ],
+    "data": [
+        "report/report_compilation_f3.xml",
+        "views/budget_appropriation_compilation_views.xml",
+    ],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/budget_appropriation_summary_f3/controllers/__init__.py
+++ b/budget_appropriation_summary_f3/controllers/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import main

--- a/budget_appropriation_summary_f3/controllers/main.py
+++ b/budget_appropriation_summary_f3/controllers/main.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+
+class BudgetCompilationF3Controller(http.Controller):
+
+    @http.route(
+        "/budget_appropriation_summary/compilation/<int:compilation_id>/f3/<string:report_type>",
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def compilation_f3_report(self, compilation_id, report_type, **kw):
+        record = request.env["budget.appropriation.compilation"].browse(compilation_id)
+        if not record.exists():
+            return request.redirect("/web")
+
+        report = request.env.ref(
+            "budget_appropriation_summary_f3.action_report_compilation_f3"
+        )
+
+        if report_type == "html":
+            html = (
+                request.env["ir.actions.report"]
+                .with_context(html_preview=True)
+                ._render_qweb_html(report.id, [record.id])[0]
+            )
+            return request.make_response(
+                html,
+                headers=[
+                    ("Content-Type", "text/html"),
+                    ("Content-Length", len(html)),
+                ],
+            )
+        elif report_type == "pdf":
+            pdf_content, _ = request.env["ir.actions.report"]._render_qweb_pdf(
+                report.id, [record.id]
+            )
+            return request.make_response(
+                pdf_content,
+                headers=[
+                    ("Content-Type", "application/pdf"),
+                    ("Content-Length", len(pdf_content)),
+                    (
+                        "Content-Disposition",
+                        f'inline; filename="{record.name} - F3.pdf"',
+                    ),
+                ],
+            )
+
+        return request.redirect("/web")

--- a/budget_appropriation_summary_f3/controllers/main.py
+++ b/budget_appropriation_summary_f3/controllers/main.py
@@ -24,7 +24,11 @@ class BudgetCompilationF3Controller(http.Controller):
             html = (
                 request.env["ir.actions.report"]
                 .with_context(html_preview=True)
-                ._render_qweb_html(report.id, [record.id])[0]
+                ._render_qweb_html(
+                    report.id,
+                    [record.id],
+                    data={"title": f"{record.name} - F3"},
+                )[0]
             )
             return request.make_response(
                 html,

--- a/budget_appropriation_summary_f3/models/__init__.py
+++ b/budget_appropriation_summary_f3/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import budget_appropriation_compilation

--- a/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+import logging
+from collections import defaultdict
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+# Source codes classified as government budget (เงินงบประมาณ)
+BUDGET_SOURCE_CODES = ("1", "3", "5")
+
+# Top-level expense account codes in display order
+EXPENSE_LEVEL0_CODES = ["51000", "52000", "53000", "54000", "55000", "07020"]
+
+
+class BudgetAppropriationCompilation(models.Model):
+    _inherit = "budget.appropriation.compilation"
+
+    def get_f3_report_data(self):
+        """Prepare F3 report data for QWeb rendering.
+
+        Returns a dict with:
+        - is_budget_source: bool - whether amounts go in the budget column
+        - revenue_rows: list of {name, amount}
+        - revenue_total: float
+        - expenditure_rows: list of {level, prefix, name, amount}
+        - expenditure_total: float
+        """
+        self.ensure_one()
+        is_budget_source = self.source_analytic_id.code in BUDGET_SOURCE_CODES
+        revenue_rows = self._get_f3_revenue_rows()
+        revenue_total = sum(r["amount"] for r in revenue_rows)
+        expenditure_rows = self._get_f3_expenditure_rows()
+        expenditure_total = sum(
+            r["amount"] for r in expenditure_rows if r["level"] == 0
+        )
+        return {
+            "is_budget_source": is_budget_source,
+            "revenue_rows": revenue_rows,
+            "revenue_total": revenue_total,
+            "expenditure_rows": expenditure_rows,
+            "expenditure_total": expenditure_total,
+        }
+
+    def _get_f3_revenue_rows(self):
+        """Revenue summary grouped by top-level budget account."""
+        lines = self.revenue_appropriation_ids.mapped("line_ids")
+        if not lines:
+            return []
+
+        BudgetAccount = self.env["budget.account"]
+        account_totals = {}
+
+        for line in lines:
+            account = line.account_id
+            if account.parent_path:
+                root_id = int(account.parent_path.strip("/").split("/")[0])
+            else:
+                root_id = account.id
+
+            if root_id not in account_totals:
+                root = BudgetAccount.browse(root_id)
+                account_totals[root_id] = {
+                    "name": root.name,
+                    "code": root.code or "",
+                    "amount": 0.0,
+                }
+            account_totals[root_id]["amount"] += line.balance
+
+        return sorted(account_totals.values(), key=lambda r: r["code"])
+
+    def _get_f3_expenditure_rows(self):
+        """Expenditure summary with 4-level hierarchy.
+
+        Level 0: expense type (51000, 52000, ...)
+        Level 1: sub-category (children of level 0)
+        Level 2: activity plan (children of activity_06 / activity_09)
+        Level 3: fund
+        """
+        lines = self.expense_appropriation_ids.mapped("line_ids")
+        if not lines:
+            return []
+
+        BudgetAccount = self.env["budget.account"]
+        Analytic = self.env["account.analytic.account"]
+
+        # --- Build budget account mappings ---
+        level0_accounts = BudgetAccount.search(
+            [("code", "in", EXPENSE_LEVEL0_CODES)], order="code"
+        )
+        if not level0_accounts:
+            return []
+
+        # Map every descendant account_id → its level0 parent
+        level0_map = {}
+        for l0 in level0_accounts:
+            for desc in BudgetAccount.search(
+                [("parent_path", "=like", f"{l0.parent_path}%")]
+            ):
+                level0_map[desc.id] = l0
+
+        # Map every descendant account_id → its level1 parent
+        level1_accounts = BudgetAccount.search(
+            [("parent_id", "in", level0_accounts.ids)], order="code"
+        )
+        level1_map = {}
+        for l1 in level1_accounts:
+            for desc in BudgetAccount.search(
+                [("parent_path", "=like", f"{l1.parent_path}%")]
+            ):
+                level1_map[desc.id] = l1
+
+        # --- Build activity plan mapping ---
+        activity_06 = self.env.ref(
+            "account_analytic_kmitl.activity_06", raise_if_not_found=False
+        )
+        activity_09 = self.env.ref(
+            "account_analytic_kmitl.activity_09", raise_if_not_found=False
+        )
+        allowed_parents = activity_06 | activity_09
+        plan_activities = Analytic.search(
+            [("parent_id", "in", allowed_parents.ids)], order="code"
+        )
+
+        # Map activity_id → its plan-level ancestor
+        plan_activity_map = {}
+        for plan in plan_activities:
+            for desc in Analytic.search(
+                [("parent_path", "=like", f"{plan.parent_path}%")]
+            ):
+                plan_activity_map[desc.id] = plan
+
+        # --- Aggregate lines into hierarchy ---
+        # {l0_id: {l1_id: {activity_id: {fund_id: amount}}}}
+        data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(float))))
+
+        for line in lines:
+            l0 = level0_map.get(line.account_id.id)
+            l1 = level1_map.get(line.account_id.id)
+            if not l0 or not l1:
+                continue
+
+            plan_act = plan_activity_map.get(line.activity_analytic_id.id)
+            act_id = plan_act.id if plan_act else 0
+            fund_id = line.fund_analytic_id.id or 0
+
+            data[l0.id][l1.id][act_id][fund_id] += line.balance
+
+        # --- Build flat row list ---
+        rows = []
+        l0_order = {code: i for i, code in enumerate(EXPENSE_LEVEL0_CODES)}
+        sorted_l0 = sorted(
+            (l0 for l0 in level0_accounts if l0.id in data),
+            key=lambda a: l0_order.get(a.code, 99),
+        )
+
+        plan_act_by_id = {a.id: a for a in plan_activities}
+        fund_cache = {}
+
+        def get_fund(fund_id):
+            if fund_id not in fund_cache:
+                fund_cache[fund_id] = Analytic.browse(fund_id)
+            return fund_cache[fund_id]
+
+        l0_num = 0
+        for l0 in sorted_l0:
+            l0_num += 1
+            l0_data = data[l0.id]
+            l0_total = sum(
+                amt
+                for l1d in l0_data.values()
+                for actd in l1d.values()
+                for amt in actd.values()
+            )
+            rows.append(
+                {"level": 0, "prefix": f"{l0_num}.", "name": l0.name, "amount": l0_total}
+            )
+
+            sorted_l1 = sorted(
+                (l1 for l1 in level1_accounts if l1.id in l0_data and l1.parent_id == l0),
+                key=lambda a: a.code or "",
+            )
+            l1_num = 0
+            for l1 in sorted_l1:
+                l1_num += 1
+                l1_data = l0_data[l1.id]
+                l1_total = sum(
+                    amt for actd in l1_data.values() for amt in actd.values()
+                )
+                rows.append(
+                    {
+                        "level": 1,
+                        "prefix": f"{l0_num}.{l1_num}",
+                        "name": l1.name,
+                        "amount": l1_total,
+                    }
+                )
+
+                # Level 2: activities (only those matching plan_activities)
+                sorted_act_ids = sorted(
+                    (aid for aid in l1_data if aid in plan_act_by_id),
+                    key=lambda aid: plan_act_by_id[aid].code or "",
+                )
+                for act_id in sorted_act_ids:
+                    act = plan_act_by_id[act_id]
+                    act_data = l1_data[act_id]
+                    act_total = sum(act_data.values())
+                    rows.append(
+                        {"level": 2, "prefix": "-", "name": act.name, "amount": act_total}
+                    )
+
+                    # Level 3: funds
+                    sorted_fund_ids = sorted(
+                        (fid for fid in act_data if fid),
+                        key=lambda fid: get_fund(fid).code or "",
+                    )
+                    for fund_id in sorted_fund_ids:
+                        fund = get_fund(fund_id)
+                        rows.append(
+                            {
+                                "level": 3,
+                                "prefix": ":",
+                                "name": fund.name,
+                                "amount": act_data[fund_id],
+                            }
+                        )
+
+        return rows
+
+    def action_open_f3_report(self):
+        """Open F3 report in a new browser tab as HTML."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/budget_appropriation_summary/compilation/{self.id}/f3/html",
+            "target": "new",
+        }
+
+    def action_print_f3_report(self):
+        """Print F3 report as PDF."""
+        self.ensure_one()
+        return self.env.ref(
+            "budget_appropriation_summary_f3.action_report_compilation_f3"
+        ).report_action(self)

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -129,6 +129,11 @@
                             </tr>
                             <t t-foreach="f3['expenditure_rows']" t-as="row">
                                 <!-- Level 0: ประเภทงบประมาณ -->
+                                <t t-if="row['level'] == 0 and not row_first">
+                                    <tr style="height: 24pt;">
+                                        <td colspan="4" />
+                                    </tr>
+                                </t>
                                 <t t-if="row['level'] == 0">
                                     <tr style="font-weight: bold;">
                                         <td>

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Paper Format -->
+    <record id="paperformat_compilation_f3" model="report.paperformat">
+        <field name="name">Budget Compilation F3P Portrait</field>
+        <field name="default" eval="False" />
+        <field name="format">A4</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">8</field>
+        <field name="margin_bottom">8</field>
+        <field name="margin_left">8</field>
+        <field name="margin_right">8</field>
+        <field name="dpi">90</field>
+    </record>
+    <!-- Report Action -->
+    <record id="action_report_compilation_f3" model="ir.actions.report">
+        <field name="name">รายงาน F3</field>
+        <field name="model">budget.appropriation.compilation</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">budget_appropriation_summary_f3.report_compilation_f3</field>
+        <field name="report_file">budget_appropriation_summary_f3.report_compilation_f3</field>
+        <field name="paperformat_id" ref="paperformat_compilation_f3" />
+        <field name="binding_type">report</field>
+    </record>
+    <!-- F3 Document Template -->
+    <template id="report_compilation_f3_document">
+        <t t-call="web.basic_layout">
+            <t t-call="budget_appropriation_summary_f3.report_compilation_f3_styles" />
+            <t t-set="f3" t-value="o.get_f3_report_data()" />
+            <t t-if="o.env.context.get('html_preview', False)">
+                <button class="f3-print-btn" onclick="window.print()">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="6 9 6 2 18 2 18 9" />
+                        <path
+                            d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+                        <rect x="6" y="14" width="12" height="8" />
+                    </svg>
+                    พิมพ์รายงาน </button>
+            </t>
+            <div class="page budget-compilation-f3-report"
+                t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+                <div class="report-header" contenteditable="false">
+                    <h4 class="pb-2">สรุปประมาณรายรับ - รายจ่าย</h4>
+                    <h4 class="pb-2"> ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
+                    </h4>
+                    <h4 class="pb-2">
+                        <t t-out="o.department_analytic_id.name" />
+                    </h4>
+                </div>
+                <div class="report-body">
+                    <table class="table table-sm table-borderless">
+                        <thead>
+                            <tr>
+                                <th />
+                                <th class="text-center" colspan="3">
+                                    แหล่งเงิน (หน่วย: บาท)
+                                </th>
+                            </tr>
+                            <tr>
+                                <th />
+                                <th style="width: 85pt;" class="text-center">
+                                    <small>เงินงบประมาณ</small>
+                                </th>
+                                <th style="width: 85pt;" class="text-center">
+                                    <small>เงินรายได้</small>
+                                </th>
+                                <th style="width: 85pt;" class="text-center">
+                                    <small>รวมทั้งสิ้น</small>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <!-- ===== รายรับ ===== -->
+                            <tr style="font-weight: bold">
+                                <td colspan="4">
+                                    รายรับ :-
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="4">
+                                    1. เงินงบประมาณที่รัฐบาลจัดสรรให้
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="4">
+                                    2. เงินรายได้สถาบันฯ
+                                </td>
+                            </tr>
+                            <t t-foreach="f3['revenue_rows']" t-as="row">
+                                <tr>
+                                    <td style="padding-left: 20pt;">
+                                        - <t t-out="row['name']" />
+                                    </td>
+                                    <td class="text-end">
+                                        <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                    </td>
+                                    <td class="text-end">
+                                        <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                    </td>
+                                    <td class="text-end">
+                                        <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                    </td>
+                                </tr>
+                            </t>
+                            <!-- Revenue total -->
+                            <tr style="font-weight: bold; border-top: 1px solid #000;">
+                                <td>รวมรายรับ</td>
+                                <td class="text-end">
+                                    <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['revenue_total'])" />
+                                </td>
+                                <td class="text-end">
+                                    <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['revenue_total'])" />
+                                </td>
+                                <td class="text-end" style="border-bottom: double 3px #000;">
+                                    <t t-out="'{:,.0f}'.format(f3['revenue_total'])" />
+                                </td>
+                            </tr>
+
+                            <!-- ===== รายจ่าย ===== -->
+                            <tr style="font-weight: bold">
+                                <td colspan="4">
+                                    รายจ่าย :-
+                                </td>
+                            </tr>
+                            <t t-foreach="f3['expenditure_rows']" t-as="row">
+                                <!-- Level 0: ประเภทงบประมาณ -->
+                                <t t-if="row['level'] == 0">
+                                    <tr style="font-weight: bold;">
+                                        <td>
+                                            <t t-out="row['prefix']" /> <t t-out="row['name']" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Level 1: หมวดหมู่ค่าใช้จ่าย -->
+                                <t t-if="row['level'] == 1">
+                                    <tr>
+                                        <td style="padding-left: 15pt;">
+                                            <t t-out="row['prefix']" /> <t t-out="row['name']" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Level 2: แผนงาน -->
+                                <t t-if="row['level'] == 2">
+                                    <tr>
+                                        <td style="padding-left: 30pt;">
+                                            <t t-out="row['prefix']" /> <t t-out="row['name']" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                    </tr>
+                                </t>
+                                <!-- Level 3: กองทุน -->
+                                <t t-if="row['level'] == 3">
+                                    <tr>
+                                        <td style="padding-left: 45pt;">
+                                            <t t-out="row['prefix']" /> <t t-out="row['name']" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                        <td class="text-end">
+                                            <t t-out="'{:,.0f}'.format(row['amount'])" />
+                                        </td>
+                                    </tr>
+                                </t>
+                            </t>
+                            <!-- Expenditure total -->
+                            <tr style="font-weight: bold; border-top: 1px solid #000;">
+                                <td>รวมรายจ่าย</td>
+                                <td class="text-end">
+                                    <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['expenditure_total'])" />
+                                </td>
+                                <td class="text-end">
+                                    <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['expenditure_total'])" />
+                                </td>
+                                <td class="text-end" style="border-bottom: double 3px #000;">
+                                    <t t-out="'{:,.0f}'.format(f3['expenditure_total'])" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </t>
+    </template>
+    <!-- Styles template -->
+    <template id="report_compilation_f3_styles">
+        <t t-set="is_html_preview" t-value="o.env.context.get('html_preview', False)" />
+        <t t-if="is_html_preview">
+            <style>html, body {
+                background: #e8e8e8 !important;
+                margin: 0;
+                padding: 0;
+                }
+
+                .page {
+                position: relative;
+                width: 210mm;
+                min-height: 297mm;
+                background-color: white !important;
+                background-image: repeating-linear-gradient(
+                to bottom,
+                transparent,
+                transparent calc(274mm - 1px),
+                rgba(239, 68, 68, 0.35) calc(274mm - 1px),
+                rgba(239, 68, 68, 0.35) 274mm
+                ) !important;
+                margin: 40px auto;
+                padding: 25mm 8mm !important;
+                box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
+                box-sizing: border-box;
+                border-radius: 2px;
+                }
+                .page::after {
+                content: 'ตำแหน่งตัดหน้า';
+                position: absolute;
+                top: calc(274mm - 10px);
+                right: -90px;
+                font-size: 10px;
+                color: rgba(239, 68, 68, 0.6);
+                font-family: 'TH SarabunPSK', 'Sarabun', sans-serif;
+                pointer-events: none;
+                }
+
+                [contenteditable]:focus {
+                outline: none;
+                }
+
+                .f3-page-label {
+                position: absolute;
+                top: 0;
+                right: 0;
+                font-size: 10pt;
+                color: #333;
+                pointer-events: none;
+                }
+
+                .f3-print-btn {
+                position: fixed;
+                top: 20px;
+                right: 20px;
+                z-index: 1000;
+                padding: 8px 20px;
+                background: #714B67;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                font-size: 14px;
+                cursor: pointer;
+                font-family: 'TH SarabunPSK', 'Sarabun', Arial, sans-serif;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .f3-print-btn:hover {
+                background: #5a3a52;
+                }
+
+                @media print {
+                html, body {
+                background: white !important;
+                margin: 0;
+                padding: 0;
+                }
+                .page {
+                width: auto;
+                min-height: auto;
+                margin: 0 !important;
+                padding: 0 !important;
+                box-shadow: none;
+                border-radius: 0;
+                background-image: none !important;
+                }
+                .page::after {
+                display: none;
+                }
+                @page {
+                margin: 0 !important;
+                padding: 24mm 8mm !important;
+                size: A4;
+                }
+                .f3-page-label {
+                position: fixed;
+                top: 5mm;
+                right: 5mm;
+                }
+                .f3-print-btn {
+                display: none !important;
+                }
+                }
+
+                *[contenteditable="false"] {
+                cursor: not-allowed;
+                }
+            </style>
+        </t>
+        <t t-else="">
+            <style>
+                * {
+                line-height: 1.4;
+                }
+            </style>
+        </t>
+        <style>.page {
+            page-break-after: always;
+            }
+            .page:last-child {
+            page-break-after: auto;
+            }
+
+            .budget-compilation-f3-report {
+            font-family: 'TH SarabunPSK', 'Sarabun', Arial, sans-serif;
+            font-size: 10pt;
+            }
+
+            .budget-compilation-f3-report h3 {
+            margin: 0;
+            font-size: 14pt;
+            font-weight: 600;
+            }
+
+            .budget-compilation-f3-report h4 {
+            margin: 0;
+            font-size: 12pt;
+            font-weight: normal;
+            }
+
+            .report-header {
+            position: relative;
+            text-align: center;
+            cursor: not-allowed;
+            }</style>
+    </template>
+    <!-- Main report template -->
+    <template id="report_compilation_f3">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="budget_appropriation_summary_f3.report_compilation_f3_document" />
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -130,7 +130,7 @@
                             <t t-foreach="f3['expenditure_rows']" t-as="row">
                                 <!-- Level 0: ประเภทงบประมาณ -->
                                 <t t-if="row['level'] == 0 and not row_first">
-                                    <tr style="height: 24pt;">
+                                    <tr style="height: 16pt;">
                                         <td colspan="4" />
                                     </tr>
                                 </t>

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -42,7 +42,7 @@
             <div class="page budget-compilation-f3-report"
                 t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
                 <div class="report-header" contenteditable="false">
-                    <h4 class="pb-2">สรุปประมาณรายรับ - รายจ่าย</h4>
+                    <h4 class="pb-2">สรุปประมาณการรายรับ - รายจ่าย</h4>
                     <h4 class="pb-2"> ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
                     </h4>
                     <h4 class="pb-2">

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -27,20 +27,20 @@
         <t t-call="web.basic_layout">
             <t t-call="budget_appropriation_summary_f3.report_compilation_f3_styles" />
             <t t-set="f3" t-value="o.get_f3_report_data()" />
-            <t t-if="o.env.context.get('html_preview', False)">
-                <button class="f3-print-btn" onclick="window.print()">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                        viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                        stroke-linecap="round" stroke-linejoin="round">
-                        <polyline points="6 9 6 2 18 2 18 9" />
-                        <path
-                            d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
-                        <rect x="6" y="14" width="12" height="8" />
-                    </svg>
-                    พิมพ์รายงาน </button>
-            </t>
             <div class="page budget-compilation-f3-report"
                 t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+                <t t-if="o.env.context.get('html_preview', False)">
+                    <button class="f3-print-btn" onclick="window.print()" contenteditable="false">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                            stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="6 9 6 2 18 2 18 9" />
+                            <path
+                                d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+                            <rect x="6" y="14" width="12" height="8" />
+                        </svg>
+                        พิมพ์รายงาน </button>
+                </t>
                 <div class="report-header" contenteditable="false">
                     <h4 class="pb-2">สรุปประมาณการรายรับ - รายจ่าย</h4>
                     <h4 class="pb-2"> ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
@@ -142,10 +142,10 @@
                                         <td class="text-end">
                                             <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" style="border-bottom: solid 1px #000;">
                                             <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" style="border-bottom: solid 1px #000;">
                                             <t t-out="'{:,.0f}'.format(row['amount'])" />
                                         </td>
                                     </tr>
@@ -159,10 +159,10 @@
                                         <td class="text-end">
                                             <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" style="border-bottom: solid 1px #202020;">
                                             <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(row['amount'])" />
                                         </td>
-                                        <td class="text-end">
+                                        <td class="text-end" style="border-bottom: solid 1px #202020;">
                                             <t t-out="'{:,.0f}'.format(row['amount'])" />
                                         </td>
                                     </tr>
@@ -274,7 +274,7 @@
                 }
 
                 .f3-print-btn {
-                position: fixed;
+                position: absolute;
                 top: 20px;
                 right: 20px;
                 z-index: 1000;

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -110,12 +110,15 @@
                                 <td class="text-end">
                                     <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['revenue_total'])" />
                                 </td>
-                                <td class="text-end">
+                                <td class="text-end" style="border-bottom: double 3px #000;">
                                     <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['revenue_total'])" />
                                 </td>
                                 <td class="text-end" style="border-bottom: double 3px #000;">
                                     <t t-out="'{:,.0f}'.format(f3['revenue_total'])" />
                                 </td>
+                            </tr>
+                            <tr style="height: 32pt;">
+                                <td colspan="4" />
                             </tr>
 
                             <!-- ===== รายจ่าย ===== -->
@@ -200,7 +203,7 @@
                                 <td class="text-end">
                                     <t t-if="f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['expenditure_total'])" />
                                 </td>
-                                <td class="text-end">
+                                <td class="text-end" style="border-bottom: double 3px #000;">
                                     <t t-if="not f3['is_budget_source']" t-out="'{:,.0f}'.format(f3['expenditure_total'])" />
                                 </td>
                                 <td class="text-end" style="border-bottom: double 3px #000;">

--- a/budget_appropriation_summary_f3/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary_f3/views/budget_appropriation_compilation_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_budget_appropriation_compilation_form_f3" model="ir.ui.view">
+        <field name="name">budget.appropriation.compilation.form.f3</field>
+        <field name="model">budget.appropriation.compilation</field>
+        <field name="inherit_id" ref="budget_appropriation_summary.view_budget_appropriation_compilation_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_open_f3_report"
+                    string="รายงาน F3"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-file-text-o"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- Add new module `budget_appropriation_summary_f3` implementing F3-P report (สรุปประมาณการรายรับ-รายจ่าย ประจำหน่วยงาน) on `budget.appropriation.compilation`
- Revenue section: groups revenue appropriation lines by top-level budget account with amounts in the correct source column (เงินงบประมาณ / เงินรายได้)
- Expenditure section: 4-level hierarchy — Level 0: expense type (51000–55000, 07020), Level 1: sub-category, Level 2: activity plan (children of activity_06/activity_09), Level 3: fund
- Includes QWeb PDF/HTML report with A4 layout, print button, controller for HTML preview, and stat button on compilation form