### PR TITLE
[16.0][IMP] budget_appropriation_summary_f3: exclude หักโอน from revenue

### DIFF
--- a/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
@@ -50,6 +50,7 @@ class BudgetAppropriationCompilation(models.Model):
 
         BudgetAccount = self.env["budget.account"]
         account_totals = {}
+        excluded_root_ids = set()
 
         for line in lines:
             account = line.account_id
@@ -58,8 +59,14 @@ class BudgetAppropriationCompilation(models.Model):
             else:
                 root_id = account.id
 
+            if root_id in excluded_root_ids:
+                continue
+
             if root_id not in account_totals:
                 root = BudgetAccount.browse(root_id)
+                if root.code == "99000":
+                    excluded_root_ids.add(root_id)
+                    continue
                 account_totals[root_id] = {
                     "name": root.name,
                     "code": root.code or "",

--- a/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
@@ -43,30 +43,39 @@ class BudgetAppropriationCompilation(models.Model):
         }
 
     def _get_f3_revenue_rows(self):
-        """Revenue summary grouped by top-level budget account."""
+        """Revenue summary grouped by top-level budget account, excluding หักโอน (code 99000)."""
         lines = self.revenue_appropriation_ids.mapped("line_ids")
         if not lines:
             return []
 
         BudgetAccount = self.env["budget.account"]
+
+        # Exclude หักโอน (code 99000) and all its descendants
+        transfer_account = BudgetAccount.search(
+            [("code", "=", "99000"), ("budget_type", "=", "revenue")], limit=1
+        )
+        excluded_ids = set()
+        if transfer_account:
+            excluded_ids = set(
+                BudgetAccount.search(
+                    [("parent_path", "like", f"{transfer_account.parent_path}%")]
+                ).ids
+            )
+
         account_totals = {}
-        excluded_root_ids = set()
 
         for line in lines:
+            if line.account_id.id in excluded_ids:
+                continue
+
             account = line.account_id
             if account.parent_path:
                 root_id = int(account.parent_path.strip("/").split("/")[0])
             else:
                 root_id = account.id
 
-            if root_id in excluded_root_ids:
-                continue
-
             if root_id not in account_totals:
                 root = BudgetAccount.browse(root_id)
-                if root.code == "99000":
-                    excluded_root_ids.add(root_id)
-                    continue
                 account_totals[root_id] = {
                     "name": root.name,
                     "code": root.code or "",


### PR DESCRIPTION
Exclude budget accounts with code `99000` (หักโอน) from the revenue (รายรับ) section of the F3 report.

A set tracks excluded root IDs to avoid redundant ORM browses for subsequent lines under the same account.