### PR TITLE
[16.0][IMP] budget_appropriation_summary: show fiscal year in compilation kanban

### DIFF
--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -116,6 +116,7 @@
                                 domain="[
                                     ('account_fiscal_year_id', '=', account_fiscal_year_id),
                                     ('budget_type', '=', 'revenue'),
+                                    ('state', '!=', 'cancel'),
                                     '|',
                                         ('source_analytic_id', '=', source_analytic_id),
                                         ('source_analytic_id', '=', False),
@@ -144,6 +145,7 @@
                                 domain="[
                                     ('account_fiscal_year_id', '=', account_fiscal_year_id),
                                     ('budget_type', '=', 'expense'),
+                                    ('state', '!=', 'cancel'),
                                     '|',
                                         ('source_analytic_id', '=', source_analytic_id),
                                         ('source_analytic_id', '=', False),
@@ -388,8 +390,8 @@
                     />
                 </group>
                 <searchpanel>
-                    <field name="account_fiscal_year_id" icon="fa-calendar" enable_counters="1" />
-                    <field name="department_analytic_id" icon="fa-users" select="multi" limit="0" />
+                    <field name="account_fiscal_year_id" icon="fa-calendar" enable_counters="1" order="date_from desc" />
+                    <field name="department_analytic_id" icon="fa-users" limit="0" order="code asc" />
                 </searchpanel>
             </search>
         </field>

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -283,8 +283,11 @@
                             <div class="oe_kanban_content">
                                 <div class="o_kanban_record_top mb-0">
                                     <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title">
-                                            <field name="department_analytic_id" />
+                                        <strong class="o_kanban_record_title fs-5">
+                                          <div>
+                                            ปีงบประมาณ <field name="account_fiscal_year_id"/>
+                                          </div>
+                                          <field name="department_analytic_id"/>
                                         </strong>
                                     </div>
                                     <field


### PR DESCRIPTION
## Summary
- Display the fiscal year (ปีงบประมาณ) above the department name in the budget appropriation compilation kanban view
- Increase the title font size (`fs-5`) for better readability