### PR TITLE
[16.0][IMP] budget,budget_appropriation,budget_appropriation_summary: improve permission controls

### DIFF
--- a/budget/models/budget_commitment.py
+++ b/budget/models/budget_commitment.py
@@ -227,6 +227,13 @@ class BudgetCommitment(models.Model):
         store=True,
     )
     notes = fields.Text(string="Notes")
+    is_auto_created = fields.Boolean(
+        string="Auto Created",
+        default=False,
+        readonly=True,
+        copy=False,
+        help="Automatically created from upstream process (PR, PO, etc.)",
+    )
 
     # Ledger lines
     line_ids = fields.One2many(
@@ -370,8 +377,18 @@ class BudgetCommitment(models.Model):
 
     # --- Workflow Methods ---
 
+    def _check_commitment_group(self):
+        """Check that the user has the budget commitment group."""
+        if not self.env.user.has_group("budget.group_budget_commitment"):
+            raise UserError(
+                _("You do not have permission to perform budget commitment operations.")
+            )
+
     def action_reserve(self):
         """Draft -> Reserved: validate reserve lines exist"""
+        manual = self.filtered(lambda r: not r.is_auto_created)
+        if manual:
+            manual._check_commitment_group()
         for record in self:
             if record.state != "draft":
                 raise UserError(_("Only draft commitments can be reserved."))
@@ -422,6 +439,7 @@ class BudgetCommitment(models.Model):
     def action_obligate(self):
         """Open wizard to add an obligate line."""
         self.ensure_one()
+        self._check_commitment_group()
         if self.state not in ("reserved", "partial"):
             raise UserError(
                 _("Can only obligate in reserved or in-progress state.")
@@ -441,6 +459,7 @@ class BudgetCommitment(models.Model):
     def action_consume(self):
         """Open wizard to add a consume line."""
         self.ensure_one()
+        self._check_commitment_group()
         if self.state not in ("reserved", "partial"):
             raise UserError(
                 _("Can only consume in reserved or in-progress state.")

--- a/budget/models/budget_commitment_mixin.py
+++ b/budget/models/budget_commitment_mixin.py
@@ -215,6 +215,7 @@ class BudgetCommitmentMixin(models.AbstractModel):
             "ref": ref,
             "description": description or "",
             "user_id": self.env.user.id,
+            "is_auto_created": True,
             "line_ids": [(0, 0, line_vals)],
         }
 

--- a/budget/models/budget_controller.py
+++ b/budget/models/budget_controller.py
@@ -473,5 +473,6 @@ class BudgetController(models.AbstractModel):
             "company_id": company_id,
             "currency_id": self.env.company.currency_id.id,
             "amount": amount,
+            "is_auto_created": True,
             "line_ids": [(0, 0, line_vals)],
         }

--- a/budget/models/budget_mixin.py
+++ b/budget/models/budget_mixin.py
@@ -378,6 +378,7 @@ class BudgetMixin(models.AbstractModel):
             'account_fiscal_year_id': self._get_fiscal_year_id(),
             'company_id': self.company_id.id,
             'currency_id': self.currency_id.id,
+            'is_auto_created': True,
         }
 
     def _prepare_default_budget_lines(self):

--- a/budget/views/budget_commitment_views.xml
+++ b/budget/views/budget_commitment_views.xml
@@ -39,12 +39,15 @@
                         type="object" class="oe_highlight"
                         attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <button name="action_reserve" string="Reserve Budget" type="object"
+                        groups="budget.group_budget_commitment"
                         attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                     <button name="action_obligate" string="ผูกพัน" type="object"
                         class="oe_highlight"
+                        groups="budget.group_budget_commitment"
                         attrs="{'invisible': [('state', 'not in', ['reserved', 'partial'])]}"/>
                     <button name="action_consume" string="ตัดงบ" type="object"
                         class="oe_highlight"
+                        groups="budget.group_budget_commitment"
                         attrs="{'invisible': [('state', 'not in', ['reserved', 'partial'])]}"/>
                     <button name="action_return_leftover" string="ส่งคืนเงินเหลือจ่าย"
                         type="object"

--- a/budget/views/budget_transfer_views.xml
+++ b/budget/views/budget_transfer_views.xml
@@ -9,9 +9,9 @@
             <form string="Budget Transfer">
                 <header>
                     <button name="action_submit" type="object" string="Submit for Approval" class="btn-primary" attrs="{'invisible': [('show_submit_button', '=', False)]}"/>
-                    <button name="action_approve" type="object" string="Approve" class="btn-success" attrs="{'invisible': [('show_approve_button', '=', False)]}"/>
-                    <button name="action_reject" type="object" string="Reject" class="btn-warning" attrs="{'invisible': [('show_reject_button', '=', False)]}"/>
-                    <button name="action_post" type="object" string="Post Transfer" class="btn-primary" attrs="{'invisible': [('show_post_button', '=', False)]}"/>
+                    <button name="action_approve" type="object" string="Approve" class="btn-success" groups="budget.group_budget_manager" attrs="{'invisible': [('show_approve_button', '=', False)]}"/>
+                    <button name="action_reject" type="object" string="Reject" class="btn-warning" groups="budget.group_budget_manager" attrs="{'invisible': [('show_reject_button', '=', False)]}"/>
+                    <button name="action_post" type="object" string="Post Transfer" class="btn-primary" groups="budget.group_budget_manager" attrs="{'invisible': [('show_post_button', '=', False)]}"/>
                     <button name="action_cancel" type="object" string="Cancel" attrs="{'invisible': [('show_cancel_button', '=', False)]}"/>
                     <button name="action_reset_to_draft" type="object" string="Reset to Draft" attrs="{'invisible': [('show_reset_button', '=', False)]}"/>
 

--- a/budget_appropriation/models/budget_appropriation.py
+++ b/budget_appropriation/models/budget_appropriation.py
@@ -355,7 +355,7 @@ class BudgetAppropriation(models.Model):
         for record in self:
             if record.state != "review":
                 record.hide_post_button = True
-            elif not is_manager and record.appropriation_type == "initial":
+            elif not is_manager:
                 record.hide_post_button = True
             else:
                 record.hide_post_button = False
@@ -378,15 +378,12 @@ class BudgetAppropriation(models.Model):
 
     def action_post(self):
         """Post appropriation and create budget move"""
-        is_manager = self.env.user.has_group("budget.group_budget_manager")
-        if not is_manager:
-            initial = self.filtered(lambda r: r.appropriation_type == "initial")
-            if initial:
-                raise UserError(
-                    _(
-                        "เฉพาะผู้จัดการงบประมาณเท่านั้นที่สามารถอนุมัติการจัดสรรงบประมาณต้นปีได้"
-                    )
+        if not self.env.user.has_group("budget.group_budget_manager"):
+            raise UserError(
+                _(
+                    "เฉพาะผู้จัดการงบประมาณเท่านั้นที่สามารถอนุมัติการจัดสรรงบประมาณได้"
                 )
+            )
         self._create_budget_move()
         self.write({"state": "posted"})
 
@@ -412,6 +409,13 @@ class BudgetAppropriation(models.Model):
             if record.budget_move_id and record.budget_move_id.state == "posted":
                 raise UserError(
                     _("Cannot reset to draft: Related budget move is already posted.")
+                )
+            if (
+                record.user_id != self.env.user
+                and not self.env.user.has_group("budget.group_budget_manager")
+            ):
+                raise UserError(
+                    _("Only the responsible user or a budget manager can reset to draft.")
                 )
         self.write({"state": "draft"})
 

--- a/budget_appropriation_operating_unit/security/budget_appropriation_security.xml
+++ b/budget_appropriation_operating_unit/security/budget_appropriation_security.xml
@@ -8,8 +8,8 @@
         </field>
         <field name="name">budget appropriation from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -22,8 +22,8 @@
         </field>
         <field name="name">budget appropriation line from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -1,5 +1,5 @@
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class BudgetAppropriationCompilation(models.Model):
@@ -576,9 +576,26 @@ class BudgetAppropriationCompilation(models.Model):
         self.write({"state": "confirmed"})
 
     def action_done(self):
+        if not self.env.user.has_group("budget.group_budget_manager"):
+            raise UserError(
+                _("เฉพาะผู้จัดการงบประมาณเท่านั้นที่สามารถเปลี่ยนสถานะเป็นเสร็จสิ้นได้")
+            )
         self.write({"state": "done"})
 
     def action_draft(self):
+        if not self.env.user.has_group("budget.group_budget_manager"):
+            raise UserError(
+                _("เฉพาะผู้จัดการงบประมาณเท่านั้นที่สามารถเปลี่ยนสถานะกลับเป็นร่างได้")
+            )
+        for record in self:
+            if record.master_summary_id and record.master_summary_id.state != "draft":
+                raise UserError(
+                    _(
+                        "ไม่สามารถเปลี่ยนสถานะกลับเป็นร่างได้ เนื่องจากสรุปภาพรวม '%s' "
+                        "อยู่ในสถานะ %s อยู่"
+                    )
+                    % (record.master_summary_id.name, record.master_summary_id.state)
+                )
         self.write({"state": "draft"})
 
     def action_open_f4_report(self):

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -20,12 +20,14 @@
                         string="เสร็จสิ้น"
                         type="object"
                         class="btn-primary"
+                        groups="budget.group_budget_manager"
                         attrs="{'invisible': [('state', '!=', 'confirmed')]}"
                     />
                     <button
                         name="action_draft"
                         string="กลับไปร่าง"
                         type="object"
+                        groups="budget.group_budget_manager"
                         attrs="{'invisible': [('state', '=', 'draft')]}"
                     />
                     <field

--- a/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
@@ -13,6 +13,7 @@
                         string="ยืนยัน"
                         type="object"
                         class="btn-primary"
+                        groups="budget.group_budget_manager"
                         attrs="{'invisible': [('state', '!=', 'draft')]}"
                     />
                     <button
@@ -20,12 +21,14 @@
                         string="เสร็จสิ้น"
                         type="object"
                         class="btn-primary"
+                        groups="budget.group_budget_manager"
                         attrs="{'invisible': [('state', '!=', 'confirmed')]}"
                     />
                     <button
                         name="action_draft"
                         string="กลับไปร่าง"
                         type="object"
+                        groups="budget.group_budget_manager"
                         attrs="{'invisible': [('state', '=', 'draft')]}"
                     />
                     <button

--- a/budget_appropriation_summary_operating_unit/security/security.xml
+++ b/budget_appropriation_summary_operating_unit/security/security.xml
@@ -8,8 +8,8 @@
         </field>
         <field name="name">budget appropriation compilation from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -22,8 +22,8 @@
         </field>
         <field name="name">budget appropriation compilation impact from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -36,8 +36,8 @@
         </field>
         <field name="name">budget appropriation master summary from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>

--- a/budget_operating_unit/security/budget_security.xml
+++ b/budget_operating_unit/security/budget_security.xml
@@ -8,8 +8,8 @@
         </field>
         <field name="name">budget move from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -22,8 +22,8 @@
         </field>
         <field name="name">budget move line from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -36,8 +36,8 @@
         </field>
         <field name="name">budget transfer from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -50,8 +50,8 @@
         </field>
         <field name="name">budget transfer line from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
@@ -64,8 +64,8 @@
         </field>
         <field name="name">budget commitment from allowed operating units</field>
         <field name="global" eval="True" />
-        <field eval="0" name="perm_unlink" />
-        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_unlink" />
+        <field eval="1" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>


### PR DESCRIPTION
## Summary

- Enforce `group_budget_commitment` on commitment reserve/obligate/consume actions, with `is_auto_created` flag so mixin-created commitments bypass the check
- Add `groups="budget.group_budget_manager"` on transfer Approve/Reject/Post buttons (XML) alongside existing Python `has_group` checks
- Require budget manager to post **all** appropriation types (previously only initial); restrict `button_draft` to the responsible user or manager
- Require budget manager for compilation `action_done` and `action_draft`, with guard preventing draft revert when master summary is already confirmed/done
- Add `groups="budget.group_budget_manager"` on master summary and compilation buttons (Confirm/Done/Back to Draft)
- Enable `perm_write` and `perm_unlink` on all operating unit ir.rules across 3 OU modules for full read/write/delete isolation

## Test plan

- [ ] Verify budget_user cannot see Reserve/Obligate/Consume buttons on commitment form (requires group_budget_commitment)
- [ ] Verify mixin-created commitments (from PR/PO) still auto-reserve without group check
- [ ] Verify budget_user cannot see Approve/Reject/Post buttons on transfer form
- [ ] Verify budget_user cannot post any appropriation type (initial or supplementary)
- [ ] Verify only responsible user or manager can reset appropriation to draft
- [ ] Verify budget_user cannot see Done/Back to Draft buttons on compilation and master summary
- [ ] Verify compilation cannot revert to draft when master summary is confirmed/done
- [ ] Verify operating unit isolation blocks cross-OU write/delete via RPC