### PR TITLE
[16.0][IMP] budget_appropriation_summary: refine F4 report styling

### DIFF
--- a/budget_appropriation_summary/report/report_compilation_f4.xml
+++ b/budget_appropriation_summary/report/report_compilation_f4.xml
@@ -120,7 +120,7 @@
                 </t>
                 <!-- Deduct Lines Table -->
                 <t t-if="data.get('deduct_hierarchy')">
-                    <tr style="height: 32pt;">
+                    <tr style="height: 24pt;">
                       <td/>
                     </tr>
                     <tr class="fw-bold">
@@ -212,7 +212,7 @@
                     box-sizing: border-box;
                     border-radius: 2px;
                 }
-                * {
+                *, span {
                   line-height: 1.145;
                 }
 


### PR DESCRIPTION
## Summary
- Reduce deduct section spacer row height from 32pt to 24pt for tighter layout
- Fix CSS line-height selector to also target `span` elements