### PR TITLE
[16.0][IMP] budget_appropriation_summary: add individual report buttons for master summary

### DIFF
--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -755,9 +755,7 @@ class BudgetAppropriationSummaryController(http.Controller):
                 ],
             )
         elif report_type == "pdf":
-            pdf_content, _ = request.env["ir.actions.report"]._render_qweb_pdf(
-                report.id, [record.id]
-            )
+            pdf_content = record._get_merged_pdf()
             pdfhttpheaders = [
                 ("Content-Type", "application/pdf"),
                 ("Content-Length", len(pdf_content)),

--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -744,7 +744,10 @@ class BudgetAppropriationSummaryController(http.Controller):
         )
 
         if report_type == "html":
-            html = request.env["ir.actions.report"]._render_qweb_html(
+            report_env = request.env["ir.actions.report"].with_context(
+                html_preview=True
+            )
+            html = report_env._render_qweb_html(
                 report.id, [record.id], data={"title": record.name}
             )[0]
             return request.make_response(

--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -794,7 +794,10 @@ class BudgetAppropriationSummaryController(http.Controller):
         report = request.env.ref(report_ref)
 
         if report_type == "html":
-            html = request.env["ir.actions.report"]._render_qweb_html(
+            report_env = request.env["ir.actions.report"].with_context(
+                html_preview=True
+            )
+            html = report_env._render_qweb_html(
                 report.id,
                 [record.id],
                 data={"title": f"{record.name} - {report_name.upper()}"},

--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -761,7 +761,7 @@ class BudgetAppropriationSummaryController(http.Controller):
                 ("Content-Length", len(pdf_content)),
                 (
                     "Content-Disposition",
-                    f'inline; filename="{record.name}.pdf"',
+                    f'inline; filename="{record._get_pdf_filename()}"',
                 ),
             ]
             return request.make_response(pdf_content, headers=pdfhttpheaders)

--- a/budget_appropriation_summary/controllers/main.py
+++ b/budget_appropriation_summary/controllers/main.py
@@ -713,6 +713,20 @@ class BudgetAppropriationSummaryController(http.Controller):
                 add_children_fund(act_id, 1)
         return {"columns": columns, "rows": rows}
 
+    MASTER_SUMMARY_REPORT_MAP = {
+        "f2": "budget_appropriation_summary.action_report_f2_revenue",
+        "f4p": "budget_appropriation_summary.action_report_f4p_revenue",
+        "f4w": "budget_appropriation_summary.action_report_f4w_revenue",
+        "f3w_f6w": "budget_appropriation_summary.action_report_f3w_f6w_revenue",
+        "f5p": "budget_appropriation_summary.action_report_f5p_expense",
+        "f5w": "budget_appropriation_summary.action_report_f5w_expense",
+        "f7w": "budget_appropriation_summary.action_report_f7w_expense",
+        "f8w": "budget_appropriation_summary.action_report_f8w_expense",
+        "f9w": "budget_appropriation_summary.action_report_f9w_expense",
+        "f10w": "budget_appropriation_summary.action_report_f10w_expense",
+        "f11w": "budget_appropriation_summary.action_report_f11w_expense",
+    }
+
     @http.route(
         ["/budget_appropriation_summary/<int:summary_id>/<string:report_type>"],
         type="http",
@@ -750,6 +764,58 @@ class BudgetAppropriationSummaryController(http.Controller):
                 (
                     "Content-Disposition",
                     f'inline; filename="{record.name}.pdf"',
+                ),
+            ]
+            return request.make_response(pdf_content, headers=pdfhttpheaders)
+
+        return request.redirect("/web")
+
+    @http.route(
+        [
+            "/budget_appropriation_summary/<int:summary_id>"
+            "/report/<string:report_name>/<string:report_type>"
+        ],
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def budget_appropriation_summary_individual_report(
+        self, summary_id, report_name, report_type, **kw
+    ):
+        """Render individual master summary report in HTML or PDF format."""
+        record = request.env["budget.appropriation.master.summary"].browse(summary_id)
+        if not record.exists():
+            return request.redirect("/web")
+
+        report_ref = self.MASTER_SUMMARY_REPORT_MAP.get(report_name)
+        if not report_ref:
+            return request.redirect("/web")
+
+        report = request.env.ref(report_ref)
+
+        if report_type == "html":
+            html = request.env["ir.actions.report"]._render_qweb_html(
+                report.id,
+                [record.id],
+                data={"title": f"{record.name} - {report_name.upper()}"},
+            )[0]
+            return request.make_response(
+                html,
+                headers=[
+                    ("Content-Type", "text/html"),
+                    ("Content-Length", len(html)),
+                ],
+            )
+        elif report_type == "pdf":
+            pdf_content, _ = request.env["ir.actions.report"]._render_qweb_pdf(
+                report.id, [record.id]
+            )
+            pdfhttpheaders = [
+                ("Content-Type", "application/pdf"),
+                ("Content-Length", len(pdf_content)),
+                (
+                    "Content-Disposition",
+                    f'inline; filename="{record.name} - {report_name.upper()}.pdf"',
                 ),
             ]
             return request.make_response(pdf_content, headers=pdfhttpheaders)

--- a/budget_appropriation_summary/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary/models/budget_appropriation_master_summary.py
@@ -307,7 +307,7 @@ class BudgetAppropriationMasterSummary(models.Model):
         self.write({"state": "draft"})
 
     def action_open_report(self):
-        """Open the report in a new browser tab as HTML."""
+        """Open the combined report in a new browser tab as HTML."""
         self.ensure_one()
         return {
             "type": "ir.actions.act_url",
@@ -320,3 +320,63 @@ class BudgetAppropriationMasterSummary(models.Model):
         return self.env.ref(
             "budget_appropriation_summary.action_report_master_summary"
         ).report_action(self)
+
+    # --- Individual report actions ---
+
+    REPORT_MAP = {
+        "f2": "action_report_f2_revenue",
+        "f4p": "action_report_f4p_revenue",
+        "f4w": "action_report_f4w_revenue",
+        "f3w_f6w": "action_report_f3w_f6w_revenue",
+        "f5p": "action_report_f5p_expense",
+        "f5w": "action_report_f5w_expense",
+        "f7w": "action_report_f7w_expense",
+        "f8w": "action_report_f8w_expense",
+        "f9w": "action_report_f9w_expense",
+        "f10w": "action_report_f10w_expense",
+        "f11w": "action_report_f11w_expense",
+    }
+
+    def _action_open_individual_report(self, report_name):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_url",
+            "url": (
+                f"/budget_appropriation_summary/{self.id}"
+                f"/report/{report_name}/html"
+            ),
+            "target": "new",
+        }
+
+    def action_open_f2_report(self):
+        return self._action_open_individual_report("f2")
+
+    def action_open_f4p_report(self):
+        return self._action_open_individual_report("f4p")
+
+    def action_open_f4w_report(self):
+        return self._action_open_individual_report("f4w")
+
+    def action_open_f3w_f6w_report(self):
+        return self._action_open_individual_report("f3w_f6w")
+
+    def action_open_f5p_report(self):
+        return self._action_open_individual_report("f5p")
+
+    def action_open_f5w_report(self):
+        return self._action_open_individual_report("f5w")
+
+    def action_open_f7w_report(self):
+        return self._action_open_individual_report("f7w")
+
+    def action_open_f8w_report(self):
+        return self._action_open_individual_report("f8w")
+
+    def action_open_f9w_report(self):
+        return self._action_open_individual_report("f9w")
+
+    def action_open_f10w_report(self):
+        return self._action_open_individual_report("f10w")
+
+    def action_open_f11w_report(self):
+        return self._action_open_individual_report("f11w")

--- a/budget_appropriation_summary/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary/models/budget_appropriation_master_summary.py
@@ -16,6 +16,20 @@ class BudgetAppropriationMasterSummary(models.Model):
         "done": [("readonly", True)],
     }
 
+    PRINT_REPORT_ORDER = [
+        "action_report_f2_revenue",
+        "action_report_f4p_revenue",
+        "action_report_f4w_revenue",
+        "action_report_f3w_f6w_revenue",
+        "action_report_f7w_expense",
+        "action_report_f5p_expense",
+        "action_report_f5w_expense",
+        "action_report_f8w_expense",
+        "action_report_f9w_expense",
+        "action_report_f11w_expense",
+        "action_report_f10w_expense",
+    ]
+
     name = fields.Char(
         string="ชื่อสรุปภาพรวม",
         compute="_compute_name",
@@ -317,20 +331,6 @@ class BudgetAppropriationMasterSummary(models.Model):
             "url": f"/budget_appropriation_summary/{self.id}/html",
             "target": "new",
         }
-
-    PRINT_REPORT_ORDER = [
-        "action_report_f2_revenue",
-        "action_report_f4p_revenue",
-        "action_report_f4w_revenue",
-        "action_report_f3w_f6w_revenue",
-        "action_report_f7w_expense",
-        "action_report_f5p_expense",
-        "action_report_f5w_expense",
-        "action_report_f8w_expense",
-        "action_report_f9w_expense",
-        "action_report_f11w_expense",
-        "action_report_f10w_expense",
-    ]
 
     def _get_merged_pdf(self):
         """Render each sub-report with its own paperformat and merge into one PDF.

--- a/budget_appropriation_summary/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary/models/budget_appropriation_master_summary.py
@@ -342,16 +342,26 @@ class BudgetAppropriationMasterSummary(models.Model):
         pdfs = []
         for ref in self.PRINT_REPORT_ORDER:
             report = self.env.ref(f"budget_appropriation_summary.{ref}")
-            pdf_content, _ = report._render_qweb_pdf(report.id, self.ids)
+            pdf_content, __ = report._render_qweb_pdf(report.id, self.ids)
             pdfs.append(pdf_content)
         return merge_pdf(pdfs)
+
+    def _get_pdf_filename(self):
+        """Return an ASCII-safe PDF filename so it survives HTTP transport."""
+        self.ensure_one()
+        parts = [
+            self.source_analytic_id.code or "",
+            self.account_fiscal_year_id.name or "",
+        ]
+        slug = "-".join(p for p in parts if p) or str(self.id)
+        return f"budget-summary-{slug}.pdf"
 
     def action_print_report(self):
         self.ensure_one()
         merged = self._get_merged_pdf()
         attachment = self.env["ir.attachment"].create(
             {
-                "name": f"{self.name or 'master-summary'}.pdf",
+                "name": self._get_pdf_filename(),
                 "type": "binary",
                 "datas": base64.b64encode(merged),
                 "res_model": self._name,

--- a/budget_appropriation_summary/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary/models/budget_appropriation_master_summary.py
@@ -1,5 +1,8 @@
+import base64
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.pdf import merge_pdf
 
 
 class BudgetAppropriationMasterSummary(models.Model):
@@ -315,11 +318,52 @@ class BudgetAppropriationMasterSummary(models.Model):
             "target": "new",
         }
 
+    PRINT_REPORT_ORDER = [
+        "action_report_f2_revenue",
+        "action_report_f4p_revenue",
+        "action_report_f4w_revenue",
+        "action_report_f3w_f6w_revenue",
+        "action_report_f7w_expense",
+        "action_report_f5p_expense",
+        "action_report_f5w_expense",
+        "action_report_f8w_expense",
+        "action_report_f9w_expense",
+        "action_report_f11w_expense",
+        "action_report_f10w_expense",
+    ]
+
+    def _get_merged_pdf(self):
+        """Render each sub-report with its own paperformat and merge into one PDF.
+
+        Using merge_pdf preserves each report's orientation (portrait/landscape)
+        and starts every sub-report on a new page.
+        """
+        self.ensure_one()
+        pdfs = []
+        for ref in self.PRINT_REPORT_ORDER:
+            report = self.env.ref(f"budget_appropriation_summary.{ref}")
+            pdf_content, _ = report._render_qweb_pdf(report.id, self.ids)
+            pdfs.append(pdf_content)
+        return merge_pdf(pdfs)
+
     def action_print_report(self):
         self.ensure_one()
-        return self.env.ref(
-            "budget_appropriation_summary.action_report_master_summary"
-        ).report_action(self)
+        merged = self._get_merged_pdf()
+        attachment = self.env["ir.attachment"].create(
+            {
+                "name": f"{self.name or 'master-summary'}.pdf",
+                "type": "binary",
+                "datas": base64.b64encode(merged),
+                "res_model": self._name,
+                "res_id": self.id,
+                "mimetype": "application/pdf",
+            }
+        )
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/web/content/{attachment.id}?download=false",
+            "target": "new",
+        }
 
     # --- Individual report actions ---
 

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -26,6 +26,10 @@
             .table-sm > :not(caption) > * > * {
                 padding: 0.065rem 0.15rem;
             }
+            h3 {
+                font-size: 18pt;
+                margin-bottom: 0;
+            }
         </style>
     </template>
 

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -96,11 +96,19 @@
                         background: white !important;
                         margin: 0 !important;
                         padding: 0 !important;
+                        width: auto !important;
+                        height: auto !important;
+                    }
+                    .article, main, header, footer, .o_report_layout_standard {
+                        margin: 0 !important;
+                        padding: 0 !important;
                     }
                     .page {
-                        width: 100% !important;
+                        width: auto !important;
                         min-height: auto !important;
+                        max-width: none !important;
                         margin: 0 !important;
+                        padding: 0 !important;
                         box-shadow: none !important;
                         border-radius: 0 !important;
                         page-break-after: always;
@@ -116,16 +124,14 @@
             <t t-if="is_landscape">
                 <style>
                     @media print {
-                        @page { size: A4 landscape; margin: 0; }
-                        .page.landscape { padding: 8mm 15mm !important; }
+                        @page { size: A4 landscape; margin: 8mm 15mm; }
                     }
                 </style>
             </t>
             <t t-else="">
                 <style>
                     @media print {
-                        @page { size: A4 portrait; margin: 0; }
-                        .page:not(.landscape) { padding: 15mm 8mm !important; }
+                        @page { size: A4 portrait; margin: 15mm 8mm; }
                     }
                 </style>
             </t>

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -90,30 +90,41 @@
                 @media print {
                     html, body {
                         background: white !important;
-                        margin: 0;
-                        padding: 0;
+                        margin: 0 !important;
+                        padding: 0 !important;
                     }
                     .page {
-                        width: auto;
-                        min-height: auto;
+                        width: 100% !important;
+                        min-height: auto !important;
                         margin: 0 !important;
-                        padding: 0 !important;
-                        box-shadow: none;
-                        border-radius: 0;
+                        box-shadow: none !important;
+                        border-radius: 0 !important;
+                        page-break-after: always;
                     }
-                    @page {
-                        margin: 0 !important;
-                        padding: 24mm 8mm !important;
-                        size: A4;
-                    }
-                    .page.landscape {
-                        padding: 0 !important;
+                    .page:last-child {
+                        page-break-after: auto;
                     }
                     .print-btn {
                         display: none !important;
                     }
                 }
             </style>
+            <t t-if="is_landscape">
+                <style>
+                    @media print {
+                        @page { size: A4 landscape; margin: 0; }
+                        .page.landscape { padding: 8mm 15mm !important; }
+                    }
+                </style>
+            </t>
+            <t t-else="">
+                <style>
+                    @media print {
+                        @page { size: A4 portrait; margin: 0; }
+                        .page:not(.landscape) { padding: 15mm 8mm !important; }
+                    }
+                </style>
+            </t>
         </t>
     </template>
 

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -151,11 +151,16 @@
         </t>
     </template>
 
+    <!-- Printer icon SVG (reusable) -->
+    <template id="report_print_icon">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+    </template>
+
     <!-- Print button (call inside .page div, only shown in individual html_preview) -->
     <template id="report_print_button">
         <t t-if="o.env.context.get('html_preview', False) and not skip_orientation_page">
             <button class="print-btn" onclick="window.print()" contenteditable="false">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+                <t t-call="budget_appropriation_summary.report_print_icon" />
                 พิมพ์รายงาน
             </button>
         </t>

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -35,7 +35,7 @@
 
     <!-- Preview styles for A4 paper page effect (set is_landscape before calling) -->
     <template id="report_preview_styles">
-        <t t-set="is_html_preview" t-value="o.env.context.get('html_preview', False)" />
+        <t t-set="is_html_preview" t-value="o.env.context.get('html_preview', False)"/>
         <t t-if="is_html_preview">
             <style>
                 html, body {
@@ -104,7 +104,7 @@
                         padding: 0 !important;
                     }
                     .page {
-                        width: auto !important;
+                        width: 100% !important;
                         min-height: auto !important;
                         max-width: none !important;
                         margin: 0 !important;
@@ -112,6 +112,9 @@
                         box-shadow: none !important;
                         border-radius: 0 !important;
                         page-break-after: always;
+                    }
+                    .page.landscape {
+                      width: 297mm !important;
                     }
                     .page:last-child {
                         page-break-after: auto;
@@ -124,14 +127,22 @@
             <t t-if="is_landscape">
                 <style>
                     @media print {
-                        @page { size: A4 landscape; margin: 8mm 15mm; }
+                        @page {
+                          size: A4 landscape;
+                          margin: 8mm 15mm;
+                          padding: 24mm 0mm !important;
+                        }
                     }
                 </style>
             </t>
             <t t-else="">
                 <style>
                     @media print {
-                        @page { size: A4 portrait; margin: 15mm 8mm; }
+                        @page {
+                          size: A4 portrait;
+                          margin: 0 !important;
+                          padding: 14mm 8mm !important;
+                        }
                     }
                 </style>
             </t>

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -29,6 +29,104 @@
         </style>
     </template>
 
+    <!-- Preview styles for A4 paper page effect (set is_landscape before calling) -->
+    <template id="report_preview_styles">
+        <t t-set="is_html_preview" t-value="o.env.context.get('html_preview', False)" />
+        <t t-if="is_html_preview">
+            <style>
+                html, body {
+                    background: #e8e8e8 !important;
+                    margin: 0;
+                    padding: 0;
+                }
+                .page {
+                    position: relative;
+                    background-color: white !important;
+                    margin: 40px auto;
+                    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
+                    box-sizing: border-box;
+                    border-radius: 2px;
+                }
+                .page.landscape {
+                    width: 297mm;
+                    min-height: 210mm;
+                    padding: 8mm 15mm !important;
+                }
+                .page:not(.landscape) {
+                    width: 210mm;
+                    min-height: 297mm;
+                    padding: 25mm 8mm !important;
+                }
+                * {
+                    line-height: 1.145;
+                }
+                [contenteditable]:focus {
+                    outline: none;
+                }
+                *[contenteditable="false"] {
+                    cursor: not-allowed;
+                }
+                .print-btn {
+                    position: fixed;
+                    top: 20px;
+                    right: 20px;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #714B67;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 16pt;
+                    cursor: pointer;
+                    font-family: 'THSarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .print-btn:hover {
+                    background: #5a3a52;
+                }
+                @media print {
+                    html, body {
+                        background: white !important;
+                        margin: 0;
+                        padding: 0;
+                    }
+                    .page {
+                        width: auto;
+                        min-height: auto;
+                        margin: 0 !important;
+                        padding: 0 !important;
+                        box-shadow: none;
+                        border-radius: 0;
+                    }
+                    @page {
+                        margin: 0 !important;
+                        padding: 24mm 8mm !important;
+                        size: A4;
+                    }
+                    .page.landscape {
+                        padding: 0 !important;
+                    }
+                    .print-btn {
+                        display: none !important;
+                    }
+                }
+            </style>
+        </t>
+    </template>
+
+    <!-- Print button (call inside .page div, only shown in html_preview) -->
+    <template id="report_print_button">
+        <t t-if="o.env.context.get('html_preview', False)">
+            <button class="print-btn" onclick="window.print()" contenteditable="false">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+                พิมพ์รายงาน
+            </button>
+        </t>
+    </template>
+
     <!-- Council meeting header template (reusable) -->
     <template id="report_council_header">
         <t t-set="show_council_header" t-value="o.env.context.get('show_council_header', False)" />

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -124,34 +124,36 @@
                     }
                 }
             </style>
-            <t t-if="is_landscape">
-                <style>
-                    @media print {
-                        @page {
-                          size: A4 landscape;
-                          margin: 8mm 15mm;
-                          padding: 24mm 0mm !important;
+            <t t-if="not skip_orientation_page">
+                <t t-if="is_landscape">
+                    <style>
+                        @media print {
+                            @page {
+                              size: A4 landscape;
+                              margin: 8mm 15mm;
+                              padding: 24mm 0mm !important;
+                            }
                         }
-                    }
-                </style>
-            </t>
-            <t t-else="">
-                <style>
-                    @media print {
-                        @page {
-                          size: A4 portrait;
-                          margin: 0 !important;
-                          padding: 14mm 8mm !important;
+                    </style>
+                </t>
+                <t t-else="">
+                    <style>
+                        @media print {
+                            @page {
+                              size: A4 portrait;
+                              margin: 0 !important;
+                              padding: 14mm 8mm !important;
+                            }
                         }
-                    }
-                </style>
+                    </style>
+                </t>
             </t>
         </t>
     </template>
 
-    <!-- Print button (call inside .page div, only shown in html_preview) -->
+    <!-- Print button (call inside .page div, only shown in individual html_preview) -->
     <template id="report_print_button">
-        <t t-if="o.env.context.get('html_preview', False)">
+        <t t-if="o.env.context.get('html_preview', False) and not skip_orientation_page">
             <button class="print-btn" onclick="window.print()" contenteditable="false">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
                 พิมพ์รายงาน

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -4,7 +4,7 @@
     <template id="report_common_styles">
         <style>
             * {
-                font-family: "THSarabunNew", Arial, sans-serif;
+                font-family: 'THSarabun', Arial, sans-serif;
                 --bs-body-font-size: 15pt;
             }
             p,

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -38,7 +38,7 @@
                 border-bottom: 0;
             }
         </style>
-        <div class="page f10w">
+        <div class="page f10w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -38,7 +38,8 @@
                 border-bottom: 0;
             }
         </style>
-        <div class="page f10w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+        <div class="page f10w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -107,6 +108,8 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-set="is_landscape" t-value="True" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f10w_expense_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -3,58 +3,60 @@
     <!-- Partial template for F10-W content (reusable) -->
     <template id="report_f10w_expense_content">
         <style>
-            .f10w table {
-            }
-            .f10w th, .f10w td {
-                padding: 2px 4px;
-            }
             .f10w .level-0 td:first-child {
                 font-weight: bold;
             }
-            .f10w .level-0 td:first-child span {
+            .f10w .level-0 td:first-child {
                 text-decoration: underline;
             }
             .f10w .level-1 td:first-child {
-                padding-left: 1rem;
+                padding-left: 8pt;
                 font-weight: bold;
             }
-            .f10w .level-1 td:first-child span {
+            .f10w .level-1 td:first-child {
                 text-decoration: underline;
             }
             .f10w .level-2 td:first-child {
-                padding-left: 1.5rem;
+                padding-left: 12pt;
             }
             .f10w .level-3 td:first-child {
-                padding-left: 2rem;
+                padding-left: 16pt;
             }
             .table {
                 border-color: #000 !important;
             }
-            .table > :not(:first-child) {
+            .table &gt; :not(:first-child) {
                 border-top: 0;
             }
             .table tbody td, .table tbody tr {
                 border-top: 0;
                 border-bottom: 0;
             }
+            p,
+            span,
+            div {
+                font-size: 13pt;
+                line-height: 1.1;
+            }
         </style>
         <div class="page f10w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center" style="font-weight: bold">
                 <h3>
-                    สรุปประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
+                    สรุปประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามแผนงานและงบรายจ่าย</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
                         <tr>
                             <th class="text-center" style="width: 30%;">แผนงาน/กิจกรรม</th>
                             <t t-foreach="o.f10w_expense_data['columns']" t-as="column">
-                                <th class="text-center"><t t-out="column['name']" /></th>
+                                <th class="text-center"><t t-out="column['name']"/></th>
                             </t>
                             <th class="text-center">รวมทุกงบรายจ่าย</th>
                         </tr>
@@ -62,20 +64,18 @@
                     <tbody>
                         <t t-foreach="o.f10w_expense_data['rows']" t-as="row">
                             <tr t-attf-class="level-#{row['level']}">
-                                <td>
-                                    <span><t t-out="row['name']" /></span>
-                                </td>
+                                <td t-esc="row['name']"/>
                                 <t t-foreach="o.f10w_expense_data['columns']" t-as="column">
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(row['columns'][column['code']])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(row['columns'][column['code']])"/>
                                     </td>
                                 </t>
-                                <td class="text-end">
+                                <td class="text-end fw-bold" contenteditable="false">
                                     <t t-if="row['level'] in [0, 1]">
-                                        <strong><t t-out="'{0:,.2f}'.format(row['total'])" /></strong>
+                                        <t t-out="'{0:,.2f}'.format(row['total'])"/>
                                     </t>
                                     <t t-else="">
-                                        <t t-out="'{0:,.2f}'.format(row['total'])" />
+                                        <t t-out="'{0:,.2f}'.format(row['total'])"/>
                                     </t>
                                 </td>
                             </tr>
@@ -87,12 +87,12 @@
                                 รวมทั้งสิ้น
                             </td>
                             <t t-foreach="o.f10w_expense_data['columns']" t-as="column">
-                                <td class="text-end">
-                                    <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['column_totals'][column['code']])" />
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['column_totals'][column['code']])"/>
                                 </td>
                             </t>
-                            <td class="text-end">
-                                <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['summary']['total_amount'])" />
+                            <td class="text-end" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -106,7 +106,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-set="is_landscape" t-value="True" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -42,11 +42,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามแผนงานและงบรายจ่าย</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามแผนงานและงบรายจ่าย</h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -23,7 +23,7 @@
                 border-bottom: 0;
             }
         </style>
-        <div class="page f11w">
+        <div class="page f11w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -27,11 +27,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามหน่วยงานและกองทุน</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามหน่วยงานและกองทุน</h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -3,77 +3,84 @@
     <!-- Partial template for F11-W content (reusable) -->
     <template id="report_f11w_expense_content">
         <style>
-            .f11w table {
-                font-size: 9pt;
-            }
-            .f11w table .column-name {
-                font-size: 8pt;
-            }
-            .f11w th, .f11w td {
-                padding: 2px 3px;
+            p,
+            span,
+            div {
+                font-size: 7.5pt;
+                line-height: 1.1;
             }
             .table {
                 border-color: #000 !important;
             }
-            .table > :not(:first-child) {
+            .table &gt; :not(:first-child) {
                 border-top: 0;
             }
             .table tbody td, .table tbody tr {
                 border-top: 0;
                 border-bottom: 0;
             }
+            h3 {
+              font-weight: bold;
+            }
         </style>
         <div class="page f11w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center">
                 <h3>
-                    สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
+                    สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและกองทุน</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
+                            <th style="width: 80pt;"/>
+                            <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
+                                <th style="width: 30pt;"/>
+                                <th style="width: 18pt;"/>
+                            </t>
+                            <th style="width: 50pt;"/>
+                        </tr>
                         <tr>
                             <th class="text-center" rowspan="2" style="width: 10%;">หน่วยงาน</th>
                             <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
-                                <th class="text-center column-name" colspan="2"><t t-out="column['name']" /></th>
+                                <th class="text-center column-name" colspan="2"><t t-out="column['name']"/></th>
                             </t>
                             <th class="text-center" rowspan="2">รวมทุกกองทุน</th>
                         </tr>
                         <tr>
                             <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
                                 <th class="text-center">เงินรายได้</th>
-                                <th class="text-center" style="20pt;">%</th>
+                                <th class="text-center">%</th>
                             </t>
                         </tr>
                     </thead>
                     <tbody>
-                        <t t-set="row_no" t-value="1" />
+                        <t t-set="row_no" t-value="1"/>
                         <t t-foreach="o.f11w_expense_data['departments']" t-as="department">
                             <tr>
                                 <td class="">
-                                    <t t-out="department['name']" />
+                                    <t t-out="department['name']"/>
                                 </td>
                                 <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
                                     <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(department['columns'][column['code']]['amount'])" />
+                                        <t t-out="'{0:,.0f}'.format(department['columns'][column['code']]['amount'])"/>
                                     </td>
                                     <td class="text-center">
-                                        <t t-set="col_total" t-value="o.f11w_expense_data['column_totals'][column['code']]['amount']" />
-                                        <t t-set="pct" t-value="(department['columns'][column['code']]['amount'] / col_total * 100) if col_total else 0" />
-                                        <t t-out="'{0:.2f}'.format(pct)" />
+                                        <t t-set="col_total" t-value="o.f11w_expense_data['column_totals'][column['code']]['amount']"/>
+                                        <t t-set="pct" t-value="(department['columns'][column['code']]['amount'] / col_total * 100) if col_total else 0"/>
+                                        <t t-out="'{0:,.2f}'.format(pct)"/>
                                     </td>
                                 </t>
-                                <td class="text-end">
-                                    <strong>
-                                        <t t-out="'{0:,.2f}'.format(department['total']['amount'])" />
-                                    </strong>
+                                <td class="text-end fw-bold">
+                                      <t t-out="'{0:,.0f}'.format(department['total']['amount'])"/>
                                 </td>
                             </tr>
-                            <t t-set="row_no" t-value="row_no + 1" />
+                            <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
                     </tbody>
                     <tfoot>
@@ -83,14 +90,14 @@
                             </td>
                             <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
                                 <td class="text-end">
-                                    <t t-out="'{0:,.2f}'.format(o.f11w_expense_data['column_totals'][column['code']]['amount'])" />
+                                    <t t-out="'{0:,.0f}'.format(o.f11w_expense_data['column_totals'][column['code']]['amount'])"/>
                                 </td>
                                 <td class="text-center">
                                     100.00
                                 </td>
                             </t>
                             <td class="text-end">
-                                <t t-out="'{0:,.2f}'.format(o.f11w_expense_data['summary']['total_amount'])" />
+                                <t t-out="'{0:,.0f}'.format(o.f11w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -23,7 +23,8 @@
                 border-bottom: 0;
             }
         </style>
-        <div class="page f11w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+        <div class="page f11w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -105,6 +106,8 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-set="is_landscape" t-value="True" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f11w_expense_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -104,7 +104,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-set="is_landscape" t-value="True" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -16,9 +16,6 @@
             .table tbody .revenue .border-bottom {
                 border-bottom: 1pt solid #000 !important;
             }
-            h3 {
-              margin-bottom: 0;
-            }
         </style>
         <div class="page landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -17,7 +17,7 @@
                 border-bottom: 1pt solid #000 !important;
             }
         </style>
-        <div class="page" style="width: 100%">
+        <div class="page" style="width: 100%" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>สรุปเปรียบเทียบประมาณการรายรับ</div>

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -16,125 +16,110 @@
             .table tbody .revenue .border-bottom {
                 border-bottom: 1pt solid #000 !important;
             }
+            h3 {
+              margin-bottom: 0;
+            }
         </style>
         <div class="page landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>สรุปเปรียบเทียบประมาณการรายรับ</div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามประเภท</div>
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center" style="font-weight: bold">
+                <h3>สรุปเปรียบเทียบประมาณการรายรับ</h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามประเภท</h3>
             </div>
-            <div style="width: 80%; margin: 0 auto;">
-                <table class="table table-sm table-bordered f2w me-auto">
+            <div class="mt-5">
+                <table class="table table-sm table-bordered f2w">
                     <thead>
                         <tr class="text-center">
                             <th style="width: 35%" rowspan="2">ประเภท</th>
                             <th colspan="2">
                                 ปีงบประมาณ
-                                <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
+                                <t t-out="o.compare_summary_id.account_fiscal_year_id.name"/>
                             </th>
                             <th colspan="2">
-                                ปีงบประมาณ <t t-out="o.account_fiscal_year_id.name" />
+                                ปีงบประมาณ <t t-out="o.account_fiscal_year_id.name"/>
                             </th>
-                            <th rowspan="2">
-                                + เพิ่ม - ลด <br />
+                            <th rowspan="2" style="width: 96pt">
+                                + เพิ่ม - ลด <br/>
                                 จำนวนเงิน
                             </th>
-                            <th rowspan="2" style="width: 80px">
+                            <th rowspan="2" style="width: 42pt">
                                 %
                             </th>
                         </tr>
                         <tr class="text-center">
                             <th>จำนวนเงิน</th>
-                            <th style="width: 60px">%</th>
+                            <th>%</th>
                             <th>จำนวนเงิน</th>
-                            <th style="width: 60px">%</th>
+                            <th>%</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr style="font-weight: bold;">
                             <td class="">1. รายรับจากรัฐบาล</td>
-                            <td class="text-end">0</td>
-                            <td class="text-end">0.00</td>
-                            <td class="text-end">0</td>
-                            <td class="text-end">0.00</td>
-                            <td class="text-end">0</td>
-                            <td class="text-end">0.00</td>
+                            <td class="text-end" contenteditable="false">0</td>
+                            <td class="text-end" contenteditable="false">0.00</td>
+                            <td class="text-end" contenteditable="false">0</td>
+                            <td class="text-end" contenteditable="false">0.00</td>
+                            <td class="text-end" contenteditable="false">0</td>
+                            <td class="text-end" contenteditable="false">0.00</td>
                         </tr>
                         <tr class="revenue" style="font-weight: bold;">
                             <td>2. เงินรายได้</td>
-                            <td class="text-end border-bottom">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])" />
+                            <td class="text-end border-bottom" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
-                            <td class="text-end border-bottom">100.0</td>
-                            <td class="text-end border-bottom">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['total_amount'])" />
+                            <td class="text-end border-bottom" contenteditable="false">100.0</td>
+                            <td class="text-end border-bottom" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end border-bottom">100.0</td>
-                            <td class="text-end border-bottom">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_amount'])" />
+                            <td class="text-end border-bottom" contenteditable="false">100.0</td>
+                            <td class="text-end border-bottom" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_amount'])"/>
                             </td>
-                            <td class="text-end border-bottom">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_percentage'])" />
+                            <td class="text-end border-bottom" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>
                         <t t-foreach="o.f2_revenue_data['categories']" t-as="row">
                             <tr>
-                                <td class="ps-4" t-out="row['name']" />
-                                <td class="text-end">
-                                    <t
-                                        t-out="'{0:,.2f}'.format(row['compare_amount'])"
-                                    />
+                                <td class="ps-4" t-out="row['name']"/>
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end">
-                                    <t
-                                        t-out="'{0:,.2f}'.format(row['compare_percentage'])"
-                                    />
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
-                                <td class="text-end">
-                                    <t t-out="'{0:,.2f}'.format(row['amount'])" />
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end" t-out="row['percentage']" />
-                                <td class="text-end">
-                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])" />
+                                <td class="text-end" contenteditable="false" t-out="row['percentage']"/>
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end">
-                                    <t
-                                        t-out="'{0:,.2f}'.format(row['diff_percentage'])"
-                                    />
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>
                         </t>
                     </tbody>
                     <tfoot>
-                        <tr style="padding-top: 60px">
+                        <tr style="padding-top: 48pt">
                             <th class="text-center">รวมรายได้ทั้งสิ้น</th>
-                            <th class="text-end">
-                                <strong
-                                    ><t
-                                        t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"
-                                /></strong>
+                            <th class="text-end" contenteditable="false">
+                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"/></strong>
                             </th>
-                            <th class="text-end">100.0</th>
-                            <th class="text-end">
-                                <strong
-                                    ><t
-                                        t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['total_amount'])"
-                                /></strong>
+                            <th class="text-end" contenteditable="false">100.0</th>
+                            <th class="text-end" contenteditable="false">
+                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['total_amount'])"/></strong>
                             </th>
-                            <th class="text-end">100.0</th>
-                            <th class="text-end">
-                                <strong
-                                    ><t
-                                        t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_amount'])"
-                                /></strong>
+                            <th class="text-end" contenteditable="false">100.0</th>
+                            <th class="text-end" contenteditable="false">
+                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_amount'])"/></strong>
                             </th>
-                            <th class="text-end">
-                                <strong
-                                    ><t
-                                        t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_percentage'])"
-                                /></strong>
+                            <th class="text-end" contenteditable="false">
+                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_percentage'])"/></strong>
                             </th>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -17,7 +17,8 @@
                 border-bottom: 1pt solid #000 !important;
             }
         </style>
-        <div class="page" style="width: 100%" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+        <div class="page landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>สรุปเปรียบเทียบประมาณการรายรับ</div>
@@ -149,6 +150,8 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-set="is_landscape" t-value="True" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f2_revenue_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -148,7 +148,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-set="is_landscape" t-value="True" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -16,11 +16,14 @@
             .table tbody .revenue .border-bottom {
                 border-bottom: 1pt solid #000 !important;
             }
+            h3 {
+              font-weight: bold;
+            }
         </style>
         <div class="page landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
             <t t-call="budget_appropriation_summary.report_council_header"/>
-            <div class="text-center" style="font-weight: bold">
+            <div class="text-center">
                 <h3>สรุปเปรียบเทียบประมาณการรายรับ</h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามประเภท</h3>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -11,6 +11,7 @@
             }
         </style>
         <div class="page f3w_f6w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -113,6 +114,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f3w_f6w_revenue_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -9,27 +9,46 @@
             .f3w_f6w .table {
                 border-color: #000 !important;
             }
+            p,
+            span,
+            div,
+            strong {
+                font-size: 14pt;
+                line-height: 1.4;
+            }
         </style>
         <div class="page f3w_f6w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center fw-bold">
                 <h3>
                     สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
-                <h3>จําแนกตามหน่วยงาน ปีงบประมาณ พ.ศ.                    <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
- และ                    <t t-out="o.account_fiscal_year_id.name" />
+                <h3>จําแนกตามหน่วยงาน ปีงบประมาณ พ.ศ.                    <t t-out="o.compare_summary_id.account_fiscal_year_id.name"/>
+ และ                    <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
+                          <td style="width: auto;"/>
+                          <td style="width: 74pt;"/>
+                          <td style="width: 32pt;"/>
+                          <td style="width: 74pt;"/>
+                          <td style="width: 32pt;"/>
+                          <td style="width: 74pt;"/>
+                          <td style="width: 32pt;"/>
+                        </tr>
                         <tr>
-                            <th class="text-center" rowspan="2" style="width: 35%;">หน่วยงาน</th>
-                            <th class="text-center" colspan="2">ปีงบประมาณ                                <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
+                            <th class="text-center" rowspan="2">หน่วยงาน</th>
+                            <th class="text-center" colspan="2">
+                              ปีงบประมาณ <t t-out="o.compare_summary_id.account_fiscal_year_id.name"/>
                             </th>
-                            <th class="text-center" colspan="2">ปีงบประมาณ                                <t t-out="o.account_fiscal_year_id.name" />
+                            <th class="text-center" colspan="2">
+                              ปีงบประมาณ <t t-out="o.account_fiscal_year_id.name"/>
                             </th>
                             <th class="text-center" colspan="2">+ เพิ่ม - ลด</th>
                         </tr>
@@ -44,61 +63,53 @@
                     </thead>
                     <tbody class="category">
                         <t t-foreach="o.f4w_revenue_data['departments']" t-as="row">
-                            <tr class="border-0">
+                            <tr class="border-0 fw-bold">
                                 <td class="border-0 border-start">
-                                    <t t-out="row['name']" />
+                                    <t t-out="row['name']"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>
-                                        <t t-out="'{0:,.2f}'.format(row['compare_amount'])" />
-                                    </strong>
+                                <td class="text-end">
+                                        <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>
-                                        <t t-out="'{0:,.2f}'.format(row['amount'])" />
-                                    </strong>
+                                <td class="text-end">
+                                        <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>
-                                        <t t-out="'{0:,.2f}'.format(row['diff_amount'])" />
-                                    </strong>
+                                <td class="text-end">
+                                        <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>
-                                        <t t-out="'{0:,.2f}'.format(row['diff_percentage'])" />
-                                    </strong>
+                                <td class="text-end">
+                                        <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>
                         </t>
                     </tbody>
                     <tfoot>
-                        <tr>
+                        <tr class="fw-bold">
                             <td class="text-center">
-                                <strong>รวมทั้งสิ้น</strong>
+                                รวมทั้งสิ้น
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -14,13 +14,13 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามหน่วยงาน ปีงบประมาณ พ.ศ.                    <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามหน่วยงาน ปีงบประมาณ พ.ศ.                    <t t-out="o.compare_summary_id.account_fiscal_year_id.name" />
  และ                    <t t-out="o.account_fiscal_year_id.name" />
-                </div>
+                </h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -67,23 +67,23 @@
                                 <td class="border-0 border-start">
                                     <t t-out="row['name']"/>
                                 </td>
-                                <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end">
+                                <td class="text-end" contenteditable="false">
                                     100.0
                                 </td>
-                                <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(row['amount'])"/>
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end">
+                                <td class="text-end" contenteditable="false">
                                     100.0
                                 </td>
-                                <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
+                                <td class="text-end" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>
                         </t>
@@ -93,22 +93,22 @@
                             <td class="text-center">
                                 รวมทั้งสิ้น
                             </td>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
                             </td>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -112,7 +112,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f3w_f6w_revenue_content" />

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -10,7 +10,7 @@
                 border-color: #000 !important;
             }
         </style>
-        <div class="page f3w_f6w">
+        <div class="page f3w_f6w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -11,11 +11,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปประมาณการรายรับ ประจําปีงบประมาณ
                     <t t-esc="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
             </div>
             <div>
                 <table class="table table-sm table-borderless">

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -13,13 +13,14 @@
         <div class="page f4-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
             <t t-call="budget_appropriation_summary.report_council_header"/>
-            <div class="text-center mb-3">
+            <div class="text-center">
                 <h3 class="fw-bold">
                     สรุปประมาณการรายรับ ประจําปีงบประมาณ
                     <t t-esc="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3 class="fw-bold">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-borderless">
                     <thead>

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -101,7 +101,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f4p_revenue_content" />

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -7,7 +7,7 @@
                 padding-bottom: 12pt;
             }
         </style>
-        <div class="page f4-p">
+        <div class="page f4-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -6,24 +6,27 @@
             .f4-p table tbody.category tr:last-child td {
                 padding-bottom: 12pt;
             }
+            table.table td {
+                vertical-align: middle;
+            }
         </style>
         <div class="page f4-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <h3>
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center mb-3">
+                <h3 class="fw-bold">
                     สรุปประมาณการรายรับ ประจําปีงบประมาณ
-                    <t t-esc="o.account_fiscal_year_id.name" />
+                    <t t-esc="o.account_fiscal_year_id.name"/>
                 </h3>
-                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3 class="fw-bold">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
             </div>
             <div>
                 <table class="table table-sm table-borderless">
                     <thead>
                         <tr>
-                            <th style="width: 60%" />
-                            <th style="width: 20%" />
-                            <th style="width: 20%" />
+                            <th/>
+                            <th style="width: 86pt"/>
+                            <th style="width: 102pt !important"/>
                         </tr>
                     </thead>
                     <tbody>
@@ -34,61 +37,52 @@
                         </tr>
                         <tr style="font-weight: bold">
                             <td class="ps-3" colspan="2">1. รายรับจากรัฐบาล</td>
-                            <td class="text-end">0 บาท</td>
+                            <td class="text-end" contenteditable="false">0 บาท</td>
                         </tr>
                         <tr style="font-weight: bold">
                             <td class="ps-3" colspan="2">2. เงินรายได้</td>
-                            <td class="text-end">
-                                <t t-out="'{0:,.2f}'.format(o.f4p_revenue_data['summary']['total_amount'])" />
-                                บาท
+                            <td class="text-end" contenteditable="false">
+                                <t t-out="'{0:,.2f} บาท'.format(o.f4p_revenue_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
-                    </tbody>
-                    <t t-set="row_no" t-value="1" />
-                    <t t-foreach="o.f4p_revenue_data['categories']" t-as="row">
-                        <tbody class="category">
+                        <t t-set="row_no" t-value="1"/>
+                        <t t-foreach="o.f4p_revenue_data['categories']" t-as="row">
                             <tr>
-                                <td class="ps-4" colspan="3">
-                                    <strong>
-                                        <u>
-                                            2.<t t-esc="row_no" />
-                                            <t t-esc="row['name']" />
-                                        </u>
-                                    </strong>
+                                <td class="ps-4 fw-bold" colspan="3">
+                                  <t t-esc="'2.{} {}'.format(row_no, row['name'])"/>
                                 </td>
                             </tr>
                             <t t-foreach="row['departments']" t-as="dept">
                                 <tr class="department">
                                     <td class="ps-5">
-                                        - <t t-esc="dept['name']" />
+                                        <t t-esc="'- {}'.format(dept['name'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(dept['amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(dept['amount'])"/>
                                     </td>
-                                    <td />
+                                    <td/>
                                 </tr>
                             </t>
                             <tr>
                                 <td class="text-end">รวม</td>
-                                <td class="text-end">
-                                    <strong>
-                                        <u><t t-out="'{0:,.2f}'.format(row['amount'])" /></u>
-                                    </strong>
+                                <td class="text-end fw-bold" style="border-bottom: 1px solid black;" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td />
+                                <td/>
                             </tr>
-                        </tbody>
-                        <t t-set="row_no" t-value="row_no + 1" />
-                    </t>
-                    <tbody>
+                            <tr>
+                              <td style="height: 20pt;"/>
+                            </tr>
+                          <t t-set="row_no" t-value="row_no + 1"/>
+                        </t>
                         <tr>
-                            <td class="text-end">
-                                <strong>รวมรายรับทั้งสิ้น</strong>
+                            <td class="text-end fw-bold">
+                                รวมรายรับทั้งสิ้น
                             </td>
-                            <td class="text-end" style="text-decoration: underline; text-decoration-style: double; font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4p_revenue_data['summary']['total_amount'])" />
+                            <td class="text-end fw-bold" style="border-bottom: 3px double black;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f4p_revenue_data['summary']['total_amount'])"/>
                             </td>
-                            <td />
+                            <td/>
                         </tr>
                     </tbody>
                 </table>

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -8,6 +8,7 @@
             }
         </style>
         <div class="page f4-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -102,6 +103,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f4p_revenue_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -22,13 +22,19 @@
             .table {
                 border-color: #000 !important;
             }
+            p,
+            span,
+            div {
+                font-size: 13pt;
+                line-height: 1.1;
+            }
         </style>
         <div class="page f4-w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center fw-bold">
                 <h3>
-                    สรุปเปรียบเทียบประมาณการรายรับ ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /> และ <t t-esc="o.account_fiscal_year_id.name" />
+                    สรุปเปรียบเทียบประมาณการรายรับ ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name"/> และ <t t-esc="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและประเภท</h3>
@@ -36,78 +42,82 @@
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
-                        <tr>
-                            <th class="text-center" style="width: 40%" rowspan="2">หน่วยงาน</th>
-                            <th class="text-center" style="width: 20%" colspan="2">ปีงบประมาณ <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /></th>
-                            <th class="text-center" style="width: 20%" colspan="2">ปีงบประมาณ <t t-esc="o.account_fiscal_year_id.name" /></th>
-                            <th class="text-center" style="width: 20%" colspan="2">+ เพิ่ม - ลด</th>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
+                          <td style="width: auto;"/>
+                          <td style="width: 74pt;"/>
+                          <td style="width: 32pt;"/>
+                          <td style="width: 74pt;"/>
+                          <td style="width: 32pt;"/>
+                          <td style="width: 74pt;"/>
+                          <td style="width: 32pt;"/>
                         </tr>
                         <tr>
-                            <th class="text-center" style="width: 15%">เงินรายได้</th>
-                            <th class="text-center" style="width: 5%">%</th>
-                            <th class="text-center" style="width: 15%">เงินรายได้</th>
-                            <th class="text-center" style="width: 5%">%</th>
-                            <th class="text-center" style="width: 15%">เงินรายได้</th>
-                            <th class="text-center" style="width: 5%">%</th>
+                            <th class="text-center" rowspan="2">หน่วยงาน</th>
+                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-esc="o.compare_summary_id.account_fiscal_year_id.name"/></th>
+                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-esc="o.account_fiscal_year_id.name"/></th>
+                            <th class="text-center" colspan="2">+ เพิ่ม - ลด</th>
+                        </tr>
+                        <tr>
+                            <th class="text-center">เงินรายได้</th>
+                            <th class="text-center">%</th>
+                            <th class="text-center">เงินรายได้</th>
+                            <th class="text-center">%</th>
+                            <th class="text-center">เงินรายได้</th>
+                            <th class="text-center">%</th>
                         </tr>
                     </thead>
                     <tbody class="category">
-                        <t t-set="row_no" t-value="1" />
+                        <t t-set="row_no" t-value="1"/>
                         <t t-foreach="o.f4w_revenue_data['departments']" t-as="row">
-                            <tr class="border-0">
-                                <td class="border-0 border-start">
-                                    <strong>
-                                        <u>
-                                            <t t-esc="row_no" />.
-                                            <t t-esc="row['name']" />
-                                        </u>
-                                    </strong>
+                            <tr class="border-0 fw-bold">
+                                <td class="border-0 border-start text-decoration-underline">
+                                  <t t-esc="'{}. {}'.format(row_no, row['name'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['compare_amount'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['amount'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['diff_amount'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['diff_percentage'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>
                             <t t-foreach="row['categories']" t-as="category">
                                 <tr class="department border-0">
-                                    <td class="ps-5 border-0 border-start">
-                                        - <t t-esc="category['name']" />
+                                    <td class="ps-2 border-0 border-start">
+                                        - <t t-esc="category['name']"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['compare_amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(category['compare_amount'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="category['compare_percentage']" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="category['compare_percentage']"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="category['percentage']" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="category['percentage']"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['diff_amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(category['diff_amount'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['diff_percentage'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(category['diff_percentage'])"/>
                                     </td>
                                 </tr>
                             </t>
-                            <t t-set="row_no" t-value="row_no + 1" />
+                            <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
                     </tbody>
                     <tfoot>
@@ -115,23 +125,23 @@
                             <td class="text-center">
                                 <strong>รวมทั้งสิ้น</strong>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])" />
+                            <td class="text-end" style="font-weight: bold;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                            <td class="text-end" style="font-weight: bold;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])" />
+                            <td class="text-end" style="font-weight: bold;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                            <td class="text-end" style="font-weight: bold;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])" />
+                            <td class="text-end" style="font-weight: bold;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])" />
+                            <td class="text-end" style="font-weight: bold;" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -24,6 +24,7 @@
             }
         </style>
         <div class="page f4-w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -146,6 +147,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f4w_revenue_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -23,7 +23,7 @@
                 border-color: #000 !important;
             }
         </style>
-        <div class="page f4-w">
+        <div class="page f4-w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -145,7 +145,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f4w_revenue_content" />

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -27,11 +27,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปเปรียบเทียบประมาณการรายรับ ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /> และ <t t-esc="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามหน่วยงานและประเภท</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามหน่วยงานและประเภท</h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -16,7 +16,7 @@
             <div>
                 <table class="table table-sm table-borderless">
                     <thead>
-                        <tr>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
                             <th style="width: auto;"/>
                             <th style="width: 96pt;"/>
                             <th style="width: 96pt;"/>

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -11,11 +11,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปประมาณการรายจ่าย ประจําปีงบประมาณ
                     <t t-esc="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
             </div>
             <div>
                 <table class="table table-sm table-borderless">

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -7,7 +7,7 @@
                 padding-bottom: 36px;
             }
         </style>
-        <div class="page f5-p">
+        <div class="page f5-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -8,6 +8,7 @@
             }
         </style>
         <div class="page f5-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -153,6 +154,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t
                         t-call="budget_appropriation_summary.report_f5p_expense_content"
                     />

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -152,7 +152,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -2,40 +2,42 @@
 <odoo>
     <!-- Partial template for F5-P content (reusable) -->
     <template id="report_f5p_expense_content">
-        <style>
-            .f5-p table tbody.category tr:last-child td {
-                padding-bottom: 36px;
-            }
-        </style>
         <div class="page f5-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
+            <div class="text-center fw-bold">
                 <h3>
                     สรุปประมาณการรายจ่าย ประจําปีงบประมาณ
-                    <t t-esc="o.account_fiscal_year_id.name" />
+                    <t t-esc="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-borderless">
                     <thead>
                         <tr>
-                            <th />
+                            <th style="width: auto;"/>
+                            <th style="width: 96pt;"/>
+                            <th style="width: 96pt;"/>
+                            <th style="width: 96pt;"/>
+                        </tr>
+                        <tr>
+                            <th/>
                             <th class="text-center" colspan="3">
                                 แหล่งเงิน (หน่วย: บาท)
                             </th>
                         </tr>
                         <tr>
-                            <th style="width: 60%" />
-                            <th style="width: 13.33%" class="text-end">
-                                <small>เงินงบประมาณ</small>
+                            <th/>
+                            <th class="text-end">
+                                เงินงบประมาณ
                             </th>
-                            <th style="width: 13.33%" class="text-end">
-                                <small>เงินรายได้</small>
+                            <th class="text-end">
+                                เงินรายได้
                             </th>
-                            <th style="width: 13.33%" class="text-end">
-                                <small>รวมทั้งสิ้น</small>
+                            <th class="text-end">
+                                รวมทั้งสิ้น
                             </th>
                         </tr>
                     </thead>
@@ -45,100 +47,71 @@
                                 <u> รายจ่าย :- </u>
                             </td>
                         </tr>
-                    </tbody>
-                    <t t-set="row_no" t-value="1" />
-                    <t t-foreach="o.f5p_expense_data['expense_types']" t-as="expense">
-                        <tbody class="expense">
+                        <t t-set="row_no" t-value="1"/>
+                        <t t-foreach="o.f5p_expense_data['expense_types']" t-as="expense">
                             <tr>
                                 <td class="ps-2" style="font-weight: bold">
                                     <u>
-                                        <t
-                                            t-out="'%s %s' % (row_no, expense['name'])"
-                                        />
+                                        <t t-out="'%s %s' % (row_no, expense['name'])"/>
                                     </u>
                                 </td>
-                                <td
-                                    class="text-end border-2 border-bottom border-black"
-                                    style="font-weight: bold"
-                                >
+                                <td class="text-end border-2 border-bottom border-black" style="font-weight: bold" contenteditable="false">
                                     0
                                 </td>
-                                <td
-                                    class="text-end border-2 border-bottom border-black"
-                                    style="font-weight: bold"
-                                >
-                                    <t t-out="'{0:,.2f}'.format(expense['amount'])" />
+                                <td class="text-end border-2 border-bottom border-black" style="font-weight: bold" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(expense['amount'])"/>
                                 </td>
-                                <td
-                                    class="text-end border-2 border-bottom border-black"
-                                    style="font-weight: bold"
-                                >
-                                    <t t-out="'{0:,.2f}'.format(expense['amount'])" />
+                                <td class="text-end border-2 border-bottom border-black" style="font-weight: bold" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(expense['amount'])"/>
                                 </td>
                             </tr>
-                            <t t-set="category_no" t-value="1" />
+                            <t t-set="category_no" t-value="1"/>
                             <t t-foreach="expense['categories']" t-as="category">
                                 <tr class="category">
                                     <td class="ps-3">
-                                        <t
-                                            t-out="'%s.%s %s' % (row_no, category_no, category['name'])"
-                                        />
+                                        <t t-out="'%s.%s %s' % (row_no, category_no, category['name'])"/>
                                     </td>
-                                    <td
-                                        class="text-end border-2 border-bottom border-black"
-                                    >
+                                    <td class="text-end border-2 border-bottom border-black" contenteditable="false">
                                         0
                                     </td>
-                                    <td
-                                        class="text-end border-2 border-bottom border-black"
-                                    >
-                                        <t
-                                            t-out="'{0:,.2f}'.format(category['amount'])"
-                                        />
+                                    <td class="text-end border-2 border-bottom border-black" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
                                     </td>
-                                    <td
-                                        class="text-end border-2 border-bottom border-black"
-                                    >
-                                        <t
-                                            t-out="'{0:,.2f}'.format(category['amount'])"
-                                        />
+                                    <td class="text-end border-2 border-bottom border-black" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
                                     </td>
                                 </tr>
-                                <t t-set="category_no" t-value="category_no + 1" />
+                                <t t-set="category_no" t-value="category_no + 1"/>
                                 <t t-foreach="category['departments']" t-as="dept">
                                     <tr class="departments">
                                         <td class="ps-5">
-                                            <t t-out="dept['name']" />
+                                            <t t-out="dept['name']"/>
                                         </td>
-                                        <td class="text-end">0</td>
-                                        <td class="text-end">
-                                            <t t-out="'{0:,.2f}'.format(dept['amount'])" />
+                                        <td class="text-end" contenteditable="false">0</td>
+                                        <td class="text-end" contenteditable="false">
+                                            <t t-out="'{0:,.2f}'.format(dept['amount'])"/>
                                         </td>
-                                        <td class="text-end">
-                                            <t t-out="'{0:,.2f}'.format(dept['amount'])" />
+                                        <td class="text-end" contenteditable="false">
+                                            <t t-out="'{0:,.2f}'.format(dept['amount'])"/>
                                         </td>
                                     </tr>
                                 </t>
                             </t>
-
-                        </tbody>
-                        <t t-set="row_no" t-value="row_no + 1" />
-                    </t>
-                    <tbody>
+                            <tr>
+                              <td colspan="4" style="height: 16pt;"/>
+                            </tr>
+                            <t t-set="row_no" t-value="row_no + 1"/>
+                        </t>
                         <tr>
                             <td class="text-end ps-0 pb-0">
                                 <strong>รวมทั้งสิ้น</strong>
                             </td>
-                            <td class="text-end border-4 border-bottom border-black ps-0 pb-0">0</td>
-                            <td class="text-end border-4 border-bottom border-black ps-0 pb-0">
-                                <t
-                                    t-out="'{0:,.2f}'.format(o.f5p_expense_data['summary']['total_amount'])"
-                                />
+                            <td class="text-end border-4 border-bottom border-black ps-0 pb-0" contenteditable="false">0</td>
+                            <td class="text-end border-4 border-bottom border-black ps-0 pb-0" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f5p_expense_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end border-4 border-bottom border-black ps-0 pb-0">
-                                <t
-                                    t-out="'{0:,.2f}'.format(o.f5p_expense_data['summary']['total_amount'])"
-                                />
+                            <td class="text-end border-4 border-bottom border-black ps-0 pb-0" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f5p_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tbody>

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -3,9 +3,6 @@
     <!-- Partial template for F5 content (reusable) -->
     <template id="report_f5w_expense_content">
         <style>
-            .f5w tr:last-child td {
-                padding-bottom: 36px;
-            }
             .table tbody td, .table tbody tr {
                 border-top: 0;
                 border-bottom: 0;
@@ -21,8 +18,8 @@
             }
         </style>
         <div class="page f5w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <h3>สรุปเปรียบเทียบประมาณการรายจ่าย</h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
@@ -30,52 +27,61 @@
             </div>
             <table class="table table-sm table-bordered f5w">
                 <thead>
+                    <tr style="height:0; visibility:collapse; line-height:0;">
+                        <th style="width: auto;"/>
+                        <th style="width: 86pt;"/>
+                        <th style="width: 38pt;"/>
+                        <th style="width: 86pt;"/>
+                        <th style="width: 38pt;"/>
+                        <th style="width: 86pt;"/>
+                        <th style="width: 38pt;"/>
+                    </tr>
                     <tr>
-                        <th style="width: 40%" rowspan="2" class="text-center">แผนงาน</th>
-                        <th colspan="2" class="text-center">ปีงบประมาณ <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /></th>
-                        <th colspan="2" class="text-center">ปีงบประมาณ <t t-esc="o.account_fiscal_year_id.name" /></th>
+                        <th rowspan="2" class="text-center">แผนงาน</th>
+                        <th colspan="2" class="text-center">ปีงบประมาณ <t t-esc="o.compare_summary_id.account_fiscal_year_id.name"/></th>
+                        <th colspan="2" class="text-center">ปีงบประมาณ <t t-esc="o.account_fiscal_year_id.name"/></th>
                         <th rowspan="2" class="text-center">
-                            + เพิ่ม - ลด <br />
+                            + เพิ่ม - ลด <br/>
                             จำนวนเงิน
                         </th>
-                        <th rowspan="2" class="text-center" style="width: 80px">%</th>
+                        <th rowspan="2" class="text-center">%</th>
                     </tr>
                     <tr>
                         <th class="text-center">รายได้</th>
-                        <th class="text-center" style="width: 60px">%</th>
+                        <th class="text-center">%</th>
                         <th class="text-center">รายได้</th>
-                        <th class="text-center" style="width: 60px">%</th>
+                        <th class="text-center">%</th>
                     </tr>
                 </thead>
                 <tbody>
                     <t t-foreach="o.f5w_expense_data['activities']" t-as="activity">
                         <tr>
-                            <td class="ps-4 border-0 border-start" t-esc="activity['name']" />
-                            <td class="text-end border-0 border-start"><t t-out="'{0:,.2f}'.format(activity['compare_amount'])" /></td>
-                            <td class="text-end border-0 border-start"><t t-out="'{0:,.2f}'.format(activity['compare_percentage'])" /></td>
-                            <td class="text-end border-0 border-start"><t t-out="'{0:,.2f}'.format(activity['amount'])" /></td>
-                            <td class="text-end border-0 border-start" t-esc="activity['percentage']" />
-                            <td class="text-end border-0 border-start"><t t-out="'{0:,.2f}'.format(activity['diff_amount'])" /></td>
-                            <td class="text-end border-0 border-start border-end"><t t-out="'{0:,.2f}'.format(activity['diff_percentage'])" /></td>
+                            <td class="ps-2 border-0 border-start" t-esc="activity['name']"/>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['compare_amount'])"/></td>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['compare_percentage'])"/></td>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['amount'])"/></td>
+                            <td class="text-end border-0 border-start" contenteditable="false" t-esc="activity['percentage']"/>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['diff_amount'])"/></td>
+                            <td class="text-end border-0 border-start border-end" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['diff_percentage'])"/></td>
                         </tr>
                     </t>
                 </tbody>
                 <tfoot>
                     <tr style="padding-top: 60px">
                         <th class="text-center">รวมทั้งสิ้น</th>
-                        <th class="text-end">
-                            <strong><t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['compare_total_amount'])" /></strong>
+                        <th class="text-end fw-bold" contenteditable="false">
+                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['compare_total_amount'])"/>
                         </th>
-                        <th class="text-end">100.0</th>
-                        <th class="text-end">
-                            <strong><t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['total_amount'])" /></strong>
+                        <th class="text-end" contenteditable="false">100.0</th>
+                        <th class="text-end fw-bold" contenteditable="false">
+                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['total_amount'])"/>
                         </th>
-                        <th class="text-end">100.0</th>
-                        <th class="text-end">
-                            <strong><t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['diff_amount'])" /></strong>
+                        <th class="text-end" contenteditable="false">100.0</th>
+                        <th class="text-end fw-bold" contenteditable="false">
+                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['diff_amount'])"/>
                         </th>
-                        <th class="text-end">
-                            <strong><t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['diff_percentage'])" /></strong>
+                        <th class="text-end fw-bold" contenteditable="false">
+                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['diff_percentage'])"/>
                         </th>
                     </tr>
                 </tfoot>

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -20,7 +20,8 @@
                 border-color: #000 !important;
             }
         </style>
-        <div class="page f5w" style="width: 100%;" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+        <div class="page f5w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>สรุปเปรียบเทียบประมาณการรายจ่าย</div>
@@ -89,6 +90,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f5w_expense_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -88,7 +88,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f5w_expense_content" />

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -20,7 +20,7 @@
                 border-color: #000 !important;
             }
         </style>
-        <div class="page f5w" style="width: 100%;">
+        <div class="page f5w" style="width: 100%;" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>สรุปเปรียบเทียบประมาณการรายจ่าย</div>

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -20,11 +20,12 @@
         <div class="page f5w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
             <t t-call="budget_appropriation_summary.report_council_header"/>
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <div class="text-center" style="font-weight: bold">
                 <h3>สรุปเปรียบเทียบประมาณการรายจ่าย</h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามแผนงาน</h3>
             </div>
+            <div style="height: 24pt;"/>
             <table class="table table-sm table-bordered f5w">
                 <thead>
                     <tr style="height:0; visibility:collapse; line-height:0;">

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -24,9 +24,9 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>สรุปเปรียบเทียบประมาณการรายจ่าย</div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามแผนงาน</div>
+                <h3>สรุปเปรียบเทียบประมาณการรายจ่าย</h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามแผนงาน</h3>
             </div>
             <table class="table table-sm table-bordered f5w">
                 <thead>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -24,6 +24,7 @@
             }
         </style>
         <div class="page f7w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -146,6 +147,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f7w_expense_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -29,13 +29,14 @@
         <div class="page f7w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
             <t t-call="budget_appropriation_summary.report_council_header"/>
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <div class="text-center" style="font-weight: bold">
                 <h3>
                     สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name"/> และ <t t-esc="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามประเภทงบรายจ่าย</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -145,7 +145,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f7w_expense_content" />

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -22,13 +22,16 @@
             .border-bottom {
                 border-bottom: 1pt solid #000 !important;
             }
+            h3 {
+              font-weight: bold;
+            }
         </style>
         <div class="page f7w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <h3>
-                    สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /> และ <t t-esc="o.account_fiscal_year_id.name" />
+                    สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name"/> และ <t t-esc="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามประเภทงบรายจ่าย</h3>
@@ -36,10 +39,19 @@
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
+                            <th style="width: auto;"/>
+                            <th style="width: 86pt;"/>
+                            <th style="width: 38pt;"/>
+                            <th style="width: 86pt;"/>
+                            <th style="width: 38pt;"/>
+                            <th style="width: 86pt;"/>
+                            <th style="width: 38pt;"/>
+                        </tr>
                         <tr>
-                            <th class="text-center" rowspan="2" style="width: 35%;">หน่วยงาน</th>
-                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /></th>
-                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-esc="o.account_fiscal_year_id.name" /></th>
+                            <th class="text-center" rowspan="2">หน่วยงาน</th>
+                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-esc="o.compare_summary_id.account_fiscal_year_id.name"/></th>
+                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-esc="o.account_fiscal_year_id.name"/></th>
                             <th class="text-center" colspan="2">+ เพิ่ม - ลด</th>
                         </tr>
                         <tr>
@@ -52,62 +64,57 @@
                         </tr>
                     </thead>
                     <tbody class="category">
-                        <t t-set="row_no" t-value="1" />
+                        <t t-set="row_no" t-value="1"/>
                         <t t-foreach="o.f7w_expense_data['expense_types']" t-as="row">
                             <tr class="border-0">
-                                <td class="">
-                                    <strong>
-                                        <u>
-                                            <t t-esc="row_no" />.
-                                            <t t-esc="row['name']" />
-                                        </u>
-                                    </strong>
+                                <td class="fw-bold text-decoration-underline">
+                                    <t t-esc="'{}. {}'.format(row_no, row['name'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['compare_amount'])" /></strong>
+                                <td class="text-end fw-bold border-bottom border-black">
+                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end fw-bold border-bottom border-black">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['amount'])" /></strong>
+                                <td class="text-end fw-bold border-bottom border-black">
+                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end fw-bold border-bottom border-black">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['diff_amount'])" /></strong>
+                                <td class="text-end fw-bold border-bottom border-black">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(row['diff_percentage'])" /></strong>
+                                <td class="text-end fw-bold border-bottom border-black">
+                                    <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>
                             <t t-foreach="row['categories']" t-as="category">
                                 <tr class="department border-0">
-                                    <td class="ps-5">
-                                        - <t t-esc="category['name']" />
+                                    <td class="ps-3">
+                                        - <t t-esc="category['name']"/>
                                     </td>
                                     <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['compare_amount'])" />
+                                        <t t-out="'{0:,.2f}'.format(category['compare_amount'])"/>
                                     </td>
                                     <td class="text-end">
-                                        <t t-out="category['compare_percentage']" />
+                                        <t t-out="category['compare_percentage']"/>
                                     </td>
                                     <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['amount'])" />
+                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
                                     </td>
                                     <td class="text-end">
-                                        <t t-out="category['percentage']" />
+                                        <t t-out="category['percentage']"/>
                                     </td>
                                     <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['diff_amount'])" />
+                                        <t t-out="'{0:,.2f}'.format(category['diff_amount'])"/>
                                     </td>
                                     <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(category['diff_percentage'])" />
+                                        <t t-out="'{0:,.2f}'.format(category['diff_percentage'])"/>
                                     </td>
                                 </tr>
                             </t>
-                            <t t-set="row_no" t-value="row_no + 1" />
+                            <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
                     </tbody>
                     <tfoot>
@@ -116,22 +123,22 @@
                                 <strong>รวมทั้งสิ้น</strong>
                             </td>
                             <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['compare_total_amount'])" />
+                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['compare_total_amount'])"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['total_amount'])" />
+                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_amount'])" />
+                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_amount'])"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_percentage'])" />
+                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -23,7 +23,7 @@
                 border-bottom: 1pt solid #000 !important;
             }
         </style>
-        <div class="page f7w">
+        <div class="page f7w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -27,11 +27,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปเปรียบเทียบประมาณการรายรับ - รายจ่าย ปีงบประมาณ พ.ศ. <t t-esc="o.compare_summary_id.account_fiscal_year_id.name" /> และ <t t-esc="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามประเภทงบรายจ่าย</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามประเภทงบรายจ่าย</h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -71,22 +71,22 @@
                                 <td class="fw-bold text-decoration-underline">
                                     <t t-esc="'{}. {}'.format(row_no, row['name'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black">
+                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black">
+                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     100.0
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black">
+                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black">
+                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     100.0
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black">
+                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black">
+                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>
@@ -95,22 +95,22 @@
                                     <td class="ps-3">
                                         - <t t-esc="category['name']"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(category['compare_amount'])"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" contenteditable="false">
                                         <t t-out="category['compare_percentage']"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(category['amount'])"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" contenteditable="false">
                                         <t t-out="category['percentage']"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(category['diff_amount'])"/>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(category['diff_percentage'])"/>
                                     </td>
                                 </tr>
@@ -119,26 +119,26 @@
                         </t>
                     </tbody>
                     <tfoot>
-                        <tr>
+                        <tr class="fw-bold">
                             <td class="text-center">
-                                <strong>รวมทั้งสิ้น</strong>
+                                รวมทั้งสิ้น
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['compare_total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -26,13 +26,14 @@
         <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
             <t t-call="budget_appropriation_summary.report_council_header"/>
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <div class="text-center" style="font-weight: bold">
                 <h3>
                     สรุปเปรียบเทียบประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.compare_summary_id.account_fiscal_year_id.name"/> และ <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -19,13 +19,16 @@
             .table {
                 border-color: #000 !important;
             }
+            h3 {
+                font-weight: bold;
+            }
         </style>
         <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <h3>
-                    สรุปเปรียบเทียบประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.compare_summary_id.account_fiscal_year_id.name" /> และ <t t-out="o.account_fiscal_year_id.name" />
+                    สรุปเปรียบเทียบประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.compare_summary_id.account_fiscal_year_id.name"/> และ <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
@@ -33,10 +36,19 @@
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
+                          <th style="width: auto;"/>
+                          <th style="width: 86pt;"/>
+                          <th style="width: 38pt;"/>
+                          <th style="width: 86pt;"/>
+                          <th style="width: 38pt;"/>
+                          <th style="width: 86pt;"/>
+                          <th style="width: 38pt;"/>
+                        </tr>
                         <tr>
-                            <th class="text-center" rowspan="2" style="width: 35%;">หน่วยงาน</th>
-                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-out="o.compare_summary_id.account_fiscal_year_id.name" /></th>
-                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-out="o.account_fiscal_year_id.name" /></th>
+                            <th class="text-center" rowspan="2">หน่วยงาน</th>
+                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-out="o.compare_summary_id.account_fiscal_year_id.name"/></th>
+                            <th class="text-center" colspan="2">ปีงบประมาณ <t t-out="o.account_fiscal_year_id.name"/></th>
                             <th class="text-center" colspan="2">+ เพิ่ม - ลด</th>
                         </tr>
                         <tr>
@@ -49,86 +61,81 @@
                         </tr>
                     </thead>
                     <tbody class="category">
-                        <t t-set="row_no" t-value="1" />
+                        <t t-set="row_no" t-value="1"/>
                         <t t-foreach="o.f8w_expense_data['departments']" t-as="department">
-                            <tr class="border-0">
-                                <td class="border-0 border-start">
-                                    <strong>
-                                        <u>
-                                            <t t-out="row_no" />.
-                                            <t t-out="department['name']" />
-                                        </u>
-                                    </strong>
+                            <tr class="border-0 fw-bold">
+                                <td class="border-0 border-start text-decoration-underline">
+                                    <t t-esc="'{}. {}'.format(row_no, department['name'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(department['compare_amount'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(department['compare_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(department['amount'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(department['amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong>100.0</strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    100.0
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(department['diff_amount'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(department['diff_amount'])"/>
                                 </td>
-                                <td class="text-end border-bottom border-black">
-                                    <strong><t t-out="'{0:,.2f}'.format(department['diff_percentage'])" /></strong>
+                                <td class="text-end border-bottom border-black" contenteditable="false">
+                                    <t t-out="'{0:,.2f}'.format(department['diff_percentage'])"/>
                                 </td>
                             </tr>
                             <t t-foreach="department['activities']" t-as="activity">
                                 <tr class="department border-0">
-                                    <td class="ps-5 border-0 border-start">
-                                        - <t t-out="activity['name']" />
+                                    <td class="ps-3 border-0 border-start">
+                                        - <t t-out="activity['name']"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(activity['compare_amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(activity['compare_amount'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="activity['compare_percentage']" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="activity['compare_percentage']"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(activity['amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(activity['amount'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="activity['percentage']" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="activity['percentage']"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(activity['diff_amount'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(activity['diff_amount'])"/>
                                     </td>
-                                    <td class="text-end">
-                                        <t t-out="'{0:,.2f}'.format(activity['diff_percentage'])" />
+                                    <td class="text-end" contenteditable="false">
+                                        <t t-out="'{0:,.2f}'.format(activity['diff_percentage'])"/>
                                     </td>
                                 </tr>
                             </t>
-                            <t t-set="row_no" t-value="row_no + 1" />
+                            <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
                     </tbody>
                     <tfoot>
                         <tr>
-                            <td class="text-center">
-                                <strong>รวมทั้งสิ้น</strong>
+                            <td class="text-center fw-bold">
+                                รวมทั้งสิ้น
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['compare_total_amount'])" />
+                            <td class="text-end fw-bold" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['compare_total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                            <td class="text-end fw-bold" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['total_amount'])" />
+                            <td class="text-end fw-bold" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['total_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(100)" />
+                            <td class="text-end fw-bold" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_amount'])" />
+                            <td class="text-end fw-bold" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_amount'])"/>
                             </td>
-                            <td class="text-end" style="font-weight: bold;">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_percentage'])" />
+                            <td class="text-end fw-bold" contenteditable="false">
+                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -24,11 +24,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปเปรียบเทียบประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.compare_summary_id.account_fiscal_year_id.name" /> และ <t t-out="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามหน่วยงานและแผนงาน</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -142,7 +142,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f8w_expense_content" />

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -20,7 +20,7 @@
                 border-color: #000 !important;
             }
         </style>
-        <div class="page f8w">
+        <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -21,6 +21,7 @@
             }
         </style>
         <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -143,6 +144,7 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f8w_expense_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -23,13 +23,14 @@
         <div class="page f9w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
             <t t-call="budget_appropriation_summary.report_council_header"/>
-            <div class="text-center mt-5 mb-3" style="font-weight: bold">
+            <div class="text-center" style="font-weight: bold">
                 <h3>
                     สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
             </div>
+            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -14,7 +14,8 @@
                 border-right: 1pt solid #000 !important;
             }
         </style>
-        <div class="page f9w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+        <div class="page f9w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
+            <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>
@@ -98,6 +99,8 @@
                 <t t-call="web.basic_layout">
                     <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-set="is_landscape" t-value="True" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
                     <t t-call="budget_appropriation_summary.report_f9w_expense_content" />
                 </t>
             </t>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -64,15 +64,15 @@
                                     <t t-out="department['name']"/>
                                 </td>
                                 <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                                    <th class="text-end border-0 border-end">
+                                    <th class="text-end border-0 border-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(department['columns'][column['code']]['amount'])"/>
                                     </th>
-                                    <th class="text-end border-0 border-end">
+                                    <th class="text-end border-0 border-end" contenteditable="false">
                                         0.00
                                         <!-- <t t-out="department['columns'][column['code']]['percentage']" /> -->
                                     </th>
                                 </t>
-                                <th class="text-end border-0">
+                                <th class="text-end border-0" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(department['total']['amount'])"/>
                                 </th>
                             </tr>
@@ -85,15 +85,15 @@
                                 รวมทั้งสิ้น
                             </td>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                                <th class="text-end">
+                                <th class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['column_totals'][column['code']]['amount'])"/>
                                 </th>
-                                <th class="text-end">
+                                <th class="text-end" contenteditable="false">
                                     0.00
                                     <!-- <t t-out="department['columns'][column['code']]['percentage']" /> -->
                                 </th>
                             </t>
-                            <td class="text-end">
+                            <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -13,13 +13,19 @@
             .border-end {
                 border-right: 1pt solid #000 !important;
             }
+            p,
+            span,
+            div {
+                font-size: 12pt;
+                line-height: 1.1;
+            }
         </style>
         <div class="page f9w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
-            <t t-call="budget_appropriation_summary.report_print_button" />
-            <t t-call="budget_appropriation_summary.report_council_header" />
+            <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <h3>
-                    สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
+                    สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/>
                 </h3>
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
@@ -27,45 +33,49 @@
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
+                        <tr style="height:0; visibility:collapse; line-height:0;">
+                            <th style="width: auto;"/>
+                            <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
+                              <th style="width: 70pt;"/>
+                              <th style="width: 30pt;"/>
+                            </t>
+                            <th style="width: 70pt;"/>
+                        </tr>
                         <tr>
                             <th class="text-center" rowspan="2" style="width: 20%;">หน่วยงาน</th>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                                <th class="text-center" colspan="2"><t t-out="column['name']" /></th>
+                                <th class="text-center" colspan="2"><t t-out="column['name']"/></th>
                             </t>
                             <th class="text-center" rowspan="2">รวมทั้งสิ้น</th>
                         </tr>
                         <tr>
-                            <th class="text-center">เงินรายได้</th>
-                            <th class="text-center">%</th>
-                            <th class="text-center">เงินรายได้</th>
-                            <th class="text-center">%</th>
-                            <th class="text-center">เงินรายได้</th>
-                            <th class="text-center">%</th>
-                            <th class="text-center">เงินรายได้</th>
-                            <th class="text-center">%</th>
+                            <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
+                              <th class="text-center">เงินรายได้</th>
+                              <th class="text-center">%</th>
+                            </t>
                         </tr>
                     </thead>
                     <tbody>
-                        <t t-set="row_no" t-value="1" />
+                        <t t-set="row_no" t-value="1"/>
                         <t t-foreach="o.f9w_expense_data['departments']" t-as="department">
                             <tr class="border-0 border-end">
                                 <td class="">
-                                    <t t-out="department['name']" />
+                                    <t t-out="department['name']"/>
                                 </td>
                                 <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                                    <th class="text-center border-0 border-end">
-                                        <t t-out="'{0:,.2f}'.format(department['columns'][column['code']]['amount'])" />
+                                    <th class="text-end border-0 border-end">
+                                        <t t-out="'{0:,.2f}'.format(department['columns'][column['code']]['amount'])"/>
                                     </th>
-                                    <th class="text-center border-0 border-end">
+                                    <th class="text-end border-0 border-end">
                                         0.00
                                         <!-- <t t-out="department['columns'][column['code']]['percentage']" /> -->
                                     </th>
                                 </t>
-                                <th class="text-center border-0">
-                                    <t t-out="'{0:,.2f}'.format(department['total']['amount'])" />
+                                <th class="text-end border-0">
+                                    <t t-out="'{0:,.2f}'.format(department['total']['amount'])"/>
                                 </th>
                             </tr>
-                            <t t-set="row_no" t-value="row_no + 1" />
+                            <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
                     </tbody>
                     <tfoot>
@@ -74,16 +84,16 @@
                                 รวมทั้งสิ้น
                             </td>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                                <th class="text-center">
-                                    <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['column_totals'][column['code']]['amount'])" />
+                                <th class="text-end">
+                                    <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['column_totals'][column['code']]['amount'])"/>
                                 </th>
-                                <th class="text-center">
+                                <th class="text-end">
                                     0.00
                                     <!-- <t t-out="department['columns'][column['code']]['percentage']" /> -->
                                 </th>
                             </t>
-                            <td class="text-center">
-                                <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['summary']['total_amount'])" />
+                            <td class="text-end">
+                                <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tfoot>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -18,11 +18,11 @@
             <t t-call="budget_appropriation_summary.report_print_button" />
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
-                <div>
+                <h3>
                     สรุปสัดส่วนประมาณการรายจ่าย ปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
-                </div>
-                <div>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                <div>จําแนกตามหน่วยงานและแผนงาน</div>
+                </h3>
+                <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
+                <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
             </div>
             <div>
                 <table class="table table-sm table-bordered">

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -97,7 +97,7 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
                     <t t-set="is_landscape" t-value="True" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -14,7 +14,7 @@
                 border-right: 1pt solid #000 !important;
             }
         </style>
-        <div class="page f9w">
+        <div class="page f9w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_council_header" />
             <div class="text-center mt-5 mb-3" style="font-weight: bold">
                 <div>

--- a/budget_appropriation_summary/report/report_master_summary.xml
+++ b/budget_appropriation_summary/report/report_master_summary.xml
@@ -5,8 +5,18 @@
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.basic_layout">
-                    <t t-set="o" t-value="o.with_context({'lang': 'th_TH'})" />
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')" />
                     <t t-call="budget_appropriation_summary.report_common_styles" />
+                    <t t-set="skip_orientation_page" t-value="True" />
+                    <t t-call="budget_appropriation_summary.report_preview_styles" />
+
+                    <t t-if="o.env.context.get('html_preview', False)">
+                        <a t-attf-href="/budget_appropriation_summary/#{o.id}/pdf"
+                           target="_blank" class="print-btn" contenteditable="false">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+                            พิมพ์รายงาน PDF
+                        </a>
+                    </t>
 
                     <!-- F2 Report - สรุปเปรียบเทียบประมาณการรายรับจําแนกตามประเภท -->
                     <t t-call="budget_appropriation_summary.report_f2_revenue_content" />

--- a/budget_appropriation_summary/report/report_master_summary.xml
+++ b/budget_appropriation_summary/report/report_master_summary.xml
@@ -13,7 +13,7 @@
                     <t t-if="o.env.context.get('html_preview', False)">
                         <a t-attf-href="/budget_appropriation_summary/#{o.id}/pdf"
                            target="_blank" class="print-btn" contenteditable="false">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
+                            <t t-call="budget_appropriation_summary.report_print_icon" />
                             พิมพ์รายงาน PDF
                         </a>
                     </t>

--- a/budget_appropriation_summary/report/report_master_summary.xml
+++ b/budget_appropriation_summary/report/report_master_summary.xml
@@ -10,14 +10,6 @@
                     <t t-set="skip_orientation_page" t-value="True" />
                     <t t-call="budget_appropriation_summary.report_preview_styles" />
 
-                    <t t-if="o.env.context.get('html_preview', False)">
-                        <a t-attf-href="/budget_appropriation_summary/#{o.id}/pdf"
-                           target="_blank" class="print-btn" contenteditable="false">
-                            <t t-call="budget_appropriation_summary.report_print_icon" />
-                            พิมพ์รายงาน PDF
-                        </a>
-                    </t>
-
                     <!-- F2 Report - สรุปเปรียบเทียบประมาณการรายรับจําแนกตามประเภท -->
                     <t t-call="budget_appropriation_summary.report_f2_revenue_content" />
 

--- a/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
@@ -47,6 +47,87 @@
                     />
                 </header>
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <!-- Revenue Reports -->
+                        <button
+                            name="action_open_f2_report"
+                            string="F2 รายรับตามประเภท"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f4p_report"
+                            string="F4-P รายรับตามหน่วยงาน"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f4w_report"
+                            string="F4-W เปรียบเทียบรายรับ"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f3w_f6w_report"
+                            string="F3W/F6W รายรับ-รายจ่าย"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <!-- Expense Reports -->
+                        <button
+                            name="action_open_f5p_report"
+                            string="F5-P รายจ่ายตามหน่วยงาน"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f5w_report"
+                            string="F5-W รายจ่ายตามกิจกรรม"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f7w_report"
+                            string="F7-W เปรียบเทียบรายจ่าย"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f8w_report"
+                            string="F8-W เปรียบเทียบรายจ่าย"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f9w_report"
+                            string="F9-W สัดส่วนรายจ่าย"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f10w_report"
+                            string="F10-W รายจ่ายตามแผนงาน"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                        <button
+                            name="action_open_f11w_report"
+                            string="F11-W รายจ่ายตามกองทุน"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-file-text-o"
+                        />
+                    </div>
                     <group>
                         <group>
                             <field name="name" readonly="1" />


### PR DESCRIPTION
## Summary
- เพิ่มปุ่ม stat button แยกแต่ละรายงาน (F2, F4-P, F4-W, F3W/F6W, F5-P, F5-W, F7-W, F8-W, F9-W, F10-W, F11-W) ใน form view ของ `budget.appropriation.master.summary`
- เพิ่ม controller route ใหม่สำหรับ render รายงานแต่ละตัวแยกเป็นหน้า HTML portal
- ปุ่มรวมรายงานทั้งหมด (ดูรายงาน/พิมพ์ PDF) ที่ header ยังคงใช้งานได้เหมือนเดิม

## Test plan
- [ ] เปิด form view ของ master summary แล้วเห็นปุ่ม stat button 11 ปุ่ม
- [ ] กดปุ่มแต่ละรายงานแล้วเปิดหน้า portal HTML ได้ถูกต้อง
- [ ] ปุ่มรวมรายงานใน header ยังทำงานปกติ