### PR TITLE
[16.0][IMP] purchase_work_acceptance_portal: add show all button to WA inbox

### DIFF
--- a/purchase_work_acceptance_portal/models/res_users.py
+++ b/purchase_work_acceptance_portal/models/res_users.py
@@ -58,6 +58,51 @@ class ResUsers(models.Model):
         return [r for r in result if r.get("model") != "work.acceptance"]
 
     @api.model
+    def get_wa_inbox_all(self):
+        """Return all work acceptances for the current user regardless of read status."""
+        entries = self.env["work.acceptance.inbox"].search(
+            [("user_id", "=", self.env.user.id)],
+            order="create_date desc",
+        )
+        if not entries:
+            return {"items": [], "total_count": 0}
+
+        employee = self.env["hr.employee"].search(
+            [("user_id", "=", self.env.user.id)], limit=1
+        )
+
+        done_wa_ids = set()
+        if employee:
+            done_wa_ids = set(
+                self.env["work.acceptance.committee"]
+                .search([
+                    ("wa_id", "in", entries.mapped("work_acceptance_id").ids),
+                    ("employee_id", "=", employee.id),
+                    ("status", "in", ("accept", "not_accept", "other")),
+                ])
+                .mapped("wa_id")
+                .ids
+            )
+
+        seen = set()
+        items = []
+        for entry in entries:
+            wa = entry.work_acceptance_id
+            if wa.id in done_wa_ids:
+                continue
+            if wa.id not in seen:
+                seen.add(wa.id)
+                items.append({
+                    "id": entry.id,
+                    "wa_id": wa.id,
+                    "name": wa.name,
+                    "wa_url": entry.wa_url or "",
+                    "order_url": entry.order_url or "",
+                })
+
+        return {"items": items, "total_count": len(items)}
+
+    @api.model
     def mark_all_wa_read(self):
         """Mark all unread inbox entries as read for the current user."""
         self.env["work.acceptance.inbox"].search([

--- a/purchase_work_acceptance_portal/static/src/js/wa_systray.esm.js
+++ b/purchase_work_acceptance_portal/static/src/js/wa_systray.esm.js
@@ -13,6 +13,7 @@ export class WaSystray extends Component {
         this.state = useState({
             items: [],
             totalCount: 0,
+            showAll: false,
         });
 
         onWillStart(() => this.fetchData());
@@ -22,7 +23,8 @@ export class WaSystray extends Component {
 
     async fetchData() {
         try {
-            const result = await this.orm.call("res.users", "get_wa_inbox_count", [], {});
+            const method = this.state.showAll ? "get_wa_inbox_all" : "get_wa_inbox_count";
+            const result = await this.orm.call("res.users", method, [], {});
             this.state.items = result.items || [];
             this.state.totalCount = result.total_count || 0;
         } catch {
@@ -38,6 +40,17 @@ export class WaSystray extends Component {
 
     async markAllRead() {
         await this.orm.call("res.users", "mark_all_wa_read", [], {});
+        this.state.showAll = false;
+        await this.fetchData();
+    }
+
+    async showAllItems() {
+        this.state.showAll = true;
+        await this.fetchData();
+    }
+
+    async showUnreadOnly() {
+        this.state.showAll = false;
         await this.fetchData();
     }
 }

--- a/purchase_work_acceptance_portal/static/src/xml/wa_systray.xml
+++ b/purchase_work_acceptance_portal/static/src/xml/wa_systray.xml
@@ -19,7 +19,15 @@
                     <span class="fw-bold">ตรวจรับพัสดุ</span>
                     <t t-if="state.totalCount > 0">
                         <span class="ms-auto badge bg-primary text-white" t-esc="state.totalCount"/>
-                        <button class="btn btn-sm btn-link ms-2 p-0" t-on-click="markAllRead">อ่านทั้งหมด</button>
+                        <t t-if="state.showAll">
+                            <button class="btn btn-sm btn-link ms-2 p-0" t-on-click="showUnreadOnly">เฉพาะยังไม่อ่าน</button>
+                        </t>
+                        <t t-else="">
+                            <button class="btn btn-sm btn-link ms-2 p-0" t-on-click="markAllRead">อ่านทั้งหมด</button>
+                        </t>
+                    </t>
+                    <t t-elif="!state.showAll">
+                        <button class="btn btn-sm btn-link ms-auto p-0" t-on-click="showAllItems">เปิดทั้งหมด</button>
                     </t>
                 </div>
                 <t t-if="state.items.length === 0">


### PR DESCRIPTION
## Summary
- เพิ่มปุ่ม "เปิดทั้งหมด" ใน WA inbox systray เพื่อแสดง WA ทั้งหมด (รวมที่อ่านแล้ว) กรณีผู้ใช้กด "อ่านทั้งหมด" โดยไม่ตั้งใจ
- เมื่ออยู่ในโหมดแสดงทั้งหมด จะแสดงปุ่ม "เฉพาะยังไม่อ่าน" เพื่อกลับไปแสดงเฉพาะรายการที่ยังไม่ได้อ่าน
- เพิ่ม method `get_wa_inbox_all` ใน `res.users` สำหรับดึง inbox entries ทั้งหมดโดยไม่กรอง `is_read`

## Test plan
- [ ] เปิด systray dropdown → เห็นรายการ WA ที่ยังไม่อ่าน
- [ ] กด "อ่านทั้งหมด" → รายการหายไป
- [ ] กด "เปิดทั้งหมด" → แสดง WA ทั้งหมดกลับมา (รวมที่อ่านแล้ว)
- [ ] กด "เฉพาะยังไม่อ่าน" → กลับไปแสดงเฉพาะรายการที่ยังไม่ได้อ่าน