### PR TITLE
[16.0][FIX] agx_construction: add force_save to payment_type field

### DIFF
--- a/agx_construction/views/purchase_request_views.xml
+++ b/agx_construction/views/purchase_request_views.xml
@@ -17,6 +17,7 @@
                 <field name="is_construction" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='payment_type']" position="attributes">
+                <attribute name="force_save">1</attribute>
                 <attribute
                     name="attrs"
                 >{'readonly': ['|',('is_construction', '=', True), ('is_editable','=', False)]}</attribute>


### PR DESCRIPTION
## Summary
- เพิ่ม `force_save="1"` ให้กับ field `payment_type` ใน purchase request view ของ module `agx_construction`
- แก้ปัญหาค่า `payment_type` ไม่ถูกบันทึกเมื่อ field อยู่ในสถานะ readonly (กรณี `is_construction = True` หรือ `is_editable = False`)

## Detail
ใน Odoo เมื่อ field ถูกตั้งเป็น readonly ผ่าน `attrs` ค่าจะไม่ถูกส่งไปบันทึกที่ server โดย `force_save="1"` จะบังคับให้บันทึกค่าแม้ field จะอยู่ในสถานะ readonly

## Test plan
- [ ] สร้าง Purchase Request ที่เป็น construction (`is_construction = True`)
- [ ] ตั้งค่า `payment_type` แล้วบันทึก
- [ ] ตรวจสอบว่าค่า `payment_type` ถูกบันทึกอย่างถูกต้อง