### PR TITLE
[16.0][IMP] disbursement: เพิ่มเอกสารแนบในใบขอเบิก

### DIFF
--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -175,6 +175,13 @@ class DisbursementRequest(models.Model):
         states=READONLY_STATES,
     )
 
+    attachment_ids = fields.One2many(
+        "ir.attachment",
+        "res_id",
+        string="Document Attachments",
+        domain=[("res_model", "=", "disbursement.request")],
+    )
+
     amount_untaxed = fields.Monetary(
         string="Untaxed Amount",
         compute="_compute_amount_all",

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -139,6 +139,17 @@
                             </group>
                             <div class="oe_clear" />
                         </page>
+                        <page string="Attachment" name="attachment">
+                            <field name="attachment_ids"
+                                   context="{'default_res_model': 'disbursement.request'}">
+                                <tree>
+                                    <field name="name" string="File Name"/>
+                                    <field name="type"/>
+                                    <field name="create_date" string="Upload Date"/>
+                                    <field name="create_uid" string="Uploaded By"/>
+                                </tree>
+                            </field>
+                        </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
## Summary
- เพิ่มฟิลด์ `attachment_ids` ใน model `disbursement.request` เพื่อรองรับการแนบเอกสารประกอบ
- เพิ่มแท็บ "Attachment" ใน form view สำหรับแนบไฟล์เอกสาร

## Test plan
- [ ] เปิดฟอร์มใบขอเบิก → ตรวจสอบว่ามีแท็บ "Attachment" ปรากฏ
- [ ] อัปโหลดไฟล์ผ่านแท็บ → ตรวจสอบว่าไฟล์บันทึกและแสดงผลถูกต้อง
- [ ] ตรวจสอบว่าไฟล์แนบแยกตาม record ไม่ปะปนกัน