### PR TITLE
[16.0][IMP] account_move_kmitl: assign sequence number on submit

### DIFF
--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -38,6 +38,19 @@ class AccountMove(models.Model):
     )
 
     # --- Compute ---
+    @api.depends("posted_before", "state", "journal_id", "date")
+    def _compute_name(self):
+        super()._compute_name()
+        submitted_no_name = self.filtered(
+            lambda m: m.state == "submitted" and (not m.name or m.name == "/")
+        )
+        for move in submitted_no_name.sorted(
+            lambda m: (m.date, m.ref or "", m.id)
+        ):
+            move._set_next_sequence()
+        if submitted_no_name:
+            submitted_no_name._inverse_name()
+
     @api.depends("date", "auto_post", "state", "validation_status")
     def _compute_hide_post_button(self):
         """Show Post button only when submitted AND validated.

--- a/account_move_kmitl/models/account_move.py
+++ b/account_move_kmitl/models/account_move.py
@@ -38,19 +38,6 @@ class AccountMove(models.Model):
     )
 
     # --- Compute ---
-    @api.depends("posted_before", "state", "journal_id", "date")
-    def _compute_name(self):
-        super()._compute_name()
-        submitted_no_name = self.filtered(
-            lambda m: m.state == "submitted" and (not m.name or m.name == "/")
-        )
-        for move in submitted_no_name.sorted(
-            lambda m: (m.date, m.ref or "", m.id)
-        ):
-            move._set_next_sequence()
-        if submitted_no_name:
-            submitted_no_name._inverse_name()
-
     @api.depends("date", "auto_post", "state", "validation_status")
     def _compute_hide_post_button(self):
         """Show Post button only when submitted AND validated.
@@ -74,7 +61,11 @@ class AccountMove(models.Model):
         for move in self:
             if move.state != "draft":
                 raise UserError(_("Only draft entries can be submitted."))
-            move.state = "submitted"
+        self.write({"state": "submitted"})
+        # Assign sequence number on submit (standard Odoo only assigns on post)
+        for move in self.sorted(lambda m: (m.date, m.ref or "", m.id)):
+            if not move.name or move.name == "/":
+                move._set_next_sequence()
         for move in self:
             if move.need_validation and move.state == "submitted":
                 move.request_validation()


### PR DESCRIPTION
## Summary
- Sequence number (e.g. BILL/2026/0001) is now assigned when journal entry is **submitted** instead of waiting until posted
- Uses the existing journal sequence format — no new sequence configuration needed
- Name is preserved when resetting to draft or posting

## Test plan
- [ ] Create a vendor bill → name should be "/"
- [ ] Click "Submit" → name should change to sequence (e.g. "BILL/2026/0001")
- [ ] Reset to Draft → name should remain the same
- [ ] Submit again → name should remain the same (no new number)
- [ ] Approve and Post → name should remain the same