### PR TITLE
[16.0][FIX] budget_appropriation_summary: match all descendant departments

### DIFF
--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -114,7 +114,7 @@
                                         ('source_analytic_id', '=', False),
                                     '|',
                                         ('department_analytic_id', '=', department_analytic_id),
-                                        ('department_analytic_id.parent_id', '=', department_analytic_id),
+                                        ('department_analytic_id.parent_path', 'like', str(department_analytic_id) + '/%'),
                                 ]"
                                 attrs="{'readonly': ['|', '|', ('account_fiscal_year_id', '=', False), ('source_analytic_id', '=', False), ('department_analytic_id', '=', False)]}"
                                 context="{'can_edit': False}"
@@ -143,7 +143,7 @@
                                         ('source_analytic_id', '=', False),
                                     '|',
                                         ('department_analytic_id', '=', department_analytic_id),
-                                        ('department_analytic_id.parent_id', '=', department_analytic_id),
+                                        ('department_analytic_id.parent_path', 'like', str(department_analytic_id) + '/%'),
                                 ]"
                                 attrs="{'readonly': ['|', '|', ('account_fiscal_year_id', '=', False), ('source_analytic_id', '=', False), ('department_analytic_id', '=', False)]}"
                             >


### PR DESCRIPTION
## Summary

Fix the domain on `revenue_appropriation_ids` and `expense_appropriation_ids` in the budget appropriation compilation view so that appropriations from **all descendant departments** are included, not only direct children. Switches from `department_analytic_id.parent_id = X` to `department_analytic_id.parent_path LIKE 'X/%'`, which is the recommended hierarchical query pattern.

## Test plan

- [ ] Open a Budget Appropriation Compilation and confirm revenue/expense pickers list appropriations from sub-sub-departments.