### PR TITLE
[16.0][IMP] budget_appropriation_summary: deduct หักโอน from r49000 in revenue reports

### DIFF
--- a/budget_appropriation/views/budget_appropriation_views.xml
+++ b/budget_appropriation/views/budget_appropriation_views.xml
@@ -425,6 +425,9 @@
                 </group>
                 <searchpanel>
                     <field name="account_fiscal_year_id" icon="fa-calendar" enable_counters="1" />
+                    <field name="account_id" icon="fa-sitemap" order="code asc"/>
+                    <field name="deduct_analytic_id" icon="fa-users" order="code asc"/>
+                    <field name="department_analytic_id" icon="fa-users" order="code asc"/>
                 </searchpanel>
             </search>
         </field>

--- a/budget_appropriation_summary/models/summary_f2_revenue.py
+++ b/budget_appropriation_summary/models/summary_f2_revenue.py
@@ -149,7 +149,11 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
         lines = summary.revenue_appropriation_ids.mapped("line_ids")
 
         account_totals = {}
+        deduct_total = 0
         for line in lines:
+            if line.deduct:
+                deduct_total += line.balance
+                continue
             acc_id = line.account_id.id
             account_totals[acc_id] = account_totals.get(acc_id, 0) + line.balance
 
@@ -159,6 +163,9 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
             totals[code] = sum(
                 account_totals.get(acc_id, 0) for acc_id in account_ids
             )
+
+        if "r49000" in totals:
+            totals["r49000"] -= deduct_total
 
         return totals
 

--- a/budget_appropriation_summary/models/summary_f4p_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4p_revenue.py
@@ -129,6 +129,10 @@ class BudgetAppropriationSummaryF4PRevenue(models.AbstractModel):
             top_dept_id = self._extract_top_level_dept_id(line.department_analytic_id)
 
             if top_dept_id and top_dept_id in dept_map:
+                if line.deduct:
+                    key = ("r49000", top_dept_id)
+                    totals[key] = totals.get(key, 0) - line.balance
+                    continue
                 for code, _ in self.REVENUE_CATEGORIES:
                     if acc_id in category_accounts[code]:
                         key = (code, top_dept_id)

--- a/budget_appropriation_summary/models/summary_f4w_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4w_revenue.py
@@ -137,6 +137,10 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
             top_dept_id = self._extract_top_level_dept_id(line.department_analytic_id)
 
             if top_dept_id and top_dept_id in dept_map:
+                if line.deduct:
+                    key = (top_dept_id, "r49000")
+                    totals[key] = totals.get(key, 0) - line.balance
+                    continue
                 for code, _ in self.REVENUE_CATEGORIES:
                     if acc_id in category_accounts[code]:
                         key = (top_dept_id, code)


### PR DESCRIPTION
## Summary
- Subtract deduct-flagged appropriation lines (e.g. account 99000 หักโอน) from the r49000 revenue category across master summary reports F2, F4-P and F4-W (F3W/F6W reuses F4-W data).
- Add searchpanel filters (account, deduct analytic, department analytic) to the รายการหักโอน list view for easier drill-down.

## Test plan
- [ ] Open a `budget.appropriation.master.summary` and confirm F2/F4-P/F4-W show r49000 totals net of deduct lines.
- [ ] Verify non-r49000 categories (43300/43400/43500) are unchanged.
- [ ] Filter the รายการหักโอน view by account / deduct analytic / department analytic via the searchpanel.