### PR TITLE
[16.0][ADD] advance_payment: loan contract module

### DIFF
--- a/advance_payment/__init__.py
+++ b/advance_payment/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/advance_payment/__manifest__.py
+++ b/advance_payment/__manifest__.py
@@ -1,0 +1,25 @@
+{
+    "name": "Advance Payment",
+    "summary": "Loan contract management (สัญญายืมเงิน)",
+    "version": "16.0.1.0.0",
+    "category": "Accounting",
+    "author": "KMITL",
+    "license": "LGPL-3",
+    "depends": [
+        "account",
+        "hr",
+        "account_analytic_kmitl",
+        "base_tier_validation",
+        "disbursement",
+        "purchase_request_approval_disbursement",
+    ],
+    "data": [
+        "security/security.xml",
+        "security/ir.model.access.csv",
+        "data/sequence.xml",
+        "data/tier_definition.xml",
+        "views/advance_payment_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/advance_payment/data/sequence.xml
+++ b/advance_payment/data/sequence.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="seq_advance_payment" model="ir.sequence">
+            <field name="name">Advance Payment</field>
+            <field name="code">advance.payment</field>
+            <field name="prefix">AP</field>
+            <field name="padding">5</field>
+            <field name="company_id" eval="False" />
+        </record>
+    </data>
+</odoo>

--- a/advance_payment/data/tier_definition.xml
+++ b/advance_payment/data/tier_definition.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="tier_definition_advance_payment" model="tier.definition">
+        <field name="model_id" ref="model_advance_payment"/>
+        <field name="name">Advance Payment Approval</field>
+        <field name="sequence">10</field>
+        <field name="review_type">group</field>
+        <field name="reviewer_group_id" ref="group_advance_payment_manager"/>
+        <field name="definition_type">domain</field>
+        <field name="definition_domain">[]</field>
+        <field name="approve_sequence">True</field>
+        <field name="has_comment">False</field>
+        <field name="active">True</field>
+        <field name="notify_on_create">True</field>
+        <field name="notify_on_accepted">True</field>
+        <field name="notify_on_rejected">True</field>
+        <field name="notify_on_restarted">True</field>
+    </record>
+</odoo>

--- a/advance_payment/models/__init__.py
+++ b/advance_payment/models/__init__.py
@@ -1,0 +1,1 @@
+from . import advance_payment

--- a/advance_payment/models/advance_payment.py
+++ b/advance_payment/models/advance_payment.py
@@ -1,0 +1,209 @@
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+READONLY_STATES = {
+    "pending": [("readonly", True)],
+    "approved": [("readonly", True)],
+    "done": [("readonly", True)],
+    "cancel": [("readonly", True)],
+}
+
+
+class AdvancePayment(models.Model):
+    _name = "advance.payment"
+    _description = "Advance Payment (Loan Contract)"
+    _inherit = [
+        "analytic.distribution.mixin",
+        "mail.thread",
+        "mail.activity.mixin",
+        "tier.validation",
+    ]
+    _state_from = ["draft"]
+    _state_to = ["approved"]
+    _tier_validation_manual_config = False
+    _order = "date desc, id desc"
+
+    name = fields.Char(
+        string="Number",
+        required=True,
+        readonly=True,
+        copy=False,
+        default="/",
+        tracking=True,
+    )
+    state = fields.Selection(
+        [
+            ("draft", "Draft"),
+            ("pending", "Pending"),
+            ("approved", "Approved"),
+            ("done", "Done"),
+            ("cancel", "Cancelled"),
+        ],
+        default="draft",
+        tracking=True,
+        readonly=True,
+        copy=False,
+    )
+    date = fields.Date(
+        default=fields.Date.context_today,
+        states=READONLY_STATES,
+        tracking=True,
+    )
+
+    # -- Borrower Information --
+    borrower_id = fields.Many2one(
+        "res.users",
+        string="Borrower",
+        required=True,
+        states=READONLY_STATES,
+        tracking=True,
+        default=lambda self: self.env.user,
+    )
+    borrower_partner_id = fields.Many2one(
+        "res.partner",
+        related="borrower_id.partner_id",
+    )
+    department_id = fields.Many2one(
+        "hr.department",
+        string="Department",
+        states=READONLY_STATES,
+        tracking=True,
+    )
+    partner_bank_id = fields.Many2one(
+        "res.partner.bank",
+        string="Bank Account",
+        states=READONLY_STATES,
+        tracking=True,
+        domain="[('partner_id', '=', borrower_partner_id)]",
+    )
+    use_attachment_bank = fields.Boolean(
+        string="Use Attachment Bank Account",
+    )
+    bank_attachment_ids = fields.Many2many(
+        "ir.attachment",
+        string="Bank Attachments",
+    )
+
+    # -- Loan Information --
+    loan_type = fields.Selection(
+        [
+            ("procurement", "Procurement"),
+            ("other", "Other"),
+        ],
+        string="Loan Type",
+        default="other",
+        states=READONLY_STATES,
+        tracking=True,
+    )
+    loan_reason = fields.Text(
+        string="Loan Reason",
+        states=READONLY_STATES,
+    )
+    loan_amount = fields.Monetary(
+        string="Loan Amount",
+        currency_field="currency_id",
+        states=READONLY_STATES,
+        tracking=True,
+    )
+
+    # -- Standard fields --
+    company_id = fields.Many2one(
+        "res.company",
+        default=lambda self: self.env.company,
+        required=True,
+        readonly=True,
+    )
+    currency_id = fields.Many2one(
+        "res.currency",
+        default=lambda self: self.env.company.currency_id,
+        required=True,
+        readonly=True,
+    )
+
+    # -- Purchase Request Link --
+    purchase_request_id = fields.Many2one(
+        "purchase.request",
+        string="Purchase Request",
+        readonly=True,
+        index=True,
+    )
+
+    # -- Disbursement link (AC4) --
+    disbursement_line_ids = fields.Many2many(
+        "disbursement.request.line",
+        string="Expense Items",
+        compute="_compute_disbursement_line_ids",
+    )
+    disbursement_amount_total = fields.Monetary(
+        string="Total Expenses",
+        currency_field="currency_id",
+        compute="_compute_disbursement_line_ids",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("name", "/") == "/":
+                vals["name"] = (
+                    self.env["ir.sequence"].next_by_code("advance.payment") or "/"
+                )
+        return super().create(vals_list)
+
+    def action_submit(self):
+        self.request_validation()
+        self.write({"state": "pending"})
+
+    def action_approve(self):
+        self.write({"state": "approved"})
+
+    def action_done(self):
+        self.write({"state": "done"})
+
+    def action_cancel(self):
+        self.write({"state": "cancel"})
+
+    def action_draft(self):
+        self.restart_validation()
+        self.write({"state": "draft"})
+
+    @api.depends("purchase_request_id")
+    def _compute_disbursement_line_ids(self):
+        DisbursementRequest = self.env["disbursement.request"]
+        for rec in self:
+            if rec.purchase_request_id:
+                approvals = self.env["purchase.request.approval"].search(
+                    [("request_id", "=", rec.purchase_request_id.id)]
+                )
+                disbursements = DisbursementRequest.search(
+                    [("purchase_request_approval_id", "in", approvals.ids)]
+                )
+                rec.disbursement_line_ids = disbursements.mapped("line_ids")
+                rec.disbursement_amount_total = sum(
+                    disbursements.mapped("amount_total")
+                )
+            else:
+                rec.disbursement_line_ids = False
+                rec.disbursement_amount_total = 0
+
+    def action_view_disbursement_requests(self):
+        self.ensure_one()
+        approvals = self.env["purchase.request.approval"].search(
+            [("request_id", "=", self.purchase_request_id.id)]
+        )
+        disbursements = self.env["disbursement.request"].search(
+            [("purchase_request_approval_id", "in", approvals.ids)]
+        )
+        action = {
+            "type": "ir.actions.act_window",
+            "name": _("Disbursement Requests"),
+            "res_model": "disbursement.request",
+            "view_mode": "tree,form",
+            "domain": [("id", "in", disbursements.ids)],
+        }
+        if len(disbursements) == 1:
+            action.update({"view_mode": "form", "res_id": disbursements.id})
+        return action

--- a/advance_payment/security/ir.model.access.csv
+++ b/advance_payment/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_advance_payment_user,advance.payment.user,model_advance_payment,group_advance_payment_user,1,1,1,0
+access_advance_payment_manager,advance.payment.manager,model_advance_payment,group_advance_payment_manager,1,1,1,1

--- a/advance_payment/security/security.xml
+++ b/advance_payment/security/security.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <data noupdate="0">
+        <record id="module_category_advance_payment" model="ir.module.category">
+            <field name="name">Advance Payment</field>
+            <field name="description">User groups for managing advance payments (loan contracts)</field>
+            <field name="sequence">16</field>
+        </record>
+
+        <record id="group_advance_payment_user" model="res.groups">
+            <field name="name">User</field>
+            <field name="category_id" ref="advance_payment.module_category_advance_payment"/>
+            <field name="implied_ids" eval="[(6, 0, [ref('base.group_user')])]"/>
+        </record>
+
+        <record id="group_advance_payment_manager" model="res.groups">
+            <field name="name">Manager</field>
+            <field name="category_id" ref="advance_payment.module_category_advance_payment"/>
+            <field name="implied_ids" eval="[(4, ref('group_advance_payment_user'))]"/>
+            <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/advance_payment/views/advance_payment_views.xml
+++ b/advance_payment/views/advance_payment_views.xml
@@ -28,6 +28,7 @@
         <field name="arch" type="xml">
             <form string="Advance Payment">
                 <header>
+                    <field name="validated" invisible="1"/>
                     <button name="action_submit" string="Submit"
                         type="object" class="oe_highlight"
                         attrs="{'invisible': [('state', '!=', 'draft')]}" />

--- a/advance_payment/views/advance_payment_views.xml
+++ b/advance_payment/views/advance_payment_views.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Tree View -->
+    <record id="view_advance_payment_tree" model="ir.ui.view">
+        <field name="name">advance.payment.tree</field>
+        <field name="model">advance.payment</field>
+        <field name="arch" type="xml">
+            <tree string="Advance Payments">
+                <field name="name" />
+                <field name="borrower_id" />
+                <field name="department_id" />
+                <field name="loan_type" />
+                <field name="loan_amount" />
+                <field name="date" />
+                <field name="state" widget="badge"
+                    decoration-info="state == 'draft'"
+                    decoration-warning="state == 'pending'"
+                    decoration-success="state in ('approved', 'done')"
+                    decoration-danger="state == 'cancel'" />
+            </tree>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_advance_payment_form" model="ir.ui.view">
+        <field name="name">advance.payment.form</field>
+        <field name="model">advance.payment</field>
+        <field name="arch" type="xml">
+            <form string="Advance Payment">
+                <header>
+                    <button name="action_submit" string="Submit"
+                        type="object" class="oe_highlight"
+                        attrs="{'invisible': [('state', '!=', 'draft')]}" />
+                    <button name="action_approve" string="Approve"
+                        type="object" class="oe_highlight"
+                        attrs="{'invisible': ['|', ('state', '!=', 'pending'), ('validated', '!=', True)]}"
+                        groups="advance_payment.group_advance_payment_manager" />
+                    <button name="action_done" string="Done"
+                        type="object" class="oe_highlight"
+                        attrs="{'invisible': [('state', '!=', 'approved')]}" />
+                    <button name="action_draft" string="Reset to Draft"
+                        type="object" class="btn btn-secondary"
+                        attrs="{'invisible': [('state', 'not in', ('pending', 'cancel'))]}" />
+                    <button name="action_cancel" string="Cancel"
+                        type="object"
+                        attrs="{'invisible': [('state', 'in', ('done', 'cancel'))]}" />
+                    <field name="state" widget="statusbar"
+                        statusbar_visible="draft,pending,approved,done" />
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_view_disbursement_requests"
+                            type="object" class="oe_stat_button" icon="fa-money"
+                            attrs="{'invisible': [('purchase_request_id', '=', False)]}">
+                            <field name="disbursement_amount_total" widget="statinfo" string="Expenses" />
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <h1><field name="name" readonly="1" /></h1>
+                    </div>
+                    <group>
+                        <group id="borrower_info" string="Borrower Information">
+                            <field name="purchase_request_id" invisible="1" />
+                            <field name="borrower_id"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                            <field name="borrower_partner_id" invisible="1" />
+                            <field name="department_id"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                            <field name="partner_bank_id" />
+                            <field name="use_attachment_bank" />
+                            <field name="bank_attachment_ids" widget="many2many_binary"
+                                attrs="{'invisible': [('use_attachment_bank', '=', False)]}" />
+                        </group>
+                        <group id="loan_info" string="Loan Information">
+                            <field name="loan_type"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                            <field name="loan_reason" />
+                            <field name="loan_amount"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                            <field name="purchase_request_id"
+                                attrs="{'invisible': [('purchase_request_id', '=', False)]}" />
+                            <field name="date" />
+                            <field name="company_id" groups="base.group_multi_company" />
+                            <field name="currency_id" invisible="1" />
+                        </group>
+                    </group>
+                    <group id="analytic_dimensions" string="Analytic Dimensions">
+                        <group>
+                            <field name="source_analytic_id"
+                                options="{'no_create': True, 'no_open': True}"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                            <field name="department_analytic_id"
+                                options="{'no_create': True, 'no_open': True}"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                        </group>
+                        <group>
+                            <field name="fund_analytic_id"
+                                options="{'no_create': True, 'no_open': True}"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                            <field name="activity_analytic_id"
+                                options="{'no_create': True, 'no_open': True}"
+                                attrs="{'readonly': [('purchase_request_id', '!=', False)]}" />
+                        </group>
+                        <field name="analytic_distribution" invisible="1" />
+                    </group>
+                    <!-- Tier Validation -->
+                    <field name="review_ids" widget="tier_validation" />
+                    <notebook>
+                        <page string="Expense Items" name="expense_items"
+                            attrs="{'invisible': [('purchase_request_id', '=', False)]}">
+                            <field name="disbursement_line_ids" readonly="1">
+                                <tree>
+                                    <field name="request_id" string="Disbursement" />
+                                    <field name="product_id" optional="show" />
+                                    <field name="name" />
+                                    <field name="quantity" />
+                                    <field name="price_unit" />
+                                    <field name="price_subtotal" />
+                                    <field name="currency_id" invisible="1" />
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <!-- Search View -->
+    <record id="view_advance_payment_search" model="ir.ui.view">
+        <field name="name">advance.payment.search</field>
+        <field name="model">advance.payment</field>
+        <field name="arch" type="xml">
+            <search string="Advance Payments">
+                <field name="name" filter_domain="['|', ('name', 'ilike', self), ('loan_reason', 'ilike', self)]" />
+                <field name="borrower_id" />
+                <field name="department_id" />
+                <separator />
+                <filter string="Draft" name="draft" domain="[('state', '=', 'draft')]" />
+                <filter string="Pending" name="pending" domain="[('state', '=', 'pending')]" />
+                <filter string="Approved" name="approved" domain="[('state', '=', 'approved')]" />
+                <filter string="Done" name="done" domain="[('state', '=', 'done')]" />
+                <separator />
+                <filter name="needs_review" string="Needs my Review"
+                    domain="[('reviewer_ids', 'in', uid)]" />
+                <separator />
+                <group expand="0" string="Group By">
+                    <filter string="Department" name="department" context="{'group_by': 'department_id'}" />
+                    <filter string="State" name="state" context="{'group_by': 'state'}" />
+                    <filter string="Date" name="date" context="{'group_by': 'date'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="action_advance_payment" model="ir.actions.act_window">
+        <field name="name">Advance Payments</field>
+        <field name="res_model">advance.payment</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new Advance Payment (Loan Contract)
+            </p>
+        </field>
+    </record>
+
+    <!-- Menu -->
+    <menuitem id="menu_advance_payment_root"
+        name="Advance Payment"
+        sequence="46"
+        web_icon="advance_payment,static/description/icon.png" />
+
+    <menuitem id="menu_advance_payment_list"
+        name="Advance Payments"
+        parent="menu_advance_payment_root"
+        action="action_advance_payment"
+        sequence="10"
+        groups="advance_payment.group_advance_payment_user" />
+</odoo>

--- a/advance_payment_purchase_request/__init__.py
+++ b/advance_payment_purchase_request/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/advance_payment_purchase_request/__manifest__.py
+++ b/advance_payment_purchase_request/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Advance Payment - Purchase Request",
+    "summary": "Create loan contracts from purchase requests",
+    "version": "16.0.1.0.0",
+    "category": "Accounting",
+    "author": "KMITL",
+    "license": "LGPL-3",
+    "depends": [
+        "advance_payment",
+        "purchase_request_kmitl",
+        "purchase_request_department",
+        "purchase_request_budget",
+    ],
+    "data": [
+        "views/purchase_request_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/advance_payment_purchase_request/models/__init__.py
+++ b/advance_payment_purchase_request/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_request

--- a/advance_payment_purchase_request/models/purchase_request.py
+++ b/advance_payment_purchase_request/models/purchase_request.py
@@ -1,0 +1,90 @@
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseRequest(models.Model):
+    _inherit = "purchase.request"
+
+    advance_payment_ids = fields.One2many(
+        "advance.payment",
+        "purchase_request_id",
+        string="Advance Payments",
+    )
+    advance_payment_count = fields.Integer(
+        compute="_compute_advance_payment_count",
+    )
+    hide_create_advance_payment_button = fields.Boolean(
+        compute="_compute_hide_create_advance_payment_button",
+    )
+
+    @api.depends("advance_payment_ids")
+    def _compute_advance_payment_count(self):
+        for rec in self:
+            rec.advance_payment_count = len(rec.advance_payment_ids)
+
+    @api.depends("state", "payment_type", "advance_payment_count")
+    def _compute_hide_create_advance_payment_button(self):
+        for rec in self:
+            rec.hide_create_advance_payment_button = not (
+                rec.payment_type == "loan"
+                and rec.state == "approved"
+                and rec.advance_payment_count == 0
+            )
+
+    def _prepare_advance_payment_vals(self):
+        self.ensure_one()
+        return {
+            "purchase_request_id": self.id,
+            "borrower_id": self.requested_by.id,
+            "department_id": self.department_id.id,
+            "loan_type": "procurement",
+            "loan_reason": self.description,
+            "loan_amount": self.estimated_cost,
+            "analytic_distribution": self.analytic_distribution,
+        }
+
+    def button_create_advance_payment(self):
+        self.ensure_one()
+        if self.advance_payment_count > 0:
+            raise UserError(
+                _("An advance payment has already been created for this request.")
+            )
+        advance = self.env["advance.payment"].create(
+            self._prepare_advance_payment_vals()
+        )
+        advance_link = "/web#id=%d&model=advance.payment&view_type=form" % advance.id
+        self.message_post(
+            body=_(
+                'Advance Payment <a href="%(link)s">%(name)s</a> created.'
+            )
+            % {"link": advance_link, "name": advance.name},
+            subtype_xmlid="mail.mt_note",
+        )
+        return {
+            "name": _("Advance Payment"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "advance.payment",
+            "res_id": advance.id,
+            "target": "current",
+        }
+
+    def action_view_advance_payment(self):
+        self.ensure_one()
+        action = {
+            "name": _("Advance Payments"),
+            "type": "ir.actions.act_window",
+            "res_model": "advance.payment",
+            "view_mode": "tree,form",
+            "domain": [("purchase_request_id", "=", self.id)],
+        }
+        if len(self.advance_payment_ids) == 1:
+            action.update({
+                "view_mode": "form",
+                "res_id": self.advance_payment_ids.id,
+            })
+        return action

--- a/advance_payment_purchase_request/views/purchase_request_views.xml
+++ b/advance_payment_purchase_request/views/purchase_request_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_purchase_request_form" model="ir.ui.view">
+        <field name="name">purchase.request.form.advance.payment</field>
+        <field name="model">purchase.request</field>
+        <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='button_done']" position="before">
+                <field name="hide_create_advance_payment_button" invisible="1" />
+                <button
+                    name="button_create_advance_payment"
+                    string="Create Loan Contract"
+                    type="object"
+                    class="oe_highlight"
+                    attrs="{'invisible': [('hide_create_advance_payment_button', '=', True)]}"
+                />
+            </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="advance_payment_count" invisible="1" />
+                <button
+                    type="object"
+                    name="action_view_advance_payment"
+                    class="oe_stat_button"
+                    icon="fa-money"
+                    attrs="{'invisible': [('advance_payment_count', '=', 0)]}"
+                >
+                    <field name="advance_payment_count" widget="statinfo" string="Loan Contracts" />
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- เพิ่ม module `advance_payment` สำหรับจัดการสัญญายืมเงิน (Loan Contract) พร้อม tier validation approval workflow, มิติทางบัญชี (analytic dimensions) และการเชื่อมกับใบขอเบิก
- เพิ่ม module `advance_payment_purchase_request` เป็น bridge module เชื่อมกับใบคำขอซื้อขอจ้าง (พ.1) — แสดงปุ่ม "Create Loan Contract" เมื่อ payment_type = loan และ PR อนุมัติแล้ว

## Acceptance Criteria

### AC1: เชื่อมกับคำขอซื้อขอจ้าง (พ.1)
- เมื่อ payment_type == "loan" && PR state == "approved" → แสดงปุ่ม "Create Loan Contract"
- กดปุ่มแล้วสร้าง `advance.payment` ที่เชื่อมกับ PR

### AC2: ปรับใบคำขอยืมเงิน
- **2.1 ข้อมูลผู้ยืม**: ดึง borrower จาก PR.requested_by, department จาก PR.department_id, ให้เลือกบัญชีธนาคาร, มี Boolean "ประสงค์ใช้เลขบัญชีธนาคารเอกสารแนบ" พร้อมแนบไฟล์
- **2.2 ข้อมูลการยืม**: loan_type = "procurement" (readonly), loan_reason จาก PR.description (แก้ไขได้), loan_amount จาก PR.estimated_cost (readonly)
- **2.3 มิติทางบัญชี**: ดึง analytic_distribution จาก PR (readonly เมื่อมาจาก PR)
- ถ้าสร้างเอง (ไม่จาก PR) → แสดงเป็น form เปล่าทุก field แก้ไขได้

### AC3: Tier Validation
- ใช้ `base_tier_validation` สำหรับ approval workflow
- States: draft → pending (รออนุมัติ) → approved → done / cancel

### AC4: เชื่อมกับใบขอเบิก
- แสดงรายการใช้เงิน (Expense Items) จาก disbursement request lines ที่เกี่ยวข้องกับ PR เดียวกัน

## Modules Created

| Module | Files | Purpose |
|--------|-------|---------|
| `advance_payment` | 9 files | Core model, views, security, sequence, tier definition |
| `advance_payment_purchase_request` | 5 files | Bridge: button on PR + data mapping |

## Test Plan
- [ ] Install both modules
- [ ] Create PR with payment_type = "loan", approve it
- [ ] Verify "Create Loan Contract" button appears
- [ ] Click button → verify data mapping (borrower, department, loan_type, loan_reason, loan_amount, analytic_distribution)
- [ ] Verify readonly fields when from PR
- [ ] Test use_attachment_bank toggle
- [ ] Submit → tier validation → approve flow
- [ ] Verify disbursement expense items tab
- [ ] Test standalone creation (no PR) → empty editable form