### PR TITLE
[16.0][IMP] disbursement: support multi-partner disbursement requests

### DIFF
--- a/agx_approval_disbursement/models/approval_request.py
+++ b/agx_approval_disbursement/models/approval_request.py
@@ -47,13 +47,19 @@ class ApprovalRequest(models.Model):
             else:
                 record.billing_status = "no"
 
-    def _prepare_disbursement_request_vals(self, partner, lines):
+    def _prepare_disbursement_request_vals(self):
+        """Prepare vals for a single multi-partner DR from all approval lines."""
         return {
             "approval_request_id": self.id,
-            "partner_id": partner.id,
+            "partner_type": "multi",
             "line_ids": [
-                Command.create(line._prepare_disbursement_request_line_vals())
-                for line in lines
+                Command.create(
+                    {
+                        **line._prepare_disbursement_request_line_vals(),
+                        "partner_id": line.partner_id.id,
+                    }
+                )
+                for line in self.line_ids
             ],
             "ref": self.name,
             "budget_commitment_id": self.budget_commitment_id.id,
@@ -63,45 +69,34 @@ class ApprovalRequest(models.Model):
 
     def action_create_disbursement_request(self):
         self.ensure_one()
-        # Group lines by partner
-        partner_lines = {}
-        for line in self.line_ids:
-            partner = line.partner_id
-            partner_lines.setdefault(partner, self.env["approval.request.line"])
-            partner_lines[partner] |= line
+        vals = self._prepare_disbursement_request_vals()
+        disbursement = self.env["disbursement.request"].create(vals)
 
-        disbursements = self.env["disbursement.request"]
-        for partner, lines in partner_lines.items():
-            vals = self._prepare_disbursement_request_vals(partner, lines)
-            disbursement = self.env["disbursement.request"].create(vals)
-            link = self._get_record_url()
-            disbursement.message_post(
-                body=_(
-                    'This record has been created from: '
-                    '<a href="%(link)s" target="_blank">%(name)s</a>',
-                    link=link,
-                    name=self.name,
-                ),
-                message_type="comment",
-            )
-            self.message_post(
-                body=_(
-                    "Disbursement %(dr_name)s created successfully.",
-                    dr_name=disbursement.name,
-                ),
-                message_type="comment",
-            )
-            disbursements |= disbursement
+        link = self._get_record_url()
+        disbursement.message_post(
+            body=_(
+                'This record has been created from: '
+                '<a href="%(link)s" target="_blank">%(name)s</a>',
+                link=link,
+                name=self.name,
+            ),
+            message_type="comment",
+        )
+        self.message_post(
+            body=_(
+                "Disbursement %(dr_name)s created successfully.",
+                dr_name=disbursement.name,
+            ),
+            message_type="comment",
+        )
 
-        if len(disbursements) == 1:
-            return {
-                "type": "ir.actions.act_window",
-                "res_model": "disbursement.request",
-                "view_mode": "form",
-                "res_id": disbursements.id,
-                "target": "current",
-            }
-        return self.action_view_disbursement_request()
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "disbursement.request",
+            "view_mode": "form",
+            "res_id": disbursement.id,
+            "target": "current",
+        }
 
     def action_view_disbursement_request(self):
         self.ensure_one()
@@ -115,7 +110,9 @@ class ApprovalRequest(models.Model):
             action["res_id"] = self.disbursement_request_ids.id
         else:
             action["view_mode"] = "tree,form"
-            action["domain"] = [("id", "in", self.disbursement_request_ids.ids)]
+            action["domain"] = [
+                ("id", "in", self.disbursement_request_ids.ids)
+            ]
         return action
 
     def _get_record_url(self):

--- a/disbursement/models/account_move.py
+++ b/disbursement/models/account_move.py
@@ -1,10 +1,18 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
+
+    disbursement_request_id = fields.Many2one(
+        comodel_name="disbursement.request",
+        string="Disbursement Request",
+        ondelete="set null",
+        index=True,
+        copy=False,
+    )
 
     def write(self, vals):
         res = super().write(vals)
@@ -15,11 +23,8 @@ class AccountMove(models.Model):
                 "payment_draft",
                 "payment_posted",
             )
-            disbursements = self.env["disbursement.request"].search(
-                [
-                    ("bill_id", "in", self.ids),
-                    ("state", "in", pipeline_states),
-                ]
+            disbursements = self.mapped("disbursement_request_id").filtered(
+                lambda d: d.state in pipeline_states
             )
             if disbursements:
                 disbursements._update_state_from_pipeline()

--- a/disbursement/models/account_payment.py
+++ b/disbursement/models/account_payment.py
@@ -30,7 +30,7 @@ class AccountPayment(models.Model):
             )
             disbursements = self.env["disbursement.request"].search(
                 [
-                    ("bill_id", "in", list(bill_ids)),
+                    ("bill_ids", "in", list(bill_ids)),
                     ("state", "in", pipeline_states),
                 ]
             )

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -147,6 +147,11 @@ class DisbursementRequest(models.Model):
         compute="_compute_bill_count",
     )
 
+    bill_draft_count = fields.Integer(
+        string="Draft Bill Count",
+        compute="_compute_bill_count",
+    )
+
     # --- Pipeline: Payment tracking ---
     payment_ids = fields.Many2many(
         comodel_name="account.payment",
@@ -574,11 +579,14 @@ class DisbursementRequest(models.Model):
     # -------------------------------------------------------------------------
     # Computed fields
     # -------------------------------------------------------------------------
-    @api.depends("bill_ids")
+    @api.depends("bill_ids", "bill_ids.state")
     def _compute_bill_count(self):
         """Compute the number of bills linked to this request"""
         for record in self:
             record.bill_count = len(record.bill_ids)
+            record.bill_draft_count = len(
+                record.bill_ids.filtered(lambda b: b.state == "draft")
+            )
 
     @api.depends("bill_ids", "bill_ids.state", "bill_ids.payment_state")
     def _compute_payment_ids(self):
@@ -633,7 +641,7 @@ class DisbursementRequest(models.Model):
                 rec.state = "payment_posted"
             elif all_payments:
                 rec.state = "payment_draft"
-            elif any(b.state == "posted" for b in bills):
+            elif all(b.state == "posted" for b in bills):
                 rec.state = "bill_posted"
             else:
                 rec.state = "bill_draft"

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -79,10 +79,22 @@ class DisbursementRequest(models.Model):
         store=True,
     )
 
+    partner_type = fields.Selection(
+        selection=[
+            ("single", "Single Partner"),
+            ("multi", "Multiple Partners"),
+        ],
+        string="Partner Type",
+        default="single",
+        required=True,
+        tracking=True,
+        states=READONLY_STATES,
+    )
+
     partner_id = fields.Many2one(
         comodel_name="res.partner",
         string="Partner",
-        required=True,
+        required=False,
         compute="_compute_partner_id",
         store=True,
         readonly=False,
@@ -122,12 +134,12 @@ class DisbursementRequest(models.Model):
         states=READONLY_STATES,
     )
 
-    bill_id = fields.Many2one(
+    bill_ids = fields.One2many(
         comodel_name="account.move",
-        string="Vendor Bill",
+        inverse_name="disbursement_request_id",
+        string="Vendor Bills",
         readonly=True,
         copy=False,
-        help="Link to the created vendor bill",
     )
 
     bill_count = fields.Integer(
@@ -525,7 +537,36 @@ class DisbursementRequest(models.Model):
         for rec in self:
             if rec.reference and hasattr(rec.reference, "partner_id"):
                 rec.partner_id = rec.reference.partner_id
+                rec.partner_type = "single"
         self._compute_analytic()
+
+    @api.constrains("partner_type", "partner_id")
+    def _check_partner_required(self):
+        for rec in self:
+            if rec.partner_type == "single" and not rec.partner_id:
+                raise ValidationError(
+                    _("Partner is required in single-partner mode.")
+                )
+
+    @api.onchange("partner_type")
+    def _onchange_partner_type(self):
+        if self.partner_type == "single":
+            line_partners = self.line_ids.mapped("partner_id")
+            if len(line_partners) > 1:
+                self.line_ids.update(
+                    {"partner_id": False, "partner_bank_id": False}
+                )
+                return {
+                    "warning": {
+                        "title": _("Warning"),
+                        "message": _(
+                            "Partner fields on lines have been cleared."
+                        ),
+                    }
+                }
+        elif self.partner_type == "multi":
+            self.partner_id = False
+            self.partner_bank_id = False
 
     def _compute_analytic(self):
         """Hook for extension modules to merge analytics from reference document."""
@@ -533,35 +574,36 @@ class DisbursementRequest(models.Model):
     # -------------------------------------------------------------------------
     # Computed fields
     # -------------------------------------------------------------------------
-    @api.depends("bill_id")
+    @api.depends("bill_ids")
     def _compute_bill_count(self):
         """Compute the number of bills linked to this request"""
         for record in self:
-            record.bill_count = 1 if record.bill_id else 0
+            record.bill_count = len(record.bill_ids)
 
-    @api.depends("bill_id")
+    @api.depends("bill_ids", "bill_ids.state", "bill_ids.payment_state")
     def _compute_payment_ids(self):
         Payment = self.env["account.payment"]
         for rec in self:
             payments = Payment
-            if rec.bill_id:
+            for bill in rec.bill_ids:
                 # Reconciled payments (posted & matched)
-                payments |= rec.bill_id._get_reconciled_payments()
+                payments |= bill._get_reconciled_payments()
                 # Draft/submitted payments awaiting posting (KMITL flow)
                 payments |= Payment.search([
-                    ("to_reconcile_payment_line_ids.move_id", "=", rec.bill_id.id),
+                    ("to_reconcile_payment_line_ids.move_id", "=", bill.id),
                 ])
             rec.payment_ids = payments
             rec.payment_count = len(payments)
 
-    @api.depends("bill_id", "bill_id.state", "bill_id.payment_state")
+    @api.depends("bill_ids", "bill_ids.state", "bill_ids.payment_state")
     def _compute_hide_register_payment_button(self):
         for rec in self:
-            rec.hide_register_payment_button = not (
-                rec.bill_id
-                and rec.bill_id.state == "posted"
-                and rec.bill_id.payment_state in ("not_paid", "partial")
+            has_payable = any(
+                b.state == "posted"
+                and b.payment_state in ("not_paid", "partial")
+                for b in rec.bill_ids
             )
+            rec.hide_register_payment_button = not has_payable
 
     def _update_state_from_pipeline(self):
         """Recompute state based on bill/payment status for records in pipeline."""
@@ -569,25 +611,29 @@ class DisbursementRequest(models.Model):
         for rec in self:
             if rec.state not in rec.PIPELINE_STATES:
                 continue
-            if not rec.bill_id:
+            bills = rec.bill_ids
+            if not bills:
                 continue
-            bill = rec.bill_id
-            if bill.payment_state == "paid":
+            # All bills fully paid → done
+            if all(b.payment_state == "paid" for b in bills):
                 rec.state = "done"
                 rec.message_post(
-                    body=_("Payment complete. Disbursement done."),
+                    body=_("All payments complete. Disbursement done."),
                     subtype_xmlid="mail.mt_note",
                 )
                 continue
-            payments = bill._get_reconciled_payments()
-            payments |= Payment.search(
-                [("to_reconcile_payment_line_ids.move_id", "=", bill.id)]
-            )
-            if payments.filtered(lambda p: p.state == "posted"):
+            # Collect all payments across all bills
+            all_payments = Payment
+            for bill in bills:
+                all_payments |= bill._get_reconciled_payments()
+                all_payments |= Payment.search(
+                    [("to_reconcile_payment_line_ids.move_id", "=", bill.id)]
+                )
+            if all_payments.filtered(lambda p: p.state == "posted"):
                 rec.state = "payment_posted"
-            elif payments:
+            elif all_payments:
                 rec.state = "payment_draft"
-            elif bill.state == "posted":
+            elif any(b.state == "posted" for b in bills):
                 rec.state = "bill_posted"
             else:
                 rec.state = "bill_draft"
@@ -705,66 +751,110 @@ class DisbursementRequest(models.Model):
                     {"analytic_distribution": request.analytic_distribution})
 
     def _create_bill(self):
-        """Create vendor bill from disbursement request"""
+        """Create vendor bill(s) from disbursement request."""
         self.ensure_one()
 
         if self.state != "approved":
-            raise UserError(_("Only approved requests can be used to create bills."))
-
-        # Prepare invoice lines from request lines
-        invoice_lines = []
-        for line in self.line_ids:
-            invoice_lines.append(
-                Command.create(
-                    {
-                        "product_id": line.product_id.id,
-                        "name": line.name,
-                        "account_id": line.account_id.id,
-                        "quantity": line.quantity,
-                        "price_unit": line.price_unit,
-                        "tax_ids": [Command.set(line.tax_ids.ids)],
-                        "analytic_distribution": line.analytic_distribution,
-                    }
-                )
+            raise UserError(
+                _("Only approved requests can be used to create bills.")
             )
 
-        # Create vendor bill
-        bill = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_id.id,
-                "partner_bank_id": self.partner_bank_id.id,
-                "move_type": "in_invoice",
-                "invoice_date": self.date,
-                "ref": self.ref,
-                "currency_id": self.currency_id.id,
-                "company_id": self.company_id.id,
-                "invoice_line_ids": invoice_lines,
-                "budget_commitment_id": self.budget_commitment_id.id,
-                "budget_account_id": self.budget_account_id.id,
-                "analytic_distribution": self.analytic_distribution,
-            }
-        )
+        if self.partner_type == "single":
+            bills = self._create_single_bill()
+        else:
+            bills = self._create_multi_bills()
 
-        # Update invoice lines with WHT from request lines
-        for request_line, invoice_line in zip(self.line_ids, bill.invoice_line_ids):
-            if request_line.wht_tax_id:
-                invoice_line.wht_tax_id = request_line.wht_tax_id
-
-        # Link the bill to this request and advance state
-        self.bill_id = bill.id
         self.state = "bill_draft"
 
-        # Log in Disbursement chatter
-        bill_link = "/web#id=%d&model=account.move&view_type=form" % bill.id
-        self.message_post(
-            body=_(
-                'Vendor Bill <a href="%(link)s" target="_blank">%(name)s</a>'
-                " has been created."
-            ) % {"link": bill_link, "name": bill.name},
-            subtype_xmlid="mail.mt_note",
-        )
+        for bill in bills:
+            bill_link = "/web#id=%d&model=account.move&view_type=form" % bill.id
+            self.message_post(
+                body=_(
+                    'Vendor Bill <a href="%(link)s" target="_blank">'
+                    "%(name)s</a> has been created."
+                )
+                % {"link": bill_link, "name": bill.name},
+                subtype_xmlid="mail.mt_note",
+            )
 
+        return bills
+
+    def _create_single_bill(self):
+        """Create one bill for all lines (single-partner mode)."""
+        self.ensure_one()
+        invoice_lines = [
+            Command.create(self._prepare_bill_line_vals(line))
+            for line in self.line_ids
+        ]
+        bill = self.env["account.move"].create(
+            self._prepare_bill_vals(
+                self.partner_id, self.partner_bank_id, invoice_lines
+            )
+        )
+        self._apply_wht_to_bill(bill, self.line_ids)
         return bill
+
+    def _create_multi_bills(self):
+        """Group lines by partner, create one bill per partner."""
+        self.ensure_one()
+        partner_lines = {}
+        for line in self.line_ids:
+            partner_lines.setdefault(
+                line.partner_id,
+                self.env["disbursement.request.line"],
+            )
+            partner_lines[line.partner_id] |= line
+
+        bills = self.env["account.move"]
+        for partner, lines in partner_lines.items():
+            invoice_lines = [
+                Command.create(self._prepare_bill_line_vals(line))
+                for line in lines
+            ]
+            partner_bank = lines[0].partner_bank_id
+            bill = self.env["account.move"].create(
+                self._prepare_bill_vals(partner, partner_bank, invoice_lines)
+            )
+            self._apply_wht_to_bill(bill, lines)
+            bills |= bill
+        return bills
+
+    def _prepare_bill_vals(self, partner, partner_bank, invoice_lines):
+        """Prepare values for creating a vendor bill."""
+        return {
+            "disbursement_request_id": self.id,
+            "partner_id": partner.id,
+            "partner_bank_id": partner_bank.id if partner_bank else False,
+            "move_type": "in_invoice",
+            "invoice_date": self.date,
+            "ref": self.ref,
+            "currency_id": self.currency_id.id,
+            "company_id": self.company_id.id,
+            "invoice_line_ids": invoice_lines,
+            "budget_commitment_id": self.budget_commitment_id.id,
+            "budget_account_id": self.budget_account_id.id,
+            "analytic_distribution": self.analytic_distribution,
+        }
+
+    def _prepare_bill_line_vals(self, line):
+        """Prepare values for a single invoice line."""
+        return {
+            "product_id": line.product_id.id,
+            "name": line.name,
+            "account_id": line.account_id.id,
+            "quantity": line.quantity,
+            "price_unit": line.price_unit,
+            "tax_ids": [Command.set(line.tax_ids.ids)],
+            "analytic_distribution": line.analytic_distribution,
+        }
+
+    def _apply_wht_to_bill(self, bill, request_lines):
+        """Apply WHT from request lines to the corresponding bill lines."""
+        for request_line, invoice_line in zip(
+            request_lines, bill.invoice_line_ids
+        ):
+            if request_line.wht_tax_id:
+                invoice_line.wht_tax_id = request_line.wht_tax_id
 
     def action_submit(self):
         """Submit request for approval"""
@@ -859,18 +949,22 @@ class DisbursementRequest(models.Model):
         """Cancel the request"""
         for record in self:
             if record.state in ("cancel", "done"):
-                raise UserError(_("Cannot cancel a done or already cancelled request."))
-            if record.bill_id and record.bill_id.state == "posted":
                 raise UserError(
-                    _("Cannot cancel: the bill %s is already posted. "
-                      "Reverse the bill first.")
-                    % record.bill_id.name
+                    _("Cannot cancel a done or already cancelled request.")
                 )
-            if record.bill_id and record.payment_ids:
+            posted_bills = record.bill_ids.filtered(
+                lambda b: b.state == "posted"
+            )
+            if posted_bills:
                 raise UserError(
-                    _("Cannot cancel: there are payments linked to bill %s. "
+                    _("Cannot cancel: bill(s) %s already posted. "
+                      "Reverse the bill(s) first.")
+                    % ", ".join(posted_bills.mapped("name"))
+                )
+            if record.bill_ids and record.payment_ids:
+                raise UserError(
+                    _("Cannot cancel: there are payments linked to bills. "
                       "Remove payments first.")
-                    % record.bill_id.name
                 )
             if record.budget_commitment_id:
                 try:
@@ -885,8 +979,11 @@ class DisbursementRequest(models.Model):
                         body=_("Warning: %s") % str(e),
                         subtype_xmlid="mail.mt_note",
                     )
-            if record.bill_id and record.bill_id.state == "draft":
-                record.bill_id.button_cancel()
+            draft_bills = record.bill_ids.filtered(
+                lambda b: b.state == "draft"
+            )
+            if draft_bills:
+                draft_bills.button_cancel()
             record.state = "cancel"
         return True
 
@@ -904,31 +1001,45 @@ class DisbursementRequest(models.Model):
         return True
 
     def action_view_bill(self):
-        """Open the linked vendor bill"""
+        """Open the linked vendor bill(s)"""
         self.ensure_one()
+        bills = self.bill_ids
+        if len(bills) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "name": _("Vendor Bill"),
+                "res_model": "account.move",
+                "res_id": bills.id,
+                "view_mode": "form",
+                "target": "current",
+            }
         return {
             "type": "ir.actions.act_window",
-            "name": _("Vendor Bill"),
+            "name": _("Vendor Bills"),
             "res_model": "account.move",
-            "res_id": self.bill_id.id,
-            "view_mode": "form",
+            "domain": [("id", "in", bills.ids)],
+            "view_mode": "tree,form",
             "target": "current",
         }
 
     def action_register_payment(self):
-        """Open payment wizard for the linked bill."""
+        """Open payment wizard for unpaid posted bills."""
         self.ensure_one()
-        if not self.bill_id:
-            raise UserError(_("No bill linked. Create a bill first."))
-        if self.bill_id.state != "posted":
-            raise UserError(_("The bill must be posted before registering a payment."))
+        unpaid_bills = self.bill_ids.filtered(
+            lambda b: b.state == "posted"
+            and b.payment_state in ("not_paid", "partial")
+        )
+        if not unpaid_bills:
+            raise UserError(
+                _("No posted unpaid bills to pay.")
+            )
         return {
             "name": _("Register Payment"),
             "res_model": "account.payment.register",
             "view_mode": "form",
             "context": {
                 "active_model": "account.move",
-                "active_ids": [self.bill_id.id],
+                "active_ids": unpaid_bills.ids,
                 "dont_redirect_to_payments": True,
             },
             "target": "new",
@@ -957,14 +1068,22 @@ class DisbursementRequest(models.Model):
         }
 
     def action_create_bill(self):
-        bill = self._create_bill()
+        bills = self._create_bill()
 
-        # Return action to open the created bill
+        if len(bills) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "res_model": "account.move",
+                "res_id": bills.id,
+                "view_mode": "form",
+                "target": "current",
+            }
         return {
             "type": "ir.actions.act_window",
+            "name": _("Vendor Bills"),
             "res_model": "account.move",
-            "res_id": bill.id,
-            "view_mode": "form",
+            "domain": [("id", "in", bills.ids)],
+            "view_mode": "tree,form",
             "target": "current",
         }
 

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -1073,9 +1073,35 @@ class DisbursementRequest(models.Model):
                 lambda l: l.account_type == "liability_payable"
                 and not l.reconciled
             )
+            amount = abs(bill.amount_residual)
+
+            # Compute WHT deduction from bill lines
+            wht_lines = bill.line_ids.filtered("wht_tax_id")
+            write_off_line_vals = []
+            if wht_lines:
+                deduction_list, amount_wht = (
+                    wht_lines._prepare_deduction_list(
+                        fields.Date.context_today(self),
+                        bill.currency_id,
+                    )
+                )
+                if deduction_list and amount_wht:
+                    amount -= amount_wht
+                    for deduct in deduction_list:
+                        write_off_line_vals.append({
+                            "name": deduct["name"],
+                            "account_id": deduct["account_id"],
+                            "partner_id": bill.partner_id.id,
+                            "currency_id": bill.currency_id.id,
+                            "amount_currency": -deduct["amount"],
+                            "balance": -deduct["amount"],
+                            "wht_tax_id": deduct["wht_tax_id"],
+                            "tax_base_amount": deduct["wht_amount_base"],
+                        })
+
             payment_vals = {
                 "partner_id": bill.partner_id.id,
-                "amount": abs(bill.amount_residual),
+                "amount": amount,
                 "currency_id": bill.currency_id.id,
                 "journal_id": journal.id,
                 "payment_type": "outbound",
@@ -1083,6 +1109,8 @@ class DisbursementRequest(models.Model):
                 "ref": _("%s - %s", self.name, bill.name),
                 "analytic_distribution": bill.analytic_distribution,
             }
+            if write_off_line_vals:
+                payment_vals["write_off_line_vals"] = write_off_line_vals
             if payment_type:
                 payment_vals["kmitl_payment_type_id"] = payment_type.id
             if bill.budget_commitment_id:

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -152,6 +152,11 @@ class DisbursementRequest(models.Model):
         compute="_compute_bill_count",
     )
 
+    bill_status_display = fields.Char(
+        string="Bill Status",
+        compute="_compute_bill_count",
+    )
+
     # --- Pipeline: Payment tracking ---
     payment_ids = fields.Many2many(
         comodel_name="account.payment",
@@ -162,8 +167,10 @@ class DisbursementRequest(models.Model):
         compute="_compute_payment_ids",
         string="Payment Count",
     )
-    hide_register_payment_button = fields.Boolean(
-        compute="_compute_hide_register_payment_button",
+
+    payment_status_display = fields.Char(
+        string="Payment Status",
+        compute="_compute_payment_ids",
     )
 
     company_id = fields.Many2one(
@@ -583,9 +590,14 @@ class DisbursementRequest(models.Model):
     def _compute_bill_count(self):
         """Compute the number of bills linked to this request"""
         for record in self:
-            record.bill_count = len(record.bill_ids)
-            record.bill_draft_count = len(
-                record.bill_ids.filtered(lambda b: b.state == "draft")
+            bills = record.bill_ids
+            total = len(bills)
+            draft = len(bills.filtered(lambda b: b.state == "draft"))
+            posted = total - draft
+            record.bill_count = total
+            record.bill_draft_count = draft
+            record.bill_status_display = (
+                _("ตั้งหนี้แล้ว %s/%s", posted, total) if total else ""
             )
 
     @api.depends("bill_ids", "bill_ids.state", "bill_ids.payment_state")
@@ -601,17 +613,12 @@ class DisbursementRequest(models.Model):
                     ("to_reconcile_payment_line_ids.move_id", "=", bill.id),
                 ])
             rec.payment_ids = payments
-            rec.payment_count = len(payments)
-
-    @api.depends("bill_ids", "bill_ids.state", "bill_ids.payment_state")
-    def _compute_hide_register_payment_button(self):
-        for rec in self:
-            has_payable = any(
-                b.state == "posted"
-                and b.payment_state in ("not_paid", "partial")
-                for b in rec.bill_ids
+            total = len(payments)
+            rec.payment_count = total
+            posted = len(payments.filtered(lambda p: p.state == "posted"))
+            rec.payment_status_display = (
+                _("จ่ายแล้ว %s/%s", posted, total) if total else ""
             )
-            rec.hide_register_payment_button = not has_payable
 
     def _update_state_from_pipeline(self):
         """Recompute state based on bill/payment status for records in pipeline."""
@@ -772,6 +779,7 @@ class DisbursementRequest(models.Model):
         else:
             bills = self._create_multi_bills()
 
+        bills.action_submit()
         self.state = "bill_draft"
 
         for bill in bills:
@@ -1030,28 +1038,103 @@ class DisbursementRequest(models.Model):
             "target": "current",
         }
 
-    def action_register_payment(self):
-        """Open payment wizard for unpaid posted bills."""
+    def action_create_payment(self):
+        """Create draft payments directly from DR, one per posted unpaid bill."""
         self.ensure_one()
         unpaid_bills = self.bill_ids.filtered(
             lambda b: b.state == "posted"
             and b.payment_state in ("not_paid", "partial")
         )
         if not unpaid_bills:
+            raise UserError(_("No posted unpaid bills to pay."))
+
+        # Find default bank journal and outbound payment type
+        journal = self.env["account.journal"].search(
+            [
+                ("type", "=", "bank"),
+                ("company_id", "=", self.company_id.id),
+            ],
+            limit=1,
+        )
+        if not journal:
             raise UserError(
-                _("No posted unpaid bills to pay.")
+                _("No bank journal found for company %s.")
+                % self.company_id.name
             )
+        payment_type = self.env.ref(
+            "account_payment_kmitl.payment_type_normal_outbound",
+            raise_if_not_found=False,
+        )
+
+        payments = self.env["account.payment"]
+        for bill in unpaid_bills:
+            # Get payable lines from the bill for reconciliation
+            payable_lines = bill.line_ids.filtered(
+                lambda l: l.account_type == "liability_payable"
+                and not l.reconciled
+            )
+            payment_vals = {
+                "partner_id": bill.partner_id.id,
+                "amount": abs(bill.amount_residual),
+                "currency_id": bill.currency_id.id,
+                "journal_id": journal.id,
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "ref": _("%s - %s", self.name, bill.name),
+                "analytic_distribution": bill.analytic_distribution,
+            }
+            if payment_type:
+                payment_vals["kmitl_payment_type_id"] = payment_type.id
+            if bill.budget_commitment_id:
+                payment_vals["budget_commitment_id"] = (
+                    bill.budget_commitment_id.id
+                )
+            if bill.budget_account_id:
+                payment_vals["budget_account_id"] = bill.budget_account_id.id
+
+            payment = self.env["account.payment"].create(payment_vals)
+            # Store bill lines for deferred reconciliation on post
+            payment.to_reconcile_payment_line_ids = payable_lines
+            # Propagate analytic to payment move lines
+            if bill.analytic_distribution:
+                payment.move_id.line_ids.write(
+                    {"analytic_distribution": bill.analytic_distribution}
+                )
+            payments |= payment
+
+        self.state = "payment_draft"
+
+        # Log
+        for payment in payments:
+            pay_link = (
+                "/web#id=%d&model=account.payment&view_type=form" % payment.id
+            )
+            self.message_post(
+                body=_(
+                    'Payment <a href="%(link)s" target="_blank">'
+                    "%(name)s</a> created for %(partner)s.",
+                    link=pay_link,
+                    name=payment.name,
+                    partner=payment.partner_id.name,
+                ),
+                subtype_xmlid="mail.mt_note",
+            )
+
+        if len(payments) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "res_model": "account.payment",
+                "res_id": payments.id,
+                "view_mode": "form",
+                "target": "current",
+            }
         return {
-            "name": _("Register Payment"),
-            "res_model": "account.payment.register",
-            "view_mode": "form",
-            "context": {
-                "active_model": "account.move",
-                "active_ids": unpaid_bills.ids,
-                "dont_redirect_to_payments": True,
-            },
-            "target": "new",
             "type": "ir.actions.act_window",
+            "name": _("Payments"),
+            "res_model": "account.payment",
+            "domain": [("id", "in", payments.ids)],
+            "view_mode": "tree,form",
+            "target": "current",
         }
 
     def action_view_payments(self):

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -173,6 +173,16 @@ class DisbursementRequest(models.Model):
         compute="_compute_payment_ids",
     )
 
+    payment_move_ids = fields.Many2many(
+        comodel_name="account.move",
+        compute="_compute_payment_ids",
+        string="Payment Journal Entries",
+    )
+    payment_move_count = fields.Integer(
+        compute="_compute_payment_ids",
+        string="Payment Move Count",
+    )
+
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
@@ -619,6 +629,9 @@ class DisbursementRequest(models.Model):
             rec.payment_status_display = (
                 _("จ่ายแล้ว %s/%s", posted, total) if total else ""
             )
+            payment_moves = payments.mapped("move_id")
+            rec.payment_move_ids = payment_moves
+            rec.payment_move_count = len(payment_moves)
 
     def _update_state_from_pipeline(self):
         """Recompute state based on bill/payment status for records in pipeline."""
@@ -1182,6 +1195,28 @@ class DisbursementRequest(models.Model):
             "name": _("Payments"),
             "res_model": "account.payment",
             "domain": [("id", "in", self.payment_ids.ids)],
+            "view_mode": "tree,form",
+            "target": "current",
+        }
+
+    def action_view_payment_moves(self):
+        """Open journal entries linked to payments."""
+        self.ensure_one()
+        moves = self.payment_move_ids
+        if len(moves) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "name": _("Journal Entry"),
+                "res_model": "account.move",
+                "res_id": moves.id,
+                "view_mode": "form",
+                "target": "current",
+            }
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("รายการล้างหนี้"),
+            "res_model": "account.move",
+            "domain": [("id", "in", moves.ids)],
             "view_mode": "tree,form",
             "target": "current",
         }

--- a/disbursement/models/disbursement_request_line.py
+++ b/disbursement/models/disbursement_request_line.py
@@ -26,6 +26,7 @@ class DisbursementRequestLine(models.Model):
     product_id = fields.Many2one(
         comodel_name="product.product",
         string="Product",
+        required=True,
         domain=["|", ("company_id", "=", False), ("company_id", "=", "company_id")],
     )
 

--- a/disbursement/models/disbursement_request_line.py
+++ b/disbursement/models/disbursement_request_line.py
@@ -1,6 +1,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class DisbursementRequestLine(models.Model):
@@ -97,6 +98,23 @@ class DisbursementRequestLine(models.Model):
         store=True,
     )
 
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Partner",
+        compute="_compute_line_partner_id",
+        store=True,
+        readonly=False,
+    )
+
+    partner_bank_id = fields.Many2one(
+        comodel_name="res.partner.bank",
+        string="Recipient Bank",
+        compute="_compute_line_partner_bank_id",
+        store=True,
+        readonly=False,
+        domain="[('partner_id', '=', partner_id)]",
+    )
+
     analytic_distribution = fields.Json(
         copy=False,
     )
@@ -159,7 +177,7 @@ class DisbursementRequestLine(models.Model):
         self.ensure_one()
         return self.env["account.tax"]._convert_to_tax_base_line_dict(
             self,
-            partner=self.request_id.partner_id,
+            partner=self.partner_id or self.request_id.partner_id,
             currency=self.request_id.currency_id,
             product=self.product_id,
             taxes=self.tax_ids,
@@ -187,12 +205,54 @@ class DisbursementRequestLine(models.Model):
                 self.tax_ids = self.product_id.supplier_taxes_id
 
     # -------------------------------------------------------------------------
+    # Partner compute methods
+    # -------------------------------------------------------------------------
+    @api.depends("request_id.partner_type", "request_id.partner_id")
+    def _compute_line_partner_id(self):
+        for line in self:
+            if line.request_id.partner_type == "single":
+                line.partner_id = line.request_id.partner_id
+
+    @api.depends(
+        "partner_id",
+        "request_id.partner_type",
+        "request_id.partner_bank_id",
+        "request_id.company_id",
+    )
+    def _compute_line_partner_bank_id(self):
+        for line in self:
+            if line.request_id.partner_type == "single":
+                line.partner_bank_id = line.request_id.partner_bank_id
+            elif line.partner_id:
+                banks = line.partner_id.bank_ids.filtered(
+                    lambda b: not b.company_id
+                    or b.company_id == line.request_id.company_id
+                )
+                line.partner_bank_id = banks[0] if banks else False
+            else:
+                line.partner_bank_id = False
+
+    @api.constrains("partner_id")
+    def _check_line_partner_required(self):
+        for line in self:
+            if line.request_id.partner_type == "multi" and not line.partner_id:
+                raise ValidationError(
+                    _("Partner is required on each line in multi-partner mode.")
+                )
+
+    # -------------------------------------------------------------------------
     # WHT methods
     # -------------------------------------------------------------------------
-    @api.depends("request_id.partner_id.partner_type_id.wht_tax_id")
+    @api.depends(
+        "partner_id.partner_type_id.wht_tax_id",
+        "request_id.partner_id.partner_type_id.wht_tax_id",
+    )
     def _compute_wht_tax_id(self):
         for line in self:
-            line.wht_tax_id = line.request_id.partner_id.partner_type_id.wht_tax_id
+            partner = line.partner_id or line.request_id.partner_id
+            line.wht_tax_id = (
+                partner.partner_type_id.wht_tax_id if partner else False
+            )
 
     # -------------------------------------------------------------------------
     # Exception methods

--- a/disbursement/report/report_disbursement_request.xml
+++ b/disbursement/report/report_disbursement_request.xml
@@ -53,11 +53,14 @@
                             </div>
                         </div>
 
-                        <div class="row">
-                            <div class="col">
-                                ผู้รับเงิน                                <span class="ms-2" t-out="o.partner_id.name"/>
+                        <!-- Single partner: show partner in header -->
+                        <t t-if="o.partner_type == 'single'">
+                            <div class="row">
+                                <div class="col">
+                                    ผู้รับเงิน                                    <span class="ms-2" t-out="o.partner_id.name"/>
+                                </div>
                             </div>
-                        </div>
+                        </t>
 
                         <div class="row" t-if="o.ref">
                             <div class="col">
@@ -109,40 +112,93 @@
                             </tbody>
                         </table>
 
-                        <div class="row" t-if="o.partner_bank_id">
-                            <div class="col">
-                                ธนาคาร <span class="ms-2" t-out="o.partner_bank_id.bank_id.name"/>
-                                เลขที่บัญชี <span class="ms-2" t-out="o.partner_bank_id.acc_number"/>
+                        <!-- Single partner: bank info in header -->
+                        <t t-if="o.partner_type == 'single'">
+                            <div class="row" t-if="o.partner_bank_id">
+                                <div class="col">
+                                    ธนาคาร <span class="ms-2" t-out="o.partner_bank_id.bank_id.name"/>
+                                    เลขที่บัญชี <span class="ms-2" t-out="o.partner_bank_id.acc_number"/>
+                                </div>
                             </div>
-                        </div>
+                        </t>
 
                         <div class="my-4"/>
 
-                        <!-- Line Items Table -->
-                        <table class="table table-bordered table-sm mb-4">
-                            <thead>
-                                <tr>
-                                    <th class="text-center" style="width: 8%">ลำดับ</th>
-                                    <th class="text-center">รายละเอียด</th>
-                                    <th class="text-center">จำนวน</th>
-                                    <th class="text-end">ราคาต่อหน่วย</th>
-                                    <th class="text-end">จำนวนเงิน</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <t t-set="row_no" t-value="1"/>
-                                <t t-foreach="o.line_ids" t-as="line">
+                        <!-- Single partner: flat line items table -->
+                        <t t-if="o.partner_type == 'single'">
+                            <table class="table table-bordered table-sm mb-4">
+                                <thead>
                                     <tr>
-                                        <td class="text-center" style="width: 8%" t-out="row_no"/>
-                                        <td t-out="line.name"/>
-                                        <td class="text-center" t-out="'{0:,.2f}'.format(line.quantity)"/>
-                                        <td class="text-end" t-out="'{0:,.2f}'.format(line.price_unit)"/>
-                                        <td class="text-end" t-out="'{0:,.2f}'.format(line.price_subtotal)"/>
+                                        <th class="text-center" style="width: 8%">ลำดับ</th>
+                                        <th class="text-center">รายละเอียด</th>
+                                        <th class="text-center">จำนวน</th>
+                                        <th class="text-end">ราคาต่อหน่วย</th>
+                                        <th class="text-end">จำนวนเงิน</th>
                                     </tr>
-                                    <t t-set="row_no" t-value="row_no + 1"/>
-                                </t>
+                                </thead>
+                                <tbody>
+                                    <t t-set="row_no" t-value="1"/>
+                                    <t t-foreach="o.line_ids" t-as="line">
+                                        <tr>
+                                            <td class="text-center" style="width: 8%" t-out="row_no"/>
+                                            <td t-out="line.name"/>
+                                            <td class="text-center" t-out="'{0:,.2f}'.format(line.quantity)"/>
+                                            <td class="text-end" t-out="'{0:,.2f}'.format(line.price_unit)"/>
+                                            <td class="text-end" t-out="'{0:,.2f}'.format(line.price_subtotal)"/>
+                                        </tr>
+                                        <t t-set="row_no" t-value="row_no + 1"/>
+                                    </t>
+                                </tbody>
+                            </table>
+                        </t>
 
-                                <!-- Totals Section -->
+                        <!-- Multi partner: lines grouped by partner -->
+                        <t t-if="o.partner_type == 'multi'">
+                            <t t-set="partners" t-value="o.line_ids.mapped('partner_id')"/>
+                            <t t-set="global_row_no" t-value="1"/>
+                            <t t-foreach="partners" t-as="partner">
+                                <div class="row mt-3 mb-2">
+                                    <div class="col">
+                                        <strong>ผู้รับเงิน: <span t-out="partner.name"/></strong>
+                                    </div>
+                                </div>
+                                <t t-set="partner_lines" t-value="o.line_ids.filtered(lambda l: l.partner_id == partner)"/>
+                                <t t-set="partner_bank" t-value="partner_lines[0].partner_bank_id if partner_lines else False"/>
+                                <div class="row mb-2" t-if="partner_bank">
+                                    <div class="col">
+                                        ธนาคาร <span class="ms-2" t-out="partner_bank.bank_id.name"/>
+                                        เลขที่บัญชี <span class="ms-2" t-out="partner_bank.acc_number"/>
+                                    </div>
+                                </div>
+                                <table class="table table-bordered table-sm mb-4">
+                                    <thead>
+                                        <tr>
+                                            <th class="text-center" style="width: 8%">ลำดับ</th>
+                                            <th class="text-center">รายละเอียด</th>
+                                            <th class="text-center">จำนวน</th>
+                                            <th class="text-end">ราคาต่อหน่วย</th>
+                                            <th class="text-end">จำนวนเงิน</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-foreach="partner_lines" t-as="line">
+                                            <tr>
+                                                <td class="text-center" style="width: 8%" t-out="global_row_no"/>
+                                                <td t-out="line.name"/>
+                                                <td class="text-center" t-out="'{0:,.2f}'.format(line.quantity)"/>
+                                                <td class="text-end" t-out="'{0:,.2f}'.format(line.price_unit)"/>
+                                                <td class="text-end" t-out="'{0:,.2f}'.format(line.price_subtotal)"/>
+                                            </tr>
+                                            <t t-set="global_row_no" t-value="global_row_no + 1"/>
+                                        </t>
+                                    </tbody>
+                                </table>
+                            </t>
+                        </t>
+
+                        <!-- Totals Section (shared) -->
+                        <table class="table table-bordered table-sm mb-4">
+                            <tbody>
                                 <tr>
                                     <td colspan="2" rowspan="3" class="text-center align-middle">
                                         (                                        <t t-esc="currency.with_context({'lang': 'th_TH'}).amount_to_text(o.amount_total)"/>

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <tree string="Disbursement Requests">
                 <field name="name" />
+                <field name="partner_type" optional="hide" />
                 <field name="partner_id" />
                 <field name="user_id" optional="show" />
                 <field name="date" />
@@ -77,8 +78,16 @@
                     </div>
                     <group>
                         <group id="header_left_group" string="Partner Information">
-                            <field name="partner_id" widget="res_partner_many2one" context="{'show_address': 1, 'default_is_company': True, 'show_vat': True}" options='{"always_reload": True}' />
-                            <field name="partner_bank_id" context="{'default_partner_id': partner_id}" domain="[('partner_id', '=', partner_id)]" />
+                            <field name="partner_type" widget="radio"
+                                attrs="{'readonly': ['|', ('reference_model', '!=', False), ('state', '!=', 'draft')]}" />
+                            <field name="partner_id" widget="res_partner_many2one"
+                                context="{'show_address': 1, 'default_is_company': True, 'show_vat': True}"
+                                options='{"always_reload": True}'
+                                attrs="{'invisible': [('partner_type', '=', 'multi')], 'required': [('partner_type', '=', 'single')]}" />
+                            <field name="partner_bank_id"
+                                context="{'default_partner_id': partner_id}"
+                                domain="[('partner_id', '=', partner_id)]"
+                                attrs="{'invisible': [('partner_type', '=', 'multi')]}" />
                             <field name="company_id" groups="base.group_multi_company" />
                             <field name="is_company" readonly="1" invisible="1" />
                             <field name="ignore_exception" states="to_approve" groups='base_exception.group_exception_rule_manager' />
@@ -115,6 +124,11 @@
                             <field name="line_ids" widget="one2many" context="{'default_request_id': active_id}">
                                 <tree editable="bottom">
                                     <field name="sequence" widget="handle" />
+                                    <field name="partner_id"
+                                        attrs="{'column_invisible': [('parent.partner_type', '!=', 'multi')], 'required': [('parent.partner_type', '=', 'multi')]}" />
+                                    <field name="partner_bank_id"
+                                        attrs="{'column_invisible': [('parent.partner_type', '!=', 'multi')]}"
+                                        optional="hide" />
                                     <field name="product_id" />
                                     <field name="name" />
                                     <field name="quantity" />
@@ -182,6 +196,8 @@
                 <filter string="Payment Draft" name="payment_draft" domain="[('state', '=', 'payment_draft')]" />
                 <filter string="Payment Posted" name="payment_posted" domain="[('state', '=', 'payment_posted')]" />
                 <filter string="Done" name="done" domain="[('state', '=', 'done')]" />
+                <separator />
+                <filter string="Multi-Partner" name="multi_partner" domain="[('partner_type', '=', 'multi')]" />
                 <separator />
                 <filter icon="fa-exclamation-circle" name="tofix" string="Blocked in Draft" domain="[('main_exception_id','!=',False)]" />
                 <separator />

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -57,6 +57,9 @@
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_bill" type="object" class="oe_stat_button" icon="fa-pencil-square-o" attrs="{'invisible': [('bill_count', '=', 0)]}">
                             <field name="bill_count" widget="statinfo" string="Bill" />
+                            <span class="text-muted small" attrs="{'invisible': [('bill_draft_count', '=', 0)]}">
+                                รอตั้งหนี้ <field name="bill_draft_count" /> ใบ
+                            </span>
                         </button>
                         <button name="action_view_payments"
                                 type="object"

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -34,11 +34,11 @@
                     <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'signed')]}" confirm="Are you sure you want to validate this request?" groups="disbursement.group_disbursement_officer" />
                     <button name="action_approve" string="Approve" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'verified')]}" confirm="Are you sure you want to approve? This will reserve budget." groups="disbursement.group_disbursement_manager" />
                     <button name="action_create_bill" string="Create Bill" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'approved'), ('bill_count', '>', 0)]}" groups="disbursement.group_disbursement_officer" />
-                    <button name="action_register_payment"
-                            string="Register Payment"
+                    <button name="action_create_payment"
+                            string="Create Payment"
                             type="object"
                             class="oe_highlight"
-                            attrs="{'invisible': ['|', ('state', 'not in', ('bill_posted', 'payment_draft')), ('hide_register_payment_button', '=', True)]}"
+                            attrs="{'invisible': ['|', ('state', '!=', 'bill_posted'), ('payment_count', '>', 0)]}"
                             groups="account.group_account_invoice"/>
                     <button name="action_draft" string="Reset to draft" type="object" class="btn btn-secondary" attrs="{'invisible': [('state', 'not in', ('submitted', 'signed', 'cancel'))]}" groups="disbursement.group_disbursement_manager" />
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'in', ('draft', 'done', 'cancel', 'bill_posted', 'payment_draft', 'payment_posted'))]}" groups="disbursement.group_disbursement_officer" />
@@ -53,20 +53,23 @@
                     <button name="action_ignore_exceptions" type="object" class="btn-danger" string="Ignore Exceptions" help="Click here to be able to confirm this Disbursement Request regardless of the exceptions." groups="base_exception.group_exception_rule_manager" />
                 </div>
                 <sheet>
-                    <field name="hide_register_payment_button" invisible="1"/>
                     <div class="oe_button_box" name="button_box">
                         <button name="action_view_bill" type="object" class="oe_stat_button" icon="fa-pencil-square-o" attrs="{'invisible': [('bill_count', '=', 0)]}">
-                            <field name="bill_count" widget="statinfo" string="Bill" />
-                            <span class="text-muted small" attrs="{'invisible': [('bill_draft_count', '=', 0)]}">
-                                รอตั้งหนี้ <field name="bill_draft_count" /> ใบ
-                            </span>
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">ใบตั้งหนี้ <field name="bill_count" nolabel="1" /></span>
+                                <span class="o_stat_text text-muted small"><field name="bill_status_display" nolabel="1" /></span>
+                            </div>
                         </button>
+                        <field name="bill_draft_count" invisible="1" />
                         <button name="action_view_payments"
                                 type="object"
                                 class="oe_stat_button"
                                 icon="fa-money"
                                 attrs="{'invisible': [('payment_count', '=', 0)]}">
-                            <field name="payment_count" widget="statinfo" string="Payments"/>
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">รายการจ่ายเงิน <field name="payment_count" nolabel="1" /></span>
+                                <span class="o_stat_text text-muted small"><field name="payment_status_display" nolabel="1" /></span>
+                            </div>
                         </button>
                         <button name="open_preview" type="object" class="oe_stat_button" icon="fa-globe">
                             <div class="o_field_widget o_stat_info">

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -71,6 +71,15 @@
                                 <span class="o_stat_text text-muted small"><field name="payment_status_display" nolabel="1" /></span>
                             </div>
                         </button>
+                        <button name="action_view_payment_moves"
+                                type="object"
+                                class="oe_stat_button"
+                                icon="fa-book"
+                                attrs="{'invisible': [('payment_move_count', '=', 0)]}">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">รายการล้างหนี้ <field name="payment_move_count" nolabel="1" /></span>
+                            </div>
+                        </button>
                         <button name="open_preview" type="object" class="oe_stat_button" icon="fa-globe">
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_text">Preview</span>

--- a/disbursement_sarabun/views/disbursement_request_views.xml
+++ b/disbursement_sarabun/views/disbursement_request_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="disbursement.view_disbursement_request_form"/>
         <field name="arch" type="xml">
             <!-- Hidden fields -->
-            <xpath expr="//field[@name='hide_register_payment_button']" position="after">
+            <xpath expr="//div[@name='button_box']" position="before">
                 <field name="sarabun_in_progress" invisible="1"/>
             </xpath>
 


### PR DESCRIPTION
## Summary

- เพิ่ม toggle `partner_type` (Single Partner / Multiple Partners) บน Disbursement Request
- โหมด **1 คู่ค้า**: ทำงานเหมือนเดิมทุกประการ
- โหมด **หลายคู่ค้า**: แต่ละ line เลือก partner + bank ได้เอง, สร้าง bill อัตโนมัติแยกตาม partner, report แสดง lines แบ่งตาม partner
- Approval Request สร้าง 1 DR โหมดหลายคู่ค้า (แทนที่จะแยกหลาย DR ตาม partner)

## Changes

| File | Change |
|------|--------|
| `disbursement/models/disbursement_request.py` | `partner_type` field, `partner_id` optional, `bill_id` → `bill_ids`, refactor bill creation & pipeline tracking |
| `disbursement/models/disbursement_request_line.py` | `partner_id` + `partner_bank_id` on lines, WHT compute from line partner |
| `disbursement/models/account_move.py` | `disbursement_request_id` inverse field |
| `disbursement/models/account_payment.py` | Update search domain for `bill_ids` |
| `disbursement/views/disbursement_request_views.xml` | Radio toggle, conditional partner fields, line partner columns |
| `disbursement/report/report_disbursement_request.xml` | Conditional single/multi rendering |
| `agx_approval_disbursement/models/approval_request.py` | Create 1 multi-mode DR instead of N single DRs |

## Test plan

- [ ] Single mode: สร้าง DR → submit → approve → create bill → register payment → done (regression test)
- [ ] Multi mode: สร้าง DR เลือกหลาย partner → submit → approve → create bill (ตรวจ N bills) → post → pay → done
- [ ] สลับโหมด multi→single: ตรวจ warning + ล้าง partner บน lines
- [ ] Reference PO/PA: ตรวจว่า partner_type บังคับเป็น single + readonly
- [ ] Approval Request: สร้าง approval มีหลาย partner → create DR → ตรวจ 1 DR โหมด multi
- [ ] Report: พิมพ์ทั้ง 2 โหมด ตรวจ layout
- [ ] Cancel: cancel DR ที่มี draft bills → ตรวจว่า bills ถูก cancel