### PR TITLE
[16.0][FIX] purchase_request_budget: remove UoM domain restriction

### DIFF
--- a/purchase_request_budget/models/purchase_request_line.py
+++ b/purchase_request_budget/models/purchase_request_line.py
@@ -15,15 +15,6 @@ class PurchaseRequestLine(models.Model):
         related='request_id.analytic_distribution'
     )
 
-    product_uom_id = fields.Many2one(
-        comodel_name="uom.uom",
-        domain=lambda self: self._get_unit_domain(),
-    )
-
-    def _get_unit_domain(self):
-        unit_category = self.env.ref('uom.product_uom_categ_unit')
-        return [('category_id', '=', unit_category.id)]
-
     @api.onchange("product_id")
     def onchange_product_id(self):
         pass

--- a/purchase_request_kmitl/models/purchase_request_line.py
+++ b/purchase_request_kmitl/models/purchase_request_line.py
@@ -9,6 +9,11 @@ class PurchaseRequestLine(models.Model):
 
     name = fields.Text(string="Description", tracking=True)
 
+    product_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        domain=[],
+    )
+
     product_id = fields.Many2one(
         compute="_compute_default_product_id",
         store=True,


### PR DESCRIPTION
## Summary
- ลบ domain restriction ของ `product_uom_id` ใน `purchase_request_budget` ที่จำกัดให้เลือกได้เฉพาะหน่วยในหมวด "Unit" เท่านั้น
- กลับไปใช้ domain ของ base module (`purchase_request`) ซึ่ง filter UoM ตาม category ของ product ที่เลือก

## Test plan
- [ ] เปิด Purchase Request > เพิ่ม line > ตรวจสอบว่า field หน่วย (UoM) แสดงหน่วยได้หลายตัวตาม category ของสินค้า

runbot

https://10962-16-0-without_demo.runbot.aegis.aginix.tech/web?debug=1#action=676&model=purchase.request&view_type=list&cids=1&menu_id=518