### PR TITLE
[16.0][FIX] budget: update revenue account code r49000 to 43100 (ก)

### DIFF
--- a/budget/data/budget.account.csv
+++ b/budget/data/budget.account.csv
@@ -378,7 +378,7 @@ budget_account_07020,expense,07020,งบกองทุนสำรอง,,,tru
 budget_account_0702000000,expense,0702000000,กองทุนสำรอง,budget_account_07020,,true,account_analytic_kmitl.fund_0702
 budget_account_0702000001,expense,0702000001,เงินชดใช้เงินคงคลัง,budget_account_0702000000,,true,account_analytic_kmitl.fund_0702
 budget_account_0702000002,expense,0702000002,เงินสำรอง,budget_account_0702000000,,true,account_analytic_kmitl.fund_0702
-budget_account_r49000,revenue,"r49000","ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ",,,true,
+budget_account_r49000,revenue,"43100 (ก)","ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ",,,true,
 budget_account_r43100,revenue,"43100","รายได้ค่าธรรมเนียมการศึกษา",budget_account_r49000,,true,
 budget_account_r4121010010,revenue,"4121010010","รายได้ค่าบำรุงกีฬา",budget_account_r43100,,true,
 budget_account_r4121010011,revenue,"4121010011","รายได้ค่าบำรุงห้องสมุด",budget_account_r43100,,true,

--- a/budget_appropriation_summary/models/summary_f2_revenue.py
+++ b/budget_appropriation_summary/models/summary_f2_revenue.py
@@ -17,7 +17,7 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
     _description = "Budget Appropriation Summary F2 Revenue Report"
 
     REVENUE_CATEGORIES = [
-        ("r49000", "ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ"),
+        ("43100 (ก)", "ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ"),
         ("43300", "รายได้จากงานบริการ"),
         ("43400", "รายได้จากเงินผลประโยชน์"),
         ("43500", "รายได้จากการรับบริจาค หรือ เงินอุดหนุน"),

--- a/budget_appropriation_summary/models/summary_f4p_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4p_revenue.py
@@ -10,7 +10,7 @@ class BudgetAppropriationSummaryF4PRevenue(models.AbstractModel):
     _description = "Budget Appropriation Summary F4-P Revenue Report"
 
     REVENUE_CATEGORIES = [
-        ("r49000", "ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ"),
+        ("43100 (ก)", "ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ"),
         ("43300", "รายได้จากงานบริการ"),
         ("43400", "รายได้จากเงินผลประโยชน์"),
         ("43500", "รายได้จากการรับบริจาค หรือ เงินอุดหนุน"),

--- a/budget_appropriation_summary/models/summary_f4w_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4w_revenue.py
@@ -10,7 +10,7 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
     _description = "Budget Appropriation Summary F4-W Revenue Report"
 
     REVENUE_CATEGORIES = [
-        ("r49000", "ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ"),
+        ("43100 (ก)", "ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ"),
         ("43300", "รายได้จากงานบริการ"),
         ("43400", "รายได้จากเงินผลประโยชน์"),
         ("43500", "รายได้จากการรับบริจาค หรือ เงินอุดหนุน"),

--- a/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary_f3/models/budget_appropriation_compilation.py
@@ -10,7 +10,7 @@ _logger = logging.getLogger(__name__)
 BUDGET_SOURCE_CODES = ("1", "3", "5")
 
 # Top-level revenue account codes in display order
-REVENUE_CODES = ["r49000", "43300", "43400", "43500", "43700"]
+REVENUE_CODES = ["43100 (ก)", "43300", "43400", "43500", "43700"]
 
 # Top-level expense account codes in display order
 EXPENSE_LEVEL0_CODES = ["51000", "52000", "53000", "54000", "55000", "07020"]


### PR DESCRIPTION
## Summary
- Update budget account code `r49000` to `43100 (ก)` in master data file (`budget/data/budget.account.csv`)
- Update matching code references in revenue report models: `summary_f2_revenue.py`, `summary_f4p_revenue.py`, `summary_f4w_revenue.py`, and `budget_appropriation_compilation.py`

## Test plan
- [ ] Verify budget account `ค่าธรรมเนียมการศึกษา และค่าธรรมเนียมอื่น ๆ` displays code `43100 (ก)` after module update
- [ ] Verify revenue summary reports (F2, F4P, F4W, F3 compilation) still group this category correctly