### PR TITLE
[16.0][IMP] disbursement: overall i18n, view, and budget workflow

### DIFF
--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -132,6 +132,46 @@ msgstr "จำนวนเอกสารแนบ"
 
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "Attachments"
+msgstr "เอกสารแนบ"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "File Name"
+msgstr "ชื่อไฟล์"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "Upload Date"
+msgstr "วันที่อัปโหลด"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "Uploaded By"
+msgstr "อัปโหลดโดย"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "WHT Item"
+msgstr "รายการ WHT"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "Disburser"
+msgstr "ชื่อคนเบิก"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "Amount Before WHT"
+msgstr "มูลค่าก่อนหัก"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
+msgid "WHT Deduction"
+msgstr "ยอดหัก"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "Bill"
 msgstr "ใบตั้งหนี้"
 
@@ -155,6 +195,16 @@ msgstr "บัญชีงบประมาณ"
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__budget_commitment_id
 msgid "Budget Commitment"
 msgstr "จองงบประมาณ"
+
+#. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__budget_consumed_amount
+msgid "Budget Consumed"
+msgstr "ตัดงบประมาณแล้ว"
+
+#. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__budget_consumed_date
+msgid "Budget Consumed At"
+msgstr "วันที่ตัดงบ"
 
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
@@ -555,7 +605,7 @@ msgstr "สามารถทำการ ยืนยัน คำขอเบ�
 #: code:addons/disbursement/models/disbursement_request.py:0
 #, python-format
 msgid "Only submitted requests can be signed."
-msgstr "สามารถลงนามได้เฉพาะคำขอเบิกที่อยู่ในสถานะ \"ส่งแล้ว\" เท่านั้น"
+msgstr "สามารถลงนามได้เฉพาะคำขอเบิกที่อยู่ในสถานะ \"ยืนยันแล้ว\" เท่านั้น"
 
 #. module: disbursement
 #. odoo-python
@@ -685,13 +735,13 @@ msgstr ""
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "Submit"
-msgstr "ส่ง"
+msgstr "ยืนยัน"
 
 #. module: disbursement
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__submitted
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Submitted"
-msgstr "ส่งแล้ว"
+msgstr "ยืนยันแล้ว"
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request_line__price_subtotal
@@ -782,6 +832,7 @@ msgstr "รายการตั้งเจ้าหนี้"
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request_line__wht_tax_id
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "WHT"
 msgstr "หัก ณ ที่จ่าย"
 
@@ -1011,12 +1062,32 @@ msgstr "สามารถอนุมัติได้เฉพาะคำข
 #: code:addons/disbursement/models/disbursement_request.py:0
 #, python-format
 msgid "Only submitted, sent, or cancelled requests can be reset to draft."
-msgstr "สามารถกลับไปฉบับร่างได้เฉพาะคำขอเบิกที่อยู่ในสถานะ \"ส่งแล้ว\" \"ลงนามแล้ว\" หรือ \"ยกเลิก\" เท่านั้น"
+msgstr "สามารถกลับไปฉบับร่างได้เฉพาะคำขอเบิกที่อยู่ในสถานะ \"ยืนยันแล้ว\" \"ลงนามแล้ว\" หรือ \"ยกเลิก\" เท่านั้น"
 
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "Partner Information"
 msgstr "ข้อมูลคู่ค้า"
+
+#. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__partner_type
+msgid "Partner Type"
+msgstr "จ่ายตาม"
+
+#. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__partner_type__single
+msgid "Single Partner"
+msgstr "ตามจ่ายให้"
+
+#. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__partner_type__multi
+msgid "Multiple Partners"
+msgstr "ตามรายชื่อการเบิกจ่าย"
+
+#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
+msgid "Multi-Partner"
+msgstr "ตามรายชื่อการเบิกจ่าย"
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__payment_ids
@@ -1080,8 +1151,8 @@ msgstr "ข้อมูลอื่น ๆ"
 
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
-msgid "Are you sure you want to approve? This will reserve budget."
-msgstr "คุณแน่ใจว่าต้องการอนุมัติ? จะทำการจองงบประมาณ"
+msgid "Are you sure you want to approve? This will obligate and consume the budget."
+msgstr "ยืนยันการอนุมัติ? จะทำการผูกพันและตัดงบประมาณตามยอดรวมของใบขอเบิกนี้"
 
 #. module: disbursement
 #. odoo-python

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -209,6 +209,14 @@ class DisbursementRequest(models.Model):
         states=READONLY_STATES,
     )
 
+    wht_line_ids = fields.One2many(
+        comodel_name="disbursement.request.line",
+        inverse_name="request_id",
+        string="WHT Lines",
+        readonly=True,
+        copy=False,
+    )
+
     attachment_ids = fields.One2many(
         "ir.attachment",
         "res_id",
@@ -303,6 +311,20 @@ class DisbursementRequest(models.Model):
         tracking=True,
         copy=False,
         states=READONLY_STATES,
+    )
+
+    budget_consumed_amount = fields.Monetary(
+        string="Budget Consumed",
+        currency_field="currency_id",
+        copy=False,
+        readonly=True,
+        tracking=True,
+    )
+
+    budget_consumed_date = fields.Datetime(
+        string="Budget Consumed At",
+        copy=False,
+        readonly=True,
     )
 
     # Analytic dimension fields
@@ -923,42 +945,65 @@ class DisbursementRequest(models.Model):
         return True
 
     def _action_approve_budget(self):
-        """Reserve budget commitment on approval"""
+        """Obligate and consume from the pre-linked budget commitment.
+
+        The BC is expected to be set from an upstream process (PR/PO/PA);
+        this method does NOT create a new BC. It posts an obligate and a
+        consume line for the DR amount, leaving the BC open for other DRs.
+        """
         self.ensure_one()
-        if self.budget_commitment_id:
-            return
-        if not self.budget_account_id:
-            return
-        check = self._check_budget_availability(
-            amount=self.amount_total,
-            activity_analytic_id=self.activity_analytic_id.id,
-            department_analytic_id=self.department_analytic_id.id,
-            fund_analytic_id=self.fund_analytic_id.id,
-            source_analytic_id=self.source_analytic_id.id,
-        )
-        if not check["is_sufficient"]:
+        if not self.budget_commitment_id:
             raise UserError(
-                _(
-                    "Insufficient budget. Available: %(available)s, "
-                    "Required: %(required)s"
-                )
+                _("Budget commitment is required before approval. "
+                  "Please link one from the upstream document.")
+            )
+        commitment = self.budget_commitment_id
+        if commitment.state not in ("reserved", "partial"):
+            raise UserError(
+                _("Cannot obligate: commitment %(name)s is in state '%(state)s' "
+                  "(must be 'reserved' or 'partial').")
+                % {"name": commitment.name, "state": commitment.state}
+            )
+        if commitment.available_to_obligate < self.amount_total:
+            raise UserError(
+                _("Insufficient available to obligate on commitment %(name)s. "
+                  "Available: %(available)s, Required: %(required)s")
                 % {
-                    "available": check["available"],
+                    "name": commitment.name,
+                    "available": commitment.available_to_obligate,
                     "required": self.amount_total,
                 }
             )
-        commitment = self._create_budget_commitment(
-            amount=self.amount_total,
-            activity_analytic_id=self.activity_analytic_id.id,
-            department_analytic_id=self.department_analytic_id.id,
-            fund_analytic_id=self.fund_analytic_id.id,
-            source_analytic_id=self.source_analytic_id.id,
-            ref=self.name,
-            description=_("Disbursement Request: %s") % self.name,
-            auto_reserve=True,
-        )
+        first_reserve = commitment.line_ids.filtered(
+            lambda l: l.move_type == "reserve" and l.state == "posted"
+        )[:1]
+        if not first_reserve:
+            raise UserError(
+                _("No active reserve line on commitment %s.") % commitment.name
+            )
+        self.env["budget.commitment.line"].create([
+            {
+                "commitment_id": commitment.id,
+                "move_type": "obligate",
+                "account_id": first_reserve.account_id.id,
+                "analytic_distribution": first_reserve.analytic_distribution,
+                "amount": self.amount_total,
+                "name": _("Obligation: %s") % self.name,
+            },
+            {
+                "commitment_id": commitment.id,
+                "move_type": "consume",
+                "account_id": first_reserve.account_id.id,
+                "analytic_distribution": first_reserve.analytic_distribution,
+                "amount": self.amount_total,
+                "name": _("Consumption: %s") % self.name,
+            },
+        ])
+        self.budget_consumed_amount = self.amount_total
+        self.budget_consumed_date = fields.Datetime.now()
         self.message_post(
-            body=_("Budget committed: %s") % commitment.name,
+            body=_("Budget obligated and consumed: %(amount)s on commitment %(name)s")
+            % {"amount": self.amount_total, "name": commitment.name},
             subtype_xmlid="mail.mt_note",
         )
 

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -620,12 +620,18 @@ class DisbursementRequest(models.Model):
     # -------------------------------------------------------------------------
     @api.depends("bill_ids", "bill_ids.state")
     def _compute_bill_count(self):
-        """Compute the number of bills linked to this request"""
+        """Compute the number of bills linked to this request.
+
+        Cancelled bills are excluded from both numerator and denominator
+        so the display reflects only active bills.
+        """
         for record in self:
-            bills = record.bill_ids
-            total = len(bills)
-            draft = len(bills.filtered(lambda b: b.state == "draft"))
-            posted = total - draft
+            active_bills = record.bill_ids.filtered(
+                lambda b: b.state != "cancel"
+            )
+            total = len(active_bills)
+            draft = len(active_bills.filtered(lambda b: b.state == "draft"))
+            posted = len(active_bills.filtered(lambda b: b.state == "posted"))
             record.bill_count = total
             record.bill_draft_count = draft
             record.bill_status_display = (
@@ -644,14 +650,16 @@ class DisbursementRequest(models.Model):
                 payments |= Payment.search([
                     ("to_reconcile_payment_line_ids.move_id", "=", bill.id),
                 ])
-            rec.payment_ids = payments
-            total = len(payments)
+            # Exclude cancelled payments from both display and count
+            active_payments = payments.filtered(lambda p: p.state != "cancel")
+            rec.payment_ids = active_payments
+            total = len(active_payments)
             rec.payment_count = total
-            posted = len(payments.filtered(lambda p: p.state == "posted"))
+            posted = len(active_payments.filtered(lambda p: p.state == "posted"))
             rec.payment_status_display = (
                 _("จ่ายแล้ว %s/%s", posted, total) if total else ""
             )
-            payment_moves = payments.mapped("move_id")
+            payment_moves = active_payments.mapped("move_id")
             rec.payment_move_ids = payment_moves
             rec.payment_move_count = len(payment_moves)
 

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -32,7 +32,7 @@
                     <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}" />
                     <button name="action_sign" string="Sign" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'submitted')]}" groups="disbursement.group_disbursement_head" />
                     <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'signed')]}" confirm="Are you sure you want to validate this request?" groups="disbursement.group_disbursement_officer" />
-                    <button name="action_approve" string="Approve" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'verified')]}" confirm="Are you sure you want to approve? This will reserve budget." groups="disbursement.group_disbursement_manager" />
+                    <button name="action_approve" string="Approve" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'verified')]}" confirm="Are you sure you want to approve? This will obligate and consume the budget." groups="disbursement.group_disbursement_manager" />
                     <button name="action_create_bill" string="Create Bill" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'approved'), ('bill_count', '>', 0)]}" groups="disbursement.group_disbursement_officer" />
                     <button name="action_create_payment"
                             string="Create Payment"
@@ -44,6 +44,13 @@
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'in', ('draft', 'done', 'cancel', 'bill_posted', 'payment_draft', 'payment_posted'))]}" groups="disbursement.group_disbursement_officer" />
                     <field name="state" widget="statusbar" statusbar_visible="draft,submitted,signed,verified,approved,bill_draft,bill_posted,payment_draft,payment_posted,done" />
                 </header>
+                <!-- Budget Consumed Banner -->
+                <div class="alert alert-success" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('budget_consumed_amount', '=', 0)]}">
+                    <strong>ตัดงบประมาณแล้ว:</strong>
+                    <field name="budget_consumed_amount" widget="monetary" class="oe_inline" nolabel="1"/>
+                    <span> เมื่อ </span>
+                    <field name="budget_consumed_date" class="oe_inline" nolabel="1"/>
+                </div>
                 <!-- Exception Alert -->
                 <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('exceptions_summary','=',False)]}">
                     <p>
@@ -128,6 +135,9 @@
                             <field name="budget_account_id" options="{'no_create': True, 'no_open': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}" />
                             <field name="budget_account_id" invisible="1" />
                             <field name="analytic_distribution" invisible="1"/>
+                            <field name="budget_consumed_amount" attrs="{'invisible': [('budget_consumed_amount', '=', 0)]}" />
+                            <field name="budget_consumed_date" attrs="{'invisible': [('budget_consumed_amount', '=', 0)]}" />
+                            <field name="currency_id" invisible="1"/>
                         </group>
                         <group id="other_information" string="Other Information">
                             <field name="user_id" groups="disbursement.group_disbursement_manager" />
@@ -145,13 +155,13 @@
                                         attrs="{'column_invisible': [('parent.partner_type', '!=', 'multi')]}"
                                         optional="hide" />
                                     <field name="product_id" />
-                                    <field name="name" />
+                                    <field name="name" optional="hide" />
                                     <field name="quantity" />
                                     <field name="price_unit" />
                                     <field name="tax_ids" widget="many2many_tags" />
                                     <field name="wht_tax_id" optional="show"/>
-                                    <field name="account_id" />
-                                    <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting" readonly="1" />
+                                    <field name="account_id" optional="hide" />
+                                    <field name="analytic_distribution" widget="analytic_distribution" groups="analytic.group_analytic_accounting" readonly="1" optional="hide" />
                                     <field name="price_subtotal" />
                                     <field name="price_tax" optional="hide" />
                                     <field name="price_total" />
@@ -168,7 +178,23 @@
                             </group>
                             <div class="oe_clear" />
                         </page>
-                        <page string="Attachment" name="attachment">
+                        <page string="WHT" name="wht">
+                            <field name="wht_line_ids" nolabel="1">
+                                <tree create="0" delete="0" edit="0">
+                                    <field name="partner_id" string="Disburser"/>
+                                    <field name="name" string="Name"/>
+                                    <field name="wht_tax_id" string="WHT Item"/>
+                                    <field name="price_subtotal" string="Amount Before WHT"/>
+                                    <field name="amount_wht" string="WHT Deduction"/>
+                                    <field name="currency_id" invisible="1"/>
+                                </tree>
+                            </field>
+                            <group class="oe_subtotal_footer oe_right">
+                                <field name="amount_wht" />
+                            </group>
+                            <div class="oe_clear" />
+                        </page>
+                        <page string="Attachments" name="attachment">
                             <field name="attachment_ids"
                                    context="{'default_res_model': 'disbursement.request'}">
                                 <tree>


### PR DESCRIPTION
## Summary

ปรับปรุงโมดูล `disbursement` หลายจุดให้รองรับการใช้งานภาษาไทยและ flow งบประมาณใหม่

### i18n
- เปลี่ยนคำแปลปุ่ม Submit / สถานะ Submitted เป็น **ยืนยัน / ยืนยันแล้ว**
- เพิ่มคำแปล field `partner_type` และ selection: **จ่ายตาม / ตามจ่ายให้ / ตามรายชื่อการเบิกจ่าย**
- เพิ่มคำแปล columns ในหน้า WHT (ชื่อคนเบิก, รายการ WHT, มูลค่าก่อนหัก, ยอดหัก) และหน้า Attachments
- ปรับข้อความ confirm dialog ของปุ่ม Approve ให้สื่อถึงการ obligate + consume

### Views
- **DR line tree**: ซ่อน `name`, `account_id`, `analytic_distribution` ไว้แบบ `optional="hide"`
- **New WHT page**: tree สรุปบรรทัด DR (read-only) แสดงคนเบิก รายการ WHT มูลค่าก่อนหัก ยอดหัก พร้อม footer total
  - เพิ่ม One2many ใหม่ `wht_line_ids` บน model เพื่อหลีกเลี่ยงปัญหา duplicate-field state collision เมื่อใช้ `line_ids` 2 ครั้งในฟอร์มเดียว
- **Attachments page**: เปลี่ยน string เป็น plural และเพิ่ม column ภาษาไทย
- **Budget consumed banner**: alert สีเขียวเหนือ sheet แสดง "ตัดงบประมาณแล้ว: <ยอด> เมื่อ <วันเวลา>" เมื่อ DR ถูกตัดงบแล้ว

### Model — Budget workflow
- `action_approve` **ไม่สร้าง Budget Commitment ใหม่** แล้ว
  - ใช้ `budget_commitment_id` ที่ผูกมาจากกระบวนการก่อนหน้า (พจ.1 / PO / Procurement Plan)
  - สร้าง `obligate` line + `consume` line ตามยอด `amount_total`
  - ไม่ auto-close BC เพื่อให้ DR อื่นแชร์ BC เดียวกันได้
  - bypass mixin `_obligate_budget_commitment()` (ที่ใช้ยอดเต็ม) และ `_consume_commitment()` (ที่ auto-close)
- เพิ่ม field `budget_consumed_amount` (Monetary, tracking) + `budget_consumed_date` เพื่อบันทึกประวัติการตัดงบ

## Test plan
- [ ] ทดสอบ flow draft → ยืนยัน → ลงนาม → ตรวจสอบ → อนุมัติ → สร้างใบตั้งหนี้ → จ่ายเงิน
- [ ] ตรวจป้ายภาษาไทยทุกจุดที่แก้ (ปุ่ม / สถานะ / column / page) แสดงผลถูกต้องหลัง update โมดูลด้วย `--i18n-overwrite`
- [ ] ทดสอบ partner_type = single และ multi
- [ ] ทดสอบ approve DR ที่ผูก BC จากต้นทาง (พจ.1/PO):
  - กด approve แล้ว BC มี obligate line + consume line ใหม่ ตาม `amount_total`
  - banner สีเขียว "ตัดงบประมาณแล้ว" แสดงพร้อมยอดและวันเวลา
  - DR หลายใบที่ใช้ BC เดียวกันสามารถ approve ได้ครบ ไม่ติด state done
- [ ] ทดสอบกรณี approve DR ที่ไม่มี `budget_commitment_id` → ต้อง raise UserError
- [ ] ตรวจหน้า WHT page แสดงคนเบิก ยอดก่อนหัก ยอดหัก ครบทุกบรรทัด
- [ ] ตรวจ DR line tree เปิด/ปิด column name, account_id, analytic_distribution ผ่าน column selector ได้