### PR TITLE
[16.0][FIX] purchase_request_approval_disbursement: update billing status

### DIFF
--- a/purchase_request_approval_disbursement/i18n/th.po
+++ b/purchase_request_approval_disbursement/i18n/th.po
@@ -46,7 +46,7 @@ msgstr "สถานะการเบิก"
 #. module: purchase_request_approval_disbursement
 #: model:ir.model.fields.selection,name:purchase_request_approval_disbursement.selection__purchase_request_approval__billing_status__cancel
 msgid "Cancelled"
-msgstr "ยกเลิกแล้ว"
+msgstr "ตีกลับ"
 
 #. module: purchase_request_approval_disbursement
 #: model_terms:ir.ui.view,arch_db:purchase_request_approval_disbursement.view_purchase_request_approval_form
@@ -75,9 +75,14 @@ msgid "Disbursement Requests"
 msgstr "ใบขอเบิก"
 
 #. module: purchase_request_approval_disbursement
+#: model:ir.model.fields.selection,name:purchase_request_approval_disbursement.selection__purchase_request_approval__billing_status__done
+msgid "Done"
+msgstr "เบิกจ่ายเสร็จสิ้น"
+
+#. module: purchase_request_approval_disbursement
 #: model:ir.model.fields.selection,name:purchase_request_approval_disbursement.selection__purchase_request_approval__billing_status__draft
 msgid "Draft"
-msgstr "แบบร่าง"
+msgstr "ร่าง"
 
 #. module: purchase_request_approval_disbursement
 #. odoo-python
@@ -124,7 +129,7 @@ msgstr ""
 #. module: purchase_request_approval_disbursement
 #: model:ir.model.fields.selection,name:purchase_request_approval_disbursement.selection__purchase_request_approval__billing_status__submitted
 msgid "Submitted"
-msgstr "ส่งข้อมูลแล้ว"
+msgstr "รออนุมัติ"
 
 #. module: purchase_request_approval_disbursement
 #. odoo-python
@@ -144,9 +149,9 @@ msgid "Use Purchase Order"
 msgstr "สร้างสัญญา/ใบสั่งซื้อ/จ้าง"
 
 #. module: purchase_request_approval_disbursement
-#: model:ir.model.fields.selection,name:purchase_request_approval_disbursement.selection__purchase_request_approval__billing_status__validated
-msgid "Validated"
-msgstr "ตรวจสอบแล้ว"
+#: model:ir.model.fields.selection,name:purchase_request_approval_disbursement.selection__purchase_request_approval__billing_status__in_progress
+msgid "In Progress"
+msgstr "อยู่ระหว่างเบิกจ่าย"
 
 #. module: purchase_request_approval_disbursement
 #: model_terms:ir.ui.view,arch_db:purchase_request_approval_disbursement.view_purchase_request_approval_form

--- a/purchase_request_approval_disbursement/models/purchase_request_approval.py
+++ b/purchase_request_approval_disbursement/models/purchase_request_approval.py
@@ -35,7 +35,8 @@ class PurchaseRequestApproval(models.Model):
         selection=[
             ("draft", "Draft"),
             ("submitted", "Submitted"),
-            ("validated", "Validated"),
+            ("in_progress", "In Progress"),
+            ("done", "Done"),
             ("cancel", "Cancelled"),
         ],
         string='Billing Status',
@@ -88,8 +89,29 @@ class PurchaseRequestApproval(models.Model):
 
     @api.depends("disbursement_request_ids", "disbursement_request_ids.state")
     def _compute_billing_status(self):
+        state_map = {
+            "draft": "draft",
+            "submitted": "submitted",
+            "signed": "submitted",
+            "verified": "submitted",
+            "approved": "submitted",
+            "bill_draft": "in_progress",
+            "bill_posted": "in_progress",
+            "payment_draft": "in_progress",
+            "payment_posted": "in_progress",
+            "done": "done",
+            "cancel": "cancel",
+        }
         for approval in self:
-            approval.billing_status = approval.disbursement_request_ids.state
+            active = approval.disbursement_request_ids.filtered(
+                lambda r: r.state != "cancel"
+            )
+            if not approval.disbursement_request_ids:
+                approval.billing_status = "draft"
+            elif not active:
+                approval.billing_status = "cancel"
+            else:
+                approval.billing_status = state_map.get(active[0].state, "draft")
 
     def _prepare_disbursement_request_vals(self):
         return {

--- a/purchase_request_approval_disbursement/models/purchase_request_approval.py
+++ b/purchase_request_approval_disbursement/models/purchase_request_approval.py
@@ -94,7 +94,7 @@ class PurchaseRequestApproval(models.Model):
             "submitted": "submitted",
             "signed": "submitted",
             "verified": "submitted",
-            "approved": "submitted",
+            "approved": "in_progress",
             "bill_draft": "in_progress",
             "bill_posted": "in_progress",
             "payment_draft": "in_progress",

--- a/purchase_request_approval_disbursement/views/purchase_request_approval_views.xml
+++ b/purchase_request_approval_disbursement/views/purchase_request_approval_views.xml
@@ -54,6 +54,18 @@
                     />
                 </button>
             </xpath>
+            <xpath expr="//field[@name='payment_type']" position="after">
+                <field
+                    name="billing_status"
+                    readonly="1"
+                    widget="badge"
+                    decoration-info="billing_status == 'draft'"
+                    decoration-warning="billing_status == 'submitted'"
+                    decoration-primary="billing_status == 'in_progress'"
+                    decoration-success="billing_status == 'done'"
+                    decoration-danger="billing_status == 'cancel'"
+                />
+            </xpath>
             <xpath expr="//group[1]" position="before">
                 <h2>Purchase Request Approval Form</h2>
                 <group>


### PR DESCRIPTION
## Summary
- Update `billing_status` selection: replace `validated` with `in_progress` and `done` to properly reflect the disbursement request lifecycle
- Rewrite `_compute_billing_status` to map all 11 disbursement request states to 5 billing statuses, and filter out cancelled records to find the active one
- Update Thai translations: ร่าง, รออนุมัติ, อยู่ระหว่างเบิกจ่าย, เบิกจ่ายเสร็จสิ้น, ตีกลับ

## State Mapping
| Disbursement state | billing_status |
|---|---|
| draft | draft (ร่าง) |
| submitted, signed, verified, approved | submitted (รออนุมัติ) |
| bill_draft, bill_posted, payment_draft, payment_posted | in_progress (อยู่ระหว่างเบิกจ่าย) |
| done | done (เบิกจ่ายเสร็จสิ้น) |
| cancel | cancel (ตีกลับ) |