### PR TITLE
[16.0][ADD] budget_appropriation_deduct_from: track source budget code for deduct lines

### DIFF
--- a/budget_appropriation_deduct_from/__init__.py
+++ b/budget_appropriation_deduct_from/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/budget_appropriation_deduct_from/__manifest__.py
+++ b/budget_appropriation_deduct_from/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Budget Appropriation Deduct From",
+    "version": "16.0.1.0.0",
+    "summary": "ระบุรหัสงบประมาณต้นทางของรายการหักโอน",
+    "category": "KMITL/Budgeting",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": ["budget_appropriation"],
+    "data": [
+        "views/budget_appropriation_views.xml",
+    ],
+    "auto_install": False,
+    "application": False,
+    "installable": True,
+    "license": "AGPL-3",
+}

--- a/budget_appropriation_deduct_from/models/__init__.py
+++ b/budget_appropriation_deduct_from/models/__init__.py
@@ -1,0 +1,1 @@
+from . import budget_appropriation_line

--- a/budget_appropriation_deduct_from/models/budget_appropriation_line.py
+++ b/budget_appropriation_deduct_from/models/budget_appropriation_line.py
@@ -1,0 +1,27 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class BudgetAppropriationLine(models.Model):
+    _inherit = "budget.appropriation.line"
+
+    deduct_from_account_id = fields.Many2one(
+        comodel_name="budget.account",
+        string="หักจากรหัสงบประมาณ",
+        domain="[('budget_type', '=', budget_type),"
+        " ('deduct', '=', False), ('budgetable', '=', True)]",
+        tracking=True,
+        help="รหัสงบประมาณรายรับต้นทางที่ถูกหักโดยรายการหักโอนนี้",
+    )
+
+    @api.constrains("deduct", "deduct_from_account_id")
+    def _check_deduct_from_account_id(self):
+        for line in self:
+            if line.deduct and not line.deduct_from_account_id:
+                raise ValidationError(
+                    _(
+                        "กรุณาระบุรหัสงบประมาณต้นทางที่ต้องการหัก"
+                        " สำหรับรายการหักโอน: %s"
+                    )
+                    % (line.account_id.display_name or "")
+                )

--- a/budget_appropriation_deduct_from/views/budget_appropriation_views.xml
+++ b/budget_appropriation_deduct_from/views/budget_appropriation_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- Inherit budget.appropriation form: add field in deduct_line_ids tree -->
+    <record id="view_budget_appropriation_form_deduct_from" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.form.deduct.from</field>
+        <field name="model">budget.appropriation</field>
+        <field name="inherit_id" ref="budget_appropriation.view_budget_appropriation_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='deduct_line_ids']/tree/field[@name='deduct_analytic_id']" position="after">
+                <field name="deduct_from_account_id"
+                    options='{"no_create": True, "no_create_edit": True, "no_open": True}'
+                    required="1" />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Inherit budget.appropriation.line form -->
+    <record id="view_budget_appropriation_line_form_deduct_from" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.line.form.deduct.from</field>
+        <field name="model">budget.appropriation.line</field>
+        <field name="inherit_id" ref="budget_appropriation.view_budget_appropriation_line_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='deduct_analytic_id']" position="after">
+                <field name="deduct_from_account_id"
+                    options='{"no_create": True, "no_create_edit": True, "no_open": True}'
+                    attrs="{'invisible': [('deduct', '!=', True)], 'required': [('deduct', '=', True)]}" />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Inherit deduct overview tree -->
+    <record id="view_budget_appropriation_line_deduct_tree_deduct_from" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.line.deduct.tree.deduct.from</field>
+        <field name="model">budget.appropriation.line</field>
+        <field name="inherit_id" ref="budget_appropriation.view_budget_appropriation_line_deduct_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='deduct_analytic_id']" position="after">
+                <field name="deduct_from_account_id" string="หักจากรหัสงบประมาณ" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary
- New module `budget_appropriation_deduct_from` adding a `deduct_from_account_id` Many2one on `budget.appropriation.line` so each deduct (หักโอน) line records the revenue budget code it is deducting from.
- Field is enforced via a Python `@api.constrains` (required when `deduct=True`) and exposed in the appropriation form's deduct lines tree, the standalone line form, and the รายการหักโอน overview tree.

## Test plan
- [ ] Install module; on a revenue `budget.appropriation`, add a deduct line and confirm `หักจากรหัสงบประมาณ` is required.
- [ ] Verify the domain only offers non-deduct, budgetable revenue accounts.
- [ ] Open the รายการหักโอน list view and confirm the new column is shown.