### PR TITLE
[16.0][FIX] budget_appropriation_summary: sync compilation totals with appropriation

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Budget Appropriation Summary",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "summary": "Compilation and master summary for budget appropriations",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget_appropriation_summary/models/budget_appropriation.py
+++ b/budget_appropriation_summary/models/budget_appropriation.py
@@ -10,6 +10,25 @@ _logger = logging.getLogger(__name__)
 class BudgetAppropriation(models.Model):
     _inherit = "budget.appropriation"
 
+    # Inverse M2M needed so Odoo registers field_inverses and propagates
+    # amount_net changes back to compilation stored computes.
+    revenue_compilation_ids = fields.Many2many(
+        comodel_name="budget.appropriation.compilation",
+        relation="budget_appropriation_compilation_revenue_rel",
+        column1="appropriation_id",
+        column2="compilation_id",
+        string="รวมเล่ม (รายรับ)",
+        copy=False,
+    )
+    expense_compilation_ids = fields.Many2many(
+        comodel_name="budget.appropriation.compilation",
+        relation="budget_appropriation_compilation_expense_rel",
+        column1="appropriation_id",
+        column2="compilation_id",
+        string="รวมเล่ม (รายจ่าย)",
+        copy=False,
+    )
+
     treasury_replenishment_amount = fields.Monetary(
         string="ชดใช้เงินคงคลัง",
         currency_field="currency_id",


### PR DESCRIPTION
## Summary
- Compilation `amount_revenue_total`/`amount_expense_total` (and master_summary totals) stayed stale after appropriation amounts changed because Odoo's `@api.depends` propagation through Many2many requires inverse M2M fields registered on both sides — the compilation defined the M2M but `budget.appropriation` had no inverse, leaving `field_inverses` empty.
- Add `revenue_compilation_ids` / `expense_compilation_ids` on `budget.appropriation` sharing the same relation tables with reversed columns, restoring the trigger chain through compilation up to master_summary stored totals.

## Test plan
- [ ] Create a compilation, attach a budget.appropriation, edit a line balance, save → verify `amount_revenue_total`/`amount_expense_total` and the master_summary totals update accordingly
- [ ] Add/remove appropriations from a compilation → totals reflect the change