### PR TITLE
[16.0][IMP] budget_appropriation_summary: add document ref label to report header

### DIFF
--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -382,7 +382,7 @@
                 position: absolute;
                 top: 0;
                 right: 0;
-                font-size: 10pt;
+                font-size: 15pt;
             }</style>
     </template>
     <!-- Main report template -->

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -34,6 +34,7 @@
                     </button>
                 </t>
                 <div class="report-header mb-2" contenteditable="false">
+                    <div class="f23w-document-ref">F23-W-วง-002</div>
                     <h4>สรุปงบประมาณรายจ่าย</h4>
                     <h4>
                         ประจำปีงบประมาณ พ.ศ.
@@ -375,6 +376,13 @@
                 position: relative;
                 text-align: center;
                 cursor: not-allowed;
+            }
+
+            .f23w-document-ref {
+                position: absolute;
+                top: 0;
+                right: 0;
+                font-size: 10pt;
             }</style>
     </template>
     <!-- Main report template -->

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -42,6 +42,7 @@
                         พิมพ์รายงาน </button>
                 </t>
                 <div class="report-header mb-2" contenteditable="false">
+                    <div class="f3-document-ref">F3-P-วง-003</div>
                     <h4>สรุปประมาณการรายรับ - รายจ่าย</h4>
                     <h4> ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
                     </h4>
@@ -395,6 +396,13 @@
                 position: relative;
                 text-align: center;
                 cursor: not-allowed;
+            }
+
+            .f3-document-ref {
+                position: absolute;
+                top: 0;
+                right: 0;
+                font-size: 10pt;
             }</style>
     </template>
     <!-- Main report template -->

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -402,7 +402,7 @@
                 position: absolute;
                 top: 0;
                 right: 0;
-                font-size: 10pt;
+                font-size: 15pt;
             }</style>
     </template>
     <!-- Main report template -->


### PR DESCRIPTION
## Summary
- Add document reference label `F23-W-วง-002` at the top-right corner of the F23W compilation report header
- Add document reference label `F3-P-วง-003` at the top-right corner of the F3 compilation report header (in `budget_appropriation_summary_f3`)

## Test plan
- [ ] Open F23W report and verify "F23-W-วง-002" appears at the top-right of the document header
- [ ] Open F3 report and verify "F3-P-วง-003" appears at the top-right of the document header
- [ ] Verify both HTML preview and PDF output render the label correctly