### PR TITLE
[16.0][IMP] budget_appropriation_summary: add copy-to-clipboard button to reports

### DIFF
--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -91,6 +91,27 @@
                 .print-btn:hover {
                     background: #5a3a52;
                 }
+                .copy-btn {
+                    position: fixed;
+                    top: 70px;
+                    right: 20px;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #2563EB;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 16pt;
+                    cursor: pointer;
+                    font-family: 'THSarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .copy-btn:hover {
+                    background: #1d4ed8;
+                }
                 @media print {
                     html, body {
                         background: white !important;
@@ -119,7 +140,7 @@
                     .page:last-child {
                         page-break-after: auto;
                     }
-                    .print-btn {
+                    .print-btn, .copy-btn {
                         display: none !important;
                     }
                 }
@@ -162,6 +183,10 @@
             <button class="print-btn" onclick="window.print()" contenteditable="false">
                 <t t-call="budget_appropriation_summary.report_print_icon" />
                 พิมพ์รายงาน
+            </button>
+            <button class="copy-btn" contenteditable="false" onclick="(function(b){var p=b.closest('.page')||document.body;var f=null;for(var i=0;i&lt;p.children.length;i++){var n=p.children[i];if(n.tagName!=='BUTTON'){f=n;break;}}if(!f)f=p;var r=document.createRange();r.setStartBefore(f);r.setEndAfter(p.lastElementChild||p);var s=window.getSelection();s.removeAllRanges();s.addRange(r);document.execCommand('copy');s.removeAllRanges();var h=b.innerHTML;b.style.background='#16a34a';b.textContent='คัดลอกแล้ว!';setTimeout(function(){b.style.background='';b.innerHTML=h;},2000);})(this)">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                คัดลอกข้อมูล
             </button>
         </t>
     </template>

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -32,6 +32,10 @@
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
                         พิมพ์รายงาน
                     </button>
+                    <button class="f23w-copy-btn" contenteditable="false" onclick="(function(b){var p=b.closest('.page')||document.body;var f=null;for(var i=0;i&lt;p.children.length;i++){var n=p.children[i];if(n.tagName!=='BUTTON'){f=n;break;}}if(!f)f=p;var r=document.createRange();r.setStartBefore(f);r.setEndAfter(p.lastElementChild||p);var s=window.getSelection();s.removeAllRanges();s.addRange(r);document.execCommand('copy');s.removeAllRanges();var h=b.innerHTML;b.style.background='#16a34a';b.textContent='คัดลอกแล้ว!';setTimeout(function(){b.style.background='';b.innerHTML=h;},2000);})(this)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                        คัดลอกข้อมูล
+                    </button>
                 </t>
                 <div class="report-header mb-2" contenteditable="false">
                     <h4>สรุปงบประมาณรายจ่าย</h4>
@@ -302,6 +306,27 @@
                 .f23w-print-btn:hover {
                     background: #5a3a52;
                 }
+                .f23w-copy-btn {
+                    position: absolute;
+                    top: 70px;
+                    right: 20px;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #2563EB;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 14px;
+                    cursor: pointer;
+                    font-family: 'THSarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .f23w-copy-btn:hover {
+                    background: #1d4ed8;
+                }
 
                 @media print {
                     html, body {
@@ -331,7 +356,7 @@
                         top: 5mm;
                         right: 5mm;
                     }
-                    .f23w-print-btn {
+                    .f23w-print-btn, .f23w-copy-btn {
                         display: none !important;
                     }
                 }

--- a/budget_appropriation_summary/report/report_compilation_f4.xml
+++ b/budget_appropriation_summary/report/report_compilation_f4.xml
@@ -78,6 +78,10 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
                 พิมพ์รายงาน
             </button>
+            <button class="f4-copy-btn" contenteditable="false" onclick="(function(b){var p=b.closest('.page')||document.body;var f=null;for(var i=0;i&lt;p.children.length;i++){var n=p.children[i];if(n.tagName!=='BUTTON'){f=n;break;}}if(!f)f=p;var r=document.createRange();r.setStartBefore(f);r.setEndAfter(p.lastElementChild||p);var s=window.getSelection();s.removeAllRanges();s.addRange(r);document.execCommand('copy');s.removeAllRanges();var h=b.innerHTML;b.style.background='#16a34a';b.textContent='คัดลอกแล้ว!';setTimeout(function(){b.style.background='';b.innerHTML=h;},2000);})(this)">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                คัดลอกข้อมูล
+            </button>
         </t>
         <div class="report-header">
             <div class="document-ref">
@@ -244,7 +248,7 @@
                         top: 5mm;
                         right: 5mm;
                     }
-                    .f4-print-btn {
+                    .f4-print-btn, .f4-copy-btn {
                         display: none !important;
                     }
                 }
@@ -269,6 +273,27 @@
                 }
                 .f4-print-btn:hover {
                     background: #5a3a52;
+                }
+                .f4-copy-btn {
+                    position: absolute;
+                    top: 70px;
+                    right: 20px;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #2563EB;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 16pt;
+                    cursor: pointer;
+                    font-family: 'THSarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .f4-copy-btn:hover {
+                    background: #1d4ed8;
                 }
 
                 *[contenteditable="false"] {

--- a/budget_appropriation_summary/report/report_compilation_f5.xml
+++ b/budget_appropriation_summary/report/report_compilation_f5.xml
@@ -46,6 +46,10 @@
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect x="6" y="14" width="12" height="8"/></svg>
                                 พิมพ์รายงาน
                             </button>
+                            <button class="f5-copy-btn" onclick="(function(b){var p=b.closest('.page')||document.body;var f=null;for(var i=0;i&lt;p.children.length;i++){var n=p.children[i];if(n.tagName!=='BUTTON'){f=n;break;}}if(!f)f=p;var r=document.createRange();r.setStartBefore(f);r.setEndAfter(p.lastElementChild||p);var s=window.getSelection();s.removeAllRanges();s.addRange(r);document.execCommand('copy');s.removeAllRanges();var h=b.innerHTML;b.style.background='#16a34a';b.textContent='คัดลอกแล้ว!';setTimeout(function(){b.style.background='';b.innerHTML=h;},2000);})(this)">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                                คัดลอกข้อมูล
+                            </button>
                         </t>
                         <t
                             t-call="budget_appropriation_summary.report_compilation_f5_content"
@@ -237,7 +241,7 @@
                         top: 5mm;
                         right: 5mm;
                     }
-                    .f5-print-btn {
+                    .f5-print-btn, .f5-copy-btn {
                         display: none !important;
                     }
                 }
@@ -262,6 +266,27 @@
                 }
                 .f5-print-btn:hover {
                     background: #5a3a52;
+                }
+                .f5-copy-btn {
+                    position: fixed;
+                    top: 70px;
+                    right: 20%;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #2563EB;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 16pt;
+                    cursor: pointer;
+                    font-family: 'THSarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .f5-copy-btn:hover {
+                    background: #1d4ed8;
                 }
 
                 *[contenteditable="false"] {

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -40,6 +40,10 @@
                             <rect x="6" y="14" width="12" height="8" />
                         </svg>
                         พิมพ์รายงาน </button>
+                    <button class="f3-copy-btn" contenteditable="false" onclick="(function(b){var p=b.closest('.page')||document.body;var f=null;for(var i=0;i&lt;p.children.length;i++){var n=p.children[i];if(n.tagName!=='BUTTON'){f=n;break;}}if(!f)f=p;var r=document.createRange();r.setStartBefore(f);r.setEndAfter(p.lastElementChild||p);var s=window.getSelection();s.removeAllRanges();s.addRange(r);document.execCommand('copy');s.removeAllRanges();var h=b.innerHTML;b.style.background='#16a34a';b.textContent='คัดลอกแล้ว!';setTimeout(function(){b.style.background='';b.innerHTML=h;},2000);})(this)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+                        คัดลอกข้อมูล
+                    </button>
                 </t>
                 <div class="report-header mb-2" contenteditable="false">
                     <h4>สรุปประมาณการรายรับ - รายจ่าย</h4>
@@ -322,6 +326,27 @@
                 .f3-print-btn:hover {
                     background: #5a3a52;
                 }
+                .f3-copy-btn {
+                    position: absolute;
+                    top: 70px;
+                    right: 20px;
+                    z-index: 1000;
+                    padding: 8px 20px;
+                    background: #2563EB;
+                    color: white;
+                    border: none;
+                    border-radius: 4px;
+                    font-size: 14px;
+                    cursor: pointer;
+                    font-family: 'THSarabun', 'Sarabun', Arial, sans-serif;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+                }
+                .f3-copy-btn:hover {
+                    background: #1d4ed8;
+                }
 
                 @media print {
                     html, body {
@@ -351,7 +376,7 @@
                         top: 5mm;
                         right: 5mm;
                     }
-                    .f3-print-btn {
+                    .f3-print-btn, .f3-copy-btn {
                         display: none !important;
                     }
                 }


### PR DESCRIPTION
## Summary

- Add a blue "คัดลอกข้อมูล" (Copy Data) button to HTML preview mode in all appropriation summary reports (F3, F4, F5, F23W, and the 11 shared-template reports).
- Clicking the button programmatically selects all report content (excluding the print/copy buttons) and copies it to the clipboard — identical to manually selecting and pressing Ctrl+C.
- The button shows "คัดลอกแล้ว!" feedback for 2 seconds after copying, and is hidden automatically when printing.

## Test plan

- [ ] Open any HTML preview report (e.g. F3, F4, F5, F23W, or a shared-template report)
- [ ] Verify a blue "คัดลอกข้อมูล" button appears below the purple print button
- [ ] Click the button and paste into Excel/Google Sheets — data should appear with correct tab-separated columns
- [ ] Confirm the button text changes to "คัดลอกแล้ว!" briefly after clicking
- [ ] Verify the copy button does not appear when printing (print preview)