### PR TITLE
[16.0][ADD] accounting_kmitl, finance_kmitl: security groups and role-based menus

### DIFF
--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -12,7 +12,9 @@
         "l10n_th_account_tax",
     ],
     "data": [
+        "security/security.xml",
         "views/account_move_views.xml",
+        "views/menuitem.xml",
         "data/tier_definition.xml",
     ],
     "installable": True,

--- a/accounting_kmitl/security/security.xml
+++ b/accounting_kmitl/security/security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <!-- Module Category -->
+        <record id="module_category_accounting_kmitl" model="ir.module.category">
+            <field name="name">KMITL Accounting</field>
+            <field name="description">User groups for KMITL accounting operations</field>
+            <field name="sequence">20</field>
+        </record>
+
+        <!-- User Group -->
+        <record id="group_accounting_kmitl_user" model="res.groups">
+            <field name="name">User</field>
+            <field name="category_id" ref="accounting_kmitl.module_category_accounting_kmitl"/>
+            <field name="implied_ids" eval="[(4, ref('account.group_account_invoice'))]"/>
+        </record>
+
+        <!-- Manager Group (inherits from User + account manager) -->
+        <record id="group_accounting_kmitl_manager" model="res.groups">
+            <field name="name">Manager</field>
+            <field name="category_id" ref="accounting_kmitl.module_category_accounting_kmitl"/>
+            <field name="implied_ids" eval="[(4, ref('group_accounting_kmitl_user')), (4, ref('account.group_account_manager'))]"/>
+            <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Root menu -->
+    <menuitem
+        id="menu_accounting_root"
+        name="Accounting"
+        web_icon="accounting_kmitl,static/description/icon.png"
+        sequence="55"
+        groups="accounting_kmitl.group_accounting_kmitl_user"
+    />
+
+    <!-- Vendor Bills -->
+    <menuitem
+        id="menu_vendor_bills"
+        name="Vendor Bills"
+        parent="menu_accounting_root"
+        action="account.action_move_in_invoice_type"
+        sequence="10"
+    />
+
+    <!-- Journal Entries -->
+    <menuitem
+        id="menu_journal_entries"
+        name="Journal Entries"
+        parent="menu_accounting_root"
+        action="account.action_move_journal_line"
+        sequence="20"
+    />
+
+    <!-- Bank Statements -->
+    <menuitem
+        id="menu_bank_statements"
+        name="Bank Statements"
+        parent="menu_accounting_root"
+        action="account.action_bank_statement_tree"
+        sequence="30"
+    />
+
+    <!-- Reports submenu (placeholder — extend ผ่านโมดูล report ในอนาคต) -->
+    <menuitem
+        id="menu_accounting_reports"
+        name="Reports"
+        parent="menu_accounting_root"
+        sequence="80"
+    />
+
+    <!-- Configuration (manager only) -->
+    <menuitem
+        id="menu_accounting_config"
+        name="Configuration"
+        parent="menu_accounting_root"
+        sequence="90"
+        groups="accounting_kmitl.group_accounting_kmitl_manager"
+    />
+    <menuitem
+        id="menu_config_chart_of_accounts"
+        name="Chart of Accounts"
+        parent="menu_accounting_config"
+        action="account.action_account_form"
+        sequence="10"
+    />
+    <menuitem
+        id="menu_config_journals"
+        name="Journals"
+        parent="menu_accounting_config"
+        action="account.action_account_journal_form"
+        sequence="20"
+    />
+    <menuitem
+        id="menu_config_taxes"
+        name="Taxes"
+        parent="menu_accounting_config"
+        action="account.action_tax_form"
+        sequence="30"
+    />
+
+</odoo>

--- a/finance_kmitl/__manifest__.py
+++ b/finance_kmitl/__manifest__.py
@@ -21,6 +21,7 @@
         "l10n_th_account_wht_cert_form"
     ],
     "data": [
+        "security/security.xml",
         "security/ir.model.access.csv",
         "data/kmitl_payment_type_data.xml",
         "data/tier_definition.xml",

--- a/finance_kmitl/security/security.xml
+++ b/finance_kmitl/security/security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <!-- Module Category -->
+        <record id="module_category_finance_kmitl" model="ir.module.category">
+            <field name="name">KMITL Finance</field>
+            <field name="description">User groups for KMITL finance operations</field>
+            <field name="sequence">21</field>
+        </record>
+
+        <!-- User Group -->
+        <record id="group_finance_kmitl_user" model="res.groups">
+            <field name="name">User</field>
+            <field name="category_id" ref="finance_kmitl.module_category_finance_kmitl"/>
+            <field name="implied_ids" eval="[(4, ref('account.group_account_invoice'))]"/>
+        </record>
+
+        <!-- Manager Group (inherits from User + account manager) -->
+        <record id="group_finance_kmitl_manager" model="res.groups">
+            <field name="name">Manager</field>
+            <field name="category_id" ref="finance_kmitl.module_category_finance_kmitl"/>
+            <field name="implied_ids" eval="[(4, ref('group_finance_kmitl_user')), (4, ref('account.group_account_manager'))]"/>
+            <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/finance_kmitl/views/menuitem.xml
+++ b/finance_kmitl/views/menuitem.xml
@@ -7,6 +7,7 @@
         name="Finance"
         web_icon="finance_kmitl,static/description/icon.png"
         sequence="60"
+        groups="finance_kmitl.group_finance_kmitl_user"
     />
 
     <!-- Action: account.payment outbound -->
@@ -68,12 +69,13 @@
         sequence="25"
     />
 
-    <!-- Settings submenu -->
+    <!-- Settings submenu (manager only) -->
     <menuitem
         id="menu_payment_settings"
         name="Settings"
         parent="menu_payment_root"
         sequence="90"
+        groups="finance_kmitl.group_finance_kmitl_manager"
     />
     <menuitem
         id="menu_settings_bank_payment_template"


### PR DESCRIPTION
> Stacked on top of #720 (Phase 1 rename). Merge #720 first.

## Summary

Phase 2 ของแผนแยก disbursement เป็น 3 core apps — เพิ่ม security groups + role-based menus ให้ \`accounting_kmitl\` และ \`finance_kmitl\` เพื่อให้ทีมบัญชี/การเงินมี workspace ของตัวเอง

### accounting_kmitl
- Category ใหม่ "KMITL Accounting" + 2 groups: **User** (inherit \`account.group_account_invoice\`) / **Manager** (inherit \`account.group_account_manager\`)
- Top-level menu "Accounting" พร้อม submenus:
  - Vendor Bills, Journal Entries, Bank Statements (ใช้ standard Odoo actions)
  - Reports (parent menu placeholder — ขยายผ่านโมดูล report ในอนาคต)
  - Configuration (manager-only): Chart of Accounts / Journals / Taxes

### finance_kmitl
- Category ใหม่ "KMITL Finance" + 2 groups: **User** / **Manager**
- Apply \`group_finance_kmitl_user\` กับ root menu และ \`group_finance_kmitl_manager\` กับ Settings submenu
- เมนูเดิม (จ่ายเงิน/รับเงิน/Bank Export/WHT Cert/KMITL Payment Type) คงไว้

ยังไม่เพิ่ม WHT Report (PND.3/53) menu เพราะยังไม่มี action — รอ implement แล้วค่อยใส่ใน PR แยก

## Test plan

- [ ] Install/upgrade ผ่าน
- [ ] Settings → Users & Companies → Groups → เห็น category "KMITL Accounting" และ "KMITL Finance"
- [ ] Login เป็น user ที่ไม่มี group ทั้งคู่ → ไม่เห็น 2 apps
- [ ] Assign \`group_accounting_kmitl_user\` → เห็น Accounting app, ไม่เห็น Configuration submenu
- [ ] Assign \`group_accounting_kmitl_manager\` → เห็น Configuration submenu ครบ
- [ ] Assign \`group_finance_kmitl_user\` → เห็น Finance app, ไม่เห็น Settings submenu
- [ ] Assign \`group_finance_kmitl_manager\` → เห็น Settings submenu
- [ ] เปิดเมนู Accounting → Vendor Bills / Journal Entries / Bank Statements เปิดได้
- [ ] เปิดเมนู Accounting → Configuration → COA / Journals / Taxes เปิดได้

## Follow-ups

Phase 3 ต่อ — refactor DR state machine (แยก \`state\` + \`pipeline_status\`)