### PR TITLE
[16.0][IMP] budget_appropriation_summary: add report buttons to tree/kanban

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Budget Appropriation Summary",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "summary": "Compilation and master summary for budget appropriations",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget_appropriation_summary/models/budget_appropriation_compilation.py
+++ b/budget_appropriation_summary/models/budget_appropriation_compilation.py
@@ -634,6 +634,15 @@ class BudgetAppropriationCompilation(models.Model):
             "context": {"active_id": self.id},
         }
 
+    def action_open_f5_report_html(self):
+        """Open F5 expense report in a new browser tab as HTML with default options."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/budget_appropriation_summary/compilation/{self.id}/f5/html",
+            "target": "new",
+        }
+
     def action_print_f4_report(self):
         """Print F4 revenue report as PDF."""
         self.ensure_one()

--- a/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_compilation_views.xml
@@ -259,6 +259,33 @@
                 <field name="amount_revenue_total" sum="รวมรายรับ" />
                 <field name="amount_expense_total" sum="รวมรายจ่าย" />
                 <field name="state" />
+                <field name="revenue_appropriation_ids" invisible="1" />
+                <field name="expense_appropriation_ids" invisible="1" />
+                <field name="use_f23" invisible="1" />
+                <button
+                    name="action_open_f4_report"
+                    type="object"
+                    icon="fa-file-text-o"
+                    string="F4"
+                    title="เปิดรายงาน F4"
+                    attrs="{'invisible': [('revenue_appropriation_ids', '=', [])]}"
+                />
+                <button
+                    name="action_open_f5_report_html"
+                    type="object"
+                    icon="fa-file-text-o"
+                    string="F5"
+                    title="เปิดรายงาน F5"
+                    attrs="{'invisible': [('expense_appropriation_ids', '=', [])]}"
+                />
+                <button
+                    name="action_open_f23w_report"
+                    type="object"
+                    icon="fa-file-text-o"
+                    string="F23"
+                    title="เปิดรายงาน F23"
+                    attrs="{'invisible': [('use_f23', '=', False)]}"
+                />
             </tree>
         </field>
     </record>
@@ -271,6 +298,9 @@
             <kanban class="oe_background_grey o_kanban_dashboard o_budget_appropriation_compilation_kanban" sample="1">
                 <field name="currency_id" />
                 <field name="state" />
+                <field name="revenue_appropriation_ids" />
+                <field name="expense_appropriation_ids" />
+                <field name="use_f23" />
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_card oe_kanban_global_click">
@@ -309,6 +339,35 @@
                                                 widget="monetary"
                                             /></span>
                                     </div>
+                                </div>
+                                <div class="mt-2 d-flex flex-wrap gap-1">
+                                    <button
+                                        t-if="record.revenue_appropriation_ids.raw_value.length &gt; 0"
+                                        name="action_open_f4_report"
+                                        type="object"
+                                        class="btn btn-sm btn-outline-primary"
+                                        title="เปิดรายงาน F4"
+                                    >
+                                        <i class="fa fa-file-text-o me-1" />F4
+                                    </button>
+                                    <button
+                                        t-if="record.expense_appropriation_ids.raw_value.length &gt; 0"
+                                        name="action_open_f5_report_html"
+                                        type="object"
+                                        class="btn btn-sm btn-outline-primary"
+                                        title="เปิดรายงาน F5"
+                                    >
+                                        <i class="fa fa-file-text-o me-1" />F5
+                                    </button>
+                                    <button
+                                        t-if="record.use_f23.raw_value"
+                                        name="action_open_f23w_report"
+                                        type="object"
+                                        class="btn btn-sm btn-outline-primary"
+                                        title="เปิดรายงาน F23"
+                                    >
+                                        <i class="fa fa-file-text-o me-1" />F23
+                                    </button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Adds F4, F5, F23 quick-open report buttons to the compilation tree and kanban views so users can open reports in a new tab without drilling into each record.
- Button visibility mirrors the form view: F4 needs revenue appropriations, F5 needs expense appropriations, F23 needs ``use_f23``.
- Adds ``action_open_f5_report_html`` to open F5 directly with default options, bypassing the print-options wizard for one-click access from list/kanban.

## Test plan
- [ ] Open the compilation list view; verify F4/F5/F23 buttons appear per-row only when their respective conditions are met, and clicking each opens the portal HTML report in a new tab.
- [ ] Open the kanban view; verify the same buttons render conditionally on each card and open the corresponding report in a new tab.
- [ ] Confirm the form view buttons still work unchanged (F4 open/print, F5 wizard, F23 open).