### PR TITLE
[16.0][FIX] kmitl_demo: update fails on pr_dashboard_demo_20

### DIFF
--- a/kmitl_demo/data/purchase.request.dashboard.demo.xml
+++ b/kmitl_demo/data/purchase.request.dashboard.demo.xml
@@ -696,7 +696,7 @@
         <value eval="[ref('kmitl_demo.pr_dashboard_demo_19')]"/>
     </function>
 
-    <!-- PR D20: วิทยาศาสตร์ / จ้างทำของ / งบบุคลากร / rejected -->
+    <!-- PR D20: วิทยาศาสตร์ / จ้างทำของ / งบดำเนินงาน / rejected -->
     <record id="pr_dashboard_demo_20" model="purchase.request">
         <field name="title">จ้างวิจัยการสังเคราะห์วัสดุนาโน</field>
         <field name="description">โครงการวิจัยร่วมกับภาคเอกชน (ถูกยกเลิก)</field>
@@ -708,7 +708,7 @@
         <field name="partner_id" ref="kmitl_demo.vendor_demo_013"/>
         <field name="user_id" ref="kmitl_demo.user_demo_006"/>
         <field name="department_id" ref="kmitl_demo.05"/>
-        <field name="budget_account_id" ref="budget.budget_account_5101020016"/>
+        <field name="budget_account_id" ref="budget.budget_account_5230000000"/>
         <field name="activity_analytic_id" ref="account_analytic_kmitl.activity_06"/>
         <field name="department_analytic_id" ref="account_analytic_kmitl.dept_05"/>
         <field name="fund_analytic_id" ref="account_analytic_kmitl.fund_0100"/>

--- a/kmitl_demo/data/purchase.request.dashboard.demo.xml
+++ b/kmitl_demo/data/purchase.request.dashboard.demo.xml
@@ -714,6 +714,9 @@
         <field name="fund_analytic_id" ref="account_analytic_kmitl.fund_0100"/>
         <field name="source_analytic_id" ref="account_analytic_kmitl.source_1"/>
     </record>
+    <function model="purchase.request" name="button_draft">
+        <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>
+    </function>
     <function model="purchase.request" name="_onchange_budget_account_id"
         context="{'default_price_unit': 3200000}">
         <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>


### PR DESCRIPTION
# Fix: kmitl_demo update fails on pr_dashboard_demo_20

## Context

When updating the `kmitl_demo` module, Odoo fails at `purchase.request.dashboard.demo.xml:727` because `action_reserve_budget` calls `button_to_approve()` → `to_approve_allowed_check()`, which raises:

> "You can't request an approval for a purchase request which is empty. (PR/69/วท/0006)"

## Root Cause (two-part)

### Part 1 — wrong budget account (Fix 1: already applied)

`pr_dashboard_demo_20` originally used `budget.budget_account_5101020016` (code prefix `51` = งบบุคลากร). The `budget_product` module only assigns `purchase_ok=True` and `product_id` to accounts under roots `52000, 53000, 54000, 55000`. Since `budget_account_5101020016` has no `product_id`, `_onchange_budget_account_id` in `purchase_request_budget/models/purchase_request.py:283` returns early and creates no lines. Fix 1 changed the account to `budget.budget_account_5230000000` (52xxx, has product). **This fix is already committed.**

### Part 2 — cancelled lines on module UPDATE (Fix 2: pending)

D20's XML workflow ends with `button_rejected`, which calls `do_cancel()` on all `purchase.request.line` records. On the **next module update**, the record already exists in DB with cancelled lines.

When `_onchange_budget_account_id` is called via XML `<function>`:
- It detects `self.line_ids` is non-empty (cancelled lines exist) → enters the `if self.line_ids:` branch
- Only updates `product_id` on existing lines — does **not** uncancelled them, does **not** create new lines

Then `action_reserve_budget` calls `button_to_approve()`. The `_compute_to_approve_allowed` check in `purchase_request_budget/models/purchase_request.py:222` requires:
```python
rec.state == "to_verify" and any(not line.cancelled and line.product_qty for line in rec.line_ids)
```
All lines are cancelled → `any(...)` is `False` → `to_approve_allowed_check()` raises UserError.

Other 51xxx records (D16: `in_progress`, D28: `approved`) don't fail on UPDATE because their lines remain non-cancelled between updates — only `button_rejected` cancels lines.

## Fix 2 (pending)

**File:** `kmitl_demo/data/purchase.request.dashboard.demo.xml` around line 717

Insert a `button_draft` call **before** `_onchange_budget_account_id` in D20's workflow. `button_draft` calls `do_uncancel()` on all lines (via OCA base) and resets state to `draft`. It is safe on fresh install (no-op when lines are empty or already draft).

**Change:**
```xml
<!-- BEFORE (current state after Fix 1) -->
<function model="purchase.request" name="_onchange_budget_account_id"
    context="{'default_price_unit': 3200000}">
    <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>
</function>
<function model="purchase.request" name="action_ignore_exceptions">
    <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>
</function>
...

<!-- AFTER -->
<function model="purchase.request" name="button_draft">
    <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>
</function>
<function model="purchase.request" name="_onchange_budget_account_id"
    context="{'default_price_unit': 3200000}">
    <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>
</function>
<function model="purchase.request" name="action_ignore_exceptions">
    <value eval="[ref('kmitl_demo.pr_dashboard_demo_20')]"/>
</function>
...
```

## Critical files

- `kmitl_demo/data/purchase.request.dashboard.demo.xml` — the only file to edit (lines ~717–735 for D20's workflow)

## Verification

Update the `kmitl_demo` module and confirm no error at line 727 of `purchase.request.dashboard.demo.xml`.