### PR TITLE
[16.0][IMP] budget_appropriation_summary: add master totals breakdown

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Budget Appropriation Summary",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.0.3",
     "summary": "Compilation and master summary for budget appropriations",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget_appropriation_summary/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary/models/budget_appropriation_master_summary.py
@@ -106,6 +106,48 @@ class BudgetAppropriationMasterSummary(models.Model):
         store=True,
         currency_field="currency_id",
     )
+    amount_revenue_gross = fields.Monetary(
+        string="รายรับรวม",
+        compute="_compute_revenue_breakdown",
+        store=True,
+        currency_field="currency_id",
+    )
+    amount_revenue_deduct = fields.Monetary(
+        string="หักโอน",
+        compute="_compute_revenue_breakdown",
+        store=True,
+        currency_field="currency_id",
+    )
+    reserve_fund_amount = fields.Monetary(
+        string="งบกองทุนสำรอง",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    personnel_expense_amount = fields.Monetary(
+        string="งบบุคลากร",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    operating_expense_amount = fields.Monetary(
+        string="งบดำเนินงาน",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    capital_expenditure_amount = fields.Monetary(
+        string="งบลงทุน",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    subsidy_amount = fields.Monetary(
+        string="งบเงินอุดหนุน",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
+    other_expenditure_amount = fields.Monetary(
+        string="งบรายจ่ายอื่น",
+        compute="_compute_budget_summary_amounts",
+        currency_field="currency_id",
+    )
     state = fields.Selection(
         selection=[
             ("draft", "Draft"),
@@ -231,6 +273,43 @@ class BudgetAppropriationMasterSummary(models.Model):
             record.amount_expense_total = sum(
                 record.compilation_ids.mapped("amount_expense_total")
             )
+
+    @api.depends(
+        "compilation_ids.revenue_appropriation_ids.amount_total",
+        "compilation_ids.revenue_appropriation_ids.amount_deduct",
+    )
+    def _compute_revenue_breakdown(self):
+        for record in self:
+            record.amount_revenue_gross = sum(
+                record.revenue_appropriation_ids.mapped("amount_total")
+            )
+            record.amount_revenue_deduct = sum(
+                record.revenue_appropriation_ids.mapped("amount_deduct")
+            )
+
+    BUDGET_SUMMARY_FIELDS = [
+        "reserve_fund_amount",
+        "personnel_expense_amount",
+        "operating_expense_amount",
+        "capital_expenditure_amount",
+        "subsidy_amount",
+        "other_expenditure_amount",
+    ]
+
+    @api.depends(
+        "compilation_ids.reserve_fund_amount",
+        "compilation_ids.personnel_expense_amount",
+        "compilation_ids.operating_expense_amount",
+        "compilation_ids.capital_expenditure_amount",
+        "compilation_ids.subsidy_amount",
+        "compilation_ids.other_expenditure_amount",
+    )
+    def _compute_budget_summary_amounts(self):
+        for record in self:
+            for field_name in self.BUDGET_SUMMARY_FIELDS:
+                record[field_name] = sum(
+                    record.compilation_ids.mapped(field_name)
+                )
 
     @api.depends("revenue_appropriation_ids", "compare_summary_id")
     def _compute_f2_revenue_data(self):

--- a/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
@@ -147,8 +147,28 @@
                             <field name="compare_summary_id" domain="[('id', '!=', id)]" />
                             <field name="council_meeting_no" />
                             <field name="council_meeting_date" />
-                            <field name="amount_revenue_total" />
-                            <field name="amount_expense_total" />
+                        </group>
+                    </group>
+                    <group>
+                        <group string="ประมาณการรายรับ">
+                            <field name="amount_revenue_gross" />
+                            <field name="amount_revenue_deduct" />
+                            <field
+                                style="text-decoration-line: underline; text-decoration-style: double;"
+                                name="amount_revenue_total"
+                            />
+                        </group>
+                        <group string="สรุปตามประเภทงบ">
+                            <field name="personnel_expense_amount" />
+                            <field name="operating_expense_amount" />
+                            <field name="capital_expenditure_amount" />
+                            <field name="subsidy_amount" />
+                            <field name="other_expenditure_amount" />
+                            <field name="reserve_fund_amount" />
+                            <field
+                                style="text-decoration-line: underline; text-decoration-style: double;"
+                                name="amount_expense_total"
+                            />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
## Summary
- เพิ่มฟิลด์ผลรวมประเภทงบ (บุคลากร, ดำเนินงาน, ลงทุน, เงินอุดหนุน, รายจ่ายอื่น, กองทุนสำรอง) บน `budget.appropriation.master.summary` รวมจาก `compilation_ids`.
- เพิ่มฟิลด์รายรับแยก (รายรับรวม, หักโอน) รวมจาก `revenue_appropriation_ids.amount_total` และ `amount_deduct`.
- แสดงผลในฟอร์มเป็น 2 กลุ่มข้าง ๆ กัน ได้แก่ "ประมาณการรายรับ" และ "สรุปตามประเภทงบ" พร้อมยอดรวมขีดเส้นใต้คู่.

## Test plan
- [ ] เปิดสรุปภาพรวมสถาบัน ตรวจสอบกลุ่ม "ประมาณการรายรับ" แสดง รายรับรวม / หักโอน / รายรับรวมทั้งสถาบัน ถูกต้อง
- [ ] ตรวจสอบกลุ่ม "สรุปตามประเภทงบ" แสดงครบ 6 ประเภทตามลำดับ บุคลากร → ดำเนินงาน → ลงทุน → เงินอุดหนุน → รายจ่ายอื่น → กองทุนสำรอง และยอดรวมรายจ่ายตรงกับ compilations