### PR TITLE
[16.0][FIX] budget_appropriation_summary: align diff % column with share-based columns

### DIFF
--- a/budget_appropriation_summary/models/summary_f2_revenue.py
+++ b/budget_appropriation_summary/models/summary_f2_revenue.py
@@ -60,13 +60,19 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
         for code, name in self.REVENUE_CATEGORIES:
             amount = category_totals.get(code, 0)
             compare_amount = compare_totals.get(code, 0)
+            diff_amount = amount - compare_amount
             categories.append(
                 {
                     "code": code,
                     "name": name,
                     "amount": amount,
                     "compare_amount": compare_amount,
-                    "diff_amount": amount - compare_amount,
+                    "diff_amount": diff_amount,
+                    "diff_percentage": (
+                        round((diff_amount / compare_amount) * 100, 2)
+                        if compare_amount
+                        else 0
+                    ),
                 }
             )
 
@@ -85,9 +91,6 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
                 )
                 if compare_total_amount
                 else 0.0
-            )
-            category["diff_percentage"] = round(
-                category["percentage"] - category["compare_percentage"], 2
             )
 
         diff_total = total_amount - compare_total_amount

--- a/budget_appropriation_summary/models/summary_f2_revenue.py
+++ b/budget_appropriation_summary/models/summary_f2_revenue.py
@@ -60,21 +60,13 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
         for code, name in self.REVENUE_CATEGORIES:
             amount = category_totals.get(code, 0)
             compare_amount = compare_totals.get(code, 0)
-            diff_amount = amount - compare_amount
-            diff_percentage = (
-                round((diff_amount / compare_amount) * 100, 2)
-                if compare_amount
-                else 0
-            )
-
             categories.append(
                 {
                     "code": code,
                     "name": name,
                     "amount": amount,
                     "compare_amount": compare_amount,
-                    "diff_amount": diff_amount,
-                    "diff_percentage": diff_percentage,
+                    "diff_amount": amount - compare_amount,
                 }
             )
 
@@ -82,18 +74,21 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
         compare_total_amount = sum(c["compare_amount"] for c in categories)
 
         for category in categories:
-            if total_amount:
-                category["percentage"] = round(
-                    (category["amount"] / total_amount) * 100, 2
-                )
-            else:
-                category["percentage"] = 0.0
-            if compare_total_amount:
-                category["compare_percentage"] = round(
+            category["percentage"] = (
+                round((category["amount"] / total_amount) * 100, 2)
+                if total_amount
+                else 0.0
+            )
+            category["compare_percentage"] = (
+                round(
                     (category["compare_amount"] / compare_total_amount) * 100, 2
                 )
-            else:
-                category["compare_percentage"] = 0.0
+                if compare_total_amount
+                else 0.0
+            )
+            category["diff_percentage"] = round(
+                category["percentage"] - category["compare_percentage"], 2
+            )
 
         diff_total = total_amount - compare_total_amount
         diff_total_percentage = (

--- a/budget_appropriation_summary/models/summary_f4w_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4w_revenue.py
@@ -68,29 +68,24 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
                     compare_amount = compare_category_totals.get(code, 0)
 
                     if amount or compare_amount:
-                        diff_amount = amount - compare_amount
-                        diff_percentage = round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0
-
+                        percentage = round((amount / dept_total) * 100, 2) if dept_total else 0
+                        compare_percentage = round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0
                         categories.append({
                             "code": code,
                             "name": name,
                             "amount": amount,
                             "compare_amount": compare_amount,
-                            "diff_amount": diff_amount,
-                            "diff_percentage": diff_percentage,
-                            "percentage": round((amount / dept_total) * 100, 2) if dept_total else 0,
-                            "compare_percentage": round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0,
+                            "diff_amount": amount - compare_amount,
+                            "diff_percentage": round(percentage - compare_percentage, 2),
+                            "percentage": percentage,
+                            "compare_percentage": compare_percentage,
                         })
-
-                diff_dept_amount = dept_total - compare_dept_total
-                diff_dept_percentage = round((diff_dept_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0
 
                 departments.append({
                     **dept_info,
                     "amount": dept_total,
                     "compare_amount": compare_dept_total,
-                    "diff_amount": diff_dept_amount,
-                    "diff_percentage": diff_dept_percentage,
+                    "diff_amount": dept_total - compare_dept_total,
                     "categories": categories,
                 })
 
@@ -99,6 +94,7 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
         for dept in departments:
             dept["percentage"] = round((dept["amount"] / total_amount) * 100, 2) if total_amount else 0
             dept["compare_percentage"] = round((dept["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
+            dept["diff_percentage"] = round(dept["percentage"] - dept["compare_percentage"], 2)
 
         departments = sorted(departments, key=lambda x: x["code"])
 

--- a/budget_appropriation_summary/models/summary_f4w_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4w_revenue.py
@@ -68,24 +68,25 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
                     compare_amount = compare_category_totals.get(code, 0)
 
                     if amount or compare_amount:
-                        percentage = round((amount / dept_total) * 100, 2) if dept_total else 0
-                        compare_percentage = round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0
+                        diff_amount = amount - compare_amount
                         categories.append({
                             "code": code,
                             "name": name,
                             "amount": amount,
                             "compare_amount": compare_amount,
-                            "diff_amount": amount - compare_amount,
-                            "diff_percentage": round(percentage - compare_percentage, 2),
-                            "percentage": percentage,
-                            "compare_percentage": compare_percentage,
+                            "diff_amount": diff_amount,
+                            "diff_percentage": round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0,
+                            "percentage": round((amount / dept_total) * 100, 2) if dept_total else 0,
+                            "compare_percentage": round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0,
                         })
 
+                diff_dept_amount = dept_total - compare_dept_total
                 departments.append({
                     **dept_info,
                     "amount": dept_total,
                     "compare_amount": compare_dept_total,
-                    "diff_amount": dept_total - compare_dept_total,
+                    "diff_amount": diff_dept_amount,
+                    "diff_percentage": round((diff_dept_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0,
                     "categories": categories,
                 })
 
@@ -94,7 +95,6 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
         for dept in departments:
             dept["percentage"] = round((dept["amount"] / total_amount) * 100, 2) if total_amount else 0
             dept["compare_percentage"] = round((dept["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
-            dept["diff_percentage"] = round(dept["percentage"] - dept["compare_percentage"], 2)
 
         departments = sorted(departments, key=lambda x: x["code"])
 

--- a/budget_appropriation_summary/models/summary_f5w_expense.py
+++ b/budget_appropriation_summary/models/summary_f5w_expense.py
@@ -92,17 +92,12 @@ class BudgetAppropriationSummaryF5WExpense(models.AbstractModel):
         for xml_id, code, name in self.ACTIVITY_PLANS:
             amount = activity_totals.get(xml_id, 0)
             compare_amount = compare_totals.get(xml_id, 0)
-
-            diff_amount = amount - compare_amount
-            diff_percentage = round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0
-
             activities.append({
                 "code": code,
                 "name": name,
                 "amount": amount,
                 "compare_amount": compare_amount,
-                "diff_amount": diff_amount,
-                "diff_percentage": diff_percentage,
+                "diff_amount": amount - compare_amount,
             })
 
         # Calculate percentages
@@ -111,6 +106,7 @@ class BudgetAppropriationSummaryF5WExpense(models.AbstractModel):
         for act in activities:
             act["percentage"] = round((act["amount"] / total_amount) * 100, 2) if total_amount else 0
             act["compare_percentage"] = round((act["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
+            act["diff_percentage"] = round(act["percentage"] - act["compare_percentage"], 2)
 
         # Summary with comparison
         diff_total = total_amount - compare_total_amount

--- a/budget_appropriation_summary/models/summary_f5w_expense.py
+++ b/budget_appropriation_summary/models/summary_f5w_expense.py
@@ -92,12 +92,14 @@ class BudgetAppropriationSummaryF5WExpense(models.AbstractModel):
         for xml_id, code, name in self.ACTIVITY_PLANS:
             amount = activity_totals.get(xml_id, 0)
             compare_amount = compare_totals.get(xml_id, 0)
+            diff_amount = amount - compare_amount
             activities.append({
                 "code": code,
                 "name": name,
                 "amount": amount,
                 "compare_amount": compare_amount,
-                "diff_amount": amount - compare_amount,
+                "diff_amount": diff_amount,
+                "diff_percentage": round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0,
             })
 
         # Calculate percentages
@@ -106,7 +108,6 @@ class BudgetAppropriationSummaryF5WExpense(models.AbstractModel):
         for act in activities:
             act["percentage"] = round((act["amount"] / total_amount) * 100, 2) if total_amount else 0
             act["compare_percentage"] = round((act["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
-            act["diff_percentage"] = round(act["percentage"] - act["compare_percentage"], 2)
 
         # Summary with comparison
         diff_total = total_amount - compare_total_amount

--- a/budget_appropriation_summary/models/summary_f5w_expense.py
+++ b/budget_appropriation_summary/models/summary_f5w_expense.py
@@ -147,24 +147,23 @@ class BudgetAppropriationSummaryF5WExpense(models.AbstractModel):
         """
         lines = summary.expense_appropriation_ids.mapped("line_ids")
 
-        # Pre-compute parent_path_prefix -> xml_id mapping
-        # Using parent_path prefix (e.g., "123/") to match all descendants
+        # Match plan to descendants by full parent_path prefix; using just
+        # "{id}/" caused substring false positives (e.g. "12/" matches "112/").
         path_prefix_map = {}
         for xml_id, code, name in self.ACTIVITY_PLANS:
             parent = self.env.ref(xml_id, raise_if_not_found=False)
             if parent:
-                # parent_path starts with parent.id/ for all descendants
-                path_prefix_map[f"{parent.id}/"] = xml_id
+                path_prefix_map[parent.parent_path] = xml_id
             else:
                 _logger.warning("Activity plan with xml_id '%s' not found", xml_id)
 
-        # Aggregate
         totals = {}
         for line in lines:
             activity = line.activity_analytic_id
-            # Check which plan this activity belongs to
+            if not activity.parent_path:
+                continue
             for prefix, xml_id in path_prefix_map.items():
-                if prefix in activity.parent_path or activity.parent_path.startswith(prefix):
+                if activity.parent_path.startswith(prefix):
                     totals[xml_id] = totals.get(xml_id, 0) + line.balance
                     break
 

--- a/budget_appropriation_summary/models/summary_f7w_expense.py
+++ b/budget_appropriation_summary/models/summary_f7w_expense.py
@@ -116,11 +116,13 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
                 compare_amount = compare_totals.get(cat_key, 0)
 
                 if amount or compare_amount:
+                    diff_amount = amount - compare_amount
                     categories.append({
                         "name": cat_name,
                         "amount": amount,
                         "compare_amount": compare_amount,
-                        "diff_amount": amount - compare_amount,
+                        "diff_amount": diff_amount,
+                        "diff_percentage": round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0,
                     })
                     type_total += amount
                     compare_type_total += compare_amount
@@ -129,15 +131,16 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
             for cat in categories:
                 cat["percentage"] = round((cat["amount"] / type_total) * 100, 2) if type_total else 0
                 cat["compare_percentage"] = round((cat["compare_amount"] / compare_type_total) * 100, 2) if compare_type_total else 0
-                cat["diff_percentage"] = round(cat["percentage"] - cat["compare_percentage"], 2)
 
             if type_total or compare_type_total:
+                diff_type = type_total - compare_type_total
                 expense_types.append({
                     "code": type_code,
                     "name": type_name,
                     "amount": type_total,
                     "compare_amount": compare_type_total,
-                    "diff_amount": type_total - compare_type_total,
+                    "diff_amount": diff_type,
+                    "diff_percentage": round((diff_type / compare_type_total) * 100, 2) if compare_type_total else 0,
                     "categories": categories,
                 })
 
@@ -147,7 +150,6 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
         for t in expense_types:
             t["percentage"] = round((t["amount"] / total_amount) * 100, 2) if total_amount else 0
             t["compare_percentage"] = round((t["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
-            t["diff_percentage"] = round(t["percentage"] - t["compare_percentage"], 2)
 
         # Summary with comparison
         diff_total = total_amount - compare_total_amount

--- a/budget_appropriation_summary/models/summary_f7w_expense.py
+++ b/budget_appropriation_summary/models/summary_f7w_expense.py
@@ -116,15 +116,11 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
                 compare_amount = compare_totals.get(cat_key, 0)
 
                 if amount or compare_amount:
-                    diff_amount = amount - compare_amount
-                    diff_percentage = round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0
-
                     categories.append({
                         "name": cat_name,
                         "amount": amount,
                         "compare_amount": compare_amount,
-                        "diff_amount": diff_amount,
-                        "diff_percentage": diff_percentage,
+                        "diff_amount": amount - compare_amount,
                     })
                     type_total += amount
                     compare_type_total += compare_amount
@@ -133,18 +129,15 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
             for cat in categories:
                 cat["percentage"] = round((cat["amount"] / type_total) * 100, 2) if type_total else 0
                 cat["compare_percentage"] = round((cat["compare_amount"] / compare_type_total) * 100, 2) if compare_type_total else 0
+                cat["diff_percentage"] = round(cat["percentage"] - cat["compare_percentage"], 2)
 
             if type_total or compare_type_total:
-                diff_type = type_total - compare_type_total
-                diff_type_pct = round((diff_type / compare_type_total) * 100, 2) if compare_type_total else 0
-
                 expense_types.append({
                     "code": type_code,
                     "name": type_name,
                     "amount": type_total,
                     "compare_amount": compare_type_total,
-                    "diff_amount": diff_type,
-                    "diff_percentage": diff_type_pct,
+                    "diff_amount": type_total - compare_type_total,
                     "categories": categories,
                 })
 
@@ -154,6 +147,7 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
         for t in expense_types:
             t["percentage"] = round((t["amount"] / total_amount) * 100, 2) if total_amount else 0
             t["compare_percentage"] = round((t["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
+            t["diff_percentage"] = round(t["percentage"] - t["compare_percentage"], 2)
 
         # Summary with comparison
         diff_total = total_amount - compare_total_amount

--- a/budget_appropriation_summary/models/summary_f8w_expense.py
+++ b/budget_appropriation_summary/models/summary_f8w_expense.py
@@ -141,24 +141,25 @@ class BudgetAppropriationSummaryF8WExpense(models.AbstractModel):
                     amount = activity_totals.get(xml_id, 0)
                     compare_amount = compare_activity_totals.get(xml_id, 0)
 
-                    percentage = round((amount / dept_total) * 100, 2) if dept_total else 0
-                    compare_percentage = round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0
+                    diff_amount = amount - compare_amount
                     activities.append({
                         "code": code,
                         "name": name,
                         "amount": amount,
                         "compare_amount": compare_amount,
-                        "diff_amount": amount - compare_amount,
-                        "diff_percentage": round(percentage - compare_percentage, 2),
-                        "percentage": percentage,
-                        "compare_percentage": compare_percentage,
+                        "diff_amount": diff_amount,
+                        "diff_percentage": round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0,
+                        "percentage": round((amount / dept_total) * 100, 2) if dept_total else 0,
+                        "compare_percentage": round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0,
                     })
 
+                diff_dept_amount = dept_total - compare_dept_total
                 departments.append({
                     **dept_info,
                     "amount": dept_total,
                     "compare_amount": compare_dept_total,
-                    "diff_amount": dept_total - compare_dept_total,
+                    "diff_amount": diff_dept_amount,
+                    "diff_percentage": round((diff_dept_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0,
                     "activities": activities,
                 })
 
@@ -168,7 +169,6 @@ class BudgetAppropriationSummaryF8WExpense(models.AbstractModel):
         for dept in departments:
             dept["percentage"] = round((dept["amount"] / total_amount) * 100, 2) if total_amount else 0
             dept["compare_percentage"] = round((dept["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
-            dept["diff_percentage"] = round(dept["percentage"] - dept["compare_percentage"], 2)
 
         # Sort departments by code
         departments = sorted(departments, key=lambda x: x["code"])

--- a/budget_appropriation_summary/models/summary_f8w_expense.py
+++ b/budget_appropriation_summary/models/summary_f8w_expense.py
@@ -207,11 +207,13 @@ class BudgetAppropriationSummaryF8WExpense(models.AbstractModel):
         Returns:
             dict: path_prefix -> xml_id
         """
+        # Use full parent_path (e.g. "1/5/") instead of just "{id}/", otherwise
+        # substring search produces false positives ("12/" matches "112/").
         path_prefix_map = {}
         for xml_id, code, name in self.ACTIVITY_PLANS:
             parent = self.env.ref(xml_id, raise_if_not_found=False)
             if parent:
-                path_prefix_map[f"{parent.id}/"] = xml_id
+                path_prefix_map[parent.parent_path] = xml_id
             else:
                 _logger.warning("Activity plan with xml_id '%s' not found", xml_id)
         return path_prefix_map
@@ -236,9 +238,8 @@ class BudgetAppropriationSummaryF8WExpense(models.AbstractModel):
             activity = line.activity_analytic_id
 
             if top_dept_id and top_dept_id in dept_map and activity and activity.parent_path:
-                # Find which activity plan this belongs to
                 for prefix, xml_id in activity_path_map.items():
-                    if prefix in activity.parent_path or activity.parent_path.startswith(prefix):
+                    if activity.parent_path.startswith(prefix):
                         key = (top_dept_id, xml_id)
                         totals[key] = totals.get(key, 0) + line.balance
                         break

--- a/budget_appropriation_summary/models/summary_f8w_expense.py
+++ b/budget_appropriation_summary/models/summary_f8w_expense.py
@@ -141,29 +141,24 @@ class BudgetAppropriationSummaryF8WExpense(models.AbstractModel):
                     amount = activity_totals.get(xml_id, 0)
                     compare_amount = compare_activity_totals.get(xml_id, 0)
 
-                    diff_amount = amount - compare_amount
-                    diff_percentage = round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0
-
+                    percentage = round((amount / dept_total) * 100, 2) if dept_total else 0
+                    compare_percentage = round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0
                     activities.append({
                         "code": code,
                         "name": name,
                         "amount": amount,
                         "compare_amount": compare_amount,
-                        "diff_amount": diff_amount,
-                        "diff_percentage": diff_percentage,
-                        "percentage": round((amount / dept_total) * 100, 2) if dept_total else 0,
-                        "compare_percentage": round((compare_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0,
+                        "diff_amount": amount - compare_amount,
+                        "diff_percentage": round(percentage - compare_percentage, 2),
+                        "percentage": percentage,
+                        "compare_percentage": compare_percentage,
                     })
-
-                diff_dept_amount = dept_total - compare_dept_total
-                diff_dept_percentage = round((diff_dept_amount / compare_dept_total) * 100, 2) if compare_dept_total else 0
 
                 departments.append({
                     **dept_info,
                     "amount": dept_total,
                     "compare_amount": compare_dept_total,
-                    "diff_amount": diff_dept_amount,
-                    "diff_percentage": diff_dept_percentage,
+                    "diff_amount": dept_total - compare_dept_total,
                     "activities": activities,
                 })
 
@@ -173,6 +168,7 @@ class BudgetAppropriationSummaryF8WExpense(models.AbstractModel):
         for dept in departments:
             dept["percentage"] = round((dept["amount"] / total_amount) * 100, 2) if total_amount else 0
             dept["compare_percentage"] = round((dept["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
+            dept["diff_percentage"] = round(dept["percentage"] - dept["compare_percentage"], 2)
 
         # Sort departments by code
         departments = sorted(departments, key=lambda x: x["code"])

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -74,13 +74,13 @@
                                     <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -80,13 +80,13 @@
                                     <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['percentage'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -78,13 +78,13 @@
                                     <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['percentage'])"/>
                                 </td>
                                 <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -86,13 +86,13 @@
                                     <t t-out="'{0:,.2f}'.format(department['compare_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(department['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(department['amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(department['percentage'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(department['diff_amount'])"/>


### PR DESCRIPTION
## Summary
- Replace growth-rate `diff_percentage` with percentage-point difference (`current_share - compare_share`) for sub-rows and container rows in F2/F4W/F5W/F7W/F8W comparison models, making all three % columns consistent.
- Replace hardcoded `100.0 / 100.0` for container rows in F4W/F7W/F8W and dept rows in F3W/F6W with the actual share-of-total values so the % column is meaningful (especially in F3W/F6W where it was effectively uncomputed).
- Grand total rows keep the growth-rate formula since both shares are always 100/100 there.

## Test plan
- [ ] Open a master summary with a `compare_summary_id` set and verify each report renders correctly
- [ ] F2 รายรับ: category diff % equals current_share − compare_share; grand total diff % is overall growth rate
- [ ] F4W รายรับ: dept rows show share-of-total %; category rows show share-within-dept %; both diff % are pp differences
- [ ] F3W/F6W รายรับ-รายจ่าย: dept rows no longer display 100.0 — show real share-of-total and pp diff
- [ ] F7W รายจ่าย: expense-type rows show share-of-total %; category sub-rows show share-within-type %; diff % is pp diff
- [ ] F8W รายจ่าย: dept rows show share-of-total %; activity sub-rows show share-within-dept %; diff % is pp diff