### PR TITLE
[16.0][ADD] budget_appropriation_mis_builder: integrate with OCA mis_builder

### DIFF
--- a/budget_appropriation_mis_builder/__init__.py
+++ b/budget_appropriation_mis_builder/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/budget_appropriation_mis_builder/__manifest__.py
+++ b/budget_appropriation_mis_builder/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    "name": "Budget Appropriation MIS Builder",
+    "version": "16.0.1.0.0",
+    "summary": "MIS Builder integration for Budget Appropriation",
+    "category": "KMITL/Budgeting",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "budget_appropriation",
+        "mis_builder",
+    ],
+    "data": [
+        "views/budget_appropriation_line_views.xml",
+        "data/mis_report.xml",
+        "data/mis_report_instance.xml",
+        "views/menus.xml",
+    ],
+    "auto_install": False,
+    "application": False,
+    "installable": True,
+    "license": "AGPL-3",
+}

--- a/budget_appropriation_mis_builder/data/mis_report.xml
+++ b/budget_appropriation_mis_builder/data/mis_report.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <!-- MIS Report Template: รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ -->
+    <record id="mis_report_budget_appropriation_expense" model="mis.report">
+        <field name="name">รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ</field>
+        <field name="description">Budget Appropriation - Expense by Budget Type</field>
+        <field
+            name="move_lines_source"
+            ref="budget_appropriation.model_budget_appropriation_line"
+        />
+    </record>
+
+    <!-- KPI: งบบุคลากร (51xxx) -->
+    <record id="mis_kpi_appropriation_personnel" model="mis.report.kpi">
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="name">personnel</field>
+        <field name="description">งบบุคลากร</field>
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="auto_expand_accounts" eval="True" />
+        <field name="sequence">10</field>
+    </record>
+    <record id="mis_kpi_appropriation_personnel_expr" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="mis_kpi_appropriation_personnel" />
+        <field name="name">balp[51%]</field>
+    </record>
+
+    <!-- KPI: งบดำเนินงาน (52xxx) -->
+    <record id="mis_kpi_appropriation_operating" model="mis.report.kpi">
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="name">operating</field>
+        <field name="description">งบดำเนินงาน</field>
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="auto_expand_accounts" eval="True" />
+        <field name="sequence">20</field>
+    </record>
+    <record id="mis_kpi_appropriation_operating_expr" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="mis_kpi_appropriation_operating" />
+        <field name="name">balp[52%]</field>
+    </record>
+
+    <!-- KPI: งบลงทุน (53xxx) -->
+    <record id="mis_kpi_appropriation_capital" model="mis.report.kpi">
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="name">capital</field>
+        <field name="description">งบลงทุน</field>
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="auto_expand_accounts" eval="True" />
+        <field name="sequence">30</field>
+    </record>
+    <record id="mis_kpi_appropriation_capital_expr" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="mis_kpi_appropriation_capital" />
+        <field name="name">balp[53%]</field>
+    </record>
+
+    <!-- KPI: งบเงินอุดหนุน (54xxx) -->
+    <record id="mis_kpi_appropriation_subsidy" model="mis.report.kpi">
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="name">subsidy</field>
+        <field name="description">งบเงินอุดหนุน</field>
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="auto_expand_accounts" eval="True" />
+        <field name="sequence">40</field>
+    </record>
+    <record id="mis_kpi_appropriation_subsidy_expr" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="mis_kpi_appropriation_subsidy" />
+        <field name="name">balp[54%]</field>
+    </record>
+
+    <!-- KPI: งบรายจ่ายอื่น (55xxx) -->
+    <record id="mis_kpi_appropriation_other" model="mis.report.kpi">
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="name">other</field>
+        <field name="description">งบรายจ่ายอื่น</field>
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="auto_expand_accounts" eval="True" />
+        <field name="sequence">50</field>
+    </record>
+    <record id="mis_kpi_appropriation_other_expr" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="mis_kpi_appropriation_other" />
+        <field name="name">balp[55%]</field>
+    </record>
+
+    <!-- KPI: รวมงบประมาณรายจ่าย -->
+    <record id="mis_kpi_appropriation_total" model="mis.report.kpi">
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="name">total_expense</field>
+        <field name="description">รวมงบประมาณรายจ่ายทั้งหมด</field>
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="auto_expand_accounts" eval="False" />
+        <field name="sequence">100</field>
+    </record>
+    <record id="mis_kpi_appropriation_total_expr" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="mis_kpi_appropriation_total" />
+        <field name="name">personnel + operating + capital + subsidy + other</field>
+    </record>
+
+</odoo>

--- a/budget_appropriation_mis_builder/data/mis_report_instance.xml
+++ b/budget_appropriation_mis_builder/data/mis_report_instance.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <!-- Default Report Instance for the Budget Appropriation Expense Report -->
+    <record
+        id="mis_report_instance_budget_appropriation_expense"
+        model="mis.report.instance"
+    >
+        <field name="name">รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ</field>
+        <field name="report_id" ref="mis_report_budget_appropriation_expense" />
+        <field name="target_move">all</field>
+        <field name="temporary" eval="False" />
+    </record>
+
+    <!-- Single period showing current fiscal year -->
+    <record
+        id="mis_report_instance_period_current_year"
+        model="mis.report.instance.period"
+    >
+        <field name="name">ปีปัจจุบัน</field>
+        <field
+            name="report_instance_id"
+            ref="mis_report_instance_budget_appropriation_expense"
+        />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+        <field name="sequence">10</field>
+    </record>
+
+</odoo>

--- a/budget_appropriation_mis_builder/models/__init__.py
+++ b/budget_appropriation_mis_builder/models/__init__.py
@@ -1,0 +1,1 @@
+from . import budget_appropriation_line

--- a/budget_appropriation_mis_builder/models/budget_appropriation_line.py
+++ b/budget_appropriation_mis_builder/models/budget_appropriation_line.py
@@ -1,0 +1,30 @@
+from odoo import api, fields, models
+
+
+class BudgetAppropriationLine(models.Model):
+    _inherit = "budget.appropriation.line"
+
+    debit = fields.Float(
+        string="เดบิต",
+        digits="Budget Precision",
+        compute="_compute_debit_credit",
+        store=True,
+        help="จำนวนเงินฝั่งเดบิต (รายการจัดสรรงบประมาณปกติ)",
+    )
+    credit = fields.Float(
+        string="เครดิต",
+        digits="Budget Precision",
+        compute="_compute_debit_credit",
+        store=True,
+        help="จำนวนเงินฝั่งเครดิต (รายการหักโอน)",
+    )
+
+    @api.depends("balance", "deduct")
+    def _compute_debit_credit(self):
+        for line in self:
+            if line.deduct:
+                line.debit = 0.0
+                line.credit = line.balance
+            else:
+                line.debit = line.balance
+                line.credit = 0.0

--- a/budget_appropriation_mis_builder/views/budget_appropriation_line_views.xml
+++ b/budget_appropriation_mis_builder/views/budget_appropriation_line_views.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- Tree view for budget.appropriation.line with debit/credit columns
+         (for verifying mis_builder integration) -->
+    <record id="view_budget_appropriation_line_mis_tree" model="ir.ui.view">
+        <field name="name">view.budget.appropriation.line.mis.tree</field>
+        <field name="model">budget.appropriation.line</field>
+        <field name="arch" type="xml">
+            <tree create="false" edit="false" delete="false" sample="1">
+                <field name="appropriation_id" optional="show" />
+                <field name="date" optional="show" />
+                <field name="budget_type" optional="show" />
+                <field name="account_id" />
+                <field name="department_analytic_id" optional="show" />
+                <field name="activity_analytic_id" optional="hide" />
+                <field name="fund_analytic_id" optional="hide" />
+                <field name="source_analytic_id" optional="hide" />
+                <field name="deduct" optional="show" />
+                <field name="debit" sum="รวมเดบิต" />
+                <field name="credit" sum="รวมเครดิต" />
+                <field name="balance" sum="รวมยอด" optional="hide" />
+                <field name="parent_state" optional="show" />
+                <field name="company_id" optional="hide" groups="base.group_multi_company" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_budget_appropriation_line_mis" model="ir.actions.act_window">
+        <field name="name">รายการการจัดสรรงบประมาณ (Debit/Credit)</field>
+        <field name="res_model">budget.appropriation.line</field>
+        <field name="view_mode">tree,pivot,graph</field>
+        <field name="view_id" ref="view_budget_appropriation_line_mis_tree" />
+        <field name="context">{}</field>
+    </record>
+
+</odoo>

--- a/budget_appropriation_mis_builder/views/menus.xml
+++ b/budget_appropriation_mis_builder/views/menus.xml
@@ -9,7 +9,7 @@
         sequence="80"
     />
 
-    <!-- Action: open the Budget Appropriation Expense MIS Report instance -->
+    <!-- Action: open the Budget Appropriation Expense MIS Report preview -->
     <record
         id="action_mis_report_budget_appropriation_expense"
         model="ir.actions.act_window"
@@ -17,6 +17,10 @@
         <field name="name">รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ</field>
         <field name="res_model">mis.report.instance</field>
         <field name="view_mode">form</field>
+        <field
+            name="view_id"
+            ref="mis_builder.mis_report_instance_result_view_form"
+        />
         <field
             name="res_id"
             eval="ref('mis_report_instance_budget_appropriation_expense')"

--- a/budget_appropriation_mis_builder/views/menus.xml
+++ b/budget_appropriation_mis_builder/views/menus.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- Parent menu: รายงาน (Reports) under จัดสรรงบประมาณ -->
+    <menuitem
+        id="menu_budget_appropriation_report"
+        name="รายงาน"
+        parent="budget_appropriation.menu_budget_appropriation_root"
+        sequence="80"
+    />
+
+    <!-- Action: open the Budget Appropriation Expense MIS Report instance -->
+    <record
+        id="action_mis_report_budget_appropriation_expense"
+        model="ir.actions.act_window"
+    >
+        <field name="name">รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ</field>
+        <field name="res_model">mis.report.instance</field>
+        <field name="view_mode">form</field>
+        <field
+            name="res_id"
+            eval="ref('mis_report_instance_budget_appropriation_expense')"
+        />
+        <field name="target">current</field>
+    </record>
+
+    <menuitem
+        id="menu_mis_report_budget_appropriation_expense"
+        name="รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ"
+        parent="menu_budget_appropriation_report"
+        action="action_mis_report_budget_appropriation_expense"
+        sequence="10"
+    />
+
+    <!-- Optional: menu to view raw appropriation lines with debit/credit columns -->
+    <menuitem
+        id="menu_budget_appropriation_line_mis"
+        name="รายการการจัดสรรงบประมาณ (Debit/Credit)"
+        parent="menu_budget_appropriation_report"
+        action="action_budget_appropriation_line_mis"
+        sequence="20"
+    />
+
+</odoo>


### PR DESCRIPTION
## Summary
- New module `budget_appropriation_mis_builder` that wires `budget.appropriation.line` into OCA `mis_builder` by adding stored computed `debit`/`credit` fields (non-deduct -> debit, deduct -> credit).
- Defines a MIS Report template **รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ** with five expense-category KPIs (51xxx personnel, 52xxx operating, 53xxx capital, 54xxx subsidy, 55xxx other) plus a total, and a default report instance with a yearly period.
- Adds a **รายงาน** sub-menu under **จัดสรรงบประมาณ** with the report action and a debit/credit tree view of appropriation lines.

## Test plan
- [ ] Install `budget_appropriation_mis_builder`; verify `debit`/`credit` columns appear on `budget.appropriation.line` and equal `balance` (non-deduct) or move to `credit` for deduct lines.
- [ ] Navigate to **จัดสรรงบประมาณ → รายงาน → รายงานการจัดสรรงบประมาณรายจ่าย แยกตามประเภทงบประมาณ** and click **Preview**; KPI rows should match per-account sums from posted/draft appropriations.
- [ ] Switch `target_move` and date range; values update accordingly.