### PR TITLE
[16.0][IMP] disbursement: prevent duplicate bill/payment on DR

### DIFF
--- a/disbursement_accounting_kmitl/models/disbursement_request.py
+++ b/disbursement_accounting_kmitl/models/disbursement_request.py
@@ -238,6 +238,16 @@ class DisbursementRequest(models.Model):
         return super().action_cancel()
 
     def action_create_bill(self):
+        self.ensure_one()
+        existing_bills = self.bill_ids.filtered(lambda b: b.state != "cancel")
+        if existing_bills:
+            raise UserError(
+                _(
+                    "Cannot create new bill: existing bill(s) %s are still "
+                    "in progress. Cancel them first before creating a new one."
+                )
+                % ", ".join(existing_bills.mapped("name"))
+            )
         bills = self._create_bill()
         if len(bills) == 1:
             return {

--- a/disbursement_finance_kmitl/models/disbursement_request.py
+++ b/disbursement_finance_kmitl/models/disbursement_request.py
@@ -130,6 +130,16 @@ class DisbursementRequest(models.Model):
     def action_create_payment(self):
         """Create draft payments directly from DR, one per posted unpaid bill."""
         self.ensure_one()
+        existing_payments = self.payment_ids
+        if existing_payments:
+            raise UserError(
+                _(
+                    "Cannot create new payment: existing payment(s) %s are "
+                    "still in progress. Cancel them first before creating a "
+                    "new one."
+                )
+                % ", ".join(existing_payments.mapped("name"))
+            )
         unpaid_bills = self.bill_ids.filtered(
             lambda b: b.state == "posted"
             and b.payment_state in ("not_paid", "partial")


### PR DESCRIPTION
## Summary
- เพิ่มการตรวจสอบ backend ใน `action_create_bill` และ `action_create_payment` ของ `disbursement.request` ให้ block การสร้างซ้ำเมื่อมี bill/payment เดิมที่ยัง in-progress (state != cancel) อยู่
- เดิมมีการป้องกันเฉพาะระดับ UI (`attrs=\"invisible\"`) ทำให้ยังสามารถสร้างซ้ำผ่าน RPC, double-click, หรือ server action ได้
- ใช้ field เดิม (`bill_ids`, `payment_ids`) — `payment_ids` เป็น computed ที่กรอง state cancel ออกอยู่แล้ว

## Test plan
- [ ] สร้าง DR, approve, กด "Create Bill" → ได้ bill (draft)
- [ ] เรียก `action_create_bill` ซ้ำ → ต้อง raise UserError แจ้งชื่อ bill ที่ค้างอยู่
- [ ] Cancel bill → สร้างใหม่ได้ปกติ
- [ ] Post bill, กด "Create Payment" → ได้ payment (draft)
- [ ] เรียก `action_create_payment` ซ้ำ → ต้อง raise UserError แจ้งชื่อ payment ที่ค้างอยู่
- [ ] Cancel payment → สร้างใหม่ได้ปกติ
- [ ] Regression: flow ปกติ (create bill → post → create payment → post → reconcile) ทำงานได้