### PR TITLE
[16.0][FIX] purchase_work_acceptance_kmitl: missing dep + dev depends

### DIFF
--- a/kmitl_depends_dev/__manifest__.py
+++ b/kmitl_depends_dev/__manifest__.py
@@ -32,7 +32,12 @@
                 'purchase_guarantee_kmitl',
                 'purchase_manual_delivery_security', 'purchase_manual_delivery_work_acceptance',
                 'purchase_operating_unit_access_all', 'purchase_order_disbursement',
-                'purchase_order_disbursement_budget'],
+                'purchase_order_disbursement_budget', 'web_responsive',
+                'advance_payment_disbursement', 'agx_approval_disbursement',
+                'disbursement_accounting_kmitl', 'disbursement_finance_kmitl',
+                'disbursement_sarabun', 'purchase_order_disbursement_auto_submit',
+                'purchase_request_approval_disbursement_budget',
+                'purchase_work_acceptance_disbursement', 'web_chatter_position'],
     'data': [
 
     ],

--- a/purchase_work_acceptance_kmitl/__manifest__.py
+++ b/purchase_work_acceptance_kmitl/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Purchase Work Acceptance Kmitl",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "summary": """ Purchase Work Acceptance Kmitl Summary """,
     "category": "KMITL",
     "author": "Aginix Technologies",
@@ -16,6 +16,7 @@
         'thai_date_utils',
         'l10n_th_amount_to_text',
         'purchase_kmitl',
+        'purchase_order_received_qty_percent',
     ],
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
## Summary
- **Fix** `purchase_work_acceptance_kmitl`: declare missing dependency on `purchase_order_received_qty_percent`. The view inherit references the `received_qty_percent` field on the PO line tree, which would otherwise fail xpath validation on a fresh DB install (`Element <xpath ... received_qty_percent> cannot be located in parent view`).
- **Dev** `kmitl_depends_dev`: pull in disbursement bridges (`advance_payment_disbursement`, `agx_approval_disbursement`, `disbursement_accounting_kmitl`, `disbursement_finance_kmitl`, `disbursement_sarabun`, `purchase_order_disbursement_auto_submit`, `purchase_request_approval_disbursement_budget`, `purchase_work_acceptance_disbursement`) and web UX helpers (`web_responsive`, `web_chatter_position`).

## Test plan
- [ ] Drop / recreate DB and install `kmitl_demo` — module install completes without xpath ParseError on `purchase_work_acceptance_kmitl/views/purchase_order_views.xml`.
- [ ] Install `kmitl_depends_dev` — all newly added modules install cleanly; PO line tree, DR/PO/WA flows behave normally.