### PR TITLE
[16.0][ADD] budget_appropriation_summary_dashboard: interactive portal

### DIFF
--- a/budget_appropriation_summary_dashboard/__init__.py
+++ b/budget_appropriation_summary_dashboard/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/budget_appropriation_summary_dashboard/__manifest__.py
+++ b/budget_appropriation_summary_dashboard/__manifest__.py
@@ -1,0 +1,24 @@
+{
+    "name": "Budget Appropriation Summary Dashboard",
+    "version": "16.0.1.0.0",
+    "summary": "Interactive portal dashboard for budget appropriation overview",
+    "category": "KMITL/Budgeting",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "budget_appropriation_summary",
+        "portal",
+    ],
+    "data": [
+        "views/portal_summary_templates.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "budget_appropriation_summary_dashboard/static/src/portal_summary/**/*",
+        ],
+    },
+    "auto_install": False,
+    "application": False,
+    "installable": True,
+    "license": "AGPL-3",
+}

--- a/budget_appropriation_summary_dashboard/controllers/__init__.py
+++ b/budget_appropriation_summary_dashboard/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal_summary

--- a/budget_appropriation_summary_dashboard/controllers/portal_summary.py
+++ b/budget_appropriation_summary_dashboard/controllers/portal_summary.py
@@ -1,0 +1,51 @@
+import json
+
+from odoo import http
+from odoo.http import request
+
+
+class BudgetAppropriationPortalSummaryController(http.Controller):
+    """Public portal page for an interactive budget appropriation overview.
+
+    Independent of the backend dashboard controller; data is provided by
+    :class:`~odoo.addons.budget_appropriation_summary_dashboard.models.budget_appropriation_portal_summary.BudgetAppropriationPortalSummary`.
+    """
+
+    _FILTER_KEYS = (
+        "fiscal_year_id",
+        "department_id",
+        "source_id",
+    )
+
+    def _collect_filters(self, kw):
+        return {key: kw.get(key) for key in self._FILTER_KEYS if kw.get(key)}
+
+    @http.route(
+        "/budget/appropriation/portal_summary",
+        type="http",
+        auth="user",
+        website=True,
+    )
+    def portal_summary(self, **kw):
+        filters = self._collect_filters(kw)
+        payload = request.env["budget.appropriation.portal.summary"].get_summary(
+            filters
+        )
+        return request.render(
+            "budget_appropriation_summary_dashboard.portal_summary_page",
+            {
+                "payload": payload,
+                "payload_json": json.dumps(payload),
+            },
+        )
+
+    @http.route(
+        "/budget/appropriation/portal_summary/data",
+        type="json",
+        auth="user",
+    )
+    def portal_summary_data(self, **kw):
+        filters = self._collect_filters(kw)
+        return request.env["budget.appropriation.portal.summary"].get_summary(
+            filters
+        )

--- a/budget_appropriation_summary_dashboard/models/__init__.py
+++ b/budget_appropriation_summary_dashboard/models/__init__.py
@@ -1,0 +1,1 @@
+from . import budget_appropriation_portal_summary

--- a/budget_appropriation_summary_dashboard/models/budget_appropriation_portal_summary.py
+++ b/budget_appropriation_summary_dashboard/models/budget_appropriation_portal_summary.py
@@ -1,0 +1,893 @@
+from collections import defaultdict
+
+from odoo import api, fields, models
+
+
+class BudgetAppropriationPortalSummary(models.AbstractModel):
+    """Self-contained data provider for the public portal summary dashboard.
+
+    Independent of the backend dashboard controller. All aggregation is done
+    inside this model so the portal route is a thin renderer.
+
+    The payload is organised into three namespaces (``overview``, ``revenue``,
+    ``expense``) to match the three tabs on the portal page.
+    """
+
+    _name = "budget.appropriation.portal.summary"
+    _description = "Budget Appropriation Portal Summary"
+
+    # Expense root accounts that drive the category breakdown shown on the
+    # dashboard. Order is significant for stacked-bar visualisations.
+    EXPENSE_CATEGORY_CODES = [
+        ("51000", "งบบุคลากร"),
+        ("52000", "งบดำเนินงาน"),
+        ("53000", "งบลงทุน"),
+        ("54000", "งบเงินอุดหนุน"),
+        ("55000", "งบรายจ่ายอื่น"),
+        ("07020", "งบกองทุนสำรอง"),
+    ]
+    PERSONNEL_CATEGORY_CODE = "51000"
+
+    # Revenue deduct lines (หักโอน / 99000) cannot be classified by category
+    # because they do not carry activity/fund context. By convention they are
+    # subtracted directly from this category code (matches F2/F4P/F4W reports).
+    REVENUE_DEDUCT_BUCKET_CODE = "43100 (ก)"
+
+    TOP_ITEMS_LIMIT = 15
+    TOP_DEPT_LIMIT = 15
+    # Cap Sankey links to keep the chart readable.
+    SANKEY_LINK_LIMIT = 80
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    @api.model
+    def get_summary(self, filters=None):
+        """Build the full payload consumed by the portal page (HTML + JSON).
+
+        :param dict filters: optional dict with keys:
+            ``fiscal_year_id``, ``source_id``, ``department_id``.
+        :returns: dict with ``filter_options``, ``filters`` (echoed back)
+            and ``stats`` (overview, revenue, expense namespaces).
+        """
+        filters = self._normalize_filters(filters or {})
+        filter_options = self._get_filter_options()
+        # Defaults: latest fiscal year, first source (budget is viewed per-source).
+        if not filters.get("fiscal_year_id") and filter_options["fiscal_years"]:
+            filters["fiscal_year_id"] = filter_options["fiscal_years"][0]["id"]
+        if not filters.get("source_id") and filter_options["sources"]:
+            filters["source_id"] = filter_options["sources"][0]["id"]
+
+        lines = self._search_lines(filters)
+        stats = self._compute_stats(lines, filters)
+        return {
+            "filter_options": filter_options,
+            "filters": filters,
+            "stats": stats,
+        }
+
+    # ------------------------------------------------------------------
+    # Filter handling
+    # ------------------------------------------------------------------
+    @api.model
+    def _normalize_filters(self, filters):
+        normalized = {}
+        for key in (
+            "fiscal_year_id",
+            "department_id",
+            "source_id",
+        ):
+            raw = filters.get(key)
+            try:
+                normalized[key] = int(raw) if raw not in (None, "", False) else None
+            except (TypeError, ValueError):
+                normalized[key] = None
+        return normalized
+
+    @api.model
+    def _get_filter_options(self):
+        AnalyticAccount = self.env["account.analytic.account"]
+        # Restrict the year/source dropdowns to combinations that actually
+        # have a master summary, otherwise a user could pick a value that
+        # would always return zero rows.
+        compilations = self.env["budget.appropriation.compilation"].search(
+            [("master_summary_id", "!=", False)]
+        )
+        fiscal_years = compilations.mapped("account_fiscal_year_id").sorted(
+            key=lambda fy: fy.date_from or fields.Date.today(), reverse=True
+        )
+        sources = compilations.mapped("source_analytic_id").sorted("code")
+        # Departments level 1 = no parent
+        departments = AnalyticAccount.search(
+            [
+                ("root_plan_id.code", "=", "departments"),
+                ("parent_id", "=", False),
+            ],
+            order="code",
+        )
+        return {
+            "fiscal_years": [
+                {"id": fy.id, "name": fy.name} for fy in fiscal_years
+            ],
+            "departments": [
+                {"id": d.id, "code": d.code, "name": d.name}
+                for d in departments
+            ],
+            "sources": [
+                {"id": s.id, "code": s.code, "name": s.name} for s in sources
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Data fetch
+    # ------------------------------------------------------------------
+    @api.model
+    def _search_lines(self, filters):
+        """Return appropriation lines bound to a master summary.
+
+        Only lines whose appropriation is referenced by a
+        ``budget.appropriation.compilation`` attached to a
+        ``budget.appropriation.master.summary`` are returned. Fiscal year
+        and source filter the compilations directly; department is applied
+        at the line level so sub-hierarchy filtering keeps working.
+        """
+        AnalyticAccount = self.env["account.analytic.account"]
+        Compilation = self.env["budget.appropriation.compilation"]
+        Line = self.env["budget.appropriation.line"]
+
+        comp_domain = [("master_summary_id", "!=", False)]
+        if filters.get("fiscal_year_id"):
+            comp_domain.append(
+                ("account_fiscal_year_id", "=", filters["fiscal_year_id"])
+            )
+        if filters.get("source_id"):
+            comp_domain.append(
+                ("source_analytic_id", "=", filters["source_id"])
+            )
+        compilations = Compilation.search(comp_domain)
+        if not compilations:
+            return Line.browse()
+
+        appropriation_ids = list(
+            set(
+                compilations.mapped("revenue_appropriation_ids").ids
+                + compilations.mapped("expense_appropriation_ids").ids
+            )
+        )
+        if not appropriation_ids:
+            return Line.browse()
+
+        line_domain = [("appropriation_id", "in", appropriation_ids)]
+        if filters.get("department_id"):
+            dept = AnalyticAccount.browse(filters["department_id"])
+            if dept.exists():
+                dept_ids = AnalyticAccount.search(
+                    [("parent_path", "=like", f"{dept.parent_path}%")]
+                ).ids
+                line_domain.append(("department_analytic_id", "in", dept_ids))
+        return Line.search(line_domain)
+
+    # ------------------------------------------------------------------
+    # Aggregation orchestration
+    # ------------------------------------------------------------------
+    @api.model
+    def _compute_stats(self, lines, filters):
+        revenue_lines = lines.filtered(lambda l: l.budget_type == "revenue")
+        expense_lines = lines.filtered(
+            lambda l: l.budget_type == "expense" and not l.deduct
+        )
+
+        revenue_stats = self._build_revenue_stats(revenue_lines)
+        expense_stats = self._build_expense_stats(expense_lines)
+        kpi = {
+            "total_revenue_gross": revenue_stats["totals"]["gross"],
+            "total_revenue_deduct": revenue_stats["totals"]["deduct"],
+            "total_revenue": revenue_stats["totals"]["net"],
+            "total_expense": expense_stats["totals"]["total"],
+        }
+        context = self._build_context(filters)
+        return {
+            "kpi": kpi,
+            "context": context,
+            "revenue": revenue_stats,
+            "expense": expense_stats,
+        }
+
+    @api.model
+    def _build_context(self, filters):
+        ctx = {"fiscal_year_name": "", "source_name": ""}
+        if filters.get("fiscal_year_id"):
+            fy = self.env["account.fiscal.year"].browse(
+                filters["fiscal_year_id"]
+            )
+            if fy.exists():
+                ctx["fiscal_year_name"] = fy.name
+        if filters.get("source_id"):
+            src = self.env["account.analytic.account"].browse(
+                filters["source_id"]
+            )
+            if src.exists():
+                ctx["source_name"] = src.name
+        return ctx
+
+    # ------------------------------------------------------------------
+    # Revenue stats
+    # ------------------------------------------------------------------
+    @api.model
+    def _build_revenue_stats(self, revenue_lines):
+        # Per-line totals split by deduct flag
+        gross = 0.0
+        deduct = 0.0
+        # Revenue by root account (43100 (ก), 43300, ...)
+        root_totals = defaultdict(float)
+        root_meta = {}
+        # Per-department gross / deduct (level-1 dept on the appropriation)
+        dept_gross = defaultdict(float)
+        dept_deduct = defaultdict(float)
+        dept_meta = {}
+        # Sankey flow: source dept → deduct (recipient) dept
+        flow_links = defaultdict(float)
+        flow_dept_meta = {}
+        # Top revenue items
+        items = []
+        # Dept × revenue-category matrix (non-deduct only)
+        dept_cat = defaultdict(lambda: defaultdict(float))
+
+        for line in revenue_lines:
+            balance = line.balance or 0.0
+            dept = line.department_analytic_id
+            dept_root = self._root(dept)
+            if line.deduct:
+                deduct += balance
+                if dept_root:
+                    dept_deduct[dept_root.id] += balance
+                    dept_meta[dept_root.id] = {
+                        "code": dept_root.code,
+                        "name": dept_root.name,
+                    }
+                recipient = line.deduct_analytic_id
+                recipient_root = self._root(recipient)
+                if dept_root and recipient_root:
+                    key = (dept_root.id, recipient_root.id)
+                    flow_links[key] += balance
+                    flow_dept_meta[dept_root.id] = {
+                        "code": dept_root.code,
+                        "name": dept_root.name,
+                    }
+                    flow_dept_meta[recipient_root.id] = {
+                        "code": recipient_root.code,
+                        "name": recipient_root.name,
+                    }
+            else:
+                gross += balance
+                if dept_root:
+                    dept_gross[dept_root.id] += balance
+                    dept_meta[dept_root.id] = {
+                        "code": dept_root.code,
+                        "name": dept_root.name,
+                    }
+                root_account = line.account_id
+                while root_account.parent_id:
+                    root_account = root_account.parent_id
+                if root_account:
+                    root_totals[root_account.id] += balance
+                    root_meta[root_account.id] = {
+                        "code": root_account.code,
+                        "name": root_account.name,
+                    }
+                if dept_root and root_account:
+                    dept_cat[dept_root.id][root_account.id] += balance
+            # Track top-N items regardless of deduct flag
+            items.append(
+                {
+                    "code": line.account_id.code or "",
+                    "name": line.account_id.name or "",
+                    "department": dept_root.name if dept_root else "",
+                    "department_code": dept_root.code if dept_root else "",
+                    "is_deduct": bool(line.deduct),
+                    "value": round(balance, 2),
+                }
+            )
+
+        # Apply the 43100 (ก) deduct rule to revenue by category
+        if deduct:
+            bucket = self.env["budget.account"].search(
+                [("code", "=", self.REVENUE_DEDUCT_BUCKET_CODE)],
+                limit=1,
+            )
+            if bucket:
+                root_totals[bucket.id] = (
+                    root_totals.get(bucket.id, 0.0) - deduct
+                )
+                root_meta.setdefault(
+                    bucket.id,
+                    {"code": bucket.code, "name": bucket.name},
+                )
+
+        by_category = sorted(
+            [
+                {
+                    "name": root_meta[rid]["name"],
+                    "code": root_meta[rid]["code"],
+                    "value": round(amt, 2),
+                }
+                for rid, amt in root_totals.items()
+                if amt
+            ],
+            key=lambda x: x["value"],
+            reverse=True,
+        )
+
+        # Per-department gross/net (sorted by gross desc)
+        per_department = sorted(
+            [
+                {
+                    "id": did,
+                    "code": dept_meta[did]["code"],
+                    "name": dept_meta[did]["name"],
+                    "gross": round(dept_gross.get(did, 0.0), 2),
+                    "deduct": round(dept_deduct.get(did, 0.0), 2),
+                    "net": round(
+                        dept_gross.get(did, 0.0) - dept_deduct.get(did, 0.0),
+                        2,
+                    ),
+                }
+                for did in set(dept_gross) | set(dept_deduct)
+            ],
+            key=lambda x: x["gross"],
+            reverse=True,
+        )
+
+        # Sankey: nodes + links
+        sankey_nodes = []
+        sankey_links = []
+        if flow_links:
+            # Add a "src:" prefix to source nodes and "dst:" to destination
+            # nodes to avoid collisions when the same dept appears on both
+            # sides of a transfer.
+            for did, meta in flow_dept_meta.items():
+                pass
+            # Build node lists
+            src_ids = {key[0] for key in flow_links}
+            dst_ids = {key[1] for key in flow_links}
+            node_index = {}
+            for did in sorted(src_ids):
+                meta = flow_dept_meta[did]
+                name = f"[{meta['code']}] {meta['name']} (ต้นทาง)"
+                node_index[("src", did)] = len(sankey_nodes)
+                sankey_nodes.append({"name": name})
+            for did in sorted(dst_ids):
+                meta = flow_dept_meta[did]
+                name = f"[{meta['code']}] {meta['name']} (ปลายทาง)"
+                node_index[("dst", did)] = len(sankey_nodes)
+                sankey_nodes.append({"name": name})
+            for (src_id, dst_id), amount in flow_links.items():
+                if not amount:
+                    continue
+                sankey_links.append(
+                    {
+                        "source": sankey_nodes[node_index[("src", src_id)]][
+                            "name"
+                        ],
+                        "target": sankey_nodes[node_index[("dst", dst_id)]][
+                            "name"
+                        ],
+                        "value": round(amount, 2),
+                    }
+                )
+
+        items.sort(key=lambda x: x["value"], reverse=True)
+        top_items = items[: self.TOP_ITEMS_LIMIT]
+
+        # Dept × revenue-category heatmap (top depts only, all 43xxx categories)
+        dept_category_heatmap = self._build_dept_revenue_heatmap(
+            dept_cat, dept_meta, root_meta, by_category
+        )
+
+        return {
+            "totals": {
+                "gross": round(gross, 2),
+                "deduct": round(deduct, 2),
+                "net": round(gross - deduct, 2),
+            },
+            "by_category": by_category,
+            "per_department": per_department,
+            "deduct_flow": {"nodes": sankey_nodes, "links": sankey_links},
+            "dept_category_heatmap": dept_category_heatmap,
+            "top_items": top_items,
+        }
+
+    @api.model
+    def _build_dept_revenue_heatmap(self, dept_cat, dept_meta, root_meta, by_category):
+        """Build a heatmap where columns are revenue categories and rows are
+        level-1 departments (top 15 by total non-deduct revenue)."""
+        if not dept_cat or not by_category:
+            return {"x": [], "y": [], "data": [], "max": 0}
+        # Use the sorted by_category order so column order matches the donut
+        # (largest categories on the left).
+        cat_order = [c["code"] for c in by_category]
+        code_to_root_id = {meta["code"]: rid for rid, meta in root_meta.items()}
+        # Pick top departments by their total revenue contribution
+        dept_totals = [
+            (did, sum(cats.values())) for did, cats in dept_cat.items()
+        ]
+        dept_totals.sort(key=lambda t: t[1], reverse=True)
+        top_depts = [did for did, _ in dept_totals[: self.TOP_DEPT_LIMIT]]
+        x_labels = [c["name"] for c in by_category]
+        y_labels = [
+            f"[{dept_meta[did]['code']}] {dept_meta[did]['name']}"
+            for did in top_depts
+        ]
+        data = []
+        max_value = 0.0
+        for y_idx, did in enumerate(top_depts):
+            for x_idx, code in enumerate(cat_order):
+                rid = code_to_root_id.get(code)
+                value = dept_cat[did].get(rid, 0.0) if rid else 0.0
+                if value:
+                    rounded = round(value, 2)
+                    data.append([x_idx, y_idx, rounded])
+                    if rounded > max_value:
+                        max_value = rounded
+        return {
+            "x": x_labels,
+            "y": y_labels,
+            "data": data,
+            "max": max_value,
+        }
+
+    # ------------------------------------------------------------------
+    # Expense stats
+    # ------------------------------------------------------------------
+    @api.model
+    def _build_expense_stats(self, expense_lines):
+        cat_lookup = self._expense_category_lookup()
+        category_label_map = dict(self.EXPENSE_CATEGORY_CODES)
+
+        total = 0.0
+        category_totals = defaultdict(float)
+        dept_amounts = defaultdict(lambda: defaultdict(float))
+        dept_meta = {}
+        fund_totals = defaultdict(float)
+        fund_meta = {}
+        activity_totals = defaultdict(float)
+        activity_meta = {}
+        items = []
+        # 3-stage Sankey: (fund_root, dept_root) and (dept_root, cat_code)
+        sankey_fund_dept = defaultdict(float)
+        sankey_dept_cat = defaultdict(float)
+        # Dept × Activity (level-1) heatmap
+        dept_activity_l1 = defaultdict(lambda: defaultdict(float))
+        activity_l1_meta = {}
+        # Activity sunburst: nested {l0_id: {l1_id: {l2_id: amount}}}
+        sunburst_amounts = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(float))
+        )
+        activity_node_meta = {}
+
+        for line in expense_lines:
+            balance = line.balance or 0.0
+            total += balance
+            cat_key = cat_lookup.get(line.account_id.id)
+            dept_root = self._root(line.department_analytic_id)
+            fund_root = self._root(line.fund_analytic_id)
+            activity_root = self._root(line.activity_analytic_id)
+            activity_chain = self._ancestor_chain(line.activity_analytic_id)
+            if dept_root and cat_key:
+                dept_amounts[dept_root.id][cat_key] += balance
+                dept_meta[dept_root.id] = {
+                    "code": dept_root.code,
+                    "name": dept_root.name,
+                }
+                category_totals[cat_key] += balance
+                # Stage 2 of Sankey: dept → category
+                sankey_dept_cat[(dept_root.id, cat_key)] += balance
+            if fund_root:
+                fund_totals[fund_root.id] += balance
+                fund_meta[fund_root.id] = {
+                    "code": fund_root.code,
+                    "name": fund_root.name,
+                }
+            if activity_root:
+                activity_totals[activity_root.id] += balance
+                activity_meta[activity_root.id] = {
+                    "code": activity_root.code,
+                    "name": activity_root.name,
+                }
+            if dept_root and fund_root:
+                # Stage 1 of Sankey: fund → dept
+                sankey_fund_dept[(fund_root.id, dept_root.id)] += balance
+            # Dept × Activity level-1 (แผนงาน). If the line's activity
+            # is at level 0 (just a ด้าน without แผนงาน), fall back to
+            # using level 0 as the column.
+            if dept_root and activity_chain:
+                l1 = activity_chain[1] if len(activity_chain) > 1 else activity_chain[0]
+                dept_activity_l1[dept_root.id][l1.id] += balance
+                activity_l1_meta[l1.id] = {
+                    "code": l1.code,
+                    "name": l1.name,
+                }
+            # Sunburst: level 0 → level 1 → level 2
+            if activity_chain:
+                l0 = activity_chain[0]
+                l1 = activity_chain[1] if len(activity_chain) > 1 else None
+                l2 = activity_chain[2] if len(activity_chain) > 2 else None
+                if l0 and l1 and l2:
+                    sunburst_amounts[l0.id][l1.id][l2.id] += balance
+                elif l0 and l1:
+                    sunburst_amounts[l0.id][l1.id][None] += balance
+                elif l0:
+                    sunburst_amounts[l0.id][None][None] += balance
+                for node in (l0, l1, l2):
+                    if node:
+                        activity_node_meta[node.id] = {
+                            "code": node.code,
+                            "name": node.name,
+                        }
+            items.append(
+                {
+                    "code": line.account_id.code or "",
+                    "name": line.account_id.name or "",
+                    "department": dept_root.name if dept_root else "",
+                    "department_code": dept_root.code if dept_root else "",
+                    "fund": fund_root.name if fund_root else "",
+                    "value": round(balance, 2),
+                }
+            )
+
+        by_category = [
+            {
+                "name": category_label_map[code],
+                "code": code,
+                "value": round(category_totals.get(code, 0.0), 2),
+            }
+            for code, _label in self.EXPENSE_CATEGORY_CODES
+            if category_totals.get(code)
+        ]
+
+        dept_totals = [
+            {
+                "id": did,
+                "code": dept_meta[did]["code"],
+                "name": dept_meta[did]["name"],
+                "value": round(sum(cats.values()), 2),
+                "breakdown": {
+                    code: round(cats.get(code, 0.0), 2)
+                    for code, _ in self.EXPENSE_CATEGORY_CODES
+                },
+            }
+            for did, cats in dept_amounts.items()
+        ]
+        dept_totals.sort(key=lambda x: x["value"], reverse=True)
+
+        # Personnel-vs-other stacked bar per dept (uses category code 51000)
+        personnel_ratio = []
+        for dept in dept_totals:
+            personnel = dept["breakdown"].get(self.PERSONNEL_CATEGORY_CODE, 0.0)
+            other = dept["value"] - personnel
+            personnel_ratio.append(
+                {
+                    "id": dept["id"],
+                    "code": dept["code"],
+                    "name": dept["name"],
+                    "personnel": round(personnel, 2),
+                    "other": round(other, 2),
+                    "total": dept["value"],
+                    "pct_personnel": round(
+                        personnel / dept["value"] * 100, 1
+                    )
+                    if dept["value"]
+                    else 0.0,
+                }
+            )
+
+        heatmap = self._build_heatmap(dept_totals)
+
+        fund_pie = sorted(
+            [
+                {
+                    "name": fund_meta[fid]["name"],
+                    "code": fund_meta[fid]["code"],
+                    "value": round(amt, 2),
+                }
+                for fid, amt in fund_totals.items()
+                if amt
+            ],
+            key=lambda x: x["value"],
+            reverse=True,
+        )
+        activity_bar = sorted(
+            [
+                {
+                    "name": activity_meta[aid]["name"],
+                    "code": activity_meta[aid]["code"],
+                    "value": round(amt, 2),
+                }
+                for aid, amt in activity_totals.items()
+                if amt
+            ],
+            key=lambda x: x["value"],
+            reverse=True,
+        )
+
+        items.sort(key=lambda x: x["value"], reverse=True)
+        top_items = items[: self.TOP_ITEMS_LIMIT]
+
+        # Concentration: share captured by top-5 departments
+        sorted_totals = sorted(
+            (d["value"] for d in dept_totals), reverse=True
+        )
+        top5 = sum(sorted_totals[:5])
+        concentration_pct = round(top5 / total * 100, 1) if total else 0.0
+
+        # 3-stage Sankey: fund → dept → category
+        fund_dept_cat_sankey = self._build_fund_dept_cat_sankey(
+            sankey_fund_dept,
+            sankey_dept_cat,
+            fund_meta,
+            dept_meta,
+            category_label_map,
+        )
+        # Dept × Activity-level-1 heatmap
+        dept_activity_heatmap = self._build_dept_activity_heatmap(
+            dept_activity_l1, dept_meta, activity_l1_meta
+        )
+        # Activity sunburst (3 levels: ด้าน → แผนงาน → กิจกรรมหลัก)
+        activity_sunburst = self._build_activity_sunburst(
+            sunburst_amounts, activity_node_meta
+        )
+
+        return {
+            "totals": {"total": round(total, 2)},
+            "by_category": by_category,
+            "department_bar": dept_totals[: self.TOP_DEPT_LIMIT],
+            "department_table": dept_totals,
+            "fund_pie": fund_pie,
+            "activity_bar": activity_bar,
+            "heatmap": heatmap,
+            "personnel_ratio": personnel_ratio,
+            "top_items": top_items,
+            "categories": [
+                {"code": code, "name": label}
+                for code, label in self.EXPENSE_CATEGORY_CODES
+            ],
+            "concentration": {
+                "top5_pct": concentration_pct,
+                "total_dept_count": len(dept_totals),
+            },
+            "fund_dept_cat_sankey": fund_dept_cat_sankey,
+            "dept_activity_heatmap": dept_activity_heatmap,
+            "activity_sunburst": activity_sunburst,
+        }
+
+    @api.model
+    def _build_fund_dept_cat_sankey(
+        self, fund_dept, dept_cat, fund_meta, dept_meta, category_label_map
+    ):
+        """Build 3-stage Sankey: fund → department → expense category.
+
+        Each set of links is built independently from the raw aggregates so
+        the chart respects the per-edge totals. Edges are capped at
+        ``SANKEY_LINK_LIMIT`` per stage (largest values kept).
+        """
+        if not fund_dept or not dept_cat:
+            return {"nodes": [], "links": []}
+
+        fund_label = lambda fid: f"กองทุน: [{fund_meta[fid]['code']}] {fund_meta[fid]['name']}"
+        dept_label = lambda did: f"หน่วยงาน: [{dept_meta[did]['code']}] {dept_meta[did]['name']}"
+        cat_label = lambda code: f"หมวด: [{code}] {category_label_map.get(code, code)}"
+
+        # Stage 1: keep top-N links by value
+        s1 = sorted(fund_dept.items(), key=lambda kv: kv[1], reverse=True)[
+            : self.SANKEY_LINK_LIMIT
+        ]
+        s2 = sorted(dept_cat.items(), key=lambda kv: kv[1], reverse=True)[
+            : self.SANKEY_LINK_LIMIT
+        ]
+        node_names = set()
+        for (fid, did), _ in s1:
+            node_names.add(fund_label(fid))
+            node_names.add(dept_label(did))
+        for (did, code), _ in s2:
+            node_names.add(dept_label(did))
+            node_names.add(cat_label(code))
+
+        nodes = [{"name": n} for n in sorted(node_names)]
+        links = []
+        for (fid, did), amount in s1:
+            if amount:
+                links.append(
+                    {
+                        "source": fund_label(fid),
+                        "target": dept_label(did),
+                        "value": round(amount, 2),
+                    }
+                )
+        for (did, code), amount in s2:
+            if amount:
+                links.append(
+                    {
+                        "source": dept_label(did),
+                        "target": cat_label(code),
+                        "value": round(amount, 2),
+                    }
+                )
+        return {"nodes": nodes, "links": links}
+
+    @api.model
+    def _build_dept_activity_heatmap(
+        self, dept_activity_l1, dept_meta, activity_l1_meta
+    ):
+        """Heatmap: rows = top departments, columns = activity level-1 (แผนงาน)."""
+        if not dept_activity_l1 or not activity_l1_meta:
+            return {"x": [], "y": [], "data": [], "max": 0}
+        # Sort columns by descending total to put the bigger programs first
+        activity_totals = defaultdict(float)
+        for cats in dept_activity_l1.values():
+            for aid, amt in cats.items():
+                activity_totals[aid] += amt
+        col_ids = sorted(
+            activity_l1_meta.keys(),
+            key=lambda aid: activity_totals[aid],
+            reverse=True,
+        )
+        x_labels = [activity_l1_meta[aid]["name"] for aid in col_ids]
+        # Rows: top departments by total
+        dept_totals_local = [
+            (did, sum(cats.values()))
+            for did, cats in dept_activity_l1.items()
+        ]
+        dept_totals_local.sort(key=lambda t: t[1], reverse=True)
+        row_ids = [did for did, _ in dept_totals_local[: self.TOP_DEPT_LIMIT]]
+        y_labels = [
+            f"[{dept_meta[did]['code']}] {dept_meta[did]['name']}"
+            for did in row_ids
+        ]
+        data = []
+        max_value = 0.0
+        for y_idx, did in enumerate(row_ids):
+            for x_idx, aid in enumerate(col_ids):
+                value = dept_activity_l1[did].get(aid, 0.0)
+                if value:
+                    rounded = round(value, 2)
+                    data.append([x_idx, y_idx, rounded])
+                    if rounded > max_value:
+                        max_value = rounded
+        return {
+            "x": x_labels,
+            "y": y_labels,
+            "data": data,
+            "max": max_value,
+        }
+
+    @api.model
+    def _build_activity_sunburst(self, sunburst_amounts, node_meta):
+        """Build nested ECharts sunburst data with up to 3 rings.
+
+        Drops the synthetic ``None`` sentinel used for lines that stop at
+        level 0/1, but their amount still flows up to the parent ring.
+        """
+        if not sunburst_amounts:
+            return []
+        result = []
+        for l0_id, l1_map in sunburst_amounts.items():
+            l0_children = []
+            for l1_id, l2_map in l1_map.items():
+                if l1_id is None:
+                    # amount stays at level 0 — represented by a leaf child
+                    leaf_amount = l2_map.get(None, 0.0)
+                    if leaf_amount:
+                        l0_children.append(
+                            {"name": "(ไม่ระบุแผนงาน)", "value": round(leaf_amount, 2)}
+                        )
+                    continue
+                meta_l1 = node_meta.get(l1_id, {})
+                l1_children = []
+                for l2_id, amount in l2_map.items():
+                    if l2_id is None:
+                        if amount:
+                            l1_children.append(
+                                {
+                                    "name": "(ไม่ระบุกิจกรรมหลัก)",
+                                    "value": round(amount, 2),
+                                }
+                            )
+                        continue
+                    meta_l2 = node_meta.get(l2_id, {})
+                    if amount:
+                        l1_children.append(
+                            {
+                                "name": meta_l2.get("name", "?"),
+                                "value": round(amount, 2),
+                            }
+                        )
+                l0_children.append(
+                    {
+                        "name": meta_l1.get("name", "?"),
+                        "children": l1_children,
+                    }
+                )
+            meta_l0 = node_meta.get(l0_id, {})
+            result.append(
+                {
+                    "name": meta_l0.get("name", "?"),
+                    "children": l0_children,
+                }
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @api.model
+    def _expense_category_lookup(self):
+        """Map every expense account id to its root category code.
+
+        Looks up the five expense roots plus the reserve fund root once,
+        then walks ``parent_path`` to bucket descendants. Builds a single
+        dict so per-line lookups stay O(1).
+        """
+        BudgetAccount = self.env["budget.account"]
+        codes = [c for c, _ in self.EXPENSE_CATEGORY_CODES]
+        roots = BudgetAccount.search([("code", "in", codes)])
+        if not roots:
+            return {}
+        root_path_to_code = {r.parent_path: r.code for r in roots}
+        descendants = BudgetAccount.search(
+            ["|"] * (len(roots) - 1)
+            + [
+                ("parent_path", "=like", f"{r.parent_path}%") for r in roots
+            ]
+        )
+        lookup = {}
+        for desc in descendants:
+            for path, code in root_path_to_code.items():
+                if desc.parent_path.startswith(path):
+                    lookup[desc.id] = code
+                    break
+        return lookup
+
+    @staticmethod
+    def _root(record):
+        cur = record
+        while cur and cur.parent_id:
+            cur = cur.parent_id
+        return cur or None
+
+    @staticmethod
+    def _ancestor_chain(record):
+        """Return ancestors top-down: [level_0, level_1, ..., record]."""
+        chain = []
+        cur = record
+        while cur:
+            chain.append(cur)
+            cur = cur.parent_id
+        chain.reverse()
+        return chain
+
+    @api.model
+    def _build_heatmap(self, dept_totals):
+        if not dept_totals:
+            return {"x": [], "y": [], "data": [], "max": 0}
+        depts = [d for d in dept_totals if d["value"]]
+        x_codes = [c for c, _ in self.EXPENSE_CATEGORY_CODES]
+        x_labels = [label for _, label in self.EXPENSE_CATEGORY_CODES]
+        y_labels = [
+            f"[{d['code']}] {d['name']}" if d.get("code") else d["name"]
+            for d in depts
+        ]
+        data = []
+        max_value = 0.0
+        for y_idx, dept in enumerate(depts):
+            for x_idx, code in enumerate(x_codes):
+                value = dept["breakdown"].get(code, 0.0)
+                if value:
+                    data.append([x_idx, y_idx, value])
+                    if value > max_value:
+                        max_value = value
+        return {
+            "x": x_labels,
+            "y": y_labels,
+            "data": data,
+            "max": max_value,
+        }

--- a/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.js
+++ b/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.js
@@ -55,9 +55,6 @@
             this.payload = this._readPayload();
             this.charts = {};
             this.activeTab = this._readTabFromUrl() || "overview";
-            // Switch the portal layout's .container into full-width mode.
-            // Scoped by the body class so it doesn't leak to other pages.
-            document.body.classList.add("bap-fullwidth");
             this._setUpdated();
             this._bindFilters();
             this._bindTabs();

--- a/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.js
+++ b/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.js
@@ -1,0 +1,685 @@
+/** @odoo-module **/
+/*
+ * Portal-only summary dashboard for budget appropriation.
+ * 3 tabs: Overview / Revenue / Expense — shared filter bar.
+ * Plain DOM + fetch, ECharts loaded from CDN.
+ * Intentionally independent from the backend dashboard component.
+ */
+
+(function () {
+    "use strict";
+
+    const ECHARTS_URL = "https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js";
+    const REVENUE_COLORS = ["#28a745", "#20c997", "#17a2b8", "#0dcaf0", "#6610f2", "#ffc107", "#fd7e14"];
+    const CATEGORY_COLORS = ["#0d6efd", "#20c997", "#fd7e14", "#6f42c1", "#dc3545", "#198754"];
+    const FUND_COLORS = ["#198754", "#20c997", "#0dcaf0", "#6f42c1", "#fd7e14", "#dc3545", "#0d6efd", "#ffc107"];
+    const ACTIVITY_COLORS = ["#0d6efd", "#6610f2", "#6f42c1", "#d63384", "#dc3545", "#198754"];
+
+    function loadECharts() {
+        if (typeof window.echarts !== "undefined") return Promise.resolve();
+        return new Promise((resolve) => {
+            const script = document.createElement("script");
+            script.src = ECHARTS_URL;
+            script.onload = resolve;
+            script.onerror = () => {
+                console.error("Failed to load ECharts");
+                resolve();
+            };
+            document.head.appendChild(script);
+        });
+    }
+
+    function formatNumber(n) {
+        if (!isFinite(n)) return "0";
+        return new Intl.NumberFormat("th-TH", {maximumFractionDigits: 0}).format(Math.round(n));
+    }
+
+    function formatCompact(n) {
+        const abs = Math.abs(n);
+        if (abs >= 1e9) return (n / 1e9).toFixed(2) + " พันล้าน";
+        if (abs >= 1e6) return (n / 1e6).toFixed(2) + " ล้าน";
+        if (abs >= 1e3) return (n / 1e3).toFixed(1) + "K";
+        return formatNumber(n);
+    }
+
+    function emptyOption(text) {
+        return {
+            title: {text: text || "ไม่มีข้อมูล", left: "center", top: "center", textStyle: {color: "#adb5bd", fontSize: 14}},
+            series: [],
+        };
+    }
+
+    class PortalSummary {
+        constructor(root) {
+            this.root = root;
+            this.payload = this._readPayload();
+            this.charts = {};
+            this.activeTab = this._readTabFromUrl() || "overview";
+            // Switch the portal layout's .container into full-width mode.
+            // Scoped by the body class so it doesn't leak to other pages.
+            document.body.classList.add("bap-fullwidth");
+            this._setUpdated();
+            this._bindFilters();
+            this._bindTabs();
+            this._activateTab(this.activeTab, false);
+            this._render();
+            window.addEventListener("resize", () => this._resizeAll());
+        }
+
+        _readPayload() {
+            try {
+                return JSON.parse(this.root.dataset.payload || "{}");
+            } catch (e) {
+                console.error("Invalid portal payload", e);
+                return {};
+            }
+        }
+
+        _readTabFromUrl() {
+            const m = window.location.hash.match(/tab=(overview|revenue|expense)/);
+            return m ? m[1] : null;
+        }
+
+        _setUpdated() {
+            const el = this.root.querySelector("#bapSummaryUpdated");
+            if (el) el.textContent = "อัปเดต: " + new Date().toLocaleString("th-TH");
+        }
+
+        _bindFilters() {
+            const filterEl = this.root.querySelector("#bapSummaryFilters");
+            if (!filterEl) return;
+            filterEl.querySelectorAll("select[data-filter]").forEach((sel) => {
+                sel.addEventListener("change", () => this._fetch());
+            });
+            const resetBtn = this.root.querySelector("#bapSummaryReset");
+            if (resetBtn) {
+                resetBtn.addEventListener("click", () => {
+                    filterEl.querySelectorAll("select[data-filter]").forEach((sel) => {
+                        if (sel.dataset.required) return; // keep required selections
+                        if (sel.dataset.filter === "fiscal_year_id") return;
+                        sel.value = "";
+                    });
+                    this._fetch();
+                });
+            }
+        }
+
+        _bindTabs() {
+            const nav = this.root.querySelector("#bapTabs");
+            if (!nav) return;
+            nav.querySelectorAll("a[data-tab]").forEach((a) => {
+                a.addEventListener("click", (ev) => {
+                    ev.preventDefault();
+                    this._activateTab(a.dataset.tab, true);
+                });
+            });
+        }
+
+        _activateTab(tab, pushHash) {
+            this.activeTab = tab;
+            this.root.querySelectorAll("#bapTabs a[data-tab]").forEach((a) => {
+                a.classList.toggle("active", a.dataset.tab === tab);
+            });
+            this.root.querySelectorAll(".bap-tab-pane").forEach((pane) => {
+                pane.classList.toggle("d-none", pane.dataset.pane !== tab);
+            });
+            if (pushHash) {
+                window.location.hash = "tab=" + tab;
+            }
+            // Re-render the visible tab's charts (lazy resize/init).
+            this._renderTab(tab);
+        }
+
+        _readFilters() {
+            const out = {};
+            this.root.querySelectorAll("#bapSummaryFilters select[data-filter]").forEach((sel) => {
+                if (sel.value) out[sel.dataset.filter] = sel.value;
+            });
+            return out;
+        }
+
+        async _fetch() {
+            const params = this._readFilters();
+            this.root.classList.add("opacity-50");
+            try {
+                const resp = await fetch("/budget/appropriation/portal_summary/data", {
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify({jsonrpc: "2.0", method: "call", params: params}),
+                });
+                const json = await resp.json();
+                if (json && json.result) {
+                    this.payload = json.result;
+                    this._setUpdated();
+                    this._render();
+                }
+            } catch (err) {
+                console.error("Failed to load summary data", err);
+            } finally {
+                this.root.classList.remove("opacity-50");
+            }
+        }
+
+        _render() {
+            const stats = (this.payload && this.payload.stats) || {};
+            this._renderKpi(stats.kpi || {});
+            this._renderConcentration(stats.expense || {});
+            this._renderExpenseDetailTable(stats.expense || {});
+            this._renderRevenueItemsTable(stats.revenue || {});
+            this._renderExpenseItemsTable(stats.expense || {});
+            if (typeof window.echarts !== "undefined") {
+                this._renderTab(this.activeTab);
+            }
+        }
+
+        _renderTab(tab) {
+            if (typeof window.echarts === "undefined") return;
+            const stats = (this.payload && this.payload.stats) || {};
+            const revenue = stats.revenue || {};
+            const expense = stats.expense || {};
+            // Small delay so the pane is visible before sizing charts.
+            setTimeout(() => {
+                if (tab === "overview") {
+                    this._renderRevExp(stats.kpi || {});
+                    this._renderDonut("#bapChartOverviewRevenue", revenue.by_category || [], REVENUE_COLORS);
+                    this._renderDonut("#bapChartOverviewExpense", expense.by_category || [], CATEGORY_COLORS);
+                } else if (tab === "revenue") {
+                    this._renderDonut("#bapChartRevCategory", revenue.by_category || [], REVENUE_COLORS, true);
+                    this._renderRevByDept(revenue.per_department || []);
+                    this._renderDeductFlow(revenue.deduct_flow || {});
+                    this._renderGenericHeatmap(
+                        "#bapChartRevDeptCatHeatmap",
+                        revenue.dept_category_heatmap || {},
+                        ["#f2fbf3", "#28a745", "#0f3d1d"]
+                    );
+                } else if (tab === "expense") {
+                    this._renderDonut("#bapChartExpCategory", expense.by_category || [], CATEGORY_COLORS);
+                    this._renderDonut("#bapChartExpFund", expense.fund_pie || [], FUND_COLORS);
+                    this._renderActivity("#bapChartExpActivity", expense.activity_bar || []);
+                    this._renderTopDept(expense.department_bar || []);
+                    this._renderPersonnel(expense.personnel_ratio || []);
+                    this._renderHeatmap(expense.heatmap || {});
+                    this._renderFundDeptCatSankey(expense.fund_dept_cat_sankey || {});
+                    this._renderGenericHeatmap(
+                        "#bapChartExpDeptActivity",
+                        expense.dept_activity_heatmap || {},
+                        ["#fff4e6", "#fd7e14", "#5a2700"]
+                    );
+                    this._renderSunburst(expense.activity_sunburst || []);
+                }
+                this._resizeAll();
+            }, 50);
+        }
+
+        _setKpi(name, text) {
+            this.root.querySelectorAll(`[data-kpi="${name}"]`).forEach((el) => {
+                el.textContent = text;
+            });
+        }
+
+        _renderKpi(kpi) {
+            this._setKpi("total_revenue", formatNumber(kpi.total_revenue || 0));
+            this._setKpi("total_revenue_gross", formatNumber(kpi.total_revenue_gross || 0));
+            this._setKpi("total_revenue_deduct", formatNumber(kpi.total_revenue_deduct || 0));
+            this._setKpi("total_expense", formatNumber(kpi.total_expense || 0));
+        }
+
+        _renderConcentration(expense) {
+            const concentration = expense.concentration || {};
+            this._setKpi("exp_top5_pct", (concentration.top5_pct || 0).toFixed(1) + "%");
+            this._setKpi("exp_dept_count", concentration.total_dept_count || 0);
+            // Personnel / Other percentage over all expense
+            const total = (expense.totals && expense.totals.total) || 0;
+            let personnel = 0;
+            (expense.by_category || []).forEach((c) => {
+                if (c.code === "51000") personnel = c.value;
+            });
+            const personnelPct = total ? (personnel / total) * 100 : 0;
+            const otherPct = total ? 100 - personnelPct : 0;
+            this._setKpi("exp_personnel_pct", personnelPct.toFixed(1) + "%");
+            this._setKpi("exp_other_pct", otherPct.toFixed(1) + "%");
+            const pBar = this.root.querySelector('[data-progress="personnel"]');
+            const oBar = this.root.querySelector('[data-progress="other"]');
+            if (pBar) pBar.style.width = personnelPct.toFixed(2) + "%";
+            if (oBar) oBar.style.width = otherPct.toFixed(2) + "%";
+        }
+
+        _getChart(selector) {
+            const dom = this.root.querySelector(selector);
+            if (!dom) return null;
+            if (this.charts[selector]) return this.charts[selector];
+            const inst = window.echarts.init(dom);
+            this.charts[selector] = inst;
+            return inst;
+        }
+
+        _resizeAll() {
+            Object.values(this.charts).forEach((c) => c && c.resize());
+        }
+
+        _renderRevExp(kpi) {
+            const chart = this._getChart("#bapChartRevExp");
+            if (!chart) return;
+            const data = [
+                {name: "รายรับสุทธิ", value: kpi.total_revenue || 0},
+                {name: "รายจ่ายรวม", value: kpi.total_expense || 0},
+            ];
+            chart.setOption({
+                tooltip: {trigger: "item", formatter: (p) => `${p.name}: ${formatNumber(p.value)} (${p.percent}%)`},
+                legend: {bottom: 0},
+                color: ["#28a745", "#dc3545"],
+                series: [{
+                    type: "pie",
+                    radius: ["45%", "75%"],
+                    center: ["50%", "45%"],
+                    itemStyle: {borderRadius: 6, borderColor: "#fff", borderWidth: 2},
+                    label: {formatter: "{d}%", position: "inside", color: "#fff", fontWeight: "bold"},
+                    data: data,
+                }],
+            }, true);
+        }
+
+        _renderDonut(selector, data, colors, withLegend) {
+            const chart = this._getChart(selector);
+            if (!chart) return;
+            if (!data.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            chart.setOption({
+                tooltip: {
+                    trigger: "item",
+                    formatter: (p) => {
+                        const code = p.data && p.data.code ? `[${p.data.code}] ` : "";
+                        return `${code}${p.name}<br/>${formatNumber(p.value)} (${p.percent}%)`;
+                    },
+                },
+                legend: withLegend
+                    ? {orient: "vertical", left: 0, top: "middle", textStyle: {fontSize: 11}}
+                    : {bottom: 0, textStyle: {fontSize: 11}, type: "scroll"},
+                color: colors,
+                series: [{
+                    type: "pie",
+                    radius: ["40%", "70%"],
+                    center: withLegend ? ["65%", "50%"] : ["50%", "45%"],
+                    itemStyle: {borderRadius: 4, borderColor: "#fff", borderWidth: 2},
+                    label: {formatter: "{d}%"},
+                    data: data,
+                }],
+            }, true);
+        }
+
+        _renderActivity(selector, data) {
+            const chart = this._getChart(selector);
+            if (!chart) return;
+            if (!data.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            const sorted = data.slice().sort((a, b) => a.value - b.value);
+            chart.setOption({
+                grid: {left: 140, right: 60, top: 10, bottom: 30},
+                xAxis: {type: "value", axisLabel: {formatter: (v) => formatCompact(v)}},
+                yAxis: {type: "category", data: sorted.map((d) => d.name), axisLabel: {fontSize: 10, width: 130, overflow: "truncate"}},
+                tooltip: {trigger: "item", formatter: (p) => `${p.name}<br/>${formatNumber(p.value)} บาท`},
+                series: [{
+                    type: "bar",
+                    data: sorted.map((d, i) => ({value: d.value, itemStyle: {color: ACTIVITY_COLORS[i % ACTIVITY_COLORS.length]}})),
+                    itemStyle: {borderRadius: [0, 4, 4, 0]},
+                    label: {show: true, position: "right", formatter: (p) => formatCompact(p.value), fontSize: 10},
+                }],
+            }, true);
+        }
+
+        _renderTopDept(data) {
+            const chart = this._getChart("#bapChartExpTopDept");
+            if (!chart) return;
+            if (!data.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            const sorted = data.slice().sort((a, b) => a.value - b.value);
+            chart.setOption({
+                grid: {left: 200, right: 80, top: 10, bottom: 30},
+                xAxis: {type: "value", axisLabel: {formatter: (v) => formatCompact(v)}},
+                yAxis: {
+                    type: "category",
+                    data: sorted.map((d) => `[${d.code}] ${d.name}`),
+                    axisLabel: {fontSize: 11, width: 190, overflow: "truncate"},
+                },
+                tooltip: {trigger: "item", formatter: (p) => `${p.name}<br/>รายจ่าย: ${formatNumber(p.value)} บาท`},
+                series: [{
+                    type: "bar",
+                    data: sorted.map((d) => d.value),
+                    itemStyle: {color: "#dc3545", borderRadius: [0, 4, 4, 0]},
+                    label: {show: true, position: "right", formatter: (p) => formatCompact(p.value), fontSize: 10},
+                }],
+            }, true);
+        }
+
+        _renderPersonnel(data) {
+            const chart = this._getChart("#bapChartExpPersonnel");
+            if (!chart) return;
+            if (!data.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            const limited = data.slice(0, 15).reverse();
+            const labels = limited.map((d) => `[${d.code}] ${d.name}`);
+            chart.setOption({
+                grid: {left: 180, right: 50, top: 30, bottom: 30},
+                tooltip: {
+                    trigger: "axis", axisPointer: {type: "shadow"},
+                    formatter: (params) => {
+                        const lines = [params[0].axisValue];
+                        params.forEach((p) => {
+                            lines.push(`${p.marker} ${p.seriesName}: ${formatNumber(p.value)}`);
+                        });
+                        return lines.join("<br/>");
+                    },
+                },
+                legend: {data: ["บุคลากร", "อื่น ๆ"], top: 0},
+                xAxis: {type: "value", axisLabel: {formatter: (v) => formatCompact(v)}},
+                yAxis: {type: "category", data: labels, axisLabel: {fontSize: 11, width: 170, overflow: "truncate"}},
+                series: [
+                    {
+                        name: "บุคลากร", type: "bar", stack: "x",
+                        data: limited.map((d) => d.personnel),
+                        itemStyle: {color: "#0d6efd"},
+                        label: {
+                            show: true, position: "insideLeft", color: "#fff", fontSize: 10,
+                            formatter: (p) => p.value > 0 ? `${limited[p.dataIndex].pct_personnel.toFixed(0)}%` : "",
+                        },
+                    },
+                    {
+                        name: "อื่น ๆ", type: "bar", stack: "x",
+                        data: limited.map((d) => d.other),
+                        itemStyle: {color: "#adb5bd"},
+                    },
+                ],
+            }, true);
+        }
+
+        _renderHeatmap(data) {
+            this._renderGenericHeatmap(
+                "#bapChartExpHeatmap",
+                data,
+                ["#f0f4ff", "#0d6efd", "#0a2972"]
+            );
+        }
+
+        _renderGenericHeatmap(selector, data, colors) {
+            const chart = this._getChart(selector);
+            if (!chart) return;
+            if (!data || !data.x || !data.y || !data.x.length || !data.y.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            chart.setOption({
+                tooltip: {
+                    position: "top",
+                    formatter: (p) => `${data.y[p.value[1]]}<br/>${data.x[p.value[0]]}<br/>${formatNumber(p.value[2])} บาท`,
+                },
+                grid: {left: 220, right: 40, top: 60, bottom: 30},
+                xAxis: {
+                    type: "category", data: data.x, splitArea: {show: true},
+                    axisLabel: {fontSize: 11, interval: 0, rotate: data.x.length > 6 ? 20 : 0},
+                    position: "top",
+                },
+                yAxis: {type: "category", data: data.y, splitArea: {show: true}, axisLabel: {fontSize: 10, width: 210, overflow: "truncate"}},
+                visualMap: {
+                    min: 0, max: data.max || 1, calculable: true, orient: "horizontal",
+                    left: "center", bottom: 0,
+                    inRange: {color: colors},
+                    formatter: (v) => formatCompact(v),
+                },
+                series: [{
+                    type: "heatmap",
+                    data: data.data,
+                    label: {show: true, formatter: (p) => p.value[2] > 0 ? formatCompact(p.value[2]) : "", fontSize: 9},
+                    emphasis: {itemStyle: {shadowBlur: 10, shadowColor: "rgba(0,0,0,0.3)"}},
+                }],
+            }, true);
+        }
+
+        _renderFundDeptCatSankey(data) {
+            const chart = this._getChart("#bapChartExpFundDeptCat");
+            if (!chart) return;
+            if (!data || !data.nodes || !data.nodes.length || !data.links || !data.links.length) {
+                chart.setOption(emptyOption("ไม่มีข้อมูลในตัวกรองนี้"), true);
+                return;
+            }
+            chart.setOption({
+                tooltip: {
+                    trigger: "item",
+                    formatter: (p) => {
+                        if (p.dataType === "edge") {
+                            return `${p.data.source}<br/>→ ${p.data.target}<br/>${formatNumber(p.data.value)} บาท`;
+                        }
+                        return p.data.name;
+                    },
+                },
+                series: [{
+                    type: "sankey",
+                    left: 10, right: 220, top: 10, bottom: 10,
+                    nodeAlign: "justify",
+                    nodeGap: 8,
+                    data: data.nodes,
+                    links: data.links,
+                    label: {fontSize: 10},
+                    lineStyle: {color: "gradient", curveness: 0.5, opacity: 0.55},
+                    emphasis: {focus: "adjacency"},
+                }],
+            }, true);
+        }
+
+        _renderSunburst(data) {
+            const chart = this._getChart("#bapChartExpActivitySunburst");
+            if (!chart) return;
+            if (!data || !data.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            chart.setOption({
+                tooltip: {
+                    formatter: (p) => `${p.treePathInfo.map((n) => n.name).filter(Boolean).join(" / ")}<br/>${formatNumber(p.value)} บาท`,
+                },
+                series: [{
+                    type: "sunburst",
+                    radius: ["10%", "92%"],
+                    sort: (a, b) => b.value - a.value,
+                    data: data,
+                    emphasis: {focus: "ancestor"},
+                    levels: [
+                        {},
+                        {r0: "10%", r: "40%", itemStyle: {borderWidth: 2}, label: {rotate: "tangential", fontSize: 12}},
+                        {r0: "40%", r: "70%", itemStyle: {borderWidth: 1}, label: {fontSize: 10}},
+                        {r0: "70%", r: "92%", label: {position: "outside", padding: 3, silent: false, fontSize: 9}, itemStyle: {borderWidth: 1}},
+                    ],
+                    label: {minAngle: 12},
+                }],
+            }, true);
+        }
+
+        // ------------- Revenue charts -------------
+        _renderRevByDept(data) {
+            const chart = this._getChart("#bapChartRevByDept");
+            if (!chart) return;
+            if (!data.length) {
+                chart.setOption(emptyOption(), true);
+                return;
+            }
+            const limited = data.slice(0, 15).reverse();
+            const labels = limited.map((d) => `[${d.code}] ${d.name}`);
+            chart.setOption({
+                grid: {left: 180, right: 60, top: 30, bottom: 30},
+                tooltip: {
+                    trigger: "axis", axisPointer: {type: "shadow"},
+                    formatter: (params) => {
+                        const lines = [params[0].axisValue];
+                        params.forEach((p) => {
+                            lines.push(`${p.marker} ${p.seriesName}: ${formatNumber(p.value)}`);
+                        });
+                        return lines.join("<br/>");
+                    },
+                },
+                legend: {data: ["รายรับสุทธิ", "หักโอน"], top: 0},
+                xAxis: {type: "value", axisLabel: {formatter: (v) => formatCompact(v)}},
+                yAxis: {type: "category", data: labels, axisLabel: {fontSize: 11, width: 170, overflow: "truncate"}},
+                series: [
+                    {
+                        name: "รายรับสุทธิ", type: "bar", stack: "x",
+                        data: limited.map((d) => d.net),
+                        itemStyle: {color: "#28a745"},
+                        label: {show: true, position: "insideLeft", color: "#fff", fontSize: 10, formatter: (p) => p.value > 0 ? formatCompact(p.value) : ""},
+                    },
+                    {
+                        name: "หักโอน", type: "bar", stack: "x",
+                        data: limited.map((d) => d.deduct),
+                        itemStyle: {color: "#fd7e14"},
+                        label: {show: true, position: "insideRight", color: "#fff", fontSize: 10, formatter: (p) => p.value > 0 ? formatCompact(p.value) : ""},
+                    },
+                ],
+            }, true);
+        }
+
+        _renderDeductFlow(data) {
+            const chart = this._getChart("#bapChartRevDeductFlow");
+            if (!chart) return;
+            if (!data || !data.nodes || !data.nodes.length || !data.links || !data.links.length) {
+                chart.setOption(emptyOption("ไม่มีรายการหักโอนในตัวกรองนี้"), true);
+                return;
+            }
+            // Cap to top 50 links by value to keep chart readable
+            const links = data.links.slice().sort((a, b) => b.value - a.value).slice(0, 50);
+            const usedNames = new Set();
+            links.forEach((l) => {
+                usedNames.add(l.source);
+                usedNames.add(l.target);
+            });
+            const nodes = data.nodes.filter((n) => usedNames.has(n.name));
+            chart.setOption({
+                tooltip: {
+                    trigger: "item",
+                    formatter: (p) => {
+                        if (p.dataType === "edge") {
+                            return `${p.data.source}<br/>→ ${p.data.target}<br/>${formatNumber(p.data.value)} บาท`;
+                        }
+                        return p.data.name;
+                    },
+                },
+                series: [{
+                    type: "sankey",
+                    left: 20, right: 200, top: 20, bottom: 20,
+                    nodeAlign: "justify",
+                    data: nodes,
+                    links: links,
+                    label: {fontSize: 11},
+                    lineStyle: {color: "gradient", curveness: 0.5},
+                    emphasis: {focus: "adjacency"},
+                }],
+            }, true);
+        }
+
+        // ------------- Tables -------------
+        _renderRevenueItemsTable(revenue) {
+            const tbody = this.root.querySelector("#bapTableRevenueItems tbody");
+            if (!tbody) return;
+            const items = revenue.top_items || [];
+            tbody.innerHTML = "";
+            if (!items.length) {
+                tbody.innerHTML = `<tr><td colspan="5" class="text-center text-muted py-3">ไม่มีข้อมูล</td></tr>`;
+                return;
+            }
+            items.forEach((row, idx) => {
+                const tr = document.createElement("tr");
+                if (row.is_deduct) tr.classList.add("table-warning");
+                tr.innerHTML = `
+                    <td>${idx + 1}</td>
+                    <td><code>${row.code || "-"}</code> ${row.is_deduct ? '<span class="badge text-bg-warning">หักโอน</span>' : ''}</td>
+                    <td>${row.name || ""}</td>
+                    <td><span class="text-muted small">[${row.department_code || "-"}]</span> ${row.department || ""}</td>
+                    <td class="text-end fw-semibold">${formatNumber(row.value || 0)}</td>`;
+                tbody.appendChild(tr);
+            });
+        }
+
+        _renderExpenseItemsTable(expense) {
+            const tbody = this.root.querySelector("#bapTableExpenseItems tbody");
+            if (!tbody) return;
+            const items = expense.top_items || [];
+            tbody.innerHTML = "";
+            if (!items.length) {
+                tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted py-3">ไม่มีข้อมูล</td></tr>`;
+                return;
+            }
+            items.forEach((row, idx) => {
+                const tr = document.createElement("tr");
+                tr.innerHTML = `
+                    <td>${idx + 1}</td>
+                    <td><code>${row.code || "-"}</code></td>
+                    <td>${row.name || ""}</td>
+                    <td><span class="text-muted small">[${row.department_code || "-"}]</span> ${row.department || ""}</td>
+                    <td class="small text-muted">${row.fund || ""}</td>
+                    <td class="text-end fw-semibold">${formatNumber(row.value || 0)}</td>`;
+                tbody.appendChild(tr);
+            });
+        }
+
+        _renderExpenseDetailTable(expense) {
+            const table = this.root.querySelector("#bapSummaryTable");
+            if (!table) return;
+            const categories = expense.categories || [];
+            const rows = expense.department_table || [];
+            const tbody = table.querySelector("tbody");
+            const totals = {};
+            let grand = 0;
+            categories.forEach((c) => (totals[c.code] = 0));
+
+            tbody.innerHTML = "";
+            rows.forEach((row) => {
+                const tr = document.createElement("tr");
+                const tdName = document.createElement("td");
+                tdName.innerHTML = `<span class="dept-code">[${row.code || "-"}]</span> ${row.name || ""}`;
+                tr.appendChild(tdName);
+                categories.forEach((c) => {
+                    const v = (row.breakdown || {})[c.code] || 0;
+                    totals[c.code] += v;
+                    const td = document.createElement("td");
+                    td.className = "amount-cell text-end" + (v ? "" : " zero");
+                    td.textContent = v ? formatNumber(v) : "-";
+                    tr.appendChild(td);
+                });
+                const tdTotal = document.createElement("td");
+                tdTotal.className = "amount-cell text-end fw-semibold";
+                tdTotal.textContent = formatNumber(row.value || 0);
+                tr.appendChild(tdTotal);
+                grand += row.value || 0;
+                tbody.appendChild(tr);
+            });
+
+            categories.forEach((c) => {
+                const footCell = table.querySelector(`[data-foot="${c.code}"]`);
+                if (footCell) footCell.textContent = formatNumber(totals[c.code] || 0);
+            });
+            const grandCell = table.querySelector('[data-foot="total"]');
+            if (grandCell) grandCell.textContent = formatNumber(grand);
+
+            if (!rows.length) {
+                tbody.innerHTML = `<tr><td colspan="${categories.length + 2}" class="text-center text-muted py-3">ไม่มีข้อมูล</td></tr>`;
+            }
+        }
+    }
+
+    function boot() {
+        const root = document.getElementById("bapSummaryRoot");
+        if (!root) return;
+        loadECharts().then(() => new PortalSummary(root));
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", boot);
+    } else {
+        boot();
+    }
+})();

--- a/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.scss
+++ b/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.scss
@@ -1,26 +1,3 @@
-// When the portal summary is mounted, body gets the .bap-fullwidth class
-// (set in portal_summary.js). portal.portal_layout wraps content in TWO
-// nested .container divs (#wrap > .container.mb64 → .container.o_portal_sidebar),
-// both of which constrain max-width. Strip max-width + horizontal padding
-// from every .container variant under our scope so the dashboard fills
-// the viewport without the 100vw scrollbar-overflow problem.
-body.bap-fullwidth {
-    .container,
-    .container-sm, .container-md, .container-lg,
-    .container-xl, .container-xxl {
-        max-width: 95% !important;
-    }
-    #wrap > .container {
-        margin-bottom: 0 !important;
-    }
-    // Hide the portal breadcrumb bar (rendered by portal.portal_layout as
-    // <div class="o_portal container mt-3">). The o_portal_sidebar element
-    // uses a different class so it's unaffected.
-    > .o_portal {
-        display: none !important;
-    }
-}
-
 .bap-summary {
     background-color: #f6f7fb;
     min-height: 100vh;

--- a/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.scss
+++ b/budget_appropriation_summary_dashboard/static/src/portal_summary/portal_summary.scss
@@ -1,0 +1,98 @@
+// When the portal summary is mounted, body gets the .bap-fullwidth class
+// (set in portal_summary.js). portal.portal_layout wraps content in TWO
+// nested .container divs (#wrap > .container.mb64 → .container.o_portal_sidebar),
+// both of which constrain max-width. Strip max-width + horizontal padding
+// from every .container variant under our scope so the dashboard fills
+// the viewport without the 100vw scrollbar-overflow problem.
+body.bap-fullwidth {
+    .container,
+    .container-sm, .container-md, .container-lg,
+    .container-xl, .container-xxl {
+        max-width: 95% !important;
+    }
+    #wrap > .container {
+        margin-bottom: 0 !important;
+    }
+    // Hide the portal breadcrumb bar (rendered by portal.portal_layout as
+    // <div class="o_portal container mt-3">). The o_portal_sidebar element
+    // uses a different class so it's unaffected.
+    > .o_portal {
+        display: none !important;
+    }
+}
+
+.bap-summary {
+    background-color: #f6f7fb;
+    min-height: 100vh;
+
+    .card-header {
+        border-bottom: 1px solid #eef0f4;
+    }
+
+    .nav-tabs {
+        .nav-link {
+            color: #495057;
+            border-bottom: 2px solid transparent;
+            &.active {
+                background-color: transparent;
+                border-color: transparent transparent #0d6efd;
+                color: #0d6efd;
+                font-weight: 600;
+            }
+        }
+    }
+
+    .kpi-card {
+        border-left: 4px solid transparent;
+
+        .kpi-label {
+            color: #6c757d;
+            font-size: 0.85rem;
+            margin-bottom: 0.25rem;
+        }
+        .kpi-value {
+            font-size: 1.6rem;
+            font-weight: 600;
+            line-height: 1.2;
+        }
+        .kpi-sub {
+            margin-top: 0.15rem;
+        }
+
+        &.kpi-revenue { border-left-color: #28a745; }
+        &.kpi-expense { border-left-color: #dc3545; }
+    }
+
+    .bap-chart {
+        width: 100%;
+        height: 280px;
+    }
+    .bap-chart-lg { height: 440px; }
+    .bap-chart-xl { height: 560px; }
+
+    table {
+        font-size: 0.85rem;
+
+        td.amount-cell,
+        th.text-end {
+            font-variant-numeric: tabular-nums;
+        }
+        td.zero { color: #adb5bd; }
+        .dept-code {
+            color: #6c757d;
+            font-size: 0.75rem;
+        }
+    }
+
+    .progress {
+        background-color: #e9ecef;
+        border-radius: 4px;
+        overflow: hidden;
+        .progress-bar {
+            font-size: 0.85rem;
+            line-height: 24px;
+            padding: 0 0.5rem;
+            transition: width 0.3s ease;
+        }
+    }
+}

--- a/budget_appropriation_summary_dashboard/views/portal_summary_templates.xml
+++ b/budget_appropriation_summary_dashboard/views/portal_summary_templates.xml
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="portal_summary_page" name="Budget Appropriation Portal Summary" inherit_id="portal.portal_sidebar" primary="True">
+            <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
+                <t t-set="stats" t-value="payload.get('stats') or {}"/>
+                <t t-set="filters" t-value="payload.get('filters') or {}"/>
+                <t t-set="options" t-value="payload.get('filter_options') or {}"/>
+                <t t-set="context_info" t-value="stats.get('context') or {}"/>
+                <t t-set="expense_stats" t-value="stats.get('expense') or {}"/>
+                <t t-set="revenue_stats" t-value="stats.get('revenue') or {}"/>
+                <div class="bap-summary" id="bapSummaryRoot" t-att-data-payload="payload_json">
+                    <div class="container-fluid py-4">
+                        <!-- Header -->
+                        <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+                            <div>
+                                <h2 class="mb-0 fw-bold">ภาพรวมการจัดสรรงบประมาณ</h2>
+                                <p class="text-muted mb-0 small">ข้อมูลที่ผ่านสภาสถาบัน · ตัวเลขต้นปีงบประมาณ · ดูแยกตามแหล่งเงิน</p>
+                            </div>
+                            <div class="text-muted small" id="bapSummaryUpdated"></div>
+                        </div>
+
+                        <!-- Filter Bar -->
+                        <div class="card mb-3 shadow-sm">
+                            <div class="card-body py-3">
+                                <div class="row g-3 align-items-end" id="bapSummaryFilters">
+                                    <div class="col-lg-2 col-md-3 col-sm-6">
+                                        <label class="form-label small fw-semibold mb-1">ปีงบประมาณ</label>
+                                        <select class="form-select form-select-sm" data-filter="fiscal_year_id">
+                                            <t t-foreach="options.get('fiscal_years', [])" t-as="fy">
+                                                <option t-att-value="fy.get('id')"
+                                                        t-att-selected="filters.get('fiscal_year_id') == fy.get('id') or None"
+                                                        t-esc="fy.get('name')"/>
+                                            </t>
+                                        </select>
+                                    </div>
+                                    <div class="col-lg-3 col-md-3 col-sm-6">
+                                        <label class="form-label small fw-semibold mb-1">แหล่งเงิน <span class="text-danger">*</span></label>
+                                        <select class="form-select form-select-sm" data-filter="source_id" data-required="1">
+                                            <t t-foreach="options.get('sources', [])" t-as="s">
+                                                <option t-att-value="s.get('id')"
+                                                        t-att-selected="filters.get('source_id') == s.get('id') or None">
+                                                    [<t t-esc="s.get('code')"/>] <t t-esc="s.get('name')"/>
+                                                </option>
+                                            </t>
+                                        </select>
+                                    </div>
+                                    <div class="col-lg-3 col-md-3 col-sm-6">
+                                        <label class="form-label small fw-semibold mb-1">หน่วยงาน (Level 1)</label>
+                                        <select class="form-select form-select-sm" data-filter="department_id">
+                                            <option value="">ทุกหน่วยงาน</option>
+                                            <t t-foreach="options.get('departments', [])" t-as="d">
+                                                <option t-att-value="d.get('id')"
+                                                        t-att-selected="filters.get('department_id') == d.get('id') or None">
+                                                    [<t t-esc="d.get('code')"/>] <t t-esc="d.get('name')"/>
+                                                </option>
+                                            </t>
+                                        </select>
+                                    </div>
+                                    <div class="col-lg-2 d-flex justify-content-end gap-2">
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="bapSummaryReset">รีเซ็ต</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Context badge -->
+                        <div class="mb-3 small text-muted">
+                            แสดงข้อมูล:
+                            <span class="badge text-bg-primary"><t t-esc="context_info.get('fiscal_year_name') or '-'"/></span>
+                            <span class="badge text-bg-info"><t t-esc="context_info.get('source_name') or '-'"/></span>
+                        </div>
+
+                        <!-- Tab Navigation -->
+                        <ul class="nav nav-tabs mb-3" id="bapTabs">
+                            <li class="nav-item">
+                                <a class="nav-link active" href="#" data-tab="overview">ภาพรวม</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="#" data-tab="revenue">
+                                    <span class="text-success fw-semibold">รายรับ</span>
+                                </a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="#" data-tab="expense">
+                                    <span class="text-danger fw-semibold">รายจ่าย</span>
+                                </a>
+                            </li>
+                        </ul>
+
+                        <!-- ========================== OVERVIEW TAB ========================== -->
+                        <div class="bap-tab-pane" data-pane="overview">
+                            <div class="row g-3 mb-3">
+                                <div class="col-md-6">
+                                    <div class="card kpi-card kpi-revenue h-100 shadow-sm">
+                                        <div class="card-body">
+                                            <div class="kpi-label">รายรับสุทธิ</div>
+                                            <div class="kpi-value text-success" data-kpi="total_revenue">0</div>
+                                            <div class="kpi-sub small text-muted">
+                                                รวม <span data-kpi="total_revenue_gross">0</span> หัก <span data-kpi="total_revenue_deduct">0</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="card kpi-card kpi-expense h-100 shadow-sm">
+                                        <div class="card-body">
+                                            <div class="kpi-label">รายจ่ายรวม</div>
+                                            <div class="kpi-value text-danger" data-kpi="total_expense">0</div>
+                                            <div class="kpi-sub small text-muted">บาท</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3">
+                                <div class="col-lg-6">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายรับ vs รายจ่าย</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart" id="bapChartRevExp"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายรับตามหมวด</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart" id="bapChartOverviewRevenue"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามหมวดงบ</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart" id="bapChartOverviewExpense"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- ========================== REVENUE TAB ========================== -->
+                        <div class="bap-tab-pane d-none" data-pane="revenue">
+                            <div class="row g-3 mb-3">
+                                <div class="col-lg-5">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                            <span class="fw-semibold">รายรับตามหมวด</span>
+                                            <span class="small text-muted">หักโอนถูกลบจาก 43100 (ก)</span>
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-lg" id="bapChartRevCategory"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-7">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">
+                                            รายรับต่อหน่วยงาน (Gross vs หักโอน vs สุทธิ)
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-lg" id="bapChartRevByDept"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                            <span class="fw-semibold">การไหลของเงินหักโอน (หน่วยงานต้นทาง → ปลายทาง)</span>
+                                            <span class="small text-muted">
+                                                Sankey: เส้นแสดงจำนวนเงินที่หน่วยงานหารายได้ได้แล้วต้องส่งให้หน่วยงานปลายทาง
+                                            </span>
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-xl" id="bapChartRevDeductFlow"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 fw-semibold">
+                                            Heatmap: หน่วยงาน × หมวดรายรับ
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-lg" id="bapChartRevDeptCatHeatmap"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3">
+                                <div class="col-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายการรายรับ Top 15</div>
+                                        <div class="card-body p-0">
+                                            <div class="table-responsive">
+                                                <table class="table table-sm table-striped mb-0" id="bapTableRevenueItems">
+                                                    <thead class="table-light">
+                                                        <tr>
+                                                            <th style="width:48px">#</th>
+                                                            <th>รหัสงบประมาณ</th>
+                                                            <th>รายการ</th>
+                                                            <th>หน่วยงาน</th>
+                                                            <th class="text-end">จำนวนเงิน</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody></tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- ========================== EXPENSE TAB ========================== -->
+                        <div class="bap-tab-pane d-none" data-pane="expense">
+                            <div class="row g-3 mb-3">
+                                <div class="col-lg-4">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามหมวดงบ</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart" id="bapChartExpCategory"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-4">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามกองทุน</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart" id="bapChartExpFund"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-4">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามด้าน/แผนงาน</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart" id="bapChartExpActivity"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- Concentration KPI strip -->
+                            <div class="row g-3 mb-3">
+                                <div class="col-md-6">
+                                    <div class="card shadow-sm">
+                                        <div class="card-body py-3">
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <div>
+                                                    <div class="kpi-label">Top 5 หน่วยงาน คิดเป็นสัดส่วน</div>
+                                                    <div class="fs-4 fw-bold text-danger" data-kpi="exp_top5_pct">0%</div>
+                                                </div>
+                                                <div class="text-muted small text-end">
+                                                    ของรายจ่ายทั้งหมด<br/>
+                                                    <span data-kpi="exp_dept_count">0</span> หน่วยงานทั้งหมด
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="card shadow-sm">
+                                        <div class="card-body py-3">
+                                            <div class="kpi-label mb-2">โครงสร้างงบบุคลากร vs ไม่ใช่บุคลากร (รวม)</div>
+                                            <div class="progress" style="height: 24px;">
+                                                <div class="progress-bar bg-primary" role="progressbar" data-progress="personnel" style="width: 0%">
+                                                    <span data-kpi="exp_personnel_pct">0%</span> บุคลากร
+                                                </div>
+                                                <div class="progress-bar bg-secondary" role="progressbar" data-progress="other" style="width: 0%">
+                                                    <span data-kpi="exp_other_pct">0%</span> อื่น ๆ
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-lg-7">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">Top 15 หน่วยงาน ตามรายจ่าย</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-lg" id="bapChartExpTopDept"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-5">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">สัดส่วนบุคลากร vs ไม่ใช่บุคลากร รายหน่วยงาน</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-lg" id="bapChartExpPersonnel"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                            <span class="fw-semibold">การไหลของเงิน: กองทุน → หน่วยงาน → หมวดงบ</span>
+                                            <span class="small text-muted">Sankey 3-stage · เส้นยิ่งหนา = เงินยิ่งมาก</span>
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-xl" id="bapChartExpFundDeptCat"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-lg-6">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 fw-semibold">
+                                            Heatmap: หน่วยงาน × ด้าน/แผนงาน
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-xl" id="bapChartExpDeptActivity"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-lg-6">
+                                    <div class="card shadow-sm h-100">
+                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                            <span class="fw-semibold">Activity Hierarchy</span>
+                                            <span class="small text-muted">ด้าน → แผนงาน → กิจกรรมหลัก · click ดูใน-นอก</span>
+                                        </div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-xl" id="bapChartExpActivitySunburst"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 fw-semibold">Heatmap: หน่วยงาน × หมวดงบรายจ่าย</div>
+                                        <div class="card-body">
+                                            <div class="bap-chart bap-chart-xl" id="bapChartExpHeatmap"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row g-3 mb-3">
+                                <div class="col-12">
+                                    <div class="card shadow-sm">
+                                        <div class="card-header bg-white py-2 fw-semibold">รายการรายจ่าย Top 15</div>
+                                        <div class="card-body p-0">
+                                            <div class="table-responsive">
+                                                <table class="table table-sm table-striped mb-0" id="bapTableExpenseItems">
+                                                    <thead class="table-light">
+                                                        <tr>
+                                                            <th style="width:48px">#</th>
+                                                            <th>รหัสงบประมาณ</th>
+                                                            <th>รายการ</th>
+                                                            <th>หน่วยงาน</th>
+                                                            <th>กองทุน</th>
+                                                            <th class="text-end">จำนวนเงิน</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody></tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- Department × Category detail table -->
+                            <div class="card shadow-sm mb-3">
+                                <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                    <span class="fw-semibold">ตารางสรุปรายจ่ายตามหน่วยงาน</span>
+                                    <div class="small text-muted">หน่วย: บาท</div>
+                                </div>
+                                <div class="card-body p-0">
+                                    <div class="table-responsive">
+                                        <table class="table table-sm table-striped mb-0" id="bapSummaryTable">
+                                            <thead class="table-light">
+                                                <tr>
+                                                    <th>หน่วยงาน</th>
+                                                    <t t-foreach="expense_stats.get('categories', [])" t-as="c">
+                                                        <th class="text-end">
+                                                            <span class="d-block small text-muted" t-esc="c.get('code')"/>
+                                                            <t t-esc="c.get('name')"/>
+                                                        </th>
+                                                    </t>
+                                                    <th class="text-end">รวม</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody></tbody>
+                                            <tfoot class="table-light fw-semibold">
+                                                <tr>
+                                                    <td>รวมทั้งหมด</td>
+                                                    <t t-foreach="expense_stats.get('categories', [])" t-as="c">
+                                                        <td class="text-end" t-att-data-foot="c.get('code')">0</td>
+                                                    </t>
+                                                    <td class="text-end" data-foot="total">0</td>
+                                                </tr>
+                                            </tfoot>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/budget_appropriation_summary_dashboard/views/portal_summary_templates.xml
+++ b/budget_appropriation_summary_dashboard/views/portal_summary_templates.xml
@@ -1,411 +1,480 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <template id="portal_summary_page" name="Budget Appropriation Portal Summary" inherit_id="portal.portal_sidebar" primary="True">
-            <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
-                <t t-set="stats" t-value="payload.get('stats') or {}"/>
-                <t t-set="filters" t-value="payload.get('filters') or {}"/>
-                <t t-set="options" t-value="payload.get('filter_options') or {}"/>
-                <t t-set="context_info" t-value="stats.get('context') or {}"/>
-                <t t-set="expense_stats" t-value="stats.get('expense') or {}"/>
-                <t t-set="revenue_stats" t-value="stats.get('revenue') or {}"/>
-                <div class="bap-summary" id="bapSummaryRoot" t-att-data-payload="payload_json">
-                    <div class="container-fluid py-4">
-                        <!-- Header -->
-                        <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
-                            <div>
-                                <h2 class="mb-0 fw-bold">ภาพรวมการจัดสรรงบประมาณ</h2>
-                                <p class="text-muted mb-0 small">ข้อมูลที่ผ่านสภาสถาบัน · ตัวเลขต้นปีงบประมาณ · ดูแยกตามแหล่งเงิน</p>
-                            </div>
-                            <div class="text-muted small" id="bapSummaryUpdated"></div>
+    <template id="portal_summary_page" name="Budget Appropriation Portal Summary">
+        <t t-call="portal.frontend_layout">
+            <t t-set="stats" t-value="payload.get('stats') or {}" />
+            <t t-set="filters" t-value="payload.get('filters') or {}" />
+            <t t-set="options" t-value="payload.get('filter_options') or {}" />
+            <t t-set="context_info" t-value="stats.get('context') or {}" />
+            <t t-set="expense_stats" t-value="stats.get('expense') or {}" />
+            <t t-set="revenue_stats" t-value="stats.get('revenue') or {}" />
+            <div class="bap-summary" id="bapSummaryRoot" t-att-data-payload="payload_json">
+                <div class="container-fluid py-4">
+                    <!-- Header -->
+                    <div
+                        class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+                        <div>
+                            <h2 class="mb-0 fw-bold">ภาพรวมการจัดสรรงบประมาณ</h2>
+                            <p class="text-muted mb-0 small">ข้อมูลที่ผ่านสภาสถาบัน ·
+                                ตัวเลขต้นปีงบประมาณ · ดูแยกตามแหล่งเงิน</p>
                         </div>
+                        <div class="text-muted small" id="bapSummaryUpdated"></div>
+                    </div>
 
-                        <!-- Filter Bar -->
-                        <div class="card mb-3 shadow-sm">
-                            <div class="card-body py-3">
-                                <div class="row g-3 align-items-end" id="bapSummaryFilters">
-                                    <div class="col-lg-2 col-md-3 col-sm-6">
-                                        <label class="form-label small fw-semibold mb-1">ปีงบประมาณ</label>
-                                        <select class="form-select form-select-sm" data-filter="fiscal_year_id">
-                                            <t t-foreach="options.get('fiscal_years', [])" t-as="fy">
-                                                <option t-att-value="fy.get('id')"
-                                                        t-att-selected="filters.get('fiscal_year_id') == fy.get('id') or None"
-                                                        t-esc="fy.get('name')"/>
-                                            </t>
-                                        </select>
-                                    </div>
-                                    <div class="col-lg-3 col-md-3 col-sm-6">
-                                        <label class="form-label small fw-semibold mb-1">แหล่งเงิน <span class="text-danger">*</span></label>
-                                        <select class="form-select form-select-sm" data-filter="source_id" data-required="1">
-                                            <t t-foreach="options.get('sources', [])" t-as="s">
-                                                <option t-att-value="s.get('id')"
-                                                        t-att-selected="filters.get('source_id') == s.get('id') or None">
-                                                    [<t t-esc="s.get('code')"/>] <t t-esc="s.get('name')"/>
-                                                </option>
-                                            </t>
-                                        </select>
-                                    </div>
-                                    <div class="col-lg-3 col-md-3 col-sm-6">
-                                        <label class="form-label small fw-semibold mb-1">หน่วยงาน (Level 1)</label>
-                                        <select class="form-select form-select-sm" data-filter="department_id">
-                                            <option value="">ทุกหน่วยงาน</option>
-                                            <t t-foreach="options.get('departments', [])" t-as="d">
-                                                <option t-att-value="d.get('id')"
-                                                        t-att-selected="filters.get('department_id') == d.get('id') or None">
-                                                    [<t t-esc="d.get('code')"/>] <t t-esc="d.get('name')"/>
-                                                </option>
-                                            </t>
-                                        </select>
-                                    </div>
-                                    <div class="col-lg-2 d-flex justify-content-end gap-2">
-                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="bapSummaryReset">รีเซ็ต</button>
-                                    </div>
+                    <!-- Filter Bar -->
+                    <div class="card mb-3 shadow-sm">
+                        <div class="card-body py-3">
+                            <div class="row g-3 align-items-end" id="bapSummaryFilters">
+                                <div class="col-lg-2 col-md-3 col-sm-6">
+                                    <label class="form-label small fw-semibold mb-1">ปีงบประมาณ</label>
+                                    <select class="form-select form-select-sm"
+                                        data-filter="fiscal_year_id">
+                                        <t t-foreach="options.get('fiscal_years', [])" t-as="fy">
+                                            <option t-att-value="fy.get('id')"
+                                                t-att-selected="filters.get('fiscal_year_id') == fy.get('id') or None"
+                                                t-esc="fy.get('name')" />
+                                        </t>
+                                    </select>
                                 </div>
-                            </div>
-                        </div>
-
-                        <!-- Context badge -->
-                        <div class="mb-3 small text-muted">
-                            แสดงข้อมูล:
-                            <span class="badge text-bg-primary"><t t-esc="context_info.get('fiscal_year_name') or '-'"/></span>
-                            <span class="badge text-bg-info"><t t-esc="context_info.get('source_name') or '-'"/></span>
-                        </div>
-
-                        <!-- Tab Navigation -->
-                        <ul class="nav nav-tabs mb-3" id="bapTabs">
-                            <li class="nav-item">
-                                <a class="nav-link active" href="#" data-tab="overview">ภาพรวม</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="#" data-tab="revenue">
-                                    <span class="text-success fw-semibold">รายรับ</span>
-                                </a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="#" data-tab="expense">
-                                    <span class="text-danger fw-semibold">รายจ่าย</span>
-                                </a>
-                            </li>
-                        </ul>
-
-                        <!-- ========================== OVERVIEW TAB ========================== -->
-                        <div class="bap-tab-pane" data-pane="overview">
-                            <div class="row g-3 mb-3">
-                                <div class="col-md-6">
-                                    <div class="card kpi-card kpi-revenue h-100 shadow-sm">
-                                        <div class="card-body">
-                                            <div class="kpi-label">รายรับสุทธิ</div>
-                                            <div class="kpi-value text-success" data-kpi="total_revenue">0</div>
-                                            <div class="kpi-sub small text-muted">
-                                                รวม <span data-kpi="total_revenue_gross">0</span> หัก <span data-kpi="total_revenue_deduct">0</span>
-                                            </div>
-                                        </div>
-                                    </div>
+                                <div class="col-lg-3 col-md-3 col-sm-6">
+                                    <label class="form-label small fw-semibold mb-1">แหล่งเงิน <span
+                                            class="text-danger">*</span></label>
+                                    <select class="form-select form-select-sm"
+                                        data-filter="source_id" data-required="1">
+                                        <t t-foreach="options.get('sources', [])" t-as="s">
+                                            <option t-att-value="s.get('id')"
+                                                t-att-selected="filters.get('source_id') == s.get('id') or None">
+                                                [<t t-esc="s.get('code')" />] <t
+                                                    t-esc="s.get('name')" />
+                                            </option>
+                                        </t>
+                                    </select>
                                 </div>
-                                <div class="col-md-6">
-                                    <div class="card kpi-card kpi-expense h-100 shadow-sm">
-                                        <div class="card-body">
-                                            <div class="kpi-label">รายจ่ายรวม</div>
-                                            <div class="kpi-value text-danger" data-kpi="total_expense">0</div>
-                                            <div class="kpi-sub small text-muted">บาท</div>
-                                        </div>
-                                    </div>
+                                <div class="col-lg-3 col-md-3 col-sm-6">
+                                    <label class="form-label small fw-semibold mb-1">หน่วยงาน
+                                        (Level
+                                        1)</label>
+                                    <select class="form-select form-select-sm"
+                                        data-filter="department_id">
+                                        <option value="">ทุกหน่วยงาน</option>
+                                        <t t-foreach="options.get('departments', [])" t-as="d">
+                                            <option t-att-value="d.get('id')"
+                                                t-att-selected="filters.get('department_id') == d.get('id') or None">
+                                                [<t t-esc="d.get('code')" />] <t
+                                                    t-esc="d.get('name')" />
+                                            </option>
+                                        </t>
+                                    </select>
+                                </div>
+                                <div class="col-lg-2 d-flex justify-content-end gap-2">
+                                    <button type="button"
+                                        class="btn btn-outline-secondary btn-sm"
+                                        id="bapSummaryReset">รีเซ็ต</button>
                                 </div>
                             </div>
-                            <div class="row g-3">
-                                <div class="col-lg-6">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายรับ vs รายจ่าย</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart" id="bapChartRevExp"></div>
+                        </div>
+                    </div>
+
+                    <!-- Context badge -->
+                    <div class="mb-3 small text-muted"> แสดงข้อมูล: <span
+                            class="badge text-bg-primary">
+                            <t t-esc="context_info.get('fiscal_year_name') or '-'" />
+                        </span>
+                            <span
+                            class="badge text-bg-info">
+                            <t t-esc="context_info.get('source_name') or '-'" />
+                        </span>
+                    </div>
+
+                    <!-- Tab Navigation -->
+                    <ul class="nav nav-tabs mb-3" id="bapTabs">
+                        <li class="nav-item">
+                            <a class="nav-link active" href="#" data-tab="overview">ภาพรวม</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#" data-tab="revenue">
+                                <span class="text-success fw-semibold">รายรับ</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#" data-tab="expense">
+                                <span class="text-danger fw-semibold">รายจ่าย</span>
+                            </a>
+                        </li>
+                    </ul>
+
+                    <!-- ========================== OVERVIEW TAB ========================== -->
+                    <div class="bap-tab-pane" data-pane="overview">
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <div class="card kpi-card kpi-revenue h-100 shadow-sm">
+                                    <div class="card-body">
+                                        <div class="kpi-label">รายรับสุทธิ</div>
+                                        <div class="kpi-value text-success"
+                                            data-kpi="total_revenue">
+                                            0</div>
+                                        <div class="kpi-sub small text-muted"> รวม <span
+                                                data-kpi="total_revenue_gross">0</span> หัก <span
+                                                data-kpi="total_revenue_deduct">0</span>
                                         </div>
                                     </div>
                                 </div>
-                                <div class="col-lg-6">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายรับตามหมวด</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart" id="bapChartOverviewRevenue"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามหมวดงบ</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart" id="bapChartOverviewExpense"></div>
-                                        </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="card kpi-card kpi-expense h-100 shadow-sm">
+                                    <div class="card-body">
+                                        <div class="kpi-label">รายจ่ายรวม</div>
+                                        <div class="kpi-value text-danger"
+                                            data-kpi="total_expense">
+                                            0</div>
+                                        <div class="kpi-sub small text-muted">บาท</div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-
-                        <!-- ========================== REVENUE TAB ========================== -->
-                        <div class="bap-tab-pane d-none" data-pane="revenue">
-                            <div class="row g-3 mb-3">
-                                <div class="col-lg-5">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
-                                            <span class="fw-semibold">รายรับตามหมวด</span>
-                                            <span class="small text-muted">หักโอนถูกลบจาก 43100 (ก)</span>
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-lg" id="bapChartRevCategory"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-7">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">
-                                            รายรับต่อหน่วยงาน (Gross vs หักโอน vs สุทธิ)
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-lg" id="bapChartRevByDept"></div>
-                                        </div>
+                        <div class="row g-3">
+                            <div class="col-lg-6">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">รายรับ vs
+                                        รายจ่าย</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart" id="bapChartRevExp"></div>
                                     </div>
                                 </div>
                             </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
-                                            <span class="fw-semibold">การไหลของเงินหักโอน (หน่วยงานต้นทาง → ปลายทาง)</span>
-                                            <span class="small text-muted">
-                                                Sankey: เส้นแสดงจำนวนเงินที่หน่วยงานหารายได้ได้แล้วต้องส่งให้หน่วยงานปลายทาง
-                                            </span>
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-xl" id="bapChartRevDeductFlow"></div>
-                                        </div>
+                            <div class="col-lg-6">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        รายรับตามหมวด</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart" id="bapChartOverviewRevenue"></div>
                                     </div>
                                 </div>
                             </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 fw-semibold">
-                                            Heatmap: หน่วยงาน × หมวดรายรับ
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-lg" id="bapChartRevDeptCatHeatmap"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row g-3">
-                                <div class="col-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายการรายรับ Top 15</div>
-                                        <div class="card-body p-0">
-                                            <div class="table-responsive">
-                                                <table class="table table-sm table-striped mb-0" id="bapTableRevenueItems">
-                                                    <thead class="table-light">
-                                                        <tr>
-                                                            <th style="width:48px">#</th>
-                                                            <th>รหัสงบประมาณ</th>
-                                                            <th>รายการ</th>
-                                                            <th>หน่วยงาน</th>
-                                                            <th class="text-end">จำนวนเงิน</th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody></tbody>
-                                                </table>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- ========================== EXPENSE TAB ========================== -->
-                        <div class="bap-tab-pane d-none" data-pane="expense">
-                            <div class="row g-3 mb-3">
-                                <div class="col-lg-4">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามหมวดงบ</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart" id="bapChartExpCategory"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-4">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามกองทุน</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart" id="bapChartExpFund"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-4">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายจ่ายตามด้าน/แผนงาน</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart" id="bapChartExpActivity"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Concentration KPI strip -->
-                            <div class="row g-3 mb-3">
-                                <div class="col-md-6">
-                                    <div class="card shadow-sm">
-                                        <div class="card-body py-3">
-                                            <div class="d-flex justify-content-between align-items-center">
-                                                <div>
-                                                    <div class="kpi-label">Top 5 หน่วยงาน คิดเป็นสัดส่วน</div>
-                                                    <div class="fs-4 fw-bold text-danger" data-kpi="exp_top5_pct">0%</div>
-                                                </div>
-                                                <div class="text-muted small text-end">
-                                                    ของรายจ่ายทั้งหมด<br/>
-                                                    <span data-kpi="exp_dept_count">0</span> หน่วยงานทั้งหมด
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-md-6">
-                                    <div class="card shadow-sm">
-                                        <div class="card-body py-3">
-                                            <div class="kpi-label mb-2">โครงสร้างงบบุคลากร vs ไม่ใช่บุคลากร (รวม)</div>
-                                            <div class="progress" style="height: 24px;">
-                                                <div class="progress-bar bg-primary" role="progressbar" data-progress="personnel" style="width: 0%">
-                                                    <span data-kpi="exp_personnel_pct">0%</span> บุคลากร
-                                                </div>
-                                                <div class="progress-bar bg-secondary" role="progressbar" data-progress="other" style="width: 0%">
-                                                    <span data-kpi="exp_other_pct">0%</span> อื่น ๆ
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-lg-7">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">Top 15 หน่วยงาน ตามรายจ่าย</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-lg" id="bapChartExpTopDept"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-5">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">สัดส่วนบุคลากร vs ไม่ใช่บุคลากร รายหน่วยงาน</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-lg" id="bapChartExpPersonnel"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
-                                            <span class="fw-semibold">การไหลของเงิน: กองทุน → หน่วยงาน → หมวดงบ</span>
-                                            <span class="small text-muted">Sankey 3-stage · เส้นยิ่งหนา = เงินยิ่งมาก</span>
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-xl" id="bapChartExpFundDeptCat"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-lg-6">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 fw-semibold">
-                                            Heatmap: หน่วยงาน × ด้าน/แผนงาน
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-xl" id="bapChartExpDeptActivity"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6">
-                                    <div class="card shadow-sm h-100">
-                                        <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
-                                            <span class="fw-semibold">Activity Hierarchy</span>
-                                            <span class="small text-muted">ด้าน → แผนงาน → กิจกรรมหลัก · click ดูใน-นอก</span>
-                                        </div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-xl" id="bapChartExpActivitySunburst"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 fw-semibold">Heatmap: หน่วยงาน × หมวดงบรายจ่าย</div>
-                                        <div class="card-body">
-                                            <div class="bap-chart bap-chart-xl" id="bapChartExpHeatmap"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row g-3 mb-3">
-                                <div class="col-12">
-                                    <div class="card shadow-sm">
-                                        <div class="card-header bg-white py-2 fw-semibold">รายการรายจ่าย Top 15</div>
-                                        <div class="card-body p-0">
-                                            <div class="table-responsive">
-                                                <table class="table table-sm table-striped mb-0" id="bapTableExpenseItems">
-                                                    <thead class="table-light">
-                                                        <tr>
-                                                            <th style="width:48px">#</th>
-                                                            <th>รหัสงบประมาณ</th>
-                                                            <th>รายการ</th>
-                                                            <th>หน่วยงาน</th>
-                                                            <th>กองทุน</th>
-                                                            <th class="text-end">จำนวนเงิน</th>
-                                                        </tr>
-                                                    </thead>
-                                                    <tbody></tbody>
-                                                </table>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Department × Category detail table -->
-                            <div class="card shadow-sm mb-3">
-                                <div class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
-                                    <span class="fw-semibold">ตารางสรุปรายจ่ายตามหน่วยงาน</span>
-                                    <div class="small text-muted">หน่วย: บาท</div>
-                                </div>
-                                <div class="card-body p-0">
-                                    <div class="table-responsive">
-                                        <table class="table table-sm table-striped mb-0" id="bapSummaryTable">
-                                            <thead class="table-light">
-                                                <tr>
-                                                    <th>หน่วยงาน</th>
-                                                    <t t-foreach="expense_stats.get('categories', [])" t-as="c">
-                                                        <th class="text-end">
-                                                            <span class="d-block small text-muted" t-esc="c.get('code')"/>
-                                                            <t t-esc="c.get('name')"/>
-                                                        </th>
-                                                    </t>
-                                                    <th class="text-end">รวม</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody></tbody>
-                                            <tfoot class="table-light fw-semibold">
-                                                <tr>
-                                                    <td>รวมทั้งหมด</td>
-                                                    <t t-foreach="expense_stats.get('categories', [])" t-as="c">
-                                                        <td class="text-end" t-att-data-foot="c.get('code')">0</td>
-                                                    </t>
-                                                    <td class="text-end" data-foot="total">0</td>
-                                                </tr>
-                                            </tfoot>
-                                        </table>
+                            <div class="col-lg-12">
+                                <div class="card shadow-sm">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        รายจ่ายตามหมวดงบ</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart" id="bapChartOverviewExpense"></div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
+
+                    <!-- ========================== REVENUE TAB ========================== -->
+                    <div class="bap-tab-pane d-none" data-pane="revenue">
+                        <div class="row g-3 mb-3">
+                            <div class="col-lg-5">
+                                <div class="card shadow-sm h-100">
+                                    <div
+                                        class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                        <span class="fw-semibold">รายรับตามหมวด</span>
+                                        <span class="small text-muted">หักโอนถูกลบจาก 43100 (ก)</span>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-lg"
+                                            id="bapChartRevCategory"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-7">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        รายรับต่อหน่วยงาน (Gross vs หักโอน vs สุทธิ)
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-lg"
+                                            id="bapChartRevByDept"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12">
+                                <div class="card shadow-sm">
+                                    <div
+                                        class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                        <span class="fw-semibold">การไหลของเงินหักโอน
+                                            (หน่วยงานต้นทาง → ปลายทาง)</span>
+                                        <span class="small text-muted">
+                                            Sankey:
+                                            เส้นแสดงจำนวนเงินที่หน่วยงานหารายได้ได้แล้วต้องส่งให้หน่วยงานปลายทาง
+                                        </span>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-xl"
+                                            id="bapChartRevDeductFlow"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12">
+                                <div class="card shadow-sm">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        Heatmap: หน่วยงาน × หมวดรายรับ
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-lg"
+                                            id="bapChartRevDeptCatHeatmap"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-12">
+                                <div class="card shadow-sm">
+                                    <div class="card-header bg-white py-2 fw-semibold">รายการรายรับ
+                                        Top 15</div>
+                                    <div class="card-body p-0">
+                                        <div class="table-responsive">
+                                            <table class="table table-sm table-striped mb-0"
+                                                id="bapTableRevenueItems">
+                                                <thead class="table-light">
+                                                    <tr>
+                                                        <th style="width:48px">#</th>
+                                                        <th>รหัสงบประมาณ</th>
+                                                        <th>รายการ</th>
+                                                        <th>หน่วยงาน</th>
+                                                        <th class="text-end">จำนวนเงิน</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody></tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- ========================== EXPENSE TAB ========================== -->
+                    <div class="bap-tab-pane d-none" data-pane="expense">
+                        <div class="row g-3 mb-3">
+                            <div class="col-lg-4">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        รายจ่ายตามหมวดงบ</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart" id="bapChartExpCategory"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-4">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        รายจ่ายตามกองทุน</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart" id="bapChartExpFund"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-4">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        รายจ่ายตามด้าน/แผนงาน</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart" id="bapChartExpActivity"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Concentration KPI strip -->
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <div class="card shadow-sm">
+                                    <div class="card-body py-3">
+                                        <div
+                                            class="d-flex justify-content-between align-items-center">
+                                            <div>
+                                                <div class="kpi-label">Top 5 หน่วยงาน
+                                                    คิดเป็นสัดส่วน</div>
+                                                <div class="fs-4 fw-bold text-danger"
+                                                    data-kpi="exp_top5_pct">0%</div>
+                                            </div>
+                                            <div class="text-muted small text-end">
+                                                ของรายจ่ายทั้งหมด<br />
+                                                    <span
+                                                    data-kpi="exp_dept_count">0</span>
+                                                หน่วยงานทั้งหมด </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="card shadow-sm">
+                                    <div class="card-body py-3">
+                                        <div class="kpi-label mb-2">โครงสร้างงบบุคลากร vs
+                                            ไม่ใช่บุคลากร (รวม)</div>
+                                        <div class="progress" style="height: 48px;">
+                                            <div class="progress-bar bg-primary"
+                                                role="progressbar"
+                                                data-progress="personnel" style="width: 0%">
+                                                <span data-kpi="exp_personnel_pct">0%</span> บุคลากร </div>
+                                            <div class="progress-bar bg-secondary"
+                                                role="progressbar" data-progress="other"
+                                                style="width: 0%">
+                                                <span data-kpi="exp_other_pct">0%</span> อื่น ๆ </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-lg-7">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">Top 15
+                                        หน่วยงาน ตามรายจ่าย</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-lg"
+                                            id="bapChartExpTopDept"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-5">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">สัดส่วนบุคลากร
+                                        vs ไม่ใช่บุคลากร รายหน่วยงาน</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-lg"
+                                            id="bapChartExpPersonnel"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12">
+                                <div class="card shadow-sm">
+                                    <div
+                                        class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                        <span class="fw-semibold">การไหลของเงิน: กองทุน →
+                                            หน่วยงาน →
+                                            หมวดงบ</span>
+                                        <span class="small text-muted">Sankey 3-stage ·
+                                            เส้นยิ่งหนา
+                                            = เงินยิ่งมาก</span>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-xl"
+                                            id="bapChartExpFundDeptCat"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-lg-6">
+                                <div class="card shadow-sm h-100">
+                                    <div class="card-header bg-white py-2 fw-semibold">
+                                        Heatmap: หน่วยงาน × ด้าน/แผนงาน
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-xl"
+                                            id="bapChartExpDeptActivity"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-lg-6">
+                                <div class="card shadow-sm h-100">
+                                    <div
+                                        class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                        <span class="fw-semibold">Activity Hierarchy</span>
+                                        <span class="small text-muted">ด้าน → แผนงาน →
+                                            กิจกรรมหลัก ·
+                                            click ดูใน-นอก</span>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-xl"
+                                            id="bapChartExpActivitySunburst"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12">
+                                <div class="card shadow-sm">
+                                    <div class="card-header bg-white py-2 fw-semibold">Heatmap:
+                                        หน่วยงาน × หมวดงบรายจ่าย</div>
+                                    <div class="card-body">
+                                        <div class="bap-chart bap-chart-xl"
+                                            id="bapChartExpHeatmap"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-12">
+                                <div class="card shadow-sm">
+                                    <div class="card-header bg-white py-2 fw-semibold">รายการรายจ่าย
+                                        Top 15</div>
+                                    <div class="card-body p-0">
+                                        <div class="table-responsive">
+                                            <table class="table table-sm table-striped mb-0"
+                                                id="bapTableExpenseItems">
+                                                <thead class="table-light">
+                                                    <tr>
+                                                        <th style="width:48px">#</th>
+                                                        <th>รหัสงบประมาณ</th>
+                                                        <th>รายการ</th>
+                                                        <th>หน่วยงาน</th>
+                                                        <th>กองทุน</th>
+                                                        <th class="text-end">จำนวนเงิน</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody></tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Department × Category detail table -->
+                        <div class="card shadow-sm mb-3">
+                            <div
+                                class="card-header bg-white py-2 d-flex justify-content-between align-items-center">
+                                <span class="fw-semibold">ตารางสรุปรายจ่ายตามหน่วยงาน</span>
+                                <div class="small text-muted">หน่วย: บาท</div>
+                            </div>
+                            <div class="card-body p-0">
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-striped mb-0"
+                                        id="bapSummaryTable">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>หน่วยงาน</th>
+                                                <t
+                                                    t-foreach="expense_stats.get('categories', [])"
+                                                    t-as="c">
+                                                    <th class="text-end">
+                                                        <span class="d-block small text-muted"
+                                                            t-esc="c.get('code')" />
+                                                        <t t-esc="c.get('name')" />
+                                                    </th>
+                                                </t>
+                                                <th class="text-end">รวม</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody></tbody>
+                                        <tfoot class="table-light fw-semibold">
+                                            <tr>
+                                                <td>รวมทั้งหมด</td>
+                                                <t
+                                                    t-foreach="expense_stats.get('categories', [])"
+                                                    t-as="c">
+                                                    <td class="text-end"
+                                                        t-att-data-foot="c.get('code')">0</td>
+                                                </t>
+                                                <td class="text-end" data-foot="total">0</td>
+                                            </tr>
+                                        </tfoot>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            </xpath>
-        </template>
-    </data>
+            </div>
+        </t>
+    </template>
 </odoo>


### PR DESCRIPTION
## Summary

New module `budget_appropriation_summary_dashboard` adding a full-width portal page (`/budget/appropriation/portal_summary`) with three tabs (overview / revenue / expense) and a shared filter bar (fiscal year, level-1 department, source — source is required so figures stay per-funding-source).

Data is sourced exclusively from appropriations linked through `budget.appropriation.compilation` records that belong to a master summary; revenue หักโอน lines are netted against the `43100 (ก)` bucket, matching the F2/F4P/F4W convention.

Charts include KPI cards, donuts (by category/fund/activity), Top-15 dept bar, personnel ratio per dept, multiple heatmaps (dept × category, dept × activity, dept × revenue-category), a 3-stage Sankey (กองทุน → หน่วยงาน → หมวดงบ), a หักโอน flow Sankey on the revenue tab, an activity sunburst (ด้าน → แผนงาน → กิจกรรมหลัก), and Top-15 line-item tables.

The dashboard is intentionally separate from the existing backend dashboard component in `budget_appropriation_summary` so the portal can be deployed/un-deployed independently without touching the core summary or F-report logic.

## Test plan

- [ ] Install the new module on a database that already has `budget_appropriation_summary` and at least one posted master summary
- [ ] Visit `/budget/appropriation/portal_summary` as a portal/internal user — confirm the page renders full-width with the breadcrumb hidden
- [ ] Verify the source dropdown auto-selects the first available source and the fiscal year defaults to the latest one with a master summary
- [ ] Switch tabs (Overview/Revenue/Expense) and confirm charts render lazily without errors
- [ ] Change the department / fiscal year / source filters and confirm KPIs, charts, and tables refresh via the JSON endpoint
- [ ] Sanity-check totals: revenue net = gross − หักโอน; revenue-by-category subtracts หักโอน from \`43100 (ก)\`; expense totals match the F5 master summary numbers
- [ ] Confirm \`budget_appropriation_summary\` is unchanged (no version bump, no new files)