### PR TITLE
[16.0][IMP] budget_appropriation_summary: add report code label on every page

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Budget Appropriation Summary",
-    "version": "16.0.1.0.3",
+    "version": "16.0.1.0.4",
     "summary": "Compilation and master summary for budget appropriations",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -30,7 +30,30 @@
                 font-size: 18pt;
                 margin-bottom: 0;
             }
+            .report-page-label {
+                position: absolute;
+                top: 4mm;
+                right: 8mm;
+                font-size: 15pt;
+                font-family: 'THSarabun', Arial, sans-serif;
+                z-index: 10;
+                pointer-events: none;
+            }
+            @media print {
+                .report-page-label {
+                    position: fixed;
+                    top: 5mm;
+                    right: 5mm;
+                }
+            }
         </style>
+    </template>
+
+    <!-- Reusable page label (top-right of every page, persists on print) -->
+    <template id="report_page_label">
+        <div class="report-page-label" contenteditable="false">
+            <t t-out="page_label"/>
+        </div>
     </template>
 
     <!-- Preview styles for A4 paper page effect (set is_landscape before calling) -->

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -32,7 +32,7 @@
             }
             .report-page-label {
                 position: absolute;
-                top: 4mm;
+                top: 1mm;
                 right: 8mm;
                 font-size: 15pt;
                 font-family: 'THSarabun', Arial, sans-serif;
@@ -42,7 +42,7 @@
             @media print {
                 .report-page-label {
                     position: fixed;
-                    top: 5mm;
+                    top: 2mm;
                     right: 5mm;
                 }
             }

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -303,11 +303,15 @@
                         margin: 0;
                         padding: 0;
                     }
+                    .article, main, header, footer, .o_report_layout_standard {
+                        margin: 0 !important;
+                        padding: 0 !important;
+                    }
                     .page {
                         width: auto;
                         min-height: auto;
                         margin: 0 !important;
-                        padding: 0 !important;
+                        padding: 24mm 8mm !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;
@@ -317,7 +321,6 @@
                     }
                     @page {
                         margin: 0 !important;
-                        padding: 24mm 8mm !important;
                         size: A4;
                     }
                     .f23w-print-btn {

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -300,18 +300,21 @@
                 @media print {
                     html, body {
                         background: white !important;
-                        margin: 0;
-                        padding: 0;
+                        margin: 0 !important;
+                        padding: 0 !important;
+                        width: auto !important;
+                        height: auto !important;
                     }
                     .article, main, header, footer, .o_report_layout_standard {
                         margin: 0 !important;
                         padding: 0 !important;
                     }
                     .page {
-                        width: auto;
-                        min-height: auto;
+                        width: 100% !important;
+                        min-height: auto !important;
+                        max-width: none !important;
                         margin: 0 !important;
-                        padding: 24mm 8mm !important;
+                        padding: 0 !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;
@@ -321,6 +324,7 @@
                     }
                     @page {
                         margin: 0 !important;
+                        padding: 24mm 8mm !important;
                         size: A4;
                     }
                     .f23w-print-btn {

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -33,8 +33,10 @@
                         พิมพ์รายงาน
                     </button>
                 </t>
+                <t t-call="budget_appropriation_summary.report_page_label">
+                    <t t-set="page_label" t-value="'F23-W-วง-003'"/>
+                </t>
                 <div class="report-header mb-2" contenteditable="false">
-                    <div class="f23w-document-ref">F23-W-วง-002</div>
                     <h4>สรุปงบประมาณรายจ่าย</h4>
                     <h4>
                         ประจำปีงบประมาณ พ.ศ.
@@ -273,15 +275,6 @@
                     outline: none;
                 }
 
-                .f23w-page-label {
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    font-size: 10pt;
-                    color: #333;
-                    pointer-events: none;
-                }
-
                 .f23w-print-btn {
                     position: absolute;
                     top: 20px;
@@ -326,11 +319,6 @@
                         margin: 0 !important;
                         padding: 24mm 8mm !important;
                         size: A4;
-                    }
-                    .f23w-page-label {
-                        position: fixed;
-                        top: 5mm;
-                        right: 5mm;
                     }
                     .f23w-print-btn {
                         display: none !important;
@@ -378,11 +366,21 @@
                 cursor: not-allowed;
             }
 
-            .f23w-document-ref {
+            .report-page-label {
                 position: absolute;
-                top: 0;
-                right: 0;
+                top: 4mm;
+                right: 8mm;
                 font-size: 15pt;
+                font-family: 'THSarabun', Arial, sans-serif;
+                z-index: 10;
+                pointer-events: none;
+            }
+            @media print {
+                .report-page-label {
+                    position: fixed;
+                    top: 5mm;
+                    right: 5mm;
+                }
             }</style>
     </template>
     <!-- Main report template -->

--- a/budget_appropriation_summary/report/report_compilation_f23w.xml
+++ b/budget_appropriation_summary/report/report_compilation_f23w.xml
@@ -368,7 +368,7 @@
 
             .report-page-label {
                 position: absolute;
-                top: 4mm;
+                top: 1mm;
                 right: 8mm;
                 font-size: 15pt;
                 font-family: 'THSarabun', Arial, sans-serif;
@@ -378,7 +378,7 @@
             @media print {
                 .report-page-label {
                     position: fixed;
-                    top: 5mm;
+                    top: 2mm;
                     right: 5mm;
                 }
             }</style>

--- a/budget_appropriation_summary/report/report_compilation_f5.xml
+++ b/budget_appropriation_summary/report/report_compilation_f5.xml
@@ -214,11 +214,15 @@
                         margin: 0;
                         padding: 0;
                     }
+                    .article, main, header, footer, .o_report_layout_standard {
+                        margin: 0 !important;
+                        padding: 0 !important;
+                    }
                     .page {
                         width: auto;
                         min-height: auto;
                         margin: 0 !important;
-                        padding: 0 !important;
+                        padding: 24mm 8mm !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;
@@ -228,7 +232,6 @@
                     }
                     @page {
                         margin: 0 !important;
-                        padding: 24mm 8mm !important;
                         size: A4;
                     }
                     .f5-print-btn {

--- a/budget_appropriation_summary/report/report_compilation_f5.xml
+++ b/budget_appropriation_summary/report/report_compilation_f5.xml
@@ -79,11 +79,10 @@
 
     <!-- Reusable F5 content (renders a single data dict) -->
     <template id="report_compilation_f5_content">
+        <t t-call="budget_appropriation_summary.report_page_label">
+            <t t-set="page_label" t-value="'F5-P-วง-003'"/>
+        </t>
         <div class="report-header">
-            <div class="document-ref">
-                <div>F5-P-วง-003</div>
-            </div>
-
             <div class="institution-info">
                 <h3 t-out="data.get('source', '')"/>
                 <h3>ประมาณการรายจ่าย <span t-out="data.get('fiscal_year', '')"/></h3>
@@ -232,11 +231,6 @@
                         padding: 24mm 8mm !important;
                         size: A4;
                     }
-                    .f5-page-label {
-                        position: fixed;
-                        top: 5mm;
-                        right: 5mm;
-                    }
                     .f5-print-btn {
                         display: none !important;
                     }
@@ -298,9 +292,21 @@
                 margin-bottom: 12pt;
             }
 
-            .document-ref {
-                float: right;
-                margin-bottom: 12pt;
+            .report-page-label {
+                position: absolute;
+                top: 1mm;
+                right: 8mm;
+                font-size: 15pt;
+                font-family: 'THSarabun', Arial, sans-serif;
+                z-index: 10;
+                pointer-events: none;
+            }
+            @media print {
+                .report-page-label {
+                    position: fixed;
+                    top: 2mm;
+                    right: 5mm;
+                }
             }
 
             .institution-info {

--- a/budget_appropriation_summary/report/report_compilation_f5.xml
+++ b/budget_appropriation_summary/report/report_compilation_f5.xml
@@ -211,18 +211,21 @@
                 @media print {
                     html, body {
                         background: white !important;
-                        margin: 0;
-                        padding: 0;
+                        margin: 0 !important;
+                        padding: 0 !important;
+                        width: auto !important;
+                        height: auto !important;
                     }
                     .article, main, header, footer, .o_report_layout_standard {
                         margin: 0 !important;
                         padding: 0 !important;
                     }
                     .page {
-                        width: auto;
-                        min-height: auto;
+                        width: 100% !important;
+                        min-height: auto !important;
+                        max-width: none !important;
                         margin: 0 !important;
-                        padding: 24mm 8mm !important;
+                        padding: 0 !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;
@@ -232,6 +235,7 @@
                     }
                     @page {
                         margin: 0 !important;
+                        padding: 24mm 8mm !important;
                         size: A4;
                     }
                     .f5-print-btn {

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -41,6 +41,9 @@
         </style>
         <div class="page f10w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F10-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center" style="font-weight: bold">
                 <h3>

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -25,6 +25,9 @@
         </style>
         <div class="page f11w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F11-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center">
                 <h3>

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -22,6 +22,9 @@
         </style>
         <div class="page landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F2-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center">
                 <h3>สรุปเปรียบเทียบประมาณการรายรับ</h3>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -19,6 +19,9 @@
         </style>
         <div class="page f3w_f6w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F3-W-วง-003 และ F6-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center fw-bold">
                 <h3>

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -12,6 +12,9 @@
         </style>
         <div class="page f4-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F4-P-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center">
                 <h3 class="fw-bold">

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -31,6 +31,9 @@
         </style>
         <div class="page f4-w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F4-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center fw-bold">
                 <h3>

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -4,6 +4,9 @@
     <template id="report_f5p_expense_content">
         <div class="page f5-p" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F5-P-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center fw-bold">
                 <h3>

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -19,6 +19,9 @@
         </style>
         <div class="page f5w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F5-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center" style="font-weight: bold">
                 <h3>สรุปเปรียบเทียบประมาณการรายจ่าย</h3>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -28,6 +28,9 @@
         </style>
         <div class="page f7w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F7-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center" style="font-weight: bold">
                 <h3>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -25,6 +25,9 @@
         </style>
         <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F8-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center" style="font-weight: bold">
                 <h3>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -22,6 +22,9 @@
         </style>
         <div class="page f9w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F9-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center" style="font-weight: bold">
                 <h3>

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -41,8 +41,10 @@
                         </svg>
                         พิมพ์รายงาน </button>
                 </t>
+                <t t-call="budget_appropriation_summary.report_page_label">
+                    <t t-set="page_label" t-value="'F3-P-วง-003'"/>
+                </t>
                 <div class="report-header mb-2" contenteditable="false">
-                    <div class="f3-document-ref">F3-P-วง-003</div>
                     <h4>สรุปประมาณการรายรับ - รายจ่าย</h4>
                     <h4> ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name" />
                     </h4>
@@ -293,15 +295,6 @@
                     outline: none;
                 }
 
-                .f3-page-label {
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    font-size: 10pt;
-                    color: #333;
-                    pointer-events: none;
-                }
-
                 .f3-print-btn {
                     position: absolute;
                     top: 20px;
@@ -346,11 +339,6 @@
                         margin: 0 !important;
                         padding: 24mm 8mm !important;
                         size: A4;
-                    }
-                    .f3-page-label {
-                        position: fixed;
-                        top: 5mm;
-                        right: 5mm;
                     }
                     .f3-print-btn {
                         display: none !important;
@@ -398,11 +386,21 @@
                 cursor: not-allowed;
             }
 
-            .f3-document-ref {
+            .report-page-label {
                 position: absolute;
-                top: 0;
-                right: 0;
+                top: 4mm;
+                right: 8mm;
                 font-size: 15pt;
+                font-family: 'THSarabun', Arial, sans-serif;
+                z-index: 10;
+                pointer-events: none;
+            }
+            @media print {
+                .report-page-label {
+                    position: fixed;
+                    top: 5mm;
+                    right: 5mm;
+                }
             }</style>
     </template>
     <!-- Main report template -->

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -388,7 +388,7 @@
 
             .report-page-label {
                 position: absolute;
-                top: 4mm;
+                top: 1mm;
                 right: 8mm;
                 font-size: 15pt;
                 font-family: 'THSarabun', Arial, sans-serif;
@@ -398,7 +398,7 @@
             @media print {
                 .report-page-label {
                     position: fixed;
-                    top: 5mm;
+                    top: 2mm;
                     right: 5mm;
                 }
             }</style>

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -320,18 +320,21 @@
                 @media print {
                     html, body {
                         background: white !important;
-                        margin: 0;
-                        padding: 0;
+                        margin: 0 !important;
+                        padding: 0 !important;
+                        width: auto !important;
+                        height: auto !important;
                     }
                     .article, main, header, footer, .o_report_layout_standard {
                         margin: 0 !important;
                         padding: 0 !important;
                     }
                     .page {
-                        width: auto;
-                        min-height: auto;
+                        width: 100% !important;
+                        min-height: auto !important;
+                        max-width: none !important;
                         margin: 0 !important;
-                        padding: 24mm 8mm !important;
+                        padding: 0 !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;
@@ -341,6 +344,7 @@
                     }
                     @page {
                         margin: 0 !important;
+                        padding: 24mm 8mm !important;
                         size: A4;
                     }
                     .f3-print-btn {

--- a/budget_appropriation_summary_f3/report/report_compilation_f3.xml
+++ b/budget_appropriation_summary_f3/report/report_compilation_f3.xml
@@ -323,11 +323,15 @@
                         margin: 0;
                         padding: 0;
                     }
+                    .article, main, header, footer, .o_report_layout_standard {
+                        margin: 0 !important;
+                        padding: 0 !important;
+                    }
                     .page {
                         width: auto;
                         min-height: auto;
                         margin: 0 !important;
-                        padding: 0 !important;
+                        padding: 24mm 8mm !important;
                         box-shadow: none;
                         border-radius: 0;
                         background-image: none !important;
@@ -337,7 +341,6 @@
                     }
                     @page {
                         margin: 0 !important;
-                        padding: 24mm 8mm !important;
                         size: A4;
                     }
                     .f3-print-btn {


### PR DESCRIPTION
## Summary
- Add reusable `report_page_label` template (and `.report-page-label` CSS) in `report_common.xml`. CSS uses `position: absolute` in HTML preview and `position: fixed` under `@media print`, so the label appears at the top-right corner of every printed page.
- Add the label to 13 reports: F2 (`F2-W-วง-003`), F4P (`F4-P-วง-003`), F4W (`F4-W-วง-003`), F3W/F6W (`F3-W-วง-003 และ F6-W-วง-003`), F5P, F5W, F7W, F8W, F9W, F10W, F11W, F23W (`F23-W-วง-003`, replacing the old `F23-W-วง-002` ref that only showed on the first page), and F3 (`F3-P-วง-003`, in `budget_appropriation_summary_f3`).
- Bump `budget_appropriation_summary` version to 16.0.1.0.4.

## Test plan
- [ ] Open each report from portal (html_preview) and confirm the report code label appears at the top-right of the page.
- [ ] Click "พิมพ์รายงาน" and confirm the label appears at the top-right of every printed page (not just the first).
- [ ] Confirm F23W and F3 still render the title block centered (label removed from the report header).