### PR TITLE
[16.0][ADD] kmitl_depends_dev: account_usability

### DIFF
--- a/kmitl_depends_dev/__manifest__.py
+++ b/kmitl_depends_dev/__manifest__.py
@@ -10,6 +10,7 @@
                 'account_asset_kmitl', 'account_asset_number_kmitl', 'account_asset_operating_unit_access_all',
                 'account_asset_batch', 'account_asset_subcomponent_kmitl',
                 'account_fiscal_year_all_user', 'account_fiscal_year_enhance',
+                'account_usability',
                 'disbursement', 'accounting_kmitl',
                 'analytic_operating_unit_tree', 'base_tier_validation_comment', 'budget_account_mass_edit',
                 'budget_analytic_account', 'budget_appropriation_operating_unit',


### PR DESCRIPTION
## Summary
- Add `account_usability` (OCA `account-financial-tools`) to `kmitl_depends_dev` so the dev meta-module installs OCA accounting UX improvements alongside other dev dependencies.

## Test plan
- [ ] Update `kmitl_depends_dev` and verify `account_usability` installs without error.