### PR TITLE
[IMP] hr_recruitment_kmitl: align /my/application/<id> view with /job…

### DIFF
--- a/hr_recruitment_kmitl/controllers/portal.py
+++ b/hr_recruitment_kmitl/controllers/portal.py
@@ -91,20 +91,15 @@ class HrRecruitmentPortal(CustomerPortal):
             )
         return items
 
-    def _prepare_education_item(self, application, profile):
+    def _prepare_education_items(self, application, profile):
         records = getattr(application, "education_history_ids", False)
+        education_model = "hr.applicant.education.history"
         if not records and profile:
             records = profile.education_history_ids
+            education_model = "portal.education.history"
 
         if not records:
-            return {
-                "level": "-",
-                "program": "-",
-                "major": "-",
-                "institution": "-",
-                "country": "-",
-                "graduation_date": "-",
-            }
+            return []
 
         sorted_records = records.sorted(
             key=lambda r: (
@@ -115,19 +110,45 @@ class HrRecruitmentPortal(CustomerPortal):
             ),
             reverse=True,
         )
-        rec = sorted_records[0]
 
-        return {
-            "level": rec.education_level_id.name if rec.education_level_id else "-",
-            "program": getattr(rec, "program", "") or "-",
-            "major": getattr(rec, "major", "") or "-",
-            "institution": getattr(rec, "institution", "") or "-",
-            "country": rec.country_id.name
-            if getattr(rec, "country_id", False)
-            else "-",
-            "graduation_date": self._format_date(getattr(rec, "graduation_date", False))
-            or "-",
-        }
+        items = []
+        for rec in sorted_records:
+            certificate_filename = getattr(rec, "certificate_filename", "")
+            transcript_filename = getattr(rec, "transcript_filename", "")
+            items.append(
+                {
+                    "level": rec.education_level_id.name
+                    if rec.education_level_id
+                    else "-",
+                    "program": getattr(rec, "program", "") or "-",
+                    "major": getattr(rec, "major", "") or "-",
+                    "institution": getattr(rec, "institution", "") or "-",
+                    "country": rec.country_id.name
+                    if getattr(rec, "country_id", False)
+                    else "-",
+                    "graduation_date": self._format_date(
+                        getattr(rec, "graduation_date", False)
+                    )
+                    or "-",
+                    "certificate_filename": certificate_filename,
+                    "certificate_url": (
+                        "/web/content?model=%s&id=%d&field=certificate_file"
+                        "&filename_field=certificate_filename&download=true"
+                        % (education_model, rec.id)
+                    )
+                    if certificate_filename
+                    else False,
+                    "transcript_filename": transcript_filename,
+                    "transcript_url": (
+                        "/web/content?model=%s&id=%d&field=transcript_file"
+                        "&filename_field=transcript_filename&download=true"
+                        % (education_model, rec.id)
+                    )
+                    if transcript_filename
+                    else False,
+                }
+            )
+        return items
 
     def _prepare_work_history_items(self, application, profile):
         records = getattr(application, "work_history_ids", False)
@@ -159,49 +180,143 @@ class HrRecruitmentPortal(CustomerPortal):
             )
         return items
 
+    def _prepare_academic_tab(self, application, academic_source):
+        english_test_type_map = {
+            "toefl_paper": "TOEFL (Paper-Based)",
+            "toefl_computer": "TOEFL (Computer-Based)",
+            "toefl_internet": "TOEFL (Internet-Based)",
+            "ielts": "IELTS",
+            "cutep": "CU-TEP",
+            "kmitl_tep": "KMITL-TEP",
+        }
+        english_test_type = getattr(academic_source, "english_test_type", False)
+
+        def _file(field_name, filename_field):
+            filename = getattr(application, filename_field, "")
+            if not filename:
+                return {"filename": "", "download_url": False}
+            return {
+                "filename": filename,
+                "download_url": self._applicant_file_url(
+                    application, field_name, filename_field
+                ),
+            }
+
+        return {
+            "job_role": application.job_id.role if application.job_id else False,
+            "academic_standing_id": academic_source.academic_standing_id.name
+            if getattr(academic_source, "academic_standing_id", False)
+            else "-",
+            "academic_position_date": self._format_date(
+                getattr(academic_source, "academic_position_date", False)
+            )
+            or "-",
+            "academic_position_institution": getattr(
+                academic_source, "academic_position_institution", ""
+            )
+            or "-",
+            "academic_position_file": _file(
+                "academic_position_file", "academic_position_filename"
+            ),
+            "has_ocsc_exam": "ผ่าน"
+            if getattr(academic_source, "has_ocsc_exam", False)
+            else "ไม่ผ่าน / ไม่มีข้อมูล",
+            "ocsc_exam_level": self._selection_label(
+                academic_source,
+                "ocsc_exam_level",
+                getattr(academic_source, "ocsc_exam_level", False),
+            )
+            or "-",
+            "ocsc_exam_date": self._format_date(
+                getattr(academic_source, "ocsc_exam_date", False)
+            )
+            or "-",
+            "ocsc_exam_number": getattr(academic_source, "ocsc_exam_number", "") or "-",
+            "ocsc_exam_file": _file("ocsc_exam_file", "ocsc_exam_filename"),
+            "english_test_type": english_test_type_map.get(english_test_type, "-"),
+            "english_test_score": getattr(academic_source, "english_test_score", "")
+            or "-",
+            "english_test_date": self._format_date(
+                getattr(academic_source, "english_test_date", False)
+            )
+            or "-",
+            "english_test_certificate_number": getattr(
+                academic_source, "english_test_certificate_number", ""
+            )
+            or "-",
+            "english_score_file": _file("english_score_file", "english_score_filename"),
+        }
+
+    def _applicant_file_url(self, application, field_name, filename_field):
+        return (
+            "/web/content?model=hr.applicant&id=%d&field=%s"
+            "&filename_field=%s&download=true"
+            % (application.id, field_name, filename_field)
+        )
+
     def _prepare_document_items(self, application):
-        documents = []
-        attachment_fields = [
-            ("resume_attachment_id", "Resume / CV"),
-            ("transcript_attachment_id", "Transcript"),
-            ("certificate_attachment_id", "Certificate"),
-            ("other_attachment_id", "Other Document"),
+        role = application.job_id.role if application.job_id else False
+        gender = application.gender
+
+        document_specs = [
+            ("photo_file", "photo_filename", "รูปถ่าย (Photo)", True),
+            (
+                "id_card_file",
+                "id_card_filename",
+                "สำเนาบัตรประจำตัวประชาชน",
+                True,
+            ),
+            (
+                "household_registration_file",
+                "household_registration_filename",
+                "สำเนาทะเบียนบ้าน",
+                True,
+            ),
+            (
+                "military_certificate_file",
+                "military_certificate_filename",
+                "สำเนาหนังสือรับรองผ่านการเกณฑ์ทหาร หรือได้รับการยกเว้นการเกณฑ์ทหาร "
+                "(ใบ สด.8 สด.9 หรือ สด.43 หรือหลักฐานทางทหารอื่น ๆ)",
+                gender == "male",
+            ),
+            (
+                "resume_file",
+                "resume_filename",
+                "ประวัติการทำงาน (Resume)",
+                role == "academic",
+            ),
+            (
+                "work_certificate_file",
+                "work_certificate_filename",
+                "หนังสือรับรองการทำงาน",
+                role == "academic",
+            ),
+            (
+                "other_documents_file",
+                "other_documents_filename",
+                "สำเนาเอกสารอื่น ๆ เช่น การเปลี่ยนชื่อ นามสกุล",
+                True,
+            ),
         ]
 
-        for field_name, label in attachment_fields:
+        documents = []
+        for field_name, filename_field, label, include in document_specs:
+            if not include:
+                continue
             if field_name not in application._fields:
                 continue
-            attachment = application[field_name]
-            if attachment:
-                documents.append(
-                    {
-                        "label": label,
-                        "filename": attachment.name or label,
-                        "download_url": "/web/content/%s?download=true" % attachment.id,
-                    }
-                )
-
-        if not documents:
-            attachments = (
-                request.env["ir.attachment"]
-                .sudo()
-                .search(
-                    [
-                        ("res_model", "=", "hr.applicant"),
-                        ("res_id", "=", application.id),
-                    ],
-                    order="create_date asc",
-                )
+            filename = getattr(application, filename_field, "")
+            documents.append(
+                {
+                    "label": label,
+                    "filename": filename or "-",
+                    "download_url": self._applicant_file_url(
+                        application, field_name, filename_field
+                    )
+                    if filename
+                    else False,
+                }
             )
-            for attachment in attachments:
-                documents.append(
-                    {
-                        "label": attachment.name or "Document",
-                        "filename": attachment.name or "-",
-                        "download_url": "/web/content/%s?download=true" % attachment.id,
-                    }
-                )
-
         return documents
 
     def _prepare_view_data(self, application, all_stages):
@@ -265,6 +380,43 @@ class HrRecruitmentPortal(CustomerPortal):
                 "-",
             )
 
+        title_name_en = (
+            application.applicant_title.with_context(lang="en_US").name
+            if application.applicant_title
+            else ""
+        )
+        full_name_en = " ".join(
+            part
+            for part in [
+                title_name_en or "",
+                application.first_name_en or "",
+                application.middle_name_en or "",
+                application.last_name_en or "",
+            ]
+            if part
+        )
+        if not full_name_en and profile:
+            title_name_en = (
+                profile.title.with_context(lang="en_US").name if profile.title else ""
+            )
+            full_name_en = " ".join(
+                part
+                for part in [
+                    title_name_en or "",
+                    profile.first_name_en or "",
+                    profile.middle_name_en or "",
+                    profile.last_name_en or "",
+                ]
+                if part
+            )
+
+        gender_labels = {"male": "ชาย (Male)", "female": "หญิง (Female)"}
+        gender_value = self._first_non_empty(
+            application.gender,
+            profile.gender if profile else False,
+        )
+        gender_display = gender_labels.get(gender_value, "")
+
         registered_address = self._first_non_empty(
             getattr(application, "address_address", False),
             profile.address_address if profile else False,
@@ -312,6 +464,8 @@ class HrRecruitmentPortal(CustomerPortal):
             "tabs": {
                 "personal": {
                     "full_name": full_name or "-",
+                    "full_name_en": full_name_en or "-",
+                    "gender": gender_display or "-",
                     "identification_id": self._first_non_empty(
                         getattr(application, "identification_id", False),
                         profile.identification_id if profile else False,
@@ -350,36 +504,9 @@ class HrRecruitmentPortal(CustomerPortal):
                         "-",
                     ),
                 },
-                "education": self._prepare_education_item(application, profile),
+                "education": self._prepare_education_items(application, profile),
                 "work_history": self._prepare_work_history_items(application, profile),
-                "academic": {
-                    "academic_standing_id": academic_source.academic_standing_id.name
-                    if getattr(academic_source, "academic_standing_id", False)
-                    else "-",
-                    "academic_position_date": self._format_date(
-                        getattr(academic_source, "academic_position_date", False)
-                    )
-                    or "-",
-                    "academic_position_institution": getattr(
-                        academic_source, "academic_position_institution", ""
-                    )
-                    or "-",
-                    "has_ocsc_exam": "Yes"
-                    if getattr(academic_source, "has_ocsc_exam", False)
-                    else "No",
-                    "ocsc_exam_level": self._selection_label(
-                        academic_source,
-                        "ocsc_exam_level",
-                        getattr(academic_source, "ocsc_exam_level", False),
-                    )
-                    or "-",
-                    "ocsc_exam_date": self._format_date(
-                        getattr(academic_source, "ocsc_exam_date", False)
-                    )
-                    or "-",
-                    "ocsc_exam_number": getattr(academic_source, "ocsc_exam_number", "")
-                    or "-",
-                },
+                "academic": self._prepare_academic_tab(application, academic_source),
                 "skills": {
                     "foreign_language_skills": getattr(
                         skills_source, "foreign_language_skills", ""

--- a/hr_recruitment_kmitl/views/portal_application_detail_tabs.xml
+++ b/hr_recruitment_kmitl/views/portal_application_detail_tabs.xml
@@ -13,6 +13,12 @@
                             <t t-set="value" t-value="tab['full_name']" />
                         </t>
                     </div>
+                    <div class="col-12">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">ชื่อ - นามสกุล (ภาษาอังกฤษ)</t>
+                            <t t-set="value" t-value="tab['full_name_en']" />
+                        </t>
+                    </div>
                     <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">สัญชาติ</t>
@@ -29,6 +35,12 @@
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">วัน/เดือน/ปีเกิด</t>
                             <t t-set="value" t-value="tab['birthday']" />
+                        </t>
+                    </div>
+                    <div class="col-md-6">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">เพศ</t>
+                            <t t-set="value" t-value="tab['gender']" />
                         </t>
                     </div>
                     <div class="col-md-6">
@@ -109,58 +121,137 @@
     </template>
     <template id="application_view_tab_education">
         <t t-set="tab" t-value="view_data['tabs']['education']" />
-        <t t-if="tab">
-            <div class="card shadow-sm border-0 rounded-4">
-                <div class="card-body p-4 p-md-5">
-                    <t t-call="hr_recruitment_kmitl.application_tab_intro">
-                        <t t-set="title">2. ประวัติการศึกษา (Education History)</t>
-                        <t t-set="description">แสดงวุฒิการศึกษาที่ใช้ในการสมัครงาน</t>
+        <div class="card shadow-sm border-0 rounded-4">
+            <div class="card-body p-4 p-md-5">
+                <t t-call="hr_recruitment_kmitl.application_tab_intro">
+                    <t t-set="title">2. ประวัติการศึกษา (Education History)</t>
+                    <t t-set="description">แสดงวุฒิการศึกษาที่ใช้ในการสมัครงาน</t>
+                </t>
+                <t t-if="tab">
+                    <t t-foreach="tab" t-as="edu">
+                        <div
+                            t-attf-class="border rounded-12 overflow-hidden #{'mt-3' if not edu_first else ''}"
+                        >
+                            <div class="row g-0">
+                                <div
+                                    class="col-lg-3 d-flex align-items-center justify-content-center p-3 border-end"
+                                >
+                                    <div class="text-center">
+                                        <div
+                                            class="rounded-circle border border-2 border-primary text-primary d-inline-flex align-items-center justify-content-center mb-2"
+                                            style="width: 36px; height: 36px; font-weight: bold; font-size: 1.1rem;"
+                                        >
+                                            <t t-esc="edu_index + 1" />
+                                        </div>
+                                        <h6 class="mb-0 fw-bold">
+                                            <t t-esc="edu.get('level') or '-'" />
+                                        </h6>
+                                    </div>
+                                </div>
+                                <div class="col-lg-9 p-3">
+                                    <div class="row g-3">
+                                        <div class="col-md-6">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_readonly_field"
+                                            >
+                                                <t t-set="label">หลักสูตร</t>
+                                                <t
+                                                    t-set="value"
+                                                    t-value="edu.get('program')"
+                                                />
+                                            </t>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_readonly_field"
+                                            >
+                                                <t t-set="label">สาขา/วิชาเอก</t>
+                                                <t
+                                                    t-set="value"
+                                                    t-value="edu.get('major')"
+                                                />
+                                            </t>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_readonly_field"
+                                            >
+                                                <t t-set="label">สถาบัน/มหาวิทยาลัย</t>
+                                                <t
+                                                    t-set="value"
+                                                    t-value="edu.get('institution')"
+                                                />
+                                            </t>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_readonly_field"
+                                            >
+                                                <t t-set="label">ประเทศ</t>
+                                                <t
+                                                    t-set="value"
+                                                    t-value="edu.get('country')"
+                                                />
+                                            </t>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_readonly_field"
+                                            >
+                                                <t t-set="label">สำเร็จการศึกษาเมื่อ</t>
+                                                <t
+                                                    t-set="value"
+                                                    t-value="edu.get('graduation_date')"
+                                                />
+                                            </t>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_document_item"
+                                            >
+                                                <t
+                                                    t-set="label"
+                                                >ใบรับรอง (Certificate)</t>
+                                                <t
+                                                    t-set="filename"
+                                                    t-value="edu.get('certificate_filename')"
+                                                />
+                                                <t
+                                                    t-set="download_url"
+                                                    t-value="edu.get('certificate_url')"
+                                                />
+                                            </t>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <t
+                                                t-call="hr_recruitment_kmitl.application_document_item"
+                                            >
+                                                <t
+                                                    t-set="label"
+                                                >ผลการเรียนรายวิชา (Transcript)</t>
+                                                <t
+                                                    t-set="filename"
+                                                    t-value="edu.get('transcript_filename')"
+                                                />
+                                                <t
+                                                    t-set="download_url"
+                                                    t-value="edu.get('transcript_url')"
+                                                />
+                                            </t>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </t>
-                    <h6 class="fw-bold text-dark mb-4">
-                        <t t-esc="tab.get('level') or tab.get('level_label') or '-'" />
-                    </h6>
-                    <div class="row g-4">
-                        <div class="col-md-6">
-                            <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                                <t t-set="label">หลักสูตร</t>
-                                <t t-set="value" t-value="tab.get('program')" />
-                            </t>
-                        </div>
-                        <div class="col-md-6">
-                            <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                                <t t-set="label">สาขา/วิชาเอก</t>
-                                <t t-set="value" t-value="tab.get('major')" />
-                            </t>
-                        </div>
-                        <div class="col-md-6">
-                            <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                                <t t-set="label">สถาบัน/มหาวิทยาลัย</t>
-                                <t t-set="value" t-value="tab.get('institution')" />
-                            </t>
-                        </div>
-                        <div class="col-md-6">
-                            <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                                <t t-set="label">ประเทศ</t>
-                                <t t-set="value" t-value="tab.get('country')" />
-                            </t>
-                        </div>
-                        <div class="col-md-6">
-                            <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                                <t t-set="label">สำเร็จการศึกษาเมื่อ</t>
-                                <t t-set="value" t-value="tab.get('graduation_date')" />
-                            </t>
-                        </div>
+                </t>
+                <t t-else="">
+                    <div class="text-secondary">
+                        ไม่มีข้อมูลการศึกษา
                     </div>
-                </div>
+                </t>
             </div>
-        </t>
-        <t t-else="">
-            <div class="card border rounded-4 shadow-none">
-                <div class="card-body p-4 text-secondary">
-                    ไม่มีข้อมูลการศึกษา
-                </div>
-            </div>
-        </t>
+        </div>
     </template>
     <template id="application_view_tab_work_history">
         <t t-set="tab" t-value="view_data['tabs']['work_history']" />
@@ -242,7 +333,10 @@
     </template>
     <template id="application_view_tab_academic">
         <t t-set="tab" t-value="view_data['tabs']['academic']" />
-        <div class="card shadow-sm border-0 rounded-4">
+        <div
+            class="card shadow-sm border-0 rounded-4"
+            t-if="tab['job_role'] == 'academic'"
+        >
             <div class="card-body p-4 p-md-5">
                 <t t-call="hr_recruitment_kmitl.application_tab_intro">
                     <t t-set="title">4. ข้อมูลทางวิชาการและราชการ</t>
@@ -250,19 +344,13 @@
                 </t>
                 <h6 class="fw-bold text-dark mb-4">ตำแหน่งทางวิชาการ</h6>
                 <div class="row g-4">
-                    <div class="col-md-4">
+                    <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">ตำแหน่งทางวิชาการ</t>
                             <t t-set="value" t-value="tab['academic_standing_id']" />
                         </t>
                     </div>
-                    <div class="col-md-4">
-                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                            <t t-set="label">วันที่ได้รับแต่งตั้ง</t>
-                            <t t-set="value" t-value="tab['academic_position_date']" />
-                        </t>
-                    </div>
-                    <div class="col-md-4">
+                    <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">สถาบันที่ได้รับแต่งตั้ง</t>
                             <t
@@ -271,40 +359,131 @@
                             />
                         </t>
                     </div>
+                    <div class="col-md-6">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">วันที่ได้รับแต่งตั้ง</t>
+                            <t t-set="value" t-value="tab['academic_position_date']" />
+                        </t>
+                    </div>
+                </div>
+                <div class="mt-3">
+                    <t t-call="hr_recruitment_kmitl.application_document_item">
+                        <t
+                            t-set="label"
+                        >หลักฐานตำแหน่งทางวิชาการ (Academic Position Proof)</t>
+                        <t
+                            t-set="filename"
+                            t-value="tab['academic_position_file']['filename']"
+                        />
+                        <t
+                            t-set="download_url"
+                            t-value="tab['academic_position_file']['download_url']"
+                        />
+                    </t>
                 </div>
             </div>
         </div>
-        <div class="card shadow-sm border-0 rounded-4 mt-3">
+        <div
+            class="card shadow-sm border-0 rounded-4 mt-3"
+            t-if="tab['job_role'] == 'support'"
+        >
             <div class="card-body p-4 p-md-5">
                 <t t-call="hr_recruitment_kmitl.application_tab_intro">
-                    <t t-set="title">การสอบ ก.พ.</t>
+                    <t t-set="title">4. การสอบ ก.พ. (OCSC Exam)</t>
                     <t t-set="description">ผลการสอบที่ใช้ในใบสมัครนี้</t>
                 </t>
                 <div class="row g-4">
-                    <div class="col-md-3">
+                    <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
-                            <t t-set="label">สอบผ่าน ก.พ.</t>
+                            <t t-set="label">สถานะการสอบ ก.พ.</t>
                             <t t-set="value" t-value="tab['has_ocsc_exam']" />
                         </t>
                     </div>
-                    <div class="col-md-3">
+                    <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">ระดับการสอบ</t>
                             <t t-set="value" t-value="tab['ocsc_exam_level']" />
                         </t>
                     </div>
-                    <div class="col-md-3">
+                    <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">วันที่สอบผ่าน</t>
                             <t t-set="value" t-value="tab['ocsc_exam_date']" />
                         </t>
                     </div>
-                    <div class="col-md-3">
+                    <div class="col-md-6">
                         <t t-call="hr_recruitment_kmitl.application_readonly_field">
                             <t t-set="label">เลขที่ใบรับรอง</t>
                             <t t-set="value" t-value="tab['ocsc_exam_number']" />
                         </t>
                     </div>
+                </div>
+                <div class="mt-3">
+                    <t t-call="hr_recruitment_kmitl.application_document_item">
+                        <t t-set="label">หลักฐานการสอบ ก.พ. (OCSC Exam Proof)</t>
+                        <t
+                            t-set="filename"
+                            t-value="tab['ocsc_exam_file']['filename']"
+                        />
+                        <t
+                            t-set="download_url"
+                            t-value="tab['ocsc_exam_file']['download_url']"
+                        />
+                    </t>
+                </div>
+            </div>
+        </div>
+        <div
+            class="card shadow-sm border-0 rounded-4 mt-3"
+            t-if="tab['job_role'] == 'academic'"
+        >
+            <div class="card-body p-4 p-md-5">
+                <t t-call="hr_recruitment_kmitl.application_tab_intro">
+                    <t t-set="title">ผลสอบภาษาอังกฤษ (English Test Result)</t>
+                </t>
+                <div class="row g-4">
+                    <div class="col-md-6">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">ประเภทการสอบ (Test Type)</t>
+                            <t t-set="value" t-value="tab['english_test_type']" />
+                        </t>
+                    </div>
+                    <div class="col-md-6">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">คะแนน (Score)</t>
+                            <t t-set="value" t-value="tab['english_test_score']" />
+                        </t>
+                    </div>
+                    <div class="col-md-6">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">วันที่สอบ (Test Date)</t>
+                            <t t-set="value" t-value="tab['english_test_date']" />
+                        </t>
+                    </div>
+                    <div class="col-md-6">
+                        <t t-call="hr_recruitment_kmitl.application_readonly_field">
+                            <t t-set="label">เลขที่ใบรับรอง (Certificate Number)</t>
+                            <t
+                                t-set="value"
+                                t-value="tab['english_test_certificate_number']"
+                            />
+                        </t>
+                    </div>
+                </div>
+                <div class="mt-3">
+                    <t t-call="hr_recruitment_kmitl.application_document_item">
+                        <t
+                            t-set="label"
+                        >ไฟล์แนบผลสอบภาษาอังกฤษ (English Test Result Attachment)</t>
+                        <t
+                            t-set="filename"
+                            t-value="tab['english_score_file']['filename']"
+                        />
+                        <t
+                            t-set="download_url"
+                            t-value="tab['english_score_file']['download_url']"
+                        />
+                    </t>
                 </div>
             </div>
         </div>

--- a/hr_recruitment_kmitl/views/shared_components.xml
+++ b/hr_recruitment_kmitl/views/shared_components.xml
@@ -371,13 +371,13 @@
         <label class="form-label fw-semibold text-dark">
             <t t-out="label" />
         </label>
+        <!-- prettier-ignore-start -->
         <textarea
             class="form-control text-muted border-0 py-2"
             t-att-rows="rows or 4"
             readonly="readonly"
-        >
-            <t t-out="value or '-'" />
-        </textarea>
+        ><t t-out="value or '-'" /></textarea>
+        <!-- prettier-ignore-end -->
     </template>
     <template id="application_document_item">
         <div class="d-flex align-items-center gap-3 p-3 border rounded-3">


### PR DESCRIPTION
…s/apply form

Display the same fields and sections on the application detail page as the apply form so applicants see identical data when revisiting their submission.

- Personal: add English full name and gender
- Education: render all degrees with certificate/transcript downloads (previously only the highest degree)
- Academic: role-gate cards (academic vs support), add English test result section, and expose academic position / OCSC / English score file downloads
- Documents: source from hr.applicant KMITL binary fields (photo, id card, household registration, military for males, resume and work certificate for academic role, other documents) instead of generic ir.attachment fallback