### PR TITLE
[IMP] hr_recruitment_kmitl: enforce portal ownership with record rule…

### DIFF
--- a/hr_recruitment_kmitl/controllers/jobs_apply.py
+++ b/hr_recruitment_kmitl/controllers/jobs_apply.py
@@ -46,7 +46,6 @@ class WebsiteJobsApply(WebsiteHrRecruitment):
             partner = request.env.user.partner_id
             profile = (
                 request.env["portal.profile"]
-                .sudo()
                 .with_context(lang="th_TH")
                 .search([("partner_id", "=", partner.id)], limit=1)
             )

--- a/hr_recruitment_kmitl/controllers/portal.py
+++ b/hr_recruitment_kmitl/controllers/portal.py
@@ -13,16 +13,16 @@ class HrRecruitmentPortal(CustomerPortal):
         if "application_count" in counters:
             domain = self._get_applications_domain()
             values["application_count"] = (
-                request.env["hr.applicant"].sudo().search_count(domain)
+                request.env["hr.applicant"]
+                .with_context(active_test=False)
+                .search_count(domain)
             )
         return values
 
     def _get_applications_domain(self):
         partner = request.env.user.partner_id
         return [
-            "|",
             ("partner_id", "=", partner.id),
-            ("email_from", "=ilike", partner.email or ""),
             ("active", "in", [True, False]),
         ]
 
@@ -44,10 +44,8 @@ class HrRecruitmentPortal(CustomerPortal):
         return dict(field.selection).get(value, value)
 
     def _get_profile(self, partner):
-        return (
-            request.env["portal.profile"]
-            .sudo()
-            .search([("partner_id", "=", partner.id)], limit=1)
+        return request.env["portal.profile"].search(
+            [("partner_id", "=", partner.id)], limit=1
         )
 
     def _compute_age(self, birthday):
@@ -531,7 +529,7 @@ class HrRecruitmentPortal(CustomerPortal):
     def portal_my_applications(self, page=1, sortby=None, **kw):
         if must_set_email():
             return request.redirect("/my/profile")
-        HrApplicant = request.env["hr.applicant"].sudo()
+        HrApplicant = request.env["hr.applicant"].with_context(active_test=False)
         domain = self._get_applications_domain()
 
         sortings = {
@@ -580,7 +578,6 @@ class HrRecruitmentPortal(CustomerPortal):
         partner = request.env.user.partner_id
         application = (
             request.env["hr.applicant"]
-            .sudo()
             .with_context(active_test=False)
             .browse(application_id)
         )
@@ -588,15 +585,7 @@ class HrRecruitmentPortal(CustomerPortal):
         if not application.exists():
             return request.redirect("/my")
 
-        partner_match = (
-            application.partner_id and application.partner_id.id == partner.id
-        )
-        email_match = (
-            application.email_from
-            and partner.email
-            and application.email_from.lower() == partner.email.lower()
-        )
-        if not partner_match and not email_match:
+        if not (application.partner_id and application.partner_id.id == partner.id):
             return request.redirect("/my")
 
         stage_domain = [

--- a/hr_recruitment_kmitl/controllers/portal_onboarding.py
+++ b/hr_recruitment_kmitl/controllers/portal_onboarding.py
@@ -12,13 +12,9 @@ class PortalOnboardingHome(CustomerPortal):
         values = super()._prepare_home_portal_values(counters)
         if "onboarding_count" in counters:
             partner = request.env.user.partner_id
-            domain = [
-                "|",
-                ("applicant_id.partner_id", "=", partner.id),
-                ("applicant_id.email_from", "=ilike", partner.email or ""),
-            ]
-            values["onboarding_count"] = (
-                request.env["hr.onboarding"].sudo().search_count(domain)
+            domain = [("applicant_id.partner_id", "=", partner.id)]
+            values["onboarding_count"] = request.env["hr.onboarding"].search_count(
+                domain
             )
         return values
 
@@ -26,27 +22,17 @@ class PortalOnboardingHome(CustomerPortal):
 class PortalOnboardingController(http.Controller):
     def _get_onboarding_domain(self):
         partner = request.env.user.partner_id
-        return [
-            "|",
-            ("applicant_id.partner_id", "=", partner.id),
-            ("applicant_id.email_from", "=ilike", partner.email or ""),
-        ]
+        return [("applicant_id.partner_id", "=", partner.id)]
 
     def _get_onboarding_for_user(self, onboarding_id):
-        onboarding = request.env["hr.onboarding"].sudo().browse(onboarding_id)
+        onboarding = request.env["hr.onboarding"].browse(onboarding_id)
         if not onboarding.exists():
             return None
         partner = request.env.user.partner_id
-        partner_match = (
+        if not (
             onboarding.applicant_id.partner_id
             and onboarding.applicant_id.partner_id.id == partner.id
-        )
-        email_match = (
-            onboarding.applicant_id.email_from
-            and partner.email
-            and onboarding.applicant_id.email_from.lower() == partner.email.lower()
-        )
-        if not partner_match and not email_match:
+        ):
             return None
         return onboarding
 
@@ -183,7 +169,7 @@ class PortalOnboardingController(http.Controller):
             onboarding.write(vals)
 
     def _save_family(self, onboarding, form):
-        FamilyModel = request.env["hr.onboarding.family"].sudo()
+        FamilyModel = request.env["hr.onboarding.family"]
         family_ids = form.getlist("family_id")
         family_relation_ids = form.getlist("family_relation_id")
         family_identifications = form.getlist("family_identification_id")
@@ -321,7 +307,7 @@ class PortalOnboardingController(http.Controller):
     def portal_my_onboarding_list(self, **kwargs):
         if must_set_email():
             return request.redirect("/my/profile")
-        HrOnboarding = request.env["hr.onboarding"].sudo()
+        HrOnboarding = request.env["hr.onboarding"]
         domain = self._get_onboarding_domain()
 
         pending_onboardings = HrOnboarding.search(

--- a/hr_recruitment_kmitl/controllers/profile.py
+++ b/hr_recruitment_kmitl/controllers/profile.py
@@ -92,9 +92,9 @@ class PortalProfile(CustomerPortal):
                 "titles": request.env["res.partner.title"].sudo().search([]),
                 "countries": request.env["res.country"].sudo().search([]),
                 "zips": request.env["res.city.zip"].sudo().search([]),
-                "academic_standings": request.env["hr.employee.academic.standing"]
-                .sudo()
-                .search([]),
+                "academic_standings": request.env[
+                    "hr.employee.academic.standing"
+                ].search([]),
                 "education_levels": request.env["resource.education.level"]
                 .sudo()
                 .search(
@@ -127,7 +127,10 @@ class PortalProfile(CustomerPortal):
     @http.route(["/my/profile"], type="http", auth="user", website=True)
     def portal_my_profile(self, **post):
         partner = request.env.user.partner_id
-        profile = partner.sudo()._get_or_create_profile()
+        # sudo only for the create path; get a user-env reference for all writes
+        profile = request.env["portal.profile"].browse(
+            partner.sudo()._get_or_create_profile().id
+        )
 
         if post and request.httprequest.method == "POST":
             email_editable = self._is_email_editable(profile)
@@ -146,7 +149,8 @@ class PortalProfile(CustomerPortal):
             vals = self._prepare_profile_values(post)
             if not email_editable:
                 vals.pop("email", None)
-            profile.sudo().write(vals)
+            if vals:
+                profile.write(vals)
             self._save_education_history(profile, post)
             self._save_work_history(profile, request.httprequest.form)
             for doc_name, field_name in [
@@ -162,13 +166,13 @@ class PortalProfile(CustomerPortal):
                 ("doc_other_documents", "other_documents"),
             ]:
                 if post.get(f"delete_{doc_name}") == "1":
-                    profile.sudo().write(
+                    profile.write(
                         {f"{field_name}_file": False, f"{field_name}_filename": False}
                     )
                 else:
                     uploaded = request.httprequest.files.get(doc_name)
                     if uploaded and uploaded.filename:
-                        profile.sudo().write(
+                        profile.write(
                             {
                                 f"{field_name}_file": base64.b64encode(uploaded.read()),
                                 f"{field_name}_filename": uploaded.filename,
@@ -242,7 +246,7 @@ class PortalProfile(CustomerPortal):
 
     def _save_education_section(self, profile, post, prefix, level_id, existing):
         """Save a single education section. Returns the level_id if saved."""
-        EduHistory = request.env["portal.education.history"].sudo()
+        EduHistory = request.env["portal.education.history"]
         program = post.get(f"{prefix}program", "").strip()
         major = post.get(f"{prefix}major", "").strip()
         institution = post.get(f"{prefix}institution", "").strip()
@@ -347,7 +351,7 @@ class PortalProfile(CustomerPortal):
 
     def _save_work_history(self, profile, form):
         """Save work history from multi-value form fields."""
-        WorkHistory = request.env["portal.work.history"].sudo()
+        WorkHistory = request.env["portal.work.history"]
         wh_ids = form.getlist("wh_id")
         wh_company_names = form.getlist("wh_company_name")
         wh_job_titles = form.getlist("wh_job_title")

--- a/hr_recruitment_kmitl/models/__init__.py
+++ b/hr_recruitment_kmitl/models/__init__.py
@@ -2,6 +2,7 @@ from . import portal_education_history
 from . import portal_profile
 from . import portal_work_history
 from . import res_partner
+from . import res_users
 from . import hr_job
 from . import hr_job_old_code
 from . import hr_applicant

--- a/hr_recruitment_kmitl/models/hr_applicant.py
+++ b/hr_recruitment_kmitl/models/hr_applicant.py
@@ -333,6 +333,17 @@ class HrApplicant(models.Model):
         # Common required: education, work history, documents
         if not profile.education_history_ids:
             missing.append("ประวัติการศึกษา")
+        else:
+            for edu in profile.education_history_ids:
+                level_name = edu.education_level_id.name or "ไม่ระบุระดับ"
+                if not edu.certificate_file:
+                    missing.append(
+                        f"เอกสารแนบประวัติการศึกษา ({level_name}): วุฒิบัตร/ประกาศนียบัตร"
+                    )
+                if not edu.transcript_file:
+                    missing.append(
+                        f"เอกสารแนบประวัติการศึกษา ({level_name}): ใบแสดงผลการศึกษา (Transcript)"
+                    )
         if not profile.id_card_file:
             missing.append("สำเนาบัตรประจำตัวประชาชน")
         if not profile.household_registration_file:
@@ -346,6 +357,8 @@ class HrApplicant(models.Model):
             required = dict(self.ROLE_REQUIRED_FIELDS.get(job.role, {}))
             if job.role == "support" and profile.has_ocsc_exam:
                 required.update(self.OCSC_CONDITIONAL_FIELDS)
+                if not profile.ocsc_exam_file:
+                    missing.append("เอกสารแนบการสอบ ก.พ.: ไฟล์ใบรับรองผลสอบ ก.พ.")
             for field_name, label in required.items():
                 if not getattr(profile, field_name, False):
                     missing.append(label)

--- a/hr_recruitment_kmitl/models/res_users.py
+++ b/hr_recruitment_kmitl/models/res_users.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _update_last_login(self):
+        res = super()._update_last_login()
+        self._link_applicants_to_partner()
+        return res
+
+    def _link_applicants_to_partner(self):
+        """On login, link any unowned applicants whose email_from matches the
+        user's partner email. Runs once per session; idempotent."""
+        partner = self.partner_id
+        if not partner.email:
+            return
+        self.env["hr.applicant"].sudo().search(
+            [
+                ("partner_id", "=", False),
+                ("email_from", "=ilike", partner.email),
+            ]
+        ).write({"partner_id": partner.id})

--- a/hr_recruitment_kmitl/security/ir.model.access.csv
+++ b/hr_recruitment_kmitl/security/ir.model.access.csv
@@ -1,18 +1,22 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_portal_profile_user,portal.profile user,model_portal_profile,base.group_user,1,1,1,1
-access_portal_profile_portal,portal.profile portal,model_portal_profile,base.group_portal,1,1,1,0
+access_res_partner_portal,res.partner portal,base.model_res_partner,base.group_portal,1,1,0,0
+access_portal_profile_user,portal.profile user,model_portal_profile,base.group_user,1,1,0,0
+access_portal_profile_portal,portal.profile portal,model_portal_profile,base.group_portal,1,1,0,0
+access_portal_profile_recruiter,portal.profile recruiter,model_portal_profile,hr_recruitment.group_hr_recruitment_user,1,0,0,0
 access_portal_work_history_user,portal.work.history user,model_portal_work_history,base.group_user,1,1,1,1
-access_portal_work_history_portal,portal.work.history portal,model_portal_work_history,base.group_portal,1,1,1,0
+access_portal_work_history_portal,portal.work.history portal,model_portal_work_history,base.group_portal,1,1,1,1
+access_portal_work_history_recruiter,portal.work.history recruiter,model_portal_work_history,hr_recruitment.group_hr_recruitment_user,1,0,0,0
 access_portal_education_history_user,portal.education.history user,model_portal_education_history,base.group_user,1,1,1,1
-access_portal_education_history_portal,portal.education.history portal,model_portal_education_history,base.group_portal,1,1,1,0
+access_portal_education_history_portal,portal.education.history portal,model_portal_education_history,base.group_portal,1,1,1,1
+access_portal_education_history_recruiter,portal.education.history recruiter,model_portal_education_history,hr_recruitment.group_hr_recruitment_user,1,0,0,0
+access_hr_applicant_user,hr.applicant user,hr_recruitment.model_hr_applicant,base.group_user,1,0,0,0
 access_hr_applicant_portal,hr.applicant.portal,hr_recruitment.model_hr_applicant,base.group_portal,1,0,0,0
 access_hr_recruitment_stage_portal,hr.recruitment.stage.portal,hr_recruitment.model_hr_recruitment_stage,base.group_portal,1,0,0,0
 access_hr_job_portal,hr.job.portal,hr.model_hr_job,base.group_portal,1,0,0,0
 access_hr_department_portal,hr.department.portal,hr.model_hr_department,base.group_portal,1,0,0,0
-access_hr_applicant_education_history,access_hr_applicant_education_history,model_hr_applicant_education_history,base.group_user,1,0,0,0
 access_hr_applicant_education_history_portal,access_hr_applicant_education_history portal,model_hr_applicant_education_history,base.group_portal,1,0,0,0
 access_hr_applicant_education_history_hr,access_hr_applicant_education_history hr,model_hr_applicant_education_history,hr_recruitment.group_hr_recruitment_user,1,1,1,1
-access_hr_applicant_work_history,access_hr_applicant_work_history,model_hr_applicant_work_history,base.group_user,1,0,0,0
+access_hr_applicant_work_history_portal,access_hr_applicant_work_history portal,model_hr_applicant_work_history,base.group_portal,1,0,0,0
 access_hr_applicant_work_history_hr,access_hr_applicant_work_history hr,model_hr_applicant_work_history,hr_recruitment.group_hr_recruitment_user,1,1,1,1
 access_hr_job_category_user,hr.job.category user,model_hr_job_category,base.group_user,1,0,0,0
 access_hr_job_category_hr,hr.job.category hr,model_hr_job_category,hr.group_hr_manager,1,1,1,1
@@ -20,7 +24,10 @@ access_hr_job_old_code_hr_user,hr.job.old.code.hr.user,model_hr_job_old_code,hr_
 access_hr_job_old_code_public,hr.job.old.code public,model_hr_job_old_code,,1,0,0,0
 access_hr_recruitment_degree_public,hr.recruitment.degree.public,hr_recruitment.model_hr_recruitment_degree,,1,0,0,0
 access_resource_education_level_portal,resource.education.level portal,hr_employee_education_history.model_resource_education_level,base.group_portal,1,0,0,0
-access_hr_onboarding_user,hr.onboarding user,model_hr_onboarding,base.group_user,1,1,1,1
+access_hr_employee_academic_standing_portal,hr.employee.academic.standing portal,hr_employee_academic_standing_thailand.model_hr_employee_academic_standing,base.group_portal,1,0,0,0
+access_hr_onboarding_user,hr.onboarding user,model_hr_onboarding,base.group_user,1,1,1,0
 access_hr_onboarding_portal,hr.onboarding portal,model_hr_onboarding,base.group_portal,1,1,0,0
-access_hr_onboarding_family_user,hr.onboarding.family user,model_hr_onboarding_family,base.group_user,1,1,1,1
-access_hr_onboarding_family_portal,hr.onboarding.family portal,model_hr_onboarding_family,base.group_portal,1,1,1,0
+access_hr_onboarding_recruiter,hr.onboarding recruiter,model_hr_onboarding,hr_recruitment.group_hr_recruitment_user,1,1,1,1
+access_hr_onboarding_family_user,hr.onboarding.family user,model_hr_onboarding_family,base.group_user,1,1,1,0
+access_hr_onboarding_family_portal,hr.onboarding.family portal,model_hr_onboarding_family,base.group_portal,1,1,1,1
+access_hr_onboarding_family_recruiter,hr.onboarding.family recruiter,model_hr_onboarding_family,hr_recruitment.group_hr_recruitment_user,1,1,1,1

--- a/hr_recruitment_kmitl/security/security.xml
+++ b/hr_recruitment_kmitl/security/security.xml
@@ -1,13 +1,182 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="rule_hr_onboarding_portal" model="ir.rule">
-        <field name="name">HR Onboarding: portal users see own records</field>
-        <field name="model_id" ref="model_hr_onboarding" />
+    <!-- res.partner: portal user can write own partner (needed for portal.profile related fields) -->
+    <record id="rule_res_partner_portal_own" model="ir.rule">
+        <field name="name">Res Partner: portal user can write own record</field>
+        <field name="model_id" ref="base.model_res_partner" />
         <field name="groups" eval="[(4, ref('base.group_portal'))]" />
-        <field name="domain_force">
-            ['|',
-             ('applicant_id.partner_id', '=', user.partner_id.id),
-             ('applicant_id.email_from', '=ilike', user.partner_id.email)]
-        </field>
+        <field name="domain_force">[('id', '=', user.partner_id.id)]</field>
+    </record>
+
+    <!-- portal.profile: own-only for internal/portal, read-all for recruiter -->
+    <record id="rule_portal_profile_own" model="ir.rule">
+        <field name="name">Portal Profile: own record only</field>
+        <field name="model_id" ref="model_portal_profile" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field name="domain_force">[('partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_portal_profile_recruiter" model="ir.rule">
+        <field name="name">Portal Profile: recruiter sees all</field>
+        <field name="model_id" ref="model_portal_profile" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- portal.work.history -->
+    <record id="rule_portal_work_history_own" model="ir.rule">
+        <field name="name">Portal Work History: own records only</field>
+        <field name="model_id" ref="model_portal_work_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field
+            name="domain_force"
+        >[('profile_id.partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_portal_work_history_recruiter" model="ir.rule">
+        <field name="name">Portal Work History: recruiter sees all</field>
+        <field name="model_id" ref="model_portal_work_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- portal.education.history -->
+    <record id="rule_portal_education_history_own" model="ir.rule">
+        <field name="name">Portal Education History: own records only</field>
+        <field name="model_id" ref="model_portal_education_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field
+            name="domain_force"
+        >[('profile_id.partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_portal_education_history_recruiter" model="ir.rule">
+        <field name="name">Portal Education History: recruiter sees all</field>
+        <field name="model_id" ref="model_portal_education_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- hr.applicant -->
+    <record id="rule_hr_applicant_own" model="ir.rule">
+        <field name="name">HR Applicant: own records only</field>
+        <field name="model_id" ref="hr_recruitment.model_hr_applicant" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field name="domain_force">[('partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_hr_applicant_recruiter" model="ir.rule">
+        <field name="name">HR Applicant: recruiter sees all</field>
+        <field name="model_id" ref="hr_recruitment.model_hr_applicant" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- hr.applicant.education.history -->
+    <record id="rule_hr_applicant_education_history_own" model="ir.rule">
+        <field name="name">HR Applicant Education History: own records only</field>
+        <field name="model_id" ref="model_hr_applicant_education_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field
+            name="domain_force"
+        >[('applicant_id.partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_hr_applicant_education_history_recruiter" model="ir.rule">
+        <field name="name">HR Applicant Education History: recruiter sees all</field>
+        <field name="model_id" ref="model_hr_applicant_education_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- hr.applicant.work.history -->
+    <record id="rule_hr_applicant_work_history_own" model="ir.rule">
+        <field name="name">HR Applicant Work History: own records only</field>
+        <field name="model_id" ref="model_hr_applicant_work_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field
+            name="domain_force"
+        >[('applicant_id.partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_hr_applicant_work_history_recruiter" model="ir.rule">
+        <field name="name">HR Applicant Work History: recruiter sees all</field>
+        <field name="model_id" ref="model_hr_applicant_work_history" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- hr.onboarding: rewrite existing rule to cover both groups, drop email branch -->
+    <record id="rule_hr_onboarding_portal" model="ir.rule">
+        <field name="name">HR Onboarding: own records only</field>
+        <field name="model_id" ref="model_hr_onboarding" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field
+            name="domain_force"
+        >[('applicant_id.partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_hr_onboarding_recruiter" model="ir.rule">
+        <field name="name">HR Onboarding: recruiter sees all</field>
+        <field name="model_id" ref="model_hr_onboarding" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <!-- hr.onboarding.family -->
+    <record id="rule_hr_onboarding_family_own" model="ir.rule">
+        <field name="name">HR Onboarding Family: own records only</field>
+        <field name="model_id" ref="model_hr_onboarding_family" />
+        <field
+            name="groups"
+            eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"
+        />
+        <field
+            name="domain_force"
+        >[('onboarding_id.applicant_id.partner_id', '=', user.partner_id.id)]</field>
+    </record>
+    <record id="rule_hr_onboarding_family_recruiter" model="ir.rule">
+        <field name="name">HR Onboarding Family: recruiter sees all</field>
+        <field name="model_id" ref="model_hr_onboarding_family" />
+        <field
+            name="groups"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
+        <field name="domain_force">[(1, '=', 1)]</field>
     </record>
 </odoo>

--- a/hr_recruitment_kmitl/static/src/scss/theme.scss
+++ b/hr_recruitment_kmitl/static/src/scss/theme.scss
@@ -4,438 +4,440 @@
  */
 
 :root {
-  --grey-50: #fdfcfc;
-  --grey-100: #f8f6f5;
-  --grey-200: #f5f2f0;
-  --grey-300: #f0ecea;
-  --grey-400: #ede9e5;
-  --grey-500: #e9e3df;
-  --grey-600: #d4cfcb;
-  --grey-700: #a5a19e;
-  --grey-800: #807d7b;
-  --grey-900: #625f5e;
+    --grey-50: #fdfcfc;
+    --grey-100: #f8f6f5;
+    --grey-200: #f5f2f0;
+    --grey-300: #f0ecea;
+    --grey-400: #ede9e5;
+    --grey-500: #e9e3df;
+    --grey-600: #d4cfcb;
+    --grey-700: #a5a19e;
+    --grey-800: #807d7b;
+    --grey-900: #625f5e;
 
-  --red-50: #fcebec;
-  --red-100: #f4c0c5;
-  --red-200: #efa2a9;
-  --red-300: #e87882;
-  --red-400: #e35d6a;
-  --red-500: #dc3545;
-  --red-600: #c8303f;
-  --red-700: #9c2631;
-  --red-800: #791d26;
-  --red-900: #5c161d;
+    --red-50: #fcebec;
+    --red-100: #f4c0c5;
+    --red-200: #efa2a9;
+    --red-300: #e87882;
+    --red-400: #e35d6a;
+    --red-500: #dc3545;
+    --red-600: #c8303f;
+    --red-700: #9c2631;
+    --red-800: #791d26;
+    --red-900: #5c161d;
 
-  --orange-50: #fff2ea;
-  --orange-100: #ffd6bf;
-  --orange-200: #ffc2a0;
-  --orange-300: #ffa674;
-  --orange-400: #ff9559;
-  --orange-500: #ff7a30;
-  --orange-600: #e86f2c;
-  --orange-700: #b55722;
-  --orange-800: #8c431a;
-  --orange-900: #6b3314;
+    --orange-50: #fff2ea;
+    --orange-100: #ffd6bf;
+    --orange-200: #ffc2a0;
+    --orange-300: #ffa674;
+    --orange-400: #ff9559;
+    --orange-500: #ff7a30;
+    --orange-600: #e86f2c;
+    --orange-700: #b55722;
+    --orange-800: #8c431a;
+    --orange-900: #6b3314;
 
-  --blue-50: #ebf3fe;
-  --blue-100: #c2d8fc;
-  --blue-200: #a5c6fb;
-  --blue-300: #7cabf9;
-  --blue-400: #629bf8;
-  --blue-500: #3b82f6;
-  --blue-600: #3676e0;
-  --blue-700: #2a5caf;
-  --blue-800: #204887;
-  --blue-900: #193767;
+    --blue-50: #ebf3fe;
+    --blue-100: #c2d8fc;
+    --blue-200: #a5c6fb;
+    --blue-300: #7cabf9;
+    --blue-400: #629bf8;
+    --blue-500: #3b82f6;
+    --blue-600: #3676e0;
+    --blue-700: #2a5caf;
+    --blue-800: #204887;
+    --blue-900: #193767;
 
-  --green-50: #e9f9ef;
-  --green-100: #baedcd;
-  --green-200: #99e4b5;
-  --green-300: #6bd893;
-  --green-400: #4ed17e;
-  --green-500: #22c55e;
-  --green-600: #1fb356;
-  --green-700: #188c43;
-  --green-800: #136c34;
-  --green-900: #0e5327;
+    --green-50: #e9f9ef;
+    --green-100: #baedcd;
+    --green-200: #99e4b5;
+    --green-300: #6bd893;
+    --green-400: #4ed17e;
+    --green-500: #22c55e;
+    --green-600: #1fb356;
+    --green-700: #188c43;
+    --green-800: #136c34;
+    --green-900: #0e5327;
 
-  --cyan-blue-50: #e6e8ed;
-  --cyan-blue-100: #b0b9c7;
-  --cyan-blue-200: #8a97ac;
-  --cyan-blue-300: #546886;
-  --cyan-blue-400: #334a6e;
-  --cyan-blue-500: #001d4a;
-  --cyan-blue-600: #001a43;
-  --cyan-blue-700: #001535;
-  --cyan-blue-800: #001029;
-  --cyan-blue-900: #000c1f;
+    --cyan-blue-50: #e6e8ed;
+    --cyan-blue-100: #b0b9c7;
+    --cyan-blue-200: #8a97ac;
+    --cyan-blue-300: #546886;
+    --cyan-blue-400: #334a6e;
+    --cyan-blue-500: #001d4a;
+    --cyan-blue-600: #001a43;
+    --cyan-blue-700: #001535;
+    --cyan-blue-800: #001029;
+    --cyan-blue-900: #000c1f;
 
-  --primary: var(--orange-500);
-  --primary-light: var(--orange-50);
-  --primary-border: var(--orange-300);
-  --primary-hover: var(--orange-600);
-  --primary-dark: var(--orange-900);
+    --primary: var(--orange-500);
+    --primary-light: var(--orange-50);
+    --primary-border: var(--orange-300);
+    --primary-hover: var(--orange-600);
+    --primary-dark: var(--orange-900);
 
-  --secondary: var(--grey-500);
-  --secondary-light: var(--grey-200);
-  --secondary-border: var(--grey-300);
-  --secondary-hover: var(--grey-600);
-  --secondary-dark: var(--grey-900);
+    --secondary: var(--grey-500);
+    --secondary-light: var(--grey-200);
+    --secondary-border: var(--grey-300);
+    --secondary-hover: var(--grey-600);
+    --secondary-dark: var(--grey-900);
 
-  --accent: var(--cyan-blue-500);
-  --accent-light: var(--cyan-blue-50);
-  --accent-border: var(--cyan-blue-300);
-  --accent-hover: var(--cyan-blue-600);
-  --accent-dark: var(--cyan-blue-900);
+    --accent: var(--cyan-blue-500);
+    --accent-light: var(--cyan-blue-50);
+    --accent-border: var(--cyan-blue-300);
+    --accent-hover: var(--cyan-blue-600);
+    --accent-dark: var(--cyan-blue-900);
 
-  --success: var(--green-500);
-  --success-light: var(--green-50);
-  --success-border: var(--green-300);
-  --success-hover: var(--green-600);
-  --success-dark: var(--green-900);
+    --success: var(--green-500);
+    --success-light: var(--green-50);
+    --success-border: var(--green-300);
+    --success-hover: var(--green-600);
+    --success-dark: var(--green-900);
 
-  --warning: var(--yellow-700);
-  --warning-light: var(--yellow-50);
-  --warning-border: var(--yellow-300);
-  --warning-hover: var(--yellow-600);
-  --warning-dark: var(--yellow-900);
+    --warning: var(--yellow-700);
+    --warning-light: var(--yellow-50);
+    --warning-border: var(--yellow-300);
+    --warning-hover: var(--yellow-600);
+    --warning-dark: var(--yellow-900);
 
-  --danger: var(--red-500);
-  --danger-light: var(--red-50);
-  --danger-border: var(--red-300);
-  --danger-hover: var(--red-600);
-  --danger-dark: var(--red-900);
+    --danger: var(--red-500);
+    --danger-light: var(--red-50);
+    --danger-border: var(--red-300);
+    --danger-hover: var(--red-600);
+    --danger-dark: var(--red-900);
 
-  --info: var(--blue-500);
-  --info-light: var(--blue-50);
-  --info-border: var(--blue-300);
-  --info-hover: var(--blue-600);
-  --info-dark: var(--blue-900);
+    --info: var(--blue-500);
+    --info-light: var(--blue-50);
+    --info-border: var(--blue-300);
+    --info-hover: var(--blue-600);
+    --info-dark: var(--blue-900);
 }
 
 /* -------------------------------------------------------------------
    CUSTOM UTILITY CLASSES
 ------------------------------------------------------------------- */
 .bg-primary-light {
-  background-color: var(--primary-light) !important;
+    background-color: var(--primary-light) !important;
 }
 .bg-secondary-light {
-  background-color: var(--secondary-light) !important;
+    background-color: var(--secondary-light) !important;
 }
 .bg-accent-light {
-  background-color: var(--accent-light) !important;
+    background-color: var(--accent-light) !important;
 }
 .bg-info-light {
-  background-color: var(--info-light) !important;
+    background-color: var(--info-light) !important;
 }
 .bg-danger-light {
-  background-color: var(--danger-light) !important;
+    background-color: var(--danger-light) !important;
 }
 .bg-thai-d {
-  background-color: var(--thai-d-500) !important;
+    background-color: var(--thai-d-500) !important;
 }
 .bg-thai-d-light {
-  background-color: var(--thai-d-50) !important;
+    background-color: var(--thai-d-50) !important;
 }
 .bg-thai-d-dark {
-  background-color: var(--thai-d-900) !important;
+    background-color: var(--thai-d-900) !important;
 }
 
 .text-secondary {
-  color: var(--secondary-dark) !important;
+    color: var(--secondary-dark) !important;
 }
 .text-accent {
-  color: var(--accent) !important;
+    color: var(--accent) !important;
 }
 .text-info {
-  color: var(--info) !important;
+    color: var(--info) !important;
 }
 .text-warning {
-  color: var(--warning) !important;
+    color: var(--warning) !important;
 }
 .text-success {
-  color: var(--success) !important;
+    color: var(--success) !important;
 }
 .text-danger {
-  color: var(--danger) !important;
+    color: var(--danger) !important;
 }
 .text-thai-d {
-  color: var(--thai-d-500) !important;
+    color: var(--thai-d-500) !important;
 }
 
 .border-primary {
-  border-color: var(--primary-border) !important;
+    border-color: var(--primary-border) !important;
 }
 .border-secondary {
-  border-color: var(--secondary-border) !important;
+    border-color: var(--secondary-border) !important;
 }
 .border-accent {
-  border-color: var(--accent-border) !important;
+    border-color: var(--accent-border) !important;
 }
 .border-thai-d {
-  border-color: var(--thai-d-100) !important;
+    border-color: var(--thai-d-100) !important;
 }
 
 .bg-pattern-dots {
-  background-image: radial-gradient($primary 1px, transparent 1px);
-  background-size: 24px 24px;
+    background-image: radial-gradient($primary 1px, transparent 1px);
+    background-size: 24px 24px;
 }
 
 .o_website_hr_recruitment_jobs_list {
-  .card {
-    box-shadow: $box-shadow-sm;
+    .card {
+        box-shadow: $box-shadow-sm;
 
-    &:hover {
-      transition: box-shadow 0.3s cubic-bezier(0.55, 0, 0.1, 1);
-      box-shadow: $box-shadow-lg;
+        &:hover {
+            transition: box-shadow 0.3s cubic-bezier(0.55, 0, 0.1, 1);
+            box-shadow: $box-shadow-lg;
+        }
     }
-  }
 }
 
 .o_website_hr_recruitment_job_detail {
-  .card {
-    box-shadow: $box-shadow-sm;
-  }
+    .card {
+        box-shadow: $box-shadow-sm;
+    }
 }
 
 #hr_recruitment_form {
-  .card {
-    box-shadow: $box-shadow-sm;
-  }
+    .card {
+        box-shadow: $box-shadow-sm;
+    }
 }
 
 .accordion {
-  .card {
-    border: 1px solid var(--secondary-border);
-    border-radius: 12px;
-    overflow: hidden;
-    margin-bottom: 1rem;
-    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);
-  }
+    .card {
+        border: 1px solid var(--secondary-border);
+        border-radius: 12px;
+        overflow: hidden;
+        margin-bottom: 1rem;
+        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);
+    }
 
-  .card-header {
-    background-color: var(--thai-d-500);
-    color: var(--white, #fff);
-    font-weight: 600;
-    padding: 1rem 1rem;
-    border-radius: 0;
-  }
+    .card-header {
+        background-color: var(--thai-d-500);
+        color: var(--white, #fff);
+        font-weight: 600;
+        padding: 1rem 1rem;
+        border-radius: 0;
+    }
 }
 
 .nav.nav-pills {
-  border-radius: $border-radius;
-  padding: 8px;
-  background-color: $gray-200;
+    border-radius: $border-radius;
+    padding: 8px;
+    background-color: $gray-200;
 }
 
 .wizard-tabs .nav-link {
-  min-height: 44px;
-  font-size: 1rem;
-  color: $gray-600;
-  border: 1px solid transparent;
-  font-weight: 500;
-  transition: 0.2s ease;
+    min-height: 44px;
+    font-size: 1rem;
+    color: $gray-600;
+    border: 1px solid transparent;
+    font-weight: 500;
+    transition: 0.2s ease;
 }
 
 .wizard-tabs .nav-link:hover {
-  background: $gray-300;
+    background: $gray-300;
 }
 
 .wizard-tabs .nav-link.active {
-  background: $primary;
-  color: $white;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-  font-weight: 600;
+    background: $primary;
+    color: $white;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    font-weight: 600;
 }
 
 @media (max-width: 991.98px) {
-  .wizard-tabs .nav-link {
-    font-size: 0.875rem;
-  }
+    .wizard-tabs .nav-link {
+        font-size: 0.875rem;
+    }
 }
 
 body {
-  background-color: #fbfaf9;
+    background-color: #fbfaf9;
 }
 
 .card {
-  border-radius: 12px;
+    border-radius: 12px;
 }
 
 .rounded-12 {
-  border-radius: 12px !important;
+    border-radius: 12px !important;
 }
 
 .section-indicator {
-  display: inline-block;
-  width: 6px;
-  height: 24px;
-  border-radius: 2px;
+    display: inline-block;
+    width: 6px;
+    height: 24px;
+    border-radius: 2px;
 }
 
 .breadcrumb-back-icon {
-  font-size: 0.7rem;
+    font-size: 0.7rem;
 }
 
 .summary-accent {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 6px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 6px;
 }
 
 .status-stepper-line {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  transform: translateY(-50%);
-  z-index: 0;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    transform: translateY(-50%);
+    z-index: 0;
 }
 
 .step-circle {
-  width: 36px;
-  height: 36px;
+    width: 36px;
+    height: 36px;
 }
 
 .application-progress {
-  height: 12px;
-  background-color: var(--grey-200);
+    height: 12px;
+    background-color: var(--grey-200);
 }
 
 .section-indicator {
-  display: inline-block;
-  width: 6px;
-  height: 24px;
-  border-radius: 2px;
+    display: inline-block;
+    width: 6px;
+    height: 24px;
+    border-radius: 2px;
 }
 
 .job-sidebar-card {
-  top: 100px;
-  z-index: 10;
+    top: 100px;
+    z-index: 10;
 }
 
 .job-company-logo {
-  width: 80px;
-  height: 80px;
+    width: 80px;
+    height: 80px;
 }
 
 .job-card__logo-wrap {
-  width: 60px;
-  height: 60px;
+    width: 60px;
+    height: 60px;
 }
 
 .job-card__logo {
-  width: 100%;
-  max-width: 65px;
-  object-fit: contain;
-  padding: 2px;
+    width: 100%;
+    max-width: 65px;
+    object-fit: contain;
+    padding: 2px;
 }
 
 .job-card__desc {
-  font-size: 0.95rem;
-  line-height: 1.7;
-  display: -webkit-box;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+    font-size: 0.95rem;
+    line-height: 1.7;
+    display: -webkit-box;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 #jobs_grid_left .nav-link {
-  transition: all 0.2s ease;
+    transition: all 0.2s ease;
 }
 
 #jobs_grid_left .nav-link:hover {
-  background-color: var(--primary-light);
-  color: var(--primary);
+    background-color: var(--primary-light);
+    color: var(--primary);
 }
 
 #jobs_grid_left .nav-link.active:hover {
-  color: #fff;
+    color: #fff;
 }
 
 .upload-file-icon {
-  width: 44px;
-  height: 44px;
+    width: 44px;
+    height: 44px;
 }
 
 .upload-section {
-  border: 2px dashed var(--primary);
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease;
+    border: 2px dashed var(--primary);
+    transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
 .custom-file-input::file-selector-button {
-  background-color: var(--primary);
-  color: #fff;
-  border: 0;
-  padding: 0.375rem 1rem;
-  margin: -0.375rem 1rem -0.375rem -0.75rem;
-  border-radius: 0;
-  transition: background-color 0.2s ease;
-  cursor: pointer;
+    background-color: var(--primary);
+    color: #fff;
+    border: 0;
+    padding: 0.375rem 1rem;
+    margin: -0.375rem 1rem -0.375rem -0.75rem;
+    border-radius: 0;
+    transition: background-color 0.2s ease;
+    cursor: pointer;
 }
 
 .custom-file-input::-webkit-file-upload-button {
-  background-color: var(--primary);
-  color: #fff;
-  border: 0;
-  padding: 0.375rem 1rem;
-  margin-right: 1rem;
-  border-radius: 0;
-  transition: background-color 0.2s ease;
-  cursor: pointer;
+    background-color: var(--primary);
+    color: #fff;
+    border: 0;
+    padding: 0.375rem 1rem;
+    margin-right: 1rem;
+    border-radius: 0;
+    transition: background-color 0.2s ease;
+    cursor: pointer;
 }
 
 .custom-file-input:hover::file-selector-button,
 .custom-file-input:hover::-webkit-file-upload-button {
-  background-color: var(--primary-dark);
+    background-color: var(--primary-dark);
 }
 
 .icon-box {
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.5rem;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.5rem;
 }
 
 .uploaded-file-item {
-  background: #f8fafc;
-  border-color: #cbd5e1 !important;
+    background: #f8fafc;
+    border-color: #cbd5e1 !important;
 }
 
 .file-icon-box {
-  width: 72px;
-  height: 72px;
-  background: #ffffff;
-  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
-  flex-shrink: 0;
+    width: 72px;
+    height: 72px;
+    background: #ffffff;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+    flex-shrink: 0;
 }
 
 .file-icon {
-  font-size: 2rem;
-  color: #ef4444;
+    font-size: 2rem;
+    color: #ef4444;
 }
 
 .multi-upload-dropzone {
-  background: #f8fafc;
-  border-style: dashed !important;
-  border-color: #cbd5e1 !important;
-  cursor: pointer;
-  transition: all 0.2s ease;
+    background: #f8fafc;
+    border-style: dashed !important;
+    border-color: #cbd5e1 !important;
+    cursor: pointer;
+    transition: all 0.2s ease;
 }
 
 .multi-upload-dropzone:hover {
-  background: #f1f5f9;
-  border-color: #94a3b8 !important;
+    background: #f1f5f9;
+    border-color: #94a3b8 !important;
 }
 
 .upload-cloud-icon {
-  font-size: 3rem;
-  color: #94a3b8;
+    font-size: 3rem;
+    color: #94a3b8;
+}
+
+#s_website_form_result {
+    white-space: pre-line;
 }

--- a/hr_recruitment_kmitl/views/portal_profile_views.xml
+++ b/hr_recruitment_kmitl/views/portal_profile_views.xml
@@ -201,6 +201,10 @@
         <field name="name">Portal Profiles</field>
         <field name="res_model">portal.profile</field>
         <field name="view_mode">tree,form</field>
+        <field
+            name="groups_id"
+            eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"
+        />
     </record>
 
 </odoo>


### PR DESCRIPTION
…s and fix security

- Add ir.rule ownership rules for portal.profile, portal.work.history, portal.education.history, hr.applicant, hr.applicant.education.history, hr.applicant.work.history, hr.onboarding, and hr.onboarding.family so portal users can only access their own records
- Add res.partner write ACL + own-record rule for portal group so related fields (title, first_name, last_name, email, phone) on portal.profile can be written without sudo
- Add read ACL for portal group on hr.employee.academic.standing to fix 403 error on /jobs/apply
- Add res_users._link_applicants_to_partner() hook on login to backfill partner_id on hr.applicant records matched by email
- Drop .sudo() from portal controllers; ownership is now enforced at ORM layer
- Restrict portal.profile backend action to recruiter group
- Add education history attachment validation (certificate + transcript) and OCSC exam document validation in website_form_input_filter
- Fix error message line breaks on /jobs/apply by adding white-space: pre-line to #s_website_form_result in theme.scss