### PR TITLE
[16.0][FIX] budget_appropriation_summary: fix F9-W double-counting and report page-break borders

### DIFF
--- a/budget_appropriation_summary/models/summary_f9w_expense.py
+++ b/budget_appropriation_summary/models/summary_f9w_expense.py
@@ -12,14 +12,15 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
     Business Purpose:
         Generates F9-W expense report as a pivot table showing expenses by:
         - Rows: Top-level departments
-        - Columns: 4 Activity Plans + 1 Reserve Fund
+        - Columns: Activity Plans
 
     Columns:
         - 09007: แผนงานจัดการศึกษาอุดมศึกษา
         - 09010: แผนงานบริการวิชาการแก่สังคม
         - 09011: แผนงานศาสนา ศิลปและวัฒนธรรม
         - 06004: แผนงานวิจัย
-        - 07020: งบกองทุนสำรอง (Reserve Fund)
+        - 06005: แผนงานบูรณาการ
+        - 06006: แผนงานยุทธศาสตร์
     """
 
     _name = "budget.appropriation.summary.f9w.expense"
@@ -34,12 +35,6 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
         ("account_analytic_kmitl.activity_06005", "06005", "แผนงานบูรณาการ"),
         ("account_analytic_kmitl.activity_09006", "06006", "แผนงานยุทธศาสตร์"),
     ]
-
-    # Reserve fund (xml_id, code, name)
-    RESERVE_FUND = ("budget.budget_account_07020", "07020", "งบกองทุนสำรอง")
-
-    # All column codes in order
-    COLUMN_CODES = ["09007", "09010", "09011", "06004", "06005", "06006", "07020"]
 
     @api.model
     def get_data(self, summary_id):
@@ -64,7 +59,7 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
                     },
                     ...
                 ],
-                "columns": [{"code", "name", "type"}, ...],
+                "columns": [{"code", "name"}, ...],
                 "column_totals": {"09007": {...}, ...},
                 "summary": {"total_amount", "compare_total_amount", "diff_amount", "diff_percentage"},
                 "report": {...},
@@ -72,6 +67,7 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
             }
         """
         summary = self.env["budget.appropriation.master.summary"].browse(summary_id)
+        column_codes = [code for _xml_id, code, _name in self.ACTIVITY_PLANS]
 
         if not summary.exists():
             return {
@@ -87,47 +83,36 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
         top_level_depts = self._get_top_level_departments()
         dept_map = {d.id: {"id": d.id, "code": d.code, "name": d.name} for d in top_level_depts}
 
-        # Build activity path prefix mapping
+        # Build activity plan parent_path -> code mapping (includes the plan itself + all descendants)
         activity_path_map = self._build_activity_path_map()
 
-        # Build reserve fund account IDs
-        reserve_fund_account_ids = self._get_reserve_fund_account_ids()
-
-        # Build current report totals
-        dept_column_totals = self._build_dept_column_totals(summary, dept_map, activity_path_map, reserve_fund_account_ids)
-
-        # Build comparison totals if compare_summary_id exists
+        # Build current and comparison totals
+        dept_column_totals = self._build_dept_column_totals(summary, dept_map, activity_path_map)
         compare_summary = summary.compare_summary_id
-        compare_totals = {}
-        if compare_summary:
-            compare_totals = self._build_dept_column_totals(compare_summary, dept_map, activity_path_map, reserve_fund_account_ids)
+        compare_totals = self._build_dept_column_totals(compare_summary, dept_map, activity_path_map) if compare_summary else {}
 
         # Build pivot table data
         departments = []
-        for dept_id in dept_map.keys():
-            dept_info = dept_map[dept_id]
+        for dept_id, dept_info in dept_map.items():
             columns = {}
             dept_total = 0
             compare_dept_total = 0
 
-            # Process each column
-            for column_code in self.COLUMN_CODES:
+            for column_code in column_codes:
                 key = (dept_id, column_code)
                 amount = dept_column_totals.get(key, 0)
                 compare_amount = compare_totals.get(key, 0)
                 diff_amount = amount - compare_amount
-                diff_percentage = round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0
 
                 columns[column_code] = {
                     "amount": amount,
                     "compare_amount": compare_amount,
                     "diff_amount": diff_amount,
-                    "diff_percentage": diff_percentage,
+                    "diff_percentage": round((diff_amount / compare_amount) * 100, 2) if compare_amount else 0,
                 }
                 dept_total += amount
                 compare_dept_total += compare_amount
 
-            # Include department if it has any data
             if dept_total or compare_dept_total:
                 diff_dept = dept_total - compare_dept_total
                 departments.append({
@@ -141,12 +126,11 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
                     },
                 })
 
-        # Sort by department code
-        departments = sorted(departments, key=lambda x: x["code"])
+        departments.sort(key=lambda x: x["code"] or "")
 
-        # Calculate column totals
+        # Column totals
         column_totals = {}
-        for column_code in self.COLUMN_CODES:
+        for column_code in column_codes:
             total = sum(d["columns"][column_code]["amount"] for d in departments)
             compare_total = sum(d["columns"][column_code]["compare_amount"] for d in departments)
             diff = total - compare_total
@@ -162,15 +146,7 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
         compare_total_amount = sum(d["total"]["compare_amount"] for d in departments)
         diff_total = total_amount - compare_total_amount
 
-        # Build columns metadata
-        columns_meta = []
-        for xml_id, code, name in self.ACTIVITY_PLANS:
-            columns_meta.append({"code": code, "name": name, "type": "activity"})
-        columns_meta.append({
-            "code": self.RESERVE_FUND[1],
-            "name": self.RESERVE_FUND[2],
-            "type": "reserve_fund",
-        })
+        columns_meta = [{"code": code, "name": name} for _xml_id, code, name in self.ACTIVITY_PLANS]
 
         return {
             "departments": departments,
@@ -198,73 +174,56 @@ class BudgetAppropriationSummaryF9WExpense(models.AbstractModel):
 
     def _build_activity_path_map(self):
         """
-        Build parent_path_prefix -> code mapping for activity plans.
+        Build parent_path -> code mapping for activity plans.
+
+        Each key is the plan's own ``parent_path`` (already ends with "/"), so
+        ``line.activity.parent_path.startswith(key)`` matches the plan itself
+        and every descendant — and only those.
 
         Returns:
-            dict: path_prefix -> code
+            dict: parent_path -> code
         """
-        path_prefix_map = {}
-        for xml_id, code, name in self.ACTIVITY_PLANS:
+        path_map = {}
+        for xml_id, code, _name in self.ACTIVITY_PLANS:
             parent = self.env.ref(xml_id, raise_if_not_found=False)
-            if parent:
-                path_prefix_map[f"{parent.id}/"] = code
+            if parent and parent.parent_path:
+                path_map[parent.parent_path] = code
             else:
                 _logger.warning("Activity plan with xml_id '%s' not found", xml_id)
-        return path_prefix_map
+        return path_map
 
-    def _get_reserve_fund_account_ids(self):
-        """
-        Get all budget.account IDs under reserve fund (07020) using parent_path.
-
-        Returns:
-            set: Set of budget.account IDs
-        """
-        parent = self.env.ref(self.RESERVE_FUND[0], raise_if_not_found=False)
-        if not parent:
-            _logger.warning("Reserve fund with xml_id '%s' not found", self.RESERVE_FUND[0])
-            return set()
-
-        # Find all descendants
-        descendants = self.env["budget.account"].search([
-            ("parent_path", "like", f"{parent.parent_path}%"),
-        ])
-        return set(descendants.ids)
-
-    def _build_dept_column_totals(self, summary, dept_map, activity_path_map, reserve_fund_account_ids):
+    def _build_dept_column_totals(self, summary, dept_map, activity_path_map):
         """
         Build (dept_id, column_code) -> balance mapping for a summary.
+
+        Each line contributes to at most ONE column (the activity plan its
+        ``activity_analytic_id`` belongs to), so balances cannot be
+        double-counted across columns.
 
         Args:
             summary: budget.appropriation.master.summary record
             dept_map: dict of dept_id -> dept_info
-            activity_path_map: dict of path_prefix -> code
-            reserve_fund_account_ids: set of budget.account IDs
+            activity_path_map: dict of plan parent_path -> code
 
         Returns:
             dict: (dept_id, column_code) -> balance
         """
-        lines = summary.expense_appropriation_ids.mapped("line_ids")
         totals = {}
 
-        for line in lines:
+        for line in summary.expense_appropriation_ids.mapped("line_ids"):
             top_dept_id = self._extract_top_level_dept_id(line.department_analytic_id)
-
             if not top_dept_id or top_dept_id not in dept_map:
                 continue
 
-            # Check activity plans (4 columns)
             activity = line.activity_analytic_id
-            if activity and activity.parent_path:
-                for prefix, code in activity_path_map.items():
-                    if prefix in activity.parent_path or activity.parent_path.startswith(prefix):
-                        key = (top_dept_id, code)
-                        totals[key] = totals.get(key, 0) + line.balance
-                        break
+            if not activity or not activity.parent_path:
+                continue
 
-            # Check reserve fund (1 column)
-            if line.account_id and line.account_id.id in reserve_fund_account_ids:
-                key = (top_dept_id, self.RESERVE_FUND[1])
-                totals[key] = totals.get(key, 0) + line.balance
+            for plan_path, code in activity_path_map.items():
+                if activity.parent_path.startswith(plan_path):
+                    key = (top_dept_id, code)
+                    totals[key] = totals.get(key, 0) + line.balance
+                    break
 
         return totals
 

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -32,9 +32,16 @@
                 border-top: 0;
                 border-bottom: 0;
             }
-            .table tbody tr:last-child {
+            .table tbody .summary-row {
                 border-top: 1px solid black !important;
                 border-bottom: 1px solid black !important;
+            }
+            .table tfoot .page-bottom-line td {
+                border-top: 1pt solid #000 !important;
+                padding: 0;
+                height: 0;
+                line-height: 0;
+                font-size: 0;
             }
             p,
             span,
@@ -87,7 +94,7 @@
                                 </td>
                             </tr>
                         </t>
-                        <tr style="font-weight: bold;">
+                        <tr class="summary-row" style="font-weight: bold;">
                             <td class="text-center">
                                 รวมทั้งสิ้น
                             </td>
@@ -101,6 +108,11 @@
                             </td>
                         </tr>
                     </tbody>
+                    <tfoot>
+                        <tr class="page-bottom-line">
+                            <td t-att-colspan="2 + len(o.f10w_expense_data['columns'])">&#160;</td>
+                        </tr>
+                    </tfoot>
                 </table>
             </div>
         </div>

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -32,6 +32,10 @@
                 border-top: 0;
                 border-bottom: 0;
             }
+            .table tbody tr:last-child {
+                border-top: 1px solid black !important;
+                border-bottom: 1px solid black !important;
+            }
             p,
             span,
             div {
@@ -83,8 +87,6 @@
                                 </td>
                             </tr>
                         </t>
-                    </tbody>
-                    <tfoot>
                         <tr style="font-weight: bold;">
                             <td class="text-center">
                                 รวมทั้งสิ้น
@@ -98,7 +100,7 @@
                                 <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
-                    </tfoot>
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -22,9 +22,16 @@
             h3 {
                 font-weight: bold;
             }
-            .table tbody tr:last-child {
+            .table tbody .summary-row {
                 border-top: 1px solid black !important;
                 border-bottom: 1px solid black !important;
+            }
+            .table tfoot .page-bottom-line td {
+                border-top: 1pt solid #000 !important;
+                padding: 0;
+                height: 0;
+                line-height: 0;
+                font-size: 0;
             }
         </style>
         <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
@@ -121,7 +128,7 @@
                             </t>
                             <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
-                        <tr>
+                        <tr class="summary-row">
                             <td class="text-center fw-bold">
                                 รวมทั้งสิ้น
                             </td>
@@ -145,6 +152,11 @@
                             </td>
                         </tr>
                     </tbody>
+                    <tfoot>
+                        <tr class="page-bottom-line">
+                            <td colspan="7">&#160;</td>
+                        </tr>
+                    </tfoot>
                 </table>
             </div>
         </div>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -22,6 +22,10 @@
             h3 {
                 font-weight: bold;
             }
+            .table tbody tr:last-child {
+                border-top: 1px solid black !important;
+                border-bottom: 1px solid black !important;
+            }
         </style>
         <div class="page f8w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
@@ -117,8 +121,6 @@
                             </t>
                             <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
-                    </tbody>
-                    <tfoot>
                         <tr>
                             <td class="text-center fw-bold">
                                 รวมทั้งสิ้น
@@ -142,7 +144,7 @@
                                 <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_percentage'])"/>
                             </td>
                         </tr>
-                    </tfoot>
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -16,8 +16,17 @@
             p,
             span,
             div {
-                font-size: 12pt;
+                font-size: 11pt;
                 line-height: 1.1;
+            }
+            .page.landscape {
+                width: 297mm;
+                min-height: 210mm;
+                padding: 5mm 6mm !important;
+            }
+            .table tbody tr:last-child {
+                border-top: 1px solid black !important;
+                border-bottom: 1px solid black !important;
             }
         </style>
         <div class="page f9w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
@@ -38,12 +47,12 @@
                 <table class="table table-sm table-bordered">
                     <thead>
                         <tr style="height:0; visibility:collapse; line-height:0;">
-                            <th style="width: 150pt;"/>
+                            <th style="width: 140pt;"/>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                              <th style="width: 55pt;"/>
+                              <th style="width: 62pt;"/>
                               <th style="width: 22pt;"/>
                             </t>
-                            <th style="width: 55pt;"/>
+                            <th style="width: 60pt;"/>
                         </tr>
                         <tr>
                             <th class="text-center" rowspan="2" style="width: 20%;">หน่วยงาน</th>
@@ -81,8 +90,6 @@
                             </tr>
                             <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
-                    </tbody>
-                    <tfoot>
                         <tr style="font-weight: bold;">
                             <td class="text-center">
                                 รวมทั้งสิ้น
@@ -100,7 +107,7 @@
                                 <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
-                    </tfoot>
+                    </tbody>
                 </table>
             </div>
         </div>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -24,9 +24,16 @@
                 min-height: 210mm;
                 padding: 5mm 6mm !important;
             }
-            .table tbody tr:last-child {
+            .table tbody .summary-row {
                 border-top: 1px solid black !important;
                 border-bottom: 1px solid black !important;
+            }
+            .table tfoot .page-bottom-line td {
+                border-top: 1pt solid #000 !important;
+                padding: 0;
+                height: 0;
+                line-height: 0;
+                font-size: 0;
             }
         </style>
         <div class="page f9w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
@@ -90,7 +97,7 @@
                             </tr>
                             <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
-                        <tr style="font-weight: bold;">
+                        <tr class="summary-row" style="font-weight: bold;">
                             <td class="text-center">
                                 รวมทั้งสิ้น
                             </td>
@@ -108,6 +115,11 @@
                             </td>
                         </tr>
                     </tbody>
+                    <tfoot>
+                        <tr class="page-bottom-line">
+                            <td t-att-colspan="2 + len(o.f9w_expense_data['columns']) * 2">&#160;</td>
+                        </tr>
+                    </tfoot>
                 </table>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- F9-W: drop the reserve fund (07020) column and fix per-line column attribution so each line contributes to at most one activity-plan column. Previously every line that was both under an activity plan and under a 07020 sub-account was added to two columns, inflating row and grand totals.
- F9-W: switch activity matching to plan ``parent_path`` + ``startswith`` (same pattern as F10-W), so plans that aren't at the analytic root still match correctly and digit-suffix substrings can't cause misattribution.
- F8-W / F9-W / F10-W reports: move grand-total row back into ``<tbody>`` with a bordered last-row style so the totals stay attached to the table on page breaks.

## Test plan
- [ ] Open an F9-W summary and confirm department totals and the grand total match the underlying appropriation lines (no more double counting).
- [ ] Verify the 07020 column is removed and the remaining six activity-plan columns render correctly.
- [ ] Print F8-W / F9-W / F10-W as PDF and confirm the totals row stays bordered and attached when the table spans multiple pages.