### PR TITLE
[16.0][FIX] budget_appropriation_summary: F7-W percentages vs grand total

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Budget Appropriation Summary",
-    "version": "16.0.1.0.4",
+    "version": "16.0.1.0.5",
     "summary": "Compilation and master summary for budget appropriations",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget_appropriation_summary/models/summary_f2_revenue.py
+++ b/budget_appropriation_summary/models/summary_f2_revenue.py
@@ -62,7 +62,7 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
             compare_amount = compare_totals.get(code, 0)
             diff_amount = amount - compare_amount
             diff_percentage = (
-                round((diff_amount / compare_amount) * 100, 2)
+                round(((amount - compare_amount) / compare_amount) * 100, 2)
                 if compare_amount
                 else 0
             )

--- a/budget_appropriation_summary/models/summary_f7w_expense.py
+++ b/budget_appropriation_summary/models/summary_f7w_expense.py
@@ -129,11 +129,6 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
                     type_total += amount
                     compare_type_total += compare_amount
 
-            # Calculate category percentages
-            for cat in categories:
-                cat["percentage"] = round((cat["amount"] / type_total) * 100, 2) if type_total else 0
-                cat["compare_percentage"] = round((cat["compare_amount"] / compare_type_total) * 100, 2) if compare_type_total else 0
-
             if type_total or compare_type_total:
                 diff_type = type_total - compare_type_total
                 diff_type_pct = round((diff_type / compare_type_total) * 100, 2) if compare_type_total else 0
@@ -148,12 +143,15 @@ class BudgetAppropriationSummaryF7WExpense(models.AbstractModel):
                     "categories": categories,
                 })
 
-        # Calculate type percentages
+        # Calculate percentages against grand totals
         total_amount = sum(t["amount"] for t in expense_types)
         compare_total_amount = sum(t["compare_amount"] for t in expense_types)
         for t in expense_types:
             t["percentage"] = round((t["amount"] / total_amount) * 100, 2) if total_amount else 0
             t["compare_percentage"] = round((t["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
+            for cat in t["categories"]:
+                cat["percentage"] = round((cat["amount"] / total_amount) * 100, 2) if total_amount else 0
+                cat["compare_percentage"] = round((cat["compare_amount"] / compare_total_amount) * 100, 2) if compare_total_amount else 0
 
         # Summary with comparison
         diff_total = total_amount - compare_total_amount

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -70,26 +70,26 @@
                     <tbody class="category">
                         <t t-set="row_no" t-value="1"/>
                         <t t-foreach="o.f7w_expense_data['expense_types']" t-as="row">
-                            <tr class="border-0">
-                                <td class="fw-bold text-decoration-underline">
+                            <tr class="border-0" style="font-weight: bold;">
+                                <td class="text-decoration-underline" style="font-weight: bold;">
                                     <t t-esc="'{}. {}'.format(row_no, row['name'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
+                                <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
-                                    100.0
+                                <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
+                                    <t t-out="row['compare_percentage']"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
+                                <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
-                                    100.0
+                                <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
+                                    <t t-out="row['percentage']"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
+                                <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
                                 </td>
-                                <td class="text-end fw-bold border-bottom border-black" contenteditable="false">
+                                <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
                                 </td>
                             </tr>

--- a/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
+++ b/budget_appropriation_summary/views/budget_appropriation_master_summary_views.xml
@@ -283,7 +283,7 @@
         <field name="name">สรุปภาพรวมสถาบัน</field>
         <field name="res_model">budget.appropriation.master.summary</field>
         <field name="view_mode">tree,form</field>
-        <field name="context">{'search_default_current_fiscal_year': 1}</field>
+        <field name="context">{}</field>
         <field
             name="search_view_id"
             ref="view_budget_appropriation_master_summary_search"


### PR DESCRIPTION
## Summary
- Calculate F7-W expense type and category percentages against the grand total instead of each expense type subtotal.
- Render the computed expense type % in the report (previously hard-coded 100.0) and bold the expense type row via inline font-weight.
- Drop the default current fiscal year filter on the master summary action so all years show by default.

## Test plan
- [ ] Open an F7-W master summary with a comparison report and verify category % and expense type % sum to 100 across the column.
- [ ] Confirm the expense type row renders bold in the printed PDF.