### PR TITLE
[16.0][IMP] accounting_kmitl, disbursement_accounting_kmitl: rework DR bill posting flow

### DIFF
--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "https://www.kmitl.ac.th",
     "license": "AGPL-3",
     "depends": [
-        "account_move_tier_validation",
+        "base_tier_validation",
         "budget",
         "l10n_th_account_tax",
     ],

--- a/accounting_kmitl/data/tier_definition.xml
+++ b/accounting_kmitl/data/tier_definition.xml
@@ -1,39 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
+<odoo>
 
-    <!-- Tier definitions for bills only (not payment moves) -->
-    <record id="tier_definition_account_move_accountant" model="tier.definition">
-        <field name="model_id" ref="account.model_account_move"/>
-        <field name="name">ผู้จัดทำ/ผู้ตรวจสอบ</field>
-        <field name="sequence">20</field>
-        <field name="review_type">group</field>
-        <field name="reviewer_group_id" ref="account.group_account_manager"/>
-        <field name="definition_type">domain</field>
-        <field name="definition_domain">[("payment_id", "=", False)]</field>
-        <field name="approve_sequence">True</field>
-        <field name="has_comment">False</field>
-        <field name="active">True</field>
-        <field name="notify_on_create">True</field>
-        <field name="notify_on_accepted">True</field>
-        <field name="notify_on_rejected">True</field>
-        <field name="notify_on_restarted">True</field>
-    </record>
-
-    <record id="tier_definition_account_move_head_accountant" model="tier.definition">
-        <field name="model_id" ref="account.model_account_move"/>
-        <field name="name">ผู้อำนวยการคลัง</field>
-        <field name="sequence">10</field>
-        <field name="review_type">group</field>
-        <field name="reviewer_group_id" ref="account.group_account_manager"/>
-        <field name="definition_type">domain</field>
-        <field name="definition_domain">[("payment_id", "=", False)]</field>
-        <field name="approve_sequence">True</field>
-        <field name="has_comment">False</field>
-        <field name="active">True</field>
-        <field name="notify_on_create">True</field>
-        <field name="notify_on_accepted">True</field>
-        <field name="notify_on_rejected">True</field>
-        <field name="notify_on_restarted">True</field>
-    </record>
+    <!-- Tier validation moved to disbursement.request; remove legacy
+         account.move tier definitions that previously gated bill posting. -->
+    <delete model="tier.definition" id="tier_definition_account_move_accountant"/>
+    <delete model="tier.definition" id="tier_definition_account_move_head_accountant"/>
 
 </odoo>

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -54,7 +54,7 @@ msgstr "บัญชีงบประมาณที่ใช้สำหรั
 #. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
 msgid "Submit"
-msgstr "ส่งอนุมัติ"
+msgstr "ยืนยัน"
 
 #. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl

--- a/accounting_kmitl/models/account_move.py
+++ b/accounting_kmitl/models/account_move.py
@@ -9,10 +9,6 @@ class AccountMove(models.Model):
     _inherit = ["account.move", "budget.commitment.mixin",
                 "analytic.distribution.mixin"]
 
-    # Tier validation: submitted -> posted
-    _state_from = ["submitted"]
-    _state_to = ["posted"]
-
     # Budget commitment mixin configuration
     _commitment_id_field = "budget_commitment_id"
     _commitment_account_id_field = "budget_account_id"
@@ -38,37 +34,30 @@ class AccountMove(models.Model):
     )
 
     # --- Compute ---
-    @api.depends("date", "auto_post", "state", "validation_status")
+    @api.depends("date", "auto_post", "state")
     def _compute_hide_post_button(self):
-        """Show Post button only when submitted AND validated.
+        """Show Post button only when state=submitted.
 
-        For outbound payment moves, also require bank export to be done.
+        Draft entries must be submitted (locked) before posting.
         """
         super()._compute_hide_post_button()
         for move in self:
-            if move.validation_status == "validated" and move.state == "submitted":
-                payment = move.payment_id
-                if payment and payment.payment_type == "outbound":
-                    move.hide_post_button = payment.export_status == "draft"
-                else:
-                    move.hide_post_button = False
+            if move.state == "submitted":
+                move.hide_post_button = False
             else:
                 move.hide_post_button = True
 
     # --- Actions ---
     def action_submit(self):
-        """Submit the journal entry and auto-trigger tier validation."""
+        """Submit (lock) the journal entry; assign sequence number."""
         for move in self:
             if move.state != "draft":
                 raise UserError(_("Only draft entries can be submitted."))
         self.write({"state": "submitted"})
-        # Assign sequence number on submit (standard Odoo only assigns on post)
+        # Assign sequence number on submit
         for move in self.sorted(lambda m: (m.date, m.ref or "", m.id)):
             if not move.name or move.name == "/":
                 move._set_next_sequence()
-        for move in self:
-            if move.need_validation and move.state == "submitted":
-                move.request_validation()
         return True
 
     def action_draft(self):
@@ -172,6 +161,14 @@ class AccountMove(models.Model):
                     lines_without.write(
                         {"analytic_distribution": move.analytic_distribution}
                     )
+        # Auto-submit vendor bills when caller requests it (e.g., DR flow)
+        if self.env.context.get("auto_submit_on_create"):
+            bills_to_submit = moves.filtered(
+                lambda m: m.move_type in ("in_invoice", "in_refund")
+                and m.state == "draft"
+            )
+            if bills_to_submit:
+                bills_to_submit.action_submit()
         return moves
 
     def _inverse_analytic_distribution(self):
@@ -190,4 +187,3 @@ class AccountMove(models.Model):
             self.line_ids.update(
                 {"analytic_distribution": self.analytic_distribution}
             )
-

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -12,16 +12,10 @@
                 <attribute name="statusbar_visible">draft,submitted,posted</attribute>
             </xpath>
 
-            <!-- Hidden fields for tier validation -->
-            <xpath expr="//field[@name='id']" position="after">
-                <field name="validation_status" invisible="1"/>
-                <field name="need_validation" invisible="1"/>
-            </xpath>
-
             <!-- Submit and Reset to Draft buttons -->
             <xpath expr="//button[@name='action_post'][2]" position="after">
-                <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}" />
-                <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': ['|', ('state', '!=', 'submitted'), ('validation_status', 'in', ['validated', 'rejected', 'pending'])]}" />
+                <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'submitted')]}"/>
             </xpath>
 
             <!-- Pass analytic distribution as default to new lines -->
@@ -48,13 +42,12 @@
                 }</attribute>
             </xpath>
 
-            <!-- Budget fields on main form (before notebook) -->
-            <xpath expr="//notebook" position="before">
-                <group string="Budget">
+            <!-- Budget fields on main form (before invoice_tab notebook) -->
+            <xpath expr="//page[@id='invoice_tab']/.." position="before">
+                <group name="budget_root" string="Budget">
                     <group name="budget_info">
                         <field name="budget_commitment_id" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                         <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
-                        <field name="analytic_distribution" invisible="1"/>
                     </group>
                     <group name="analytic_dimensions">
                         <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
@@ -62,7 +55,6 @@
                         <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
                         <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
                         <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                        <field name="budget_account_id" invisible="1"/>
                     </group>
                 </group>
             </xpath>

--- a/disbursement_accounting_kmitl/__manifest__.py
+++ b/disbursement_accounting_kmitl/__manifest__.py
@@ -16,6 +16,7 @@
     "data": [
         "security/ir.model.access.csv",
         "views/disbursement_request_views.xml",
+        "views/account_move_line_views.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/disbursement_accounting_kmitl/models/account_move.py
+++ b/disbursement_accounting_kmitl/models/account_move.py
@@ -1,6 +1,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class AccountMove(models.Model):
@@ -13,3 +13,18 @@ class AccountMove(models.Model):
         index=True,
         copy=False,
     )
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def action_open_move(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Vendor Bill"),
+            "res_model": "account.move",
+            "res_id": self.move_id.id,
+            "view_mode": "form",
+            "target": "current",
+        }

--- a/disbursement_accounting_kmitl/models/disbursement_request.py
+++ b/disbursement_accounting_kmitl/models/disbursement_request.py
@@ -8,6 +8,14 @@ from odoo.fields import Command
 class DisbursementRequest(models.Model):
     _inherit = "disbursement.request"
 
+    state = fields.Selection(
+        selection_add=[
+            ("bills_posted", "Bills Posted"),
+            ("cancel",),
+        ],
+        ondelete={"bills_posted": "set default"},
+    )
+
     pipeline_status = fields.Selection(
         selection_add=[
             ("bill_draft", "Bill Draft"),
@@ -23,10 +31,12 @@ class DisbursementRequest(models.Model):
         selection_add=[
             ("bill_draft", "Bill Draft"),
             ("bill_posted", "Bill Posted"),
+            ("bills_posted", "Bills Posted"),
         ],
         ondelete={
             "bill_draft": "set default",
             "bill_posted": "set default",
+            "bills_posted": "set default",
         },
     )
 
@@ -53,6 +63,11 @@ class DisbursementRequest(models.Model):
         compute="_compute_bill_count",
     )
 
+    move_line_count = fields.Integer(
+        string="Move Line Count",
+        compute="_compute_move_line_count",
+    )
+
     @api.depends("bill_ids", "bill_ids.state")
     def _compute_bill_count(self):
         """Compute the number of bills linked to this request.
@@ -64,19 +79,29 @@ class DisbursementRequest(models.Model):
                 lambda b: b.state != "cancel"
             )
             total = len(active_bills)
-            draft = len(active_bills.filtered(lambda b: b.state == "draft"))
+            unposted = len(active_bills.filtered(
+                lambda b: b.state in ("draft", "submitted")
+            ))
             posted = len(active_bills.filtered(lambda b: b.state == "posted"))
             record.bill_count = total
-            record.bill_draft_count = draft
+            record.bill_draft_count = unposted
             record.bill_status_display = (
                 _("ตั้งหนี้แล้ว %s/%s", posted, total) if total else ""
             )
+
+    @api.depends("bill_ids", "bill_ids.state", "bill_ids.line_ids")
+    def _compute_move_line_count(self):
+        for rec in self:
+            active = rec.bill_ids.filtered(lambda b: b.state != "cancel")
+            rec.move_line_count = len(active.line_ids.filtered(
+                lambda l: l.display_type not in ("line_section", "line_note")
+            ))
 
     @api.depends("bill_ids", "bill_ids.state")
     def _compute_pipeline_status(self):
         super()._compute_pipeline_status()
         for rec in self:
-            if rec.state != "approved":
+            if rec.state not in ("approved", "bills_posted"):
                 continue
             active_bills = rec.bill_ids.filtered(lambda b: b.state != "cancel")
             if not active_bills:
@@ -86,6 +111,16 @@ class DisbursementRequest(models.Model):
             else:
                 rec.pipeline_status = "bill_draft"
 
+    @api.depends("state", "pipeline_status")
+    def _compute_display_status(self):
+        super()._compute_display_status()
+        for rec in self:
+            if rec.state == "bills_posted":
+                rec.display_status = "bills_posted"
+
+    # ------------------------------------------------------------------
+    # Bill creation
+    # ------------------------------------------------------------------
     def _create_bill(self):
         """Create vendor bill(s) from disbursement request."""
         self.ensure_one()
@@ -99,8 +134,6 @@ class DisbursementRequest(models.Model):
             bills = self._create_single_bill()
         else:
             bills = self._create_multi_bills()
-
-        bills.action_submit()
 
         for bill in bills:
             bill_link = "/web#id=%d&model=account.move&view_type=form" % bill.id
@@ -122,7 +155,9 @@ class DisbursementRequest(models.Model):
             Command.create(self._prepare_bill_line_vals(line))
             for line in self.line_ids
         ]
-        bill = self.env["account.move"].create(
+        bill = self.env["account.move"].with_context(
+            auto_submit_on_create=True
+        ).create(
             self._prepare_bill_vals(
                 self.partner_id, self.partner_bank_id, invoice_lines
             )
@@ -148,7 +183,9 @@ class DisbursementRequest(models.Model):
                 for line in lines
             ]
             partner_bank = lines[0].partner_bank_id
-            bill = self.env["account.move"].create(
+            bill = self.env["account.move"].with_context(
+            auto_submit_on_create=True
+        ).create(
                 self._prepare_bill_vals(partner, partner_bank, invoice_lines)
             )
             self._apply_wht_to_bill(bill, lines)
@@ -191,6 +228,74 @@ class DisbursementRequest(models.Model):
         ):
             if request_line.wht_tax_id:
                 invoice_line.wht_tax_id = request_line.wht_tax_id
+
+    # ------------------------------------------------------------------
+    # Tier-gated actions
+    # ------------------------------------------------------------------
+    def action_create_bill(self):
+        self.ensure_one()
+        existing_bills = self.bill_ids.filtered(lambda b: b.state != "cancel")
+        if existing_bills:
+            raise UserError(
+                _(
+                    "Cannot create new bill: existing bill(s) %s are still "
+                    "in progress. Cancel them first before creating a new one."
+                )
+                % ", ".join(existing_bills.mapped("name"))
+            )
+        bills = self._create_bill()
+        if len(bills) == 1:
+            return {
+                "type": "ir.actions.act_window",
+                "res_model": "account.move",
+                "res_id": bills.id,
+                "view_mode": "form",
+                "target": "current",
+            }
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Vendor Bills"),
+            "res_model": "account.move",
+            "domain": [("id", "in", bills.ids)],
+            "view_mode": "tree,form",
+            "target": "current",
+        }
+
+    def action_post_bills(self):
+        """Post all unposted bills and transition DR state to bills_posted."""
+        for record in self:
+            if record.state != "approved":
+                raise UserError(
+                    _("Only approved disbursement requests can post bills.")
+                )
+            unposted_bills = record.bill_ids.filtered(
+                lambda b: b.state in ("draft", "submitted")
+            )
+            if not unposted_bills:
+                raise UserError(_("No bills to post."))
+            unposted_bills.action_post()
+            record.state = "bills_posted"
+        return True
+
+    # ------------------------------------------------------------------
+    # Views
+    # ------------------------------------------------------------------
+    def action_view_move_lines(self):
+        """Open a tree of move.line aggregated from this DR's active bills."""
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "disbursement_accounting_kmitl."
+            "action_disbursement_move_lines"
+        )
+        action["domain"] = [
+            ("move_id", "in", self.bill_ids.ids),
+            ("move_id.state", "!=", "cancel"),
+            ("display_type", "not in", ("line_section", "line_note")),
+        ]
+        action["context"] = {
+            "default_disbursement_request_id": self.id,
+        }
+        return action
 
     def action_view_bill(self):
         """Open the linked vendor bill(s)"""
@@ -236,32 +341,3 @@ class DisbursementRequest(models.Model):
             if draft_bills:
                 draft_bills.button_cancel()
         return super().action_cancel()
-
-    def action_create_bill(self):
-        self.ensure_one()
-        existing_bills = self.bill_ids.filtered(lambda b: b.state != "cancel")
-        if existing_bills:
-            raise UserError(
-                _(
-                    "Cannot create new bill: existing bill(s) %s are still "
-                    "in progress. Cancel them first before creating a new one."
-                )
-                % ", ".join(existing_bills.mapped("name"))
-            )
-        bills = self._create_bill()
-        if len(bills) == 1:
-            return {
-                "type": "ir.actions.act_window",
-                "res_model": "account.move",
-                "res_id": bills.id,
-                "view_mode": "form",
-                "target": "current",
-            }
-        return {
-            "type": "ir.actions.act_window",
-            "name": _("Vendor Bills"),
-            "res_model": "account.move",
-            "domain": [("id", "in", bills.ids)],
-            "view_mode": "tree,form",
-            "target": "current",
-        }

--- a/disbursement_accounting_kmitl/views/account_move_line_views.xml
+++ b/disbursement_accounting_kmitl/views/account_move_line_views.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Tree view: aggregated move.line from DR bills -->
+    <record id="view_account_move_line_disbursement_tree" model="ir.ui.view">
+        <field name="name">account.move.line.disbursement.tree</field>
+        <field name="model">account.move.line</field>
+        <field name="arch" type="xml">
+            <tree create="false" edit="false" delete="false"
+                  decoration-muted="parent_state == 'cancel'"
+                  decoration-info="parent_state == 'draft'"
+                  decoration-success="parent_state == 'posted'"
+                  default_order="move_id, id">
+                <field name="move_id"/>
+                <field name="parent_state" optional="hide"/>
+                <field name="partner_id"/>
+                <field name="product_id" optional="hide"/>
+                <field name="name" optional="hide"/>
+                <field name="account_id"/>
+                <field name="tax_ids" widget="many2many_tags" optional="hide"/>
+                <field name="tax_line_id" optional="hide"/>
+                <field name="analytic_distribution"
+                       widget="analytic_distribution" optional="show"/>
+                <field name="debit" sum="Debit"/>
+                <field name="credit" sum="Credit"/>
+                <field name="balance" sum="Balance" optional="hide"/>
+                <field name="display_type" optional="hide"/>
+                <field name="company_currency_id" invisible="1"/>
+                <field name="company_id" invisible="1"/>
+                <button name="action_open_move"
+                        type="object"
+                        icon="fa-external-link"
+                        title="Open Bill"/>
+            </tree>
+        </field>
+    </record>
+
+    <!-- Search view -->
+    <record id="view_account_move_line_disbursement_search" model="ir.ui.view">
+        <field name="name">account.move.line.disbursement.search</field>
+        <field name="model">account.move.line</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="move_id"/>
+                <field name="partner_id"/>
+                <field name="account_id"/>
+                <field name="product_id"/>
+                <field name="name"/>
+                <filter name="draft_bills" string="Draft Bills"
+                        domain="[('parent_state', '=', 'draft')]"/>
+                <filter name="posted_bills" string="Posted Bills"
+                        domain="[('parent_state', '=', 'posted')]"/>
+                <separator/>
+                <filter name="product_lines" string="Product Lines"
+                        domain="[('display_type', '=', 'product')]"/>
+                <filter name="tax_lines" string="Tax Lines"
+                        domain="[('display_type', '=', 'tax')]"/>
+                <filter name="payment_lines" string="Payment Term Lines"
+                        domain="[('display_type', '=', 'payment_term')]"/>
+                <filter name="payable_lines" string="Payable Lines"
+                        domain="[('account_id.account_type', '=', 'liability_payable')]"/>
+                <group expand="0" string="Group By">
+                    <filter name="group_by_move" string="Bill"
+                            context="{'group_by': 'move_id'}"/>
+                    <filter name="group_by_partner" string="Partner"
+                            context="{'group_by': 'partner_id'}"/>
+                    <filter name="group_by_account" string="Account"
+                            context="{'group_by': 'account_id'}"/>
+                    <filter name="group_by_state" string="Bill Status"
+                            context="{'group_by': 'parent_state'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action: move lines from DR (used by smart button + menu) -->
+    <record id="action_disbursement_move_lines" model="ir.actions.act_window">
+        <field name="name">Move Lines Review</field>
+        <field name="res_model">account.move.line</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_account_move_line_disbursement_tree"/>
+        <field name="search_view_id" ref="view_account_move_line_disbursement_search"/>
+        <field name="domain">[
+            ('move_id.disbursement_request_id', '!=', False),
+            ('move_id.state', '!=', 'cancel'),
+            ('display_type', 'not in', ('line_section', 'line_note'))
+        ]</field>
+        <field name="context">{
+            "search_default_draft_bills": 1,
+            "search_default_group_by_move": 1
+        }</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                ไม่มีรายการบัญชีจากใบขอเบิกให้ตรวจสอบ
+            </p>
+            <p>
+                แสดง account.move.line ทั้งหมดที่เกิดจาก bills ของใบขอเบิก
+                เพื่อให้ตรวจสอบในจอเดียวก่อน post bills
+            </p>
+        </field>
+    </record>
+
+    <!-- Menu: Bill Lines Review -->
+    <menuitem
+        id="menu_disbursement_move_lines"
+        name="ตรวจสอบรายการบัญชี"
+        parent="accounting_kmitl.menu_accounting_root"
+        action="action_disbursement_move_lines"
+        sequence="6"
+    />
+
+</odoo>

--- a/disbursement_accounting_kmitl/views/disbursement_request_views.xml
+++ b/disbursement_accounting_kmitl/views/disbursement_request_views.xml
@@ -32,13 +32,26 @@
         <field name="model">disbursement.request</field>
         <field name="inherit_id" ref="disbursement.view_disbursement_request_form"/>
         <field name="arch" type="xml">
-            <!-- Create Bill button placed after Approve -->
+            <!-- Statusbar: add bills_posted -->
+            <xpath expr="//field[@name='display_status']" position="attributes">
+                <attribute name="statusbar_visible">draft,submitted,signed,verified,approved,bills_posted</attribute>
+            </xpath>
+
+            <!-- Create Bill + ตั้งหนี้ buttons placed after Approve -->
             <xpath expr="//button[@name='action_approve']" position="after">
                 <button name="action_create_bill"
                         string="Create Bill"
                         type="object"
                         class="oe_highlight"
                         attrs="{'invisible': ['|', ('state', '!=', 'approved'), ('bill_count', '>', 0)]}"
+                        groups="accounting_kmitl.group_accounting_kmitl_user"/>
+                <button name="action_post_bills"
+                        string="ตั้งหนี้"
+                        type="object"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|',
+                            ('state', '!=', 'approved'),
+                            ('bill_draft_count', '=', 0)]}"
                         groups="accounting_kmitl.group_accounting_kmitl_user"/>
             </xpath>
 
@@ -52,6 +65,15 @@
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">ใบตั้งหนี้ <field name="bill_count" nolabel="1" /></span>
                         <span class="o_stat_text text-muted small"><field name="bill_status_display" nolabel="1" /></span>
+                    </div>
+                </button>
+                <button name="action_view_move_lines"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-list"
+                        attrs="{'invisible': [('move_line_count', '=', 0)]}">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">รายการบัญชี <field name="move_line_count" nolabel="1" /></span>
                     </div>
                 </button>
                 <field name="bill_draft_count" invisible="1" />


### PR DESCRIPTION
## Summary

- ย้ายการตัดสินใจ post bills จาก tier validation ของ account.move ไปเป็น flow ที่ DR ขับเคลื่อน
- เพิ่ม state `bills_posted` และปุ่ม **ตั้งหนี้** บน DR เพื่อ post bills ทั้งหมดในใบเดียวพร้อมกัน
- เพิ่ม view ตรวจสอบ `account.move.line` รวมจาก bills ของ DR (smart button + เมนู Accounting)
- คง state `submitted` บน bill ไว้เป็น lock ก่อน post (ไม่เกี่ยวกับ tier แล้ว) — auto-submit เมื่อสร้างจาก DR ผ่าน context flag
- เปลี่ยน dep `account_move_tier_validation` → `base_tier_validation` ใน accounting_kmitl

## Flow ใหม่
```
DR: draft → submitted → signed → verified → approved → bills_posted
                                              |             ^
                              [Create Bill] (bills submitted)
                                              |
                              [ตั้งหนี้] → posts unposted bills
```

## Test Plan

- [ ] Upgrade modules: `odoo -u accounting_kmitl,disbursement_accounting_kmitl --stop-after-init`
- [ ] **Manual bill (Bills → New)**: state stays `draft` after Save; user can Submit/Reset/Post as usual
- [ ] **DR happy path**: approve DR → Create Bill → bills appear in `submitted` with sequence → review via "รายการบัญชี" → ตั้งหนี้ → bills posted, DR state = `bills_posted`
- [ ] **DR multi-partner**: lines with different partner_id → Create Bill produces N bills
- [ ] **Move-line review menu**: Accounting → ตรวจสอบรายการบัญชี → list of move lines from draft bills of DRs
- [ ] **Open bill from row**: click fa-external-link icon → opens bill form
- [ ] **DR cancel**: cancel DR with draft bills → bills cancelled; with posted bills → blocked
- [ ] **Legacy submitted bills**: still editable/post-able after upgrade
- [ ] **Translation**: Submit button shows "ยืนยัน" on bill form