### PR TITLE
[16.0][IMP] finance_kmitl: refine account.payment form view

### DIFF
--- a/finance_kmitl/i18n/th.po
+++ b/finance_kmitl/i18n/th.po
@@ -117,8 +117,28 @@ msgstr "การเบิกจ่ายเงิน"
 
 #. module: finance_kmitl
 #: model:ir.model.fields,field_description:finance_kmitl.field_account_payment__kmitl_payment_type_id
-msgid "Payment Type (KMITL)"
-msgstr "ประเภทการจ่ายเงิน (KMITL)"
+msgid "Operation Type"
+msgstr "ประเภทธุรกรรม"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_payment_form_inherit
+msgid "Payer"
+msgstr "ผู้ชำระเงิน"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_payment_form_inherit
+msgid "Payee"
+msgstr "ผู้รับเงิน"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_payment_form_inherit
+msgid "Payer Bank Account"
+msgstr "บัญชีธนาคารผู้ชำระเงิน"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_payment_form_inherit
+msgid "Payee Bank Account"
+msgstr "บัญชีธนาคารผู้รับเงิน"
 
 #. module: finance_kmitl
 #: model:ir.actions.act_window,name:finance_kmitl.action_kmitl_payment_type

--- a/finance_kmitl/models/account_payment.py
+++ b/finance_kmitl/models/account_payment.py
@@ -9,7 +9,8 @@ class AccountPayment(models.Model):
 
     kmitl_payment_type_id = fields.Many2one(
         comodel_name="kmitl.payment.type",
-        string="Payment Type (KMITL)",
+        string="Operation Type",
+        required=True,
     )
     to_reconcile_payment_line_ids = fields.Many2many(
         comodel_name="account.move.line",

--- a/finance_kmitl/views/account_payment_views.xml
+++ b/finance_kmitl/views/account_payment_views.xml
@@ -33,28 +33,59 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
 
+            <!-- Hide is_internal_transfer -->
+            <xpath expr="//field[@name='is_internal_transfer']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
+            <!-- Hide bank_payment_template_id (from l10n_th_bank_payment_export) -->
+            <xpath expr="//field[@name='bank_payment_template_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
             <!-- Add KMITL payment type where payment_type was -->
             <xpath expr="//field[@name='payment_type']" position="after">
                 <field name="kmitl_payment_type_id" domain="[('direction', '=', payment_type)]"/>
+            </xpath>
+
+            <!-- Rename partner_id labels: Customer -> Payer (inbound), Vendor -> Payee (outbound).
+                 Selector cannot use @string (translated attr is forbidden); match via @attrs which
+                 contains the discriminating partner_type value. -->
+            <xpath expr="//field[@name='partner_id'][contains(@attrs, 'customer')]" position="attributes">
+                <attribute name="string">Payer</attribute>
+            </xpath>
+            <xpath expr="//field[@name='partner_id'][contains(@attrs, 'supplier')]" position="attributes">
+                <attribute name="string">Payee</attribute>
+            </xpath>
+
+            <!-- Rename partner_bank_id labels accordingly -->
+            <xpath expr="//field[@name='partner_bank_id'][contains(@attrs, 'customer')]" position="attributes">
+                <attribute name="string">Payer Bank Account</attribute>
+            </xpath>
+            <xpath expr="//field[@name='partner_bank_id'][contains(@attrs, 'supplier')]" position="attributes">
+                <attribute name="string">Payee Bank Account</attribute>
+            </xpath>
+
+            <!-- Move partner_bank_id directly under partner_id (per direction) -->
+            <xpath expr="//field[@name='partner_id'][contains(@attrs, 'customer')]" position="after">
+                <xpath expr="//field[@name='partner_bank_id'][contains(@attrs, 'customer')]" position="move"/>
+            </xpath>
+            <xpath expr="//field[@name='partner_id'][contains(@attrs, 'supplier')]" position="after">
+                <xpath expr="//field[@name='partner_bank_id'][contains(@attrs, 'supplier')]" position="move"/>
             </xpath>
 
             <!-- Add Budget tab -->
             <xpath expr="//sheet" position="inside">
                 <notebook>
                     <page string="Budget" name="budget">
-                        <group string="Budget">
-                            <group name="budget_info">
-                                <field name="budget_commitment_id" attrs="{'readonly': [('state', '!=', 'draft')]}" />
-                                <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
-                            </group>
-                            <group name="analytic_dimensions">
-                                <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                                <field name="budget_account_id" invisible="1"/>
-                            </group>
+                        <group string="Budget" name="budget_info">
+                            <field name="budget_commitment_id" attrs="{'readonly': [('state', '!=', 'draft')]}" />
+                            <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
+                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
## Summary
- ปรับ `account.payment` form view ในโมดูล `finance_kmitl`:
  - `kmitl_payment_type_id` → required, เปลี่ยน label เป็น **Operation Type** (TH: ประเภทธุรกรรม)
  - ซ่อน `is_internal_transfer` และ `bank_payment_template_id`
  - เปลี่ยน label `partner_id`/`partner_bank_id` ตามทิศของเงิน: Customer → **Payer** (ผู้ชำระเงิน), Vendor → **Payee** (ผู้รับเงิน)
  - ย้าย `partner_bank_id` มาไว้ใต้ `partner_id` ของฝั่งเดียวกัน
  - รวม field ใน Budget tab ให้อยู่ใน group เดียว
- อัปเดต i18n/th.po รองรับ label ใหม่

## Test plan
- [ ] Upgrade `finance_kmitl` แล้ว form view โหลดได้ ไม่มี error
- [ ] เปิด `account.payment` ใหม่ — `kmitl_payment_type_id` เป็น required และเลือก inbound/outbound ได้
- [ ] เมื่อ inbound: label แสดง "ผู้ชำระเงิน / บัญชีธนาคารผู้ชำระเงิน"; เมื่อ outbound: "ผู้รับเงิน / บัญชีธนาคารผู้รับเงิน"
- [ ] `is_internal_transfer` และ `bank_payment_template_id` ไม่ปรากฏบน form
- [ ] Budget tab แสดง field ทั้งหมดในคอลัมน์เดียว
- [ ] บันทึก/post payment ได้ตามปกติ (workflow draft → submitted → posted)