### PR TITLE
[16.0][FIX] budget_appropriation_summary: fix F9-W percentage column

### DIFF
--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -153,8 +153,7 @@
                         @media print {
                             @page {
                               size: A4 landscape;
-                              margin: 8mm 15mm;
-                              padding: 24mm 0mm !important;
+                              margin: 8mm 8mm;
                             }
                         }
                     </style>

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -22,6 +22,11 @@
             h3 {
               font-weight: bold;
             }
+            .page.landscape {
+                width: 297mm;
+                padding: 0mm 8mm !important;
+                margin: 10mm 0mm  !important;
+            }
         </style>
         <div class="page f11w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
@@ -36,7 +41,6 @@
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและกองทุน</h3>
             </div>
-            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -49,7 +49,6 @@
                 <h3>สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</h3>
                 <h3>จําแนกตามหน่วยงานและแผนงาน</h3>
             </div>
-            <div style="height: 24pt;"/>
             <div>
                 <table class="table table-sm table-bordered">
                     <thead>
@@ -57,7 +56,7 @@
                             <th style="width: 140pt;"/>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
                               <th style="width: 62pt;"/>
-                              <th style="width: 22pt;"/>
+                              <th style="width: 24pt;"/>
                             </t>
                             <th style="width: 60pt;"/>
                         </tr>
@@ -87,8 +86,9 @@
                                         <t t-out="'{0:,.2f}'.format(department['columns'][column['code']]['amount'])"/>
                                     </th>
                                     <th class="text-end border-0 border-end" contenteditable="false">
-                                        0.00
-                                        <!-- <t t-out="department['columns'][column['code']]['percentage']" /> -->
+                                        <t t-set="col_total" t-value="o.f9w_expense_data['column_totals'][column['code']]['amount']"/>
+                                        <t t-set="pct" t-value="(department['columns'][column['code']]['amount'] / col_total * 100) if col_total else 0"/>
+                                        <t t-out="'{0:,.2f}'.format(pct)"/>
                                     </th>
                                 </t>
                                 <th class="text-end border-0" contenteditable="false">
@@ -106,8 +106,7 @@
                                     <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['column_totals'][column['code']]['amount'])"/>
                                 </th>
                                 <th class="text-end" contenteditable="false">
-                                    0.00
-                                    <!-- <t t-out="department['columns'][column['code']]['percentage']" /> -->
+                                    100.00
                                 </th>
                             </t>
                             <td class="text-end" contenteditable="false">


### PR DESCRIPTION
## Summary
- F9-W report: compute the `%` column as `department amount / column total` instead of the hardcoded `0.00`; summary row shows `100.00`.
- F11-W report: add landscape page padding/margins for consistent print layout.
- `report_common.xml`: tighten landscape `@page` margins.

## Test plan
- [ ] Print F9-W-วง-003 and verify each department's `%` matches its share of the column total (and that each column sums to 100%).
- [ ] Print F11-W and verify the landscape margins look correct.