### PR TITLE
[16.0][FIX] budget_appropriation_summary: fix F3-W/F6-W revenue percentage column

### DIFF
--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -16,6 +16,9 @@
                 font-size: 14pt;
                 line-height: 1.4;
             }
+            .page:not(.landscape) {
+                padding: 6mm 6mm !important;
+            }
         </style>
         <div class="page f3w_f6w" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -74,13 +74,13 @@
                                     <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    100.0
+                                    <t t-out="'{0:,.2f}'.format(row['percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>


### PR DESCRIPTION
## Summary
- Fix F3-W/F6-W revenue report: per-row `%` columns were hardcoded to `100.0`. Now use `row['compare_percentage']` and `row['percentage']` from `summary_f4w_revenue` so each department row reflects its share of its fiscal-year grand total.
- Tighten portrait page padding to 6mm so the table fits better on the printed page.

## Test plan
- [ ] Open a `budget.appropriation.master.summary` with a compare summary set and print the F3-W/F6-W report; verify each department row shows its correct % of the grand total for both fiscal-year columns, the "รวมทั้งสิ้น" footer still shows 100.00, and page margins look right.