### PR TITLE
[16.0][FIX] budget_appropriation_summary: amounts without decimals

### DIFF
--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -82,7 +82,7 @@
                 .page:not(.landscape) {
                     width: 210mm;
                     min-height: 297mm;
-                    padding: 25mm 8mm !important;
+                    padding: 6mm 6mm !important;
                 }
                 * {
                     line-height: 1.145;
@@ -163,8 +163,10 @@
                         @media print {
                             @page {
                               size: A4 portrait;
-                              margin: 0 !important;
-                              padding: 14mm 8mm !important;
+                              <!-- margin: 0mm 0mm !important;
+                              padding: 0mm 0mm !important; -->
+                              margin: 2mm 0mm !important;
+                              padding: 16mm 8mm !important;
                             }
                         }
                     </style>

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -74,7 +74,7 @@
                 <table class="table table-sm table-bordered">
                     <thead>
                         <tr>
-                            <th class="text-center" style="width: 30%;">แผนงาน/กิจกรรม</th>
+                            <th class="text-center" style="width: 33%;">แผนงาน/กิจกรรม</th>
                             <t t-foreach="o.f10w_expense_data['columns']" t-as="column">
                                 <th class="text-center"><t t-out="column['name']"/></th>
                             </t>

--- a/budget_appropriation_summary/report/report_f10w_expense.xml
+++ b/budget_appropriation_summary/report/report_f10w_expense.xml
@@ -46,8 +46,14 @@
             p,
             span,
             div {
-                font-size: 13pt;
+                font-size: 14pt;
                 line-height: 1.1;
+            }
+            @media print {
+                @page {
+                    size: A4 landscape;
+                    padding: 6mm 0mm !important;
+                }
             }
         </style>
         <div class="page f10w landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
@@ -81,15 +87,15 @@
                                 <td t-esc="row['name']"/>
                                 <t t-foreach="o.f10w_expense_data['columns']" t-as="column">
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(row['columns'][column['code']])"/>
+                                        <t t-out="'{0:,.0f}'.format(row['columns'][column['code']])"/>
                                     </td>
                                 </t>
                                 <td class="text-end fw-bold" contenteditable="false">
                                     <t t-if="row['level'] in [0, 1]">
-                                        <t t-out="'{0:,.2f}'.format(row['total'])"/>
+                                        <t t-out="'{0:,.0f}'.format(row['total'])"/>
                                     </t>
                                     <t t-else="">
-                                        <t t-out="'{0:,.2f}'.format(row['total'])"/>
+                                        <t t-out="'{0:,.0f}'.format(row['total'])"/>
                                     </t>
                                 </td>
                             </tr>
@@ -100,11 +106,11 @@
                             </td>
                             <t t-foreach="o.f10w_expense_data['columns']" t-as="column">
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['column_totals'][column['code']])"/>
+                                    <t t-out="'{0:,.0f}'.format(o.f10w_expense_data['column_totals'][column['code']])"/>
                                 </td>
                             </t>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f10w_expense_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f10w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tbody>

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -6,7 +6,7 @@
             p,
             span,
             div {
-                font-size: 7.5pt;
+                font-size: 8pt;
                 line-height: 1.1;
             }
             .table {
@@ -47,10 +47,10 @@
                         <tr style="height:0; visibility:collapse; line-height:0;">
                             <th style="width: 80pt;"/>
                             <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
-                                <th style="width: 30pt;"/>
+                                <th style="width: 34pt;"/>
                                 <th style="width: 18pt;"/>
                             </t>
-                            <th style="width: 50pt;"/>
+                            <th style="width: 34pt;"/>
                         </tr>
                         <tr>
                             <th class="text-center" rowspan="2" style="width: 10%;">หน่วยงาน</th>

--- a/budget_appropriation_summary/report/report_f2_revenue.xml
+++ b/budget_appropriation_summary/report/report_f2_revenue.xml
@@ -71,15 +71,15 @@
                         <tr class="revenue" style="font-weight: bold;">
                             <td>2. เงินรายได้</td>
                             <td class="text-end border-bottom" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
                             <td class="text-end border-bottom" contenteditable="false">100.0</td>
                             <td class="text-end border-bottom" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f2_revenue_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end border-bottom" contenteditable="false">100.0</td>
                             <td class="text-end border-bottom" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f2_revenue_data['summary']['diff_amount'])"/>
                             </td>
                             <td class="text-end border-bottom" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_percentage'])"/>
@@ -89,17 +89,17 @@
                             <tr>
                                 <td class="ps-4" t-out="row['name']"/>
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false" t-out="row['percentage']"/>
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['diff_amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
@@ -111,15 +111,15 @@
                         <tr style="padding-top: 48pt">
                             <th class="text-center">รวมรายได้ทั้งสิ้น</th>
                             <th class="text-end" contenteditable="false">
-                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"/></strong>
+                                <strong><t t-out="'{0:,.0f}'.format(o.f2_revenue_data['summary']['compare_total_amount'])"/></strong>
                             </th>
                             <th class="text-end" contenteditable="false">100.0</th>
                             <th class="text-end" contenteditable="false">
-                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['total_amount'])"/></strong>
+                                <strong><t t-out="'{0:,.0f}'.format(o.f2_revenue_data['summary']['total_amount'])"/></strong>
                             </th>
                             <th class="text-end" contenteditable="false">100.0</th>
                             <th class="text-end" contenteditable="false">
-                                <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_amount'])"/></strong>
+                                <strong><t t-out="'{0:,.0f}'.format(o.f2_revenue_data['summary']['diff_amount'])"/></strong>
                             </th>
                             <th class="text-end" contenteditable="false">
                                 <strong><t t-out="'{0:,.2f}'.format(o.f2_revenue_data['summary']['diff_percentage'])"/></strong>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -74,19 +74,19 @@
                                     <t t-out="row['name']"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['compare_percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['percentage'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['diff_amount'])"/>
                                 </td>
                                 <td class="text-end" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
@@ -100,19 +100,19 @@
                                 รวมทั้งสิ้น
                             </td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
                             <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
                             </td>
                             <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])"/>

--- a/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f3w_f6w_revenue.xml
@@ -41,12 +41,12 @@
                     <thead>
                         <tr style="height:0; visibility:collapse; line-height:0;">
                           <td style="width: auto;"/>
-                          <td style="width: 74pt;"/>
-                          <td style="width: 32pt;"/>
-                          <td style="width: 74pt;"/>
-                          <td style="width: 32pt;"/>
-                          <td style="width: 74pt;"/>
-                          <td style="width: 32pt;"/>
+                          <td style="width: 70pt;"/>
+                          <td style="width: 34pt;"/>
+                          <td style="width: 70pt;"/>
+                          <td style="width: 34pt;"/>
+                          <td style="width: 70pt;"/>
+                          <td style="width: 36pt;"/>
                         </tr>
                         <tr>
                             <th class="text-center" rowspan="2">หน่วยงาน</th>

--- a/budget_appropriation_summary/report/report_f4p_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4p_revenue.xml
@@ -46,7 +46,7 @@
                         <tr style="font-weight: bold">
                             <td class="ps-3" colspan="2">2. เงินรายได้</td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f} บาท'.format(o.f4p_revenue_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f} บาท'.format(o.f4p_revenue_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                         <t t-set="row_no" t-value="1"/>
@@ -62,7 +62,7 @@
                                         <t t-esc="'- {}'.format(dept['name'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(dept['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(dept['amount'])"/>
                                     </td>
                                     <td/>
                                 </tr>
@@ -70,7 +70,7 @@
                             <tr>
                                 <td class="text-end">รวม</td>
                                 <td class="text-end fw-bold" style="border-bottom: 1px solid black;" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['amount'])"/>
                                 </td>
                                 <td/>
                             </tr>
@@ -84,7 +84,7 @@
                                 รวมรายรับทั้งสิ้น
                             </td>
                             <td class="text-end fw-bold" style="border-bottom: 3px double black;" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4p_revenue_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4p_revenue_data['summary']['total_amount'])"/>
                             </td>
                             <td/>
                         </tr>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -77,19 +77,19 @@
                                   <t t-esc="'{}. {}'.format(row_no, row['name'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     100.0
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     100.0
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['diff_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
@@ -101,19 +101,19 @@
                                         - <t t-esc="category['name']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['compare_amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['compare_amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="category['compare_percentage']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="category['percentage']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['diff_amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['diff_amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(category['diff_percentage'])"/>
@@ -129,19 +129,19 @@
                                 <strong>รวมทั้งสิ้น</strong>
                             </td>
                             <td class="text-end" style="font-weight: bold;" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4w_revenue_data['summary']['compare_total_amount'])"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4w_revenue_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f4w_revenue_data['summary']['diff_amount'])"/>
                             </td>
                             <td class="text-end" style="font-weight: bold;" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f4w_revenue_data['summary']['diff_percentage'])"/>

--- a/budget_appropriation_summary/report/report_f4w_revenue.xml
+++ b/budget_appropriation_summary/report/report_f4w_revenue.xml
@@ -48,11 +48,11 @@
                         <tr style="height:0; visibility:collapse; line-height:0;">
                           <td style="width: auto;"/>
                           <td style="width: 74pt;"/>
-                          <td style="width: 32pt;"/>
+                          <td style="width: 36pt;"/>
                           <td style="width: 74pt;"/>
-                          <td style="width: 32pt;"/>
+                          <td style="width: 36pt;"/>
                           <td style="width: 74pt;"/>
-                          <td style="width: 32pt;"/>
+                          <td style="width: 36pt;"/>
                         </tr>
                         <tr>
                             <th class="text-center" rowspan="2">หน่วยงาน</th>

--- a/budget_appropriation_summary/report/report_f5p_expense.xml
+++ b/budget_appropriation_summary/report/report_f5p_expense.xml
@@ -62,10 +62,10 @@
                                     0
                                 </td>
                                 <td class="text-end border-2 border-bottom border-black" style="font-weight: bold" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(expense['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(expense['amount'])"/>
                                 </td>
                                 <td class="text-end border-2 border-bottom border-black" style="font-weight: bold" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(expense['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(expense['amount'])"/>
                                 </td>
                             </tr>
                             <t t-set="category_no" t-value="1"/>
@@ -78,10 +78,10 @@
                                         0
                                     </td>
                                     <td class="text-end border-2 border-bottom border-black" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['amount'])"/>
                                     </td>
                                     <td class="text-end border-2 border-bottom border-black" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['amount'])"/>
                                     </td>
                                 </tr>
                                 <t t-set="category_no" t-value="category_no + 1"/>
@@ -92,10 +92,10 @@
                                         </td>
                                         <td class="text-end" contenteditable="false">0</td>
                                         <td class="text-end" contenteditable="false">
-                                            <t t-out="'{0:,.2f}'.format(dept['amount'])"/>
+                                            <t t-out="'{0:,.0f}'.format(dept['amount'])"/>
                                         </td>
                                         <td class="text-end" contenteditable="false">
-                                            <t t-out="'{0:,.2f}'.format(dept['amount'])"/>
+                                            <t t-out="'{0:,.0f}'.format(dept['amount'])"/>
                                         </td>
                                     </tr>
                                 </t>
@@ -111,10 +111,10 @@
                             </td>
                             <td class="text-end border-4 border-bottom border-black ps-0 pb-0" contenteditable="false">0</td>
                             <td class="text-end border-4 border-bottom border-black ps-0 pb-0" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f5p_expense_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f5p_expense_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end border-4 border-bottom border-black ps-0 pb-0" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f5p_expense_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f5p_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tbody>

--- a/budget_appropriation_summary/report/report_f5w_expense.xml
+++ b/budget_appropriation_summary/report/report_f5w_expense.xml
@@ -61,11 +61,11 @@
                     <t t-foreach="o.f5w_expense_data['activities']" t-as="activity">
                         <tr>
                             <td class="ps-2 border-0 border-start" t-esc="activity['name']"/>
-                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['compare_amount'])"/></td>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.0f}'.format(activity['compare_amount'])"/></td>
                             <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['compare_percentage'])"/></td>
-                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['amount'])"/></td>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.0f}'.format(activity['amount'])"/></td>
                             <td class="text-end border-0 border-start" contenteditable="false" t-esc="activity['percentage']"/>
-                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['diff_amount'])"/></td>
+                            <td class="text-end border-0 border-start" contenteditable="false"><t t-out="'{0:,.0f}'.format(activity['diff_amount'])"/></td>
                             <td class="text-end border-0 border-start border-end" contenteditable="false"><t t-out="'{0:,.2f}'.format(activity['diff_percentage'])"/></td>
                         </tr>
                     </t>
@@ -74,15 +74,15 @@
                     <tr style="padding-top: 60px">
                         <th class="text-center">รวมทั้งสิ้น</th>
                         <th class="text-end fw-bold" contenteditable="false">
-                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['compare_total_amount'])"/>
+                            <t t-out="'{0:,.0f}'.format(o.f5w_expense_data['summary']['compare_total_amount'])"/>
                         </th>
                         <th class="text-end" contenteditable="false">100.0</th>
                         <th class="text-end fw-bold" contenteditable="false">
-                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['total_amount'])"/>
+                            <t t-out="'{0:,.0f}'.format(o.f5w_expense_data['summary']['total_amount'])"/>
                         </th>
                         <th class="text-end" contenteditable="false">100.0</th>
                         <th class="text-end fw-bold" contenteditable="false">
-                            <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['diff_amount'])"/>
+                            <t t-out="'{0:,.0f}'.format(o.f5w_expense_data['summary']['diff_amount'])"/>
                         </th>
                         <th class="text-end fw-bold" contenteditable="false">
                             <t t-out="'{0:,.2f}'.format(o.f5w_expense_data['summary']['diff_percentage'])"/>

--- a/budget_appropriation_summary/report/report_f7w_expense.xml
+++ b/budget_appropriation_summary/report/report_f7w_expense.xml
@@ -75,19 +75,19 @@
                                     <t t-esc="'{}. {}'.format(row_no, row['name'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
-                                    <t t-out="'{0:,.2f}'.format(row['compare_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['compare_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="row['compare_percentage']"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
-                                    <t t-out="'{0:,.2f}'.format(row['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="row['percentage']"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
-                                    <t t-out="'{0:,.2f}'.format(row['diff_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(row['diff_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false" style="font-weight: bold;">
                                     <t t-out="'{0:,.2f}'.format(row['diff_percentage'])"/>
@@ -99,19 +99,19 @@
                                         - <t t-esc="category['name']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['compare_amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['compare_amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="category['compare_percentage']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="category['percentage']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(category['diff_amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(category['diff_amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(category['diff_percentage'])"/>
@@ -127,19 +127,19 @@
                                 รวมทั้งสิ้น
                             </td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['compare_total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f7w_expense_data['summary']['compare_total_amount'])"/>
                             </td>
                             <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f7w_expense_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f7w_expense_data['summary']['diff_amount'])"/>
                             </td>
                             <td class="text-end" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f7w_expense_data['summary']['diff_percentage'])"/>

--- a/budget_appropriation_summary/report/report_f8w_expense.xml
+++ b/budget_appropriation_summary/report/report_f8w_expense.xml
@@ -83,19 +83,19 @@
                                     <t t-esc="'{}. {}'.format(row_no, department['name'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(department['compare_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(department['compare_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     100.0
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(department['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(department['amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     100.0
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(department['diff_amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(department['diff_amount'])"/>
                                 </td>
                                 <td class="text-end border-bottom border-black" contenteditable="false">
                                     <t t-out="'{0:,.2f}'.format(department['diff_percentage'])"/>
@@ -107,19 +107,19 @@
                                         - <t t-out="activity['name']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(activity['compare_amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(activity['compare_amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="activity['compare_percentage']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(activity['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(activity['amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="activity['percentage']"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(activity['diff_amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(activity['diff_amount'])"/>
                                     </td>
                                     <td class="text-end" contenteditable="false">
                                         <t t-out="'{0:,.2f}'.format(activity['diff_percentage'])"/>
@@ -133,19 +133,19 @@
                                 รวมทั้งสิ้น
                             </td>
                             <td class="text-end fw-bold" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['compare_total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f8w_expense_data['summary']['compare_total_amount'])"/>
                             </td>
                             <td class="text-end fw-bold" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end fw-bold" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f8w_expense_data['summary']['total_amount'])"/>
                             </td>
                             <td class="text-end fw-bold" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(100)"/>
                             </td>
                             <td class="text-end fw-bold" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f8w_expense_data['summary']['diff_amount'])"/>
                             </td>
                             <td class="text-end fw-bold" contenteditable="false">
                                 <t t-out="'{0:,.2f}'.format(o.f8w_expense_data['summary']['diff_percentage'])"/>

--- a/budget_appropriation_summary/report/report_f9w_expense.xml
+++ b/budget_appropriation_summary/report/report_f9w_expense.xml
@@ -55,10 +55,10 @@
                         <tr style="height:0; visibility:collapse; line-height:0;">
                             <th style="width: 140pt;"/>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
-                              <th style="width: 62pt;"/>
-                              <th style="width: 24pt;"/>
+                              <th style="width: 52pt;"/>
+                              <th style="width: 26pt;"/>
                             </t>
-                            <th style="width: 60pt;"/>
+                            <th style="width: 50pt;"/>
                         </tr>
                         <tr>
                             <th class="text-center" rowspan="2" style="width: 20%;">หน่วยงาน</th>
@@ -83,7 +83,7 @@
                                 </td>
                                 <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
                                     <th class="text-end border-0 border-end" contenteditable="false">
-                                        <t t-out="'{0:,.2f}'.format(department['columns'][column['code']]['amount'])"/>
+                                        <t t-out="'{0:,.0f}'.format(department['columns'][column['code']]['amount'])"/>
                                     </th>
                                     <th class="text-end border-0 border-end" contenteditable="false">
                                         <t t-set="col_total" t-value="o.f9w_expense_data['column_totals'][column['code']]['amount']"/>
@@ -92,7 +92,7 @@
                                     </th>
                                 </t>
                                 <th class="text-end border-0" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(department['total']['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(department['total']['amount'])"/>
                                 </th>
                             </tr>
                             <t t-set="row_no" t-value="row_no + 1"/>
@@ -103,14 +103,14 @@
                             </td>
                             <t t-foreach="o.f9w_expense_data['columns']" t-as="column">
                                 <th class="text-end" contenteditable="false">
-                                    <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['column_totals'][column['code']]['amount'])"/>
+                                    <t t-out="'{0:,.0f}'.format(o.f9w_expense_data['column_totals'][column['code']]['amount'])"/>
                                 </th>
                                 <th class="text-end" contenteditable="false">
                                     100.00
                                 </th>
                             </t>
                             <td class="text-end" contenteditable="false">
-                                <t t-out="'{0:,.2f}'.format(o.f9w_expense_data['summary']['total_amount'])"/>
+                                <t t-out="'{0:,.0f}'.format(o.f9w_expense_data['summary']['total_amount'])"/>
                             </td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
## Summary
- Switch amount formatters from `.2f` to `.0f` across the master-summary reports (F2, F3-W/F6-W, F4-P, F4-W, F5-P, F5-W, F7-W, F8-W, F9-W, F10-W) so amount columns display as integers; percentage columns remain at `.2f`.
- Minor F11-W layout tweak: bump body font to 8pt and widen the data/total columns for readability.

## Test plan
- [ ] Open F2/F3-W/F4-P/F4-W/F5-P/F5-W/F7-W/F8-W/F9-W/F10-W master summary reports and verify amount columns show no decimals while % columns still show two decimals.
- [ ] Verify F11-W layout still fits landscape A4.