### PR TITLE
[16.0][IMP] account_analytic_kmitl: add search filters and parent searchpanel

### DIFF
--- a/account_analytic_kmitl/__manifest__.py
+++ b/account_analytic_kmitl/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Account Analytic",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "summary": """ KMITL Account Analytic""",
     "category": "KMITL/Accounting",
     "author": "Aginix Technologies",

--- a/account_analytic_kmitl/views/account_analytic_account_views.xml
+++ b/account_analytic_kmitl/views/account_analytic_account_views.xml
@@ -23,4 +23,40 @@
         </field>
     </record>
 
+    <record id="view_account_analytic_account_search" model="ir.ui.view">
+        <field name="name">account.analytic.account.search.inherit.kmitl</field>
+        <field name="model">account.analytic.account</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_account_search"/>
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator/>
+                <filter
+                    string="Activity (ด้าน/แผนงาน/กิจกรรม)"
+                    name="plan_activities"
+                    domain="[('root_plan_id', '=', %(account_analytic_kmitl.analytic_plan_activities)d)]"
+                />
+                <filter
+                    string="Departments (หน่วยงาน)"
+                    name="plan_departments"
+                    domain="[('root_plan_id', '=', %(account_analytic_kmitl.analytic_plan_departments)d)]"
+                />
+                <filter
+                    string="Fund (กองทุน)"
+                    name="plan_funds"
+                    domain="[('root_plan_id', '=', %(account_analytic_kmitl.analytic_plan_funds)d)]"
+                />
+                <filter
+                    string="ประเภทแหล่งเงิน"
+                    name="plan_sources"
+                    domain="[('root_plan_id', '=', %(account_analytic_kmitl.analytic_plan_sources)d)]"
+                />
+            </filter>
+            <search position="inside">
+                <searchpanel>
+                    <field name="parent_id" string="Parent" icon="fa-sitemap" limit="0"/>
+                </searchpanel>
+            </search>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
## Summary
- Inherit `analytic.view_account_analytic_account_search` to add filters by root plan (activities, departments, funds, sources)
- Add searchpanel on `parent_id` for easier hierarchy navigation
- Bump manifest version to 16.0.1.2.0

## Test plan
- [ ] Open Analytic Accounts list and verify the new filters appear after the Archived filter
- [ ] Verify each filter shows only accounts under the corresponding root plan
- [ ] Verify the parent searchpanel renders on the left and navigates the hierarchy