### PR TITLE
[16.0][IMP] budget_appropriation_summary_f24: page label & merge into print PDF

### DIFF
--- a/budget_appropriation_summary_f24/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary_f24/models/budget_appropriation_master_summary.py
@@ -2,6 +2,7 @@
 from collections import defaultdict
 
 from odoo import models
+from odoo.tools.pdf import merge_pdf
 
 
 # (key, type) — type drives template formatting: "money" / "pct".
@@ -31,6 +32,14 @@ F24_NUMERIC_COLUMNS = [
 
 class BudgetAppropriationMasterSummary(models.Model):
     _inherit = "budget.appropriation.master.summary"
+
+    def _get_merged_pdf(self):
+        merged = super()._get_merged_pdf()
+        report = self.env.ref(
+            "budget_appropriation_summary_f24.action_report_compilation_f24"
+        )
+        f24_pdf, __ = report._render_qweb_pdf(report.id, self.ids)
+        return merge_pdf([merged, f24_pdf])
 
     def get_f24_report_data(self):
         """Prepare F24 report data grouped by department.

--- a/budget_appropriation_summary_f24/report/report_compilation_f24.xml
+++ b/budget_appropriation_summary_f24/report/report_compilation_f24.xml
@@ -46,10 +46,14 @@
         </style>
         <div class="page landscape" t-att-contenteditable="'true' if o.env.context.get('html_preview', False) else None">
             <t t-call="budget_appropriation_summary.report_print_button"/>
+            <t t-call="budget_appropriation_summary.report_page_label">
+                <t t-set="page_label" t-value="'F24-W-วง-003'"/>
+            </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center">
-                <h3>F24 สรุปงบประมาณรายจ่ายแยกตามหน่วยงาน</h3>
+                <h3>สรุปงบประมาณรายจ่ายแยกตามหน่วยงาน</h3>
                 <h3>ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/></h3>
+                <h3>ส่วนงานวิชาการ</h3>
             </div>
             <t t-set="f24" t-value="o.get_f24_report_data()"/>
             <div class="mt-3">

--- a/budget_appropriation_summary_f24/report/report_compilation_f24.xml
+++ b/budget_appropriation_summary_f24/report/report_compilation_f24.xml
@@ -51,8 +51,8 @@
             </t>
             <t t-call="budget_appropriation_summary.report_council_header"/>
             <div class="text-center">
-                <h3>สรุปงบประมาณรายจ่ายแยกตามหน่วยงาน</h3>
-                <h3>ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/></h3>
+                <h3>สรุปงบประมาณรายจ่าย ประจำปีงบประมาณ พ.ศ. <t t-out="o.account_fiscal_year_id.name"/></h3>
+                <h3>จำแนกตามหน่วยงาน</h3>
                 <h3>ส่วนงานวิชาการ</h3>
             </div>
             <t t-set="f24" t-value="o.get_f24_report_data()"/>


### PR DESCRIPTION
## Summary
- Add "F24-W-วง-003" page label to the F24 report header to match other F* reports
- Include F24 in the master summary "พิมพ์ PDF" merged output by overriding `_get_merged_pdf` (appends F24 after the base reports)
- Tidy report headings (drop "F24" prefix, add "ส่วนงานวิชาการ" line)

## Test plan
- [ ] Open a master summary record and click "พิมพ์ PDF" — verify F24 appears as the last page in the merged PDF
- [ ] Print the F24 report standalone — verify "F24-W-วง-003" label shows at the top right