### PR TITLE
[16.0][FIX] budget_appropriation_summary: repeat page label on every PDF page

### DIFF
--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -59,14 +59,19 @@
          extracted by wkhtmltopdf into header-html so it repeats per PDF
          page (styles must be inline; header is rendered standalone). -->
     <template id="report_page_label">
-        <div class="report-page-label" contenteditable="false">
-            <t t-out="page_label"/>
-        </div>
-        <div class="header report-page-label-header">
-            <div style="text-align: right; padding-right: 5mm; font-family: 'THSarabun', Arial, sans-serif; font-size: 15pt;">
+        <t t-set="is_pdf" t-value="not o.env.context.get('html_preview', False)"/>
+        <t t-if="not is_pdf">
+            <div class="report-page-label" contenteditable="false">
                 <t t-out="page_label"/>
             </div>
-        </div>
+        </t>
+        <t t-else="">
+            <div class="header report-page-label-header">
+                <div style="text-align: right; padding-right: 5mm; font-family: 'THSarabun', Arial, sans-serif; font-size: 15pt;">
+                    <t t-out="page_label"/>
+                </div>
+            </div>
+        </t>
     </template>
 
     <!-- Preview styles for A4 paper page effect (set is_landscape before calling) -->

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -46,8 +46,8 @@
                     right: 5mm;
                 }
             }
-            /* Hide on screen — Odoo's _prepare_html extracts class="header"
-               for wkhtmltopdf's --header-html so it repeats per PDF page. */
+            /* Hide on screen. Odoo's _prepare_html extracts class="header"
+               into wkhtmltopdf's header-html so it repeats per PDF page. */
             .report-page-label-header {
                 display: none;
             }
@@ -56,8 +56,8 @@
 
     <!-- Reusable page label. Two elements: the positioned .report-page-label
          drives HTML preview + browser print; the class="header" sibling is
-         extracted by wkhtmltopdf into --header-html so it repeats per PDF
-         page (styles must be inline — header is rendered standalone). -->
+         extracted by wkhtmltopdf into header-html so it repeats per PDF
+         page (styles must be inline; header is rendered standalone). -->
     <template id="report_page_label">
         <div class="report-page-label" contenteditable="false">
             <t t-out="page_label"/>

--- a/budget_appropriation_summary/report/report_common.xml
+++ b/budget_appropriation_summary/report/report_common.xml
@@ -46,13 +46,26 @@
                     right: 5mm;
                 }
             }
+            /* Hide on screen — Odoo's _prepare_html extracts class="header"
+               for wkhtmltopdf's --header-html so it repeats per PDF page. */
+            .report-page-label-header {
+                display: none;
+            }
         </style>
     </template>
 
-    <!-- Reusable page label (top-right of every page, persists on print) -->
+    <!-- Reusable page label. Two elements: the positioned .report-page-label
+         drives HTML preview + browser print; the class="header" sibling is
+         extracted by wkhtmltopdf into --header-html so it repeats per PDF
+         page (styles must be inline — header is rendered standalone). -->
     <template id="report_page_label">
         <div class="report-page-label" contenteditable="false">
             <t t-out="page_label"/>
+        </div>
+        <div class="header report-page-label-header">
+            <div style="text-align: right; padding-right: 5mm; font-family: 'THSarabun', Arial, sans-serif; font-size: 15pt;">
+                <t t-out="page_label"/>
+            </div>
         </div>
     </template>
 


### PR DESCRIPTION
## Summary
- เมื่อกดปุ่ม "พิมพ์ PDF" จากหน้า master.summary ลาเบลมุมขวาบน (เช่น F2-W-วง-003) จะแสดงเฉพาะหน้าแรกของแต่ละ sub-report เพราะ wkhtmltopdf ไม่ทำซ้ำ element ที่ position fixed/absolute ในแต่ละหน้า
- เพิ่ม sibling \`<div class=\"header\">\` ใน template \`report_page_label\` เพื่อให้ Odoo's \`_prepare_html\` ดึงไปใส่ header-html ของ wkhtmltopdf ลาเบลจึงแสดงทุกหน้าใน PDF
- ซ่อน header div นี้บนหน้าจอด้วย CSS เพื่อคงพฤติกรรมเดิมของ HTML preview และ portal print (browser print)

## Test plan

### เคสที่ 1 — "พิมพ์ PDF" จาก master.summary (เคสที่ buggy)
1. ไปที่เมนู **งบประมาณ → สรุปงบประมาณ → สรุปภาพรวมสถาบัน**
2. เปิด record สรุปภาพรวมสถาบันที่มีข้อมูลรายงานหลายหน้า (เช่นมี F11-W ที่ทอดหลายหน้า)
3. ที่แถบปุ่มด้านบนของฟอร์ม กดปุ่ม **"พิมพ์ PDF"**
4. รอ PDF เด้งขึ้น เปิดดูทุก sub-report (F2, F4-P, F4-W, F3-W/F6-W, F7-W, F5-P, F5-W, F8-W, F9-W, F11-W, F10-W)
5. ✅ คาดหวัง: ลาเบลมุมขวาบน (เช่น \`F2-W-วง-003\`, \`F11-W-วง-003\`) แสดง **ทุกหน้า** ของแต่ละ sub-report
6. ❌ ก่อนแก้: ลาเบลแสดงเฉพาะหน้าแรกของแต่ละ sub-report

### เคสที่ 2 — Portal HTML print (ต้องไม่ regress)
1. จากฟอร์มเดียวกัน กดปุ่ม **"ดูรายงาน"** (เปิด \`/budget_appropriation_summary/<id>/html\` ในแท็บใหม่)
2. กดปุ่ม **"พิมพ์รายงาน"** มุมขวาบนของหน้า preview (เรียก \`window.print()\`)
3. ใน print dialog ของ browser ตรวจ preview
4. ✅ คาดหวัง: ลาเบลมุมขวาบนยังแสดงทุกหน้าเหมือนเดิม (ใช้ \`position: fixed\` ของ browser print)

### เคสที่ 3 — HTML preview บนหน้าจอ (ต้องไม่ regress)
1. ทำตามข้อ 1 ของเคสที่ 2 (เปิด preview ในเบราว์เซอร์)
2. เลื่อนดูทุกหน้า (.page) ในหน้า preview
3. ✅ คาดหวัง: ลาเบลแสดงตำแหน่งมุมขวาบนของแต่ละ \`.page\` ตามเดิม ไม่มีลาเบลซ้อนกลางหน้า/ค้างบรรทัด