### PR TITLE
[16.0][FIX] budget_appropriation_summary_f24: compute ma_allocated_pct from total_1

### DIFF
--- a/budget_appropriation_summary_f24/models/budget_appropriation_master_summary.py
+++ b/budget_appropriation_summary_f24/models/budget_appropriation_master_summary.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from odoo import models
 from odoo.tools.pdf import merge_pdf
 
-
 # (key, type) — type drives template formatting: "money" / "pct".
 # Keep ordering aligned with the table header.
 F24_NUMERIC_COLUMNS = [
@@ -89,14 +88,12 @@ class BudgetAppropriationMasterSummary(models.Model):
             reserve_15 = sum(c.deducted_reserve_amount for c in comps)
             treasury = sum(c.treasury_replenishment_amount for c in comps)
             ma = sum(c.maintenance_amount for c in comps)
-            # TODO: replace with real MA allocated % when upstream field exists.
-            # Until then, 0.0 will render as '-' (same as a true 0 — flagged in PR).
-            ma_allocated_pct = 0.0
             recurrent = sum(c.recurrent_budget_amount for c in comps)
             capital = sum(c.capital_budget_amount for c in comps)
             # TODO: replace mock once external_funding_amount has real data.
             external = 0.0
             total_1 = reserve_15 + treasury + ma + recurrent + capital + external
+            ma_allocated_pct = (ma / total_1 * 100) if total_1 else 0.0
             edu = sum(c.education_total for c in comps)
             aca = sum(c.academic_total for c in comps)
             ind = sum(c.industrial_total for c in comps)
@@ -107,7 +104,10 @@ class BudgetAppropriationMasterSummary(models.Model):
                 return (x / total_2 * 100) if total_2 else 0.0
 
             edu_pct, aca_pct, ind_pct, soc_pct = (
-                _pct(edu), _pct(aca), _pct(ind), _pct(soc),
+                _pct(edu),
+                _pct(aca),
+                _pct(ind),
+                _pct(soc),
             )
             return {
                 "department_name": dept.name if dept else "",
@@ -134,9 +134,7 @@ class BudgetAppropriationMasterSummary(models.Model):
 
         rows = [
             _row(dept, comps)
-            for dept, comps in sorted(
-                grouped.items(), key=lambda kv: kv[0].code or ""
-            )
+            for dept, comps in sorted(grouped.items(), key=lambda kv: kv[0].code or "")
         ]
 
         money_keys = [k for k, t in F24_NUMERIC_COLUMNS if t == "money"]
@@ -146,14 +144,17 @@ class BudgetAppropriationMasterSummary(models.Model):
         def _pct(x):
             return (x / total_2 * 100) if total_2 else 0.0
 
-        total.update({
-            "department_name": "รวม",
-            "ma_allocated_pct": 0.0,
-            "education_pct": _pct(total["education"]),
-            "academic_pct": _pct(total["academic"]),
-            "industrial_pct": _pct(total["industrial"]),
-            "social_pct": _pct(total["social"]),
-        })
+        total_1 = total["total_1"]
+        total.update(
+            {
+                "department_name": "รวม",
+                "ma_allocated_pct": ((total["ma"] / total_1 * 100) if total_1 else 0.0),
+                "education_pct": _pct(total["education"]),
+                "academic_pct": _pct(total["academic"]),
+                "industrial_pct": _pct(total["industrial"]),
+                "social_pct": _pct(total["social"]),
+            }
+        )
         total["total_pct"] = (
             total["education_pct"]
             + total["academic_pct"]


### PR DESCRIPTION
Replace the hardcoded 0.0 placeholder for ma_allocated_pct with a real computation based on the MA amount over total_1, applied to both per-department and totals rows. This resolves the TODO and provides accurate maintenance allocation percentages in the F24 report.