### PR TITLE
[16.0][FIX] budget_appropriation_summary: route dept 99 deduct to 43300

### DIFF
--- a/budget_appropriation_summary/models/summary_f2_revenue.py
+++ b/budget_appropriation_summary/models/summary_f2_revenue.py
@@ -23,6 +23,11 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
         ("43500", "รายได้จากการรับบริจาค หรือ เงินอุดหนุน"),
     ]
 
+    # หน่วยงานรหัสนี้ (และหน่วยงานภายใต้) ให้หัก deduct เข้า 43300 แทน 43100 (ก)
+    SERVICE_REVENUE_DEPT_CODE = "99"
+    DEFAULT_DEDUCT_CATEGORY = "43100 (ก)"
+    SERVICE_REVENUE_CATEGORY = "43300"
+
     @api.model
     def get_data(self, summary_id):
         """
@@ -146,8 +151,9 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
 
     def _build_category_totals(self, summary):
         """Build category_code -> balance mapping. Deduct lines are subtracted
-        directly from "43100 (ก)" because revenue deduct lines do not specify
-        activity/fund and cannot be classified by category."""
+        directly from a revenue category because they do not specify
+        activity/fund and cannot be classified by account. Dept "99" (and its
+        sub-depts) deducts from 43300; other depts deduct from 43100 (ก)."""
         appropriations = summary.revenue_appropriation_ids
         lines = appropriations.mapped("line_ids")
 
@@ -163,11 +169,28 @@ class BudgetAppropriationSummaryF2Revenue(models.AbstractModel):
                 account_totals.get(acc_id, 0) for acc_id in account_ids
             )
 
-        totals["43100 (ก)"] -= sum(
-            appropriations.mapped("deduct_line_ids.balance")
-        )
+        for line in appropriations.mapped("deduct_line_ids"):
+            top_dept_code = self._extract_top_level_dept_code(
+                line.department_analytic_id
+            )
+            cat_code = (
+                self.SERVICE_REVENUE_CATEGORY
+                if top_dept_code == self.SERVICE_REVENUE_DEPT_CODE
+                else self.DEFAULT_DEDUCT_CATEGORY
+            )
+            totals[cat_code] -= line.balance
 
         return totals
+
+    def _extract_top_level_dept_code(self, department):
+        """Return the code of the top-level ancestor department, or None."""
+        if not (department and department.parent_path):
+            return None
+        try:
+            top_id = int(department.parent_path.split("/")[0])
+        except (ValueError, IndexError):
+            return None
+        return self.env["account.analytic.account"].browse(top_id).code
 
     def _get_accounts_in_category(self, category_code):
         """Get all budget.account IDs in category hierarchy using parent_path."""

--- a/budget_appropriation_summary/models/summary_f4p_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4p_revenue.py
@@ -16,6 +16,11 @@ class BudgetAppropriationSummaryF4PRevenue(models.AbstractModel):
         ("43500", "รายได้จากการรับบริจาค หรือ เงินอุดหนุน"),
     ]
 
+    # หน่วยงานรหัสนี้ (และหน่วยงานภายใต้) ให้หัก deduct เข้า 43300 แทน 43100 (ก)
+    SERVICE_REVENUE_DEPT_CODE = "99"
+    DEFAULT_DEDUCT_CATEGORY = "43100 (ก)"
+    SERVICE_REVENUE_CATEGORY = "43300"
+
     @api.model
     def get_data(self, summary_id):
         summary = self.env["budget.appropriation.master.summary"].browse(summary_id)
@@ -136,11 +141,18 @@ class BudgetAppropriationSummaryF4PRevenue(models.AbstractModel):
                         break
 
         # Deduct lines do not specify activity/fund, so subtract them directly
-        # from each department's "43100 (ก)" cell instead of matching by account.
+        # from each department's revenue category cell instead of matching by
+        # account. Dept "99" (and its sub-depts) deducts from 43300; others
+        # deduct from 43100 (ก).
         for line in appropriations.mapped("deduct_line_ids"):
             top_dept_id = self._extract_top_level_dept_id(line.department_analytic_id)
             if top_dept_id and top_dept_id in dept_map:
-                key = ("43100 (ก)", top_dept_id)
+                cat_code = (
+                    self.SERVICE_REVENUE_CATEGORY
+                    if dept_map[top_dept_id]["code"] == self.SERVICE_REVENUE_DEPT_CODE
+                    else self.DEFAULT_DEDUCT_CATEGORY
+                )
+                key = (cat_code, top_dept_id)
                 totals[key] = totals.get(key, 0) - line.balance
 
         return totals

--- a/budget_appropriation_summary/models/summary_f4w_revenue.py
+++ b/budget_appropriation_summary/models/summary_f4w_revenue.py
@@ -16,6 +16,11 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
         ("43500", "รายได้จากการรับบริจาค หรือ เงินอุดหนุน"),
     ]
 
+    # หน่วยงานรหัสนี้ (และหน่วยงานภายใต้) ให้หัก deduct เข้า 43300 แทน 43100 (ก)
+    SERVICE_REVENUE_DEPT_CODE = "99"
+    DEFAULT_DEDUCT_CATEGORY = "43100 (ก)"
+    SERVICE_REVENUE_CATEGORY = "43300"
+
     @api.model
     def get_data(self, summary_id):
         summary = self.env["budget.appropriation.master.summary"].browse(summary_id)
@@ -144,11 +149,18 @@ class BudgetAppropriationSummaryF4WRevenue(models.AbstractModel):
                         break
 
         # Deduct lines do not specify activity/fund, so subtract them directly
-        # from each department's "43100 (ก)" cell instead of matching by account.
+        # from each department's revenue category cell instead of matching by
+        # account. Dept "99" (and its sub-depts) deducts from 43300; others
+        # deduct from 43100 (ก).
         for line in appropriations.mapped("deduct_line_ids"):
             top_dept_id = self._extract_top_level_dept_id(line.department_analytic_id)
             if top_dept_id and top_dept_id in dept_map:
-                key = (top_dept_id, "43100 (ก)")
+                cat_code = (
+                    self.SERVICE_REVENUE_CATEGORY
+                    if dept_map[top_dept_id]["code"] == self.SERVICE_REVENUE_DEPT_CODE
+                    else self.DEFAULT_DEDUCT_CATEGORY
+                )
+                key = (top_dept_id, cat_code)
                 totals[key] = totals.get(key, 0) - line.balance
 
         return totals


### PR DESCRIPTION
## Summary
Revenue deduct lines in the F2, F4-W, and F4-P master-summary reports were unconditionally subtracted from category "43100 (ก)". Per user feedback, deduct lines belonging to top-level department code "99" (and its sub-departments) must reduce "43300" (รายได้จากงานบริการ) instead. Each report now resolves the deduct line's top-level department and routes the amount to the correct revenue category.

## Test plan
- [ ] เปิดรายงาน F2 / F4-W / F4-P ที่มี deduct ของหน่วยงานรหัส 99 → ยอด deduct ไปอยู่ใน 43300
- [ ] รายงานเดียวกันที่มี deduct ของหน่วยงานอื่น → ยอด deduct ยังอยู่ใน 43100 (ก)
- [ ] ผลรวมในคอลัมน์/แถวรวมของแต่ละรายงานถูกต้อง