### PR TITLE
[IMP] budget_appropriation_summary: add allocation % column to F11-W

### DIFF
--- a/budget_appropriation_summary/__manifest__.py
+++ b/budget_appropriation_summary/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Budget Appropriation Summary",
-    "version": "16.0.1.0.5",
+    "version": "16.0.1.0.6",
     "summary": "Compilation and master summary for budget appropriations",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget_appropriation_summary/report/report_f11w_expense.xml
+++ b/budget_appropriation_summary/report/report_f11w_expense.xml
@@ -51,19 +51,22 @@
                                 <th style="width: 18pt;"/>
                             </t>
                             <th style="width: 34pt;"/>
+                            <th style="width: 18pt;"/>
                         </tr>
                         <tr>
                             <th class="text-center" rowspan="2" style="width: 10%;">หน่วยงาน</th>
                             <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
                                 <th class="text-center column-name" colspan="2"><t t-out="column['name']"/></th>
                             </t>
-                            <th class="text-center" rowspan="2">รวมทุกกองทุน</th>
+                            <th class="text-center" colspan="2">รวมทุกกองทุน</th>
                         </tr>
                         <tr>
                             <t t-foreach="o.f11w_expense_data['columns']" t-as="column">
                                 <th class="text-center">เงินรายได้</th>
                                 <th class="text-center">%</th>
                             </t>
+                            <th class="text-center">เงินรายได้</th>
+                            <th class="text-center">จัดสรร %</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -86,6 +89,11 @@
                                 <td class="text-end fw-bold">
                                       <t t-out="'{0:,.0f}'.format(department['total']['amount'])"/>
                                 </td>
+                                <td class="text-center fw-bold">
+                                    <t t-set="grand_total" t-value="o.f11w_expense_data['summary']['total_amount']"/>
+                                    <t t-set="dept_pct" t-value="(department['total']['amount'] / grand_total * 100) if grand_total else 0"/>
+                                    <t t-out="'{0:,.2f}'.format(dept_pct)"/>
+                                </td>
                             </tr>
                             <t t-set="row_no" t-value="row_no + 1"/>
                         </t>
@@ -105,6 +113,9 @@
                             </t>
                             <td class="text-end">
                                 <t t-out="'{0:,.0f}'.format(o.f11w_expense_data['summary']['total_amount'])"/>
+                            </td>
+                            <td class="text-center">
+                                100.00
                             </td>
                         </tr>
                     </tfoot>


### PR DESCRIPTION
Split the final 'รวมทุกกองทุน' column into two sub-columns: 'เงินรายได้' (amount) and 'จัดสรร %' (allocation percentage). The allocation percentage shows each department's share of the total budget.

Changes:
- Modified F11-W expense report table structure to display allocation percentages
- Bumped manifest version from 16.0.1.0.5 to 16.0.1.0.6