### PR TITLE
[16.0][IMP] accounting_kmitl_reports: KMITL Trial Balance PDF

### DIFF
--- a/accounting_kmitl_reports/__init__.py
+++ b/accounting_kmitl_reports/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/accounting_kmitl_reports/__manifest__.py
+++ b/accounting_kmitl_reports/__manifest__.py
@@ -10,6 +10,7 @@
     "license": "LGPL-3",
     "depends": [
         "accounting_kmitl",
+        "thai_date_utils",
         # OCA building blocks (clone from OCA/account-financial-reporting 16.0)
         "mis_template_financial_report",
         "mis_builder_cash_flow",
@@ -21,6 +22,10 @@
         "data/mis_report_bs_kmitl.xml",
         "data/mis_report_cf_kmitl.xml",
         "data/mis_report_instance_kmitl.xml",
+        "data/paperformat_trial_balance_kmitl.xml",
+        "data/report_action_trial_balance_kmitl.xml",
+        "report/trial_balance_kmitl_template.xml",
+        "wizard/trial_balance_wizard_kmitl_view.xml",
         "views/menuitem.xml",
     ],
     "installable": True,

--- a/accounting_kmitl_reports/__manifest__.py
+++ b/accounting_kmitl_reports/__manifest__.py
@@ -17,6 +17,7 @@
         "account_financial_report",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/mis_report_style_kmitl.xml",
         "data/mis_report_pl_kmitl.xml",
         "data/mis_report_bs_kmitl.xml",

--- a/accounting_kmitl_reports/data/paperformat_trial_balance_kmitl.xml
+++ b/accounting_kmitl_reports/data/paperformat_trial_balance_kmitl.xml
@@ -7,12 +7,12 @@
         <field name="page_height">0</field>
         <field name="page_width">0</field>
         <field name="orientation">Portrait</field>
-        <field name="margin_top">45</field>
+        <field name="margin_top">55</field>
         <field name="margin_bottom">18</field>
         <field name="margin_left">7</field>
         <field name="margin_right">7</field>
         <field name="header_line" eval="False" />
-        <field name="header_spacing">40</field>
+        <field name="header_spacing">50</field>
         <field name="dpi">90</field>
     </record>
 </odoo>

--- a/accounting_kmitl_reports/data/paperformat_trial_balance_kmitl.xml
+++ b/accounting_kmitl_reports/data/paperformat_trial_balance_kmitl.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="paperformat_trial_balance_kmitl" model="report.paperformat">
+        <field name="name">KMITL Trial Balance A4</field>
+        <field name="default" eval="False" />
+        <field name="format">A4</field>
+        <field name="page_height">0</field>
+        <field name="page_width">0</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">35</field>
+        <field name="margin_bottom">15</field>
+        <field name="margin_left">7</field>
+        <field name="margin_right">7</field>
+        <field name="header_line" eval="False" />
+        <field name="header_spacing">30</field>
+        <field name="dpi">90</field>
+    </record>
+</odoo>

--- a/accounting_kmitl_reports/data/paperformat_trial_balance_kmitl.xml
+++ b/accounting_kmitl_reports/data/paperformat_trial_balance_kmitl.xml
@@ -7,12 +7,12 @@
         <field name="page_height">0</field>
         <field name="page_width">0</field>
         <field name="orientation">Portrait</field>
-        <field name="margin_top">35</field>
-        <field name="margin_bottom">15</field>
+        <field name="margin_top">45</field>
+        <field name="margin_bottom">18</field>
         <field name="margin_left">7</field>
         <field name="margin_right">7</field>
         <field name="header_line" eval="False" />
-        <field name="header_spacing">30</field>
+        <field name="header_spacing">40</field>
         <field name="dpi">90</field>
     </record>
 </odoo>

--- a/accounting_kmitl_reports/data/report_action_trial_balance_kmitl.xml
+++ b/accounting_kmitl_reports/data/report_action_trial_balance_kmitl.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="action_report_trial_balance_kmitl" model="ir.actions.report">
+        <field name="name">Trial Balance (KMITL)</field>
+        <field name="model">trial.balance.report.wizard.kmitl</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">accounting_kmitl_reports.trial_balance_kmitl</field>
+        <field name="report_file">accounting_kmitl_reports.trial_balance_kmitl</field>
+        <field name="paperformat_id" ref="paperformat_trial_balance_kmitl" />
+        <field name="binding_model_id" eval="False" />
+    </record>
+</odoo>

--- a/accounting_kmitl_reports/data/report_action_trial_balance_kmitl.xml
+++ b/accounting_kmitl_reports/data/report_action_trial_balance_kmitl.xml
@@ -9,4 +9,13 @@
         <field name="paperformat_id" ref="paperformat_trial_balance_kmitl" />
         <field name="binding_model_id" eval="False" />
     </record>
+
+    <record id="action_report_trial_balance_kmitl_html" model="ir.actions.report">
+        <field name="name">Trial Balance (KMITL) - HTML</field>
+        <field name="model">trial.balance.report.wizard.kmitl</field>
+        <field name="report_type">qweb-html</field>
+        <field name="report_name">accounting_kmitl_reports.trial_balance_kmitl</field>
+        <field name="report_file">accounting_kmitl_reports.trial_balance_kmitl</field>
+        <field name="binding_model_id" eval="False" />
+    </record>
 </odoo>

--- a/accounting_kmitl_reports/models/__init__.py
+++ b/accounting_kmitl_reports/models/__init__.py
@@ -1,0 +1,1 @@
+from . import trial_balance_kmitl

--- a/accounting_kmitl_reports/models/trial_balance_kmitl.py
+++ b/accounting_kmitl_reports/models/trial_balance_kmitl.py
@@ -1,0 +1,57 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class TrialBalanceReportKmitl(models.AbstractModel):
+    _name = "report.accounting_kmitl_reports.trial_balance_kmitl"
+    _description = "KMITL Trial Balance Report"
+    _inherit = "report.account_financial_report.trial_balance"
+
+    @staticmethod
+    def _format_amount(value):
+        if not value:
+            return ""
+        return f"{value:,.2f}"
+
+    def _get_report_values(self, docids, data):
+        res = super()._get_report_values(docids, data)
+        wizard_id = data.get("wizard_id")
+        company = self.env["res.company"].browse(data["company_id"])
+        thai_helper = self.env["thai.date.mixin"]
+        rows = []
+        total_debit = 0.0
+        total_credit = 0.0
+        for account in res.get("trial_balance") or []:
+            opening = account.get("initial_balance") or 0.0
+            ending = account.get("ending_balance") or 0.0
+            debit = account.get("debit") or 0.0
+            credit = account.get("credit") or 0.0
+            opening_debit = opening if opening >= 0 else 0.0
+            opening_credit = -opening if opening < 0 else 0.0
+            ending_debit = ending if ending >= 0 else 0.0
+            ending_credit = -ending if ending < 0 else 0.0
+            rows.append({
+                "code": account.get("code") or "",
+                "name": account.get("name") or "",
+                "opening_debit": self._format_amount(opening_debit),
+                "opening_credit": self._format_amount(opening_credit),
+                "debit": self._format_amount(debit),
+                "credit": self._format_amount(credit),
+                "ending_debit": self._format_amount(ending_debit),
+                "ending_credit": self._format_amount(ending_credit),
+            })
+            total_debit += debit
+            total_credit += credit
+        res.update({
+            "doc_model": "trial.balance.report.wizard.kmitl",
+            "docs": self.env["trial.balance.report.wizard.kmitl"].browse(wizard_id),
+            "res_company": company,
+            "kmitl_rows": rows,
+            "kmitl_total_debit": f"{total_debit:,.2f}",
+            "kmitl_total_credit": f"{total_credit:,.2f}",
+            "kmitl_zero": "0.00",
+            "kmitl_date_from_th": thai_helper.format_date_thai_short(data["date_from"]),
+            "kmitl_date_to_th": thai_helper.format_date_thai_short(data["date_to"]),
+        })
+        return res

--- a/accounting_kmitl_reports/report/trial_balance_kmitl_template.xml
+++ b/accounting_kmitl_reports/report/trial_balance_kmitl_template.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="trial_balance_kmitl">
+        <t t-call="web.html_container">
+            <t t-call="web.basic_layout">
+                <div class="header" style="border-bottom: 1px solid #000;">
+                    <table style="width: 100%; border: none;">
+                        <tr>
+                            <td style="width: 70px; border: none; vertical-align: top;">
+                                <img
+                                    t-if="res_company.logo"
+                                    t-att-src="image_data_uri(res_company.logo)"
+                                    style="max-height: 60px; max-width: 60px;"
+                                    alt="Logo"
+                                />
+                            </td>
+                            <td style="border: none; text-align: center; vertical-align: middle;">
+                                <div style="font-size: 11pt; font-weight: bold;">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
+                                <div style="font-size: 10pt; font-style: italic;">King Mongkut's Institute of Technology Ladkrabang</div>
+                                <div style="font-size: 12pt; font-weight: bold; margin-top: 4px;">Trial Balance</div>
+                                <div style="font-size: 9pt;">
+                                    ตั้งแต่ <t t-out="kmitl_date_from_th" /> ถึง <t t-out="kmitl_date_to_th" />
+                                </div>
+                            </td>
+                            <td style="width: 70px; border: none;" />
+                        </tr>
+                    </table>
+                </div>
+
+                <div class="footer" style="text-align: right; font-size: 8pt;">
+                    <span class="page" />/<span class="topage" />
+                </div>
+
+                <div class="article">
+                    <style>
+                        table.kmitl-trial-balance {
+                            width: 100%;
+                            border-collapse: collapse;
+                            font-size: 8pt;
+                        }
+                        table.kmitl-trial-balance th,
+                        table.kmitl-trial-balance td {
+                            border: 1px solid #000;
+                            padding: 2px 4px;
+                        }
+                        table.kmitl-trial-balance thead th {
+                            background-color: #f0f0f0;
+                            text-align: center;
+                            font-weight: bold;
+                        }
+                        table.kmitl-trial-balance td.text-right {
+                            text-align: right;
+                        }
+                        table.kmitl-trial-balance tfoot td {
+                            font-weight: bold;
+                            background-color: #f0f0f0;
+                        }
+                    </style>
+                    <table class="kmitl-trial-balance">
+                        <thead style="display: table-header-group;">
+                            <tr>
+                                <th rowspan="2" style="width: 28%;">Account title</th>
+                                <th colspan="2">Opening Balance</th>
+                                <th colspan="2">During the year</th>
+                                <th colspan="2">Balance</th>
+                            </tr>
+                            <tr>
+                                <th>Debit</th>
+                                <th>Credit</th>
+                                <th>Debit</th>
+                                <th>Credit</th>
+                                <th>Debit</th>
+                                <th>Credit</th>
+                            </tr>
+                        </thead>
+                        <tfoot style="display: table-footer-group;">
+                            <tr>
+                                <td>Remains</td>
+                                <td class="text-right" t-out="kmitl_zero" />
+                                <td class="text-right" t-out="kmitl_zero" />
+                                <td class="text-right" t-out="kmitl_total_debit" />
+                                <td class="text-right" t-out="kmitl_total_credit" />
+                                <td class="text-right" t-out="kmitl_zero" />
+                                <td class="text-right" t-out="kmitl_zero" />
+                            </tr>
+                        </tfoot>
+                        <tbody>
+                            <tr t-foreach="kmitl_rows" t-as="row">
+                                <td>
+                                    <t t-out="row['code']" /> - <t t-out="row['name']" />
+                                </td>
+                                <td class="text-right" t-out="row['opening_debit']" />
+                                <td class="text-right" t-out="row['opening_credit']" />
+                                <td class="text-right" t-out="row['debit']" />
+                                <td class="text-right" t-out="row['credit']" />
+                                <td class="text-right" t-out="row['ending_debit']" />
+                                <td class="text-right" t-out="row['ending_credit']" />
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/accounting_kmitl_reports/report/trial_balance_kmitl_template.xml
+++ b/accounting_kmitl_reports/report/trial_balance_kmitl_template.xml
@@ -15,10 +15,10 @@
                                 />
                             </td>
                             <td style="border: none; text-align: center; vertical-align: middle;">
-                                <div style="font-size: 11pt; font-weight: bold;">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                                <div style="font-size: 10pt; font-style: italic;">King Mongkut's Institute of Technology Ladkrabang</div>
-                                <div style="font-size: 12pt; font-weight: bold; margin-top: 4px;">Trial Balance</div>
-                                <div style="font-size: 9pt;">
+                                <div style="font-size: 14pt; font-weight: bold;">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
+                                <div style="font-size: 12pt; font-style: italic;">King Mongkut's Institute of Technology Ladkrabang</div>
+                                <div style="font-size: 16pt; font-weight: bold; margin-top: 6px;">Trial Balance</div>
+                                <div style="font-size: 12pt;">
                                     ตั้งแต่ <t t-out="kmitl_date_from_th" /> ถึง <t t-out="kmitl_date_to_th" />
                                 </div>
                             </td>
@@ -27,7 +27,7 @@
                     </table>
                 </div>
 
-                <div class="footer" style="text-align: right; font-size: 8pt;">
+                <div class="footer" style="text-align: right; font-size: 10pt;">
                     <span class="page" />/<span class="topage" />
                 </div>
 
@@ -36,12 +36,12 @@
                         table.kmitl-trial-balance {
                             width: 100%;
                             border-collapse: collapse;
-                            font-size: 8pt;
+                            font-size: 11pt;
                         }
                         table.kmitl-trial-balance th,
                         table.kmitl-trial-balance td {
                             border: 1px solid #000;
-                            padding: 2px 4px;
+                            padding: 4px 6px;
                         }
                         table.kmitl-trial-balance thead th {
                             background-color: #f0f0f0;

--- a/accounting_kmitl_reports/report/trial_balance_kmitl_template.xml
+++ b/accounting_kmitl_reports/report/trial_balance_kmitl_template.xml
@@ -14,10 +14,10 @@
                                     alt="Logo"
                                 />
                             </td>
-                            <td style="border: none; text-align: center; vertical-align: middle;">
-                                <div style="font-size: 14pt; font-weight: bold;">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
-                                <div style="font-size: 12pt; font-style: italic;">King Mongkut's Institute of Technology Ladkrabang</div>
-                                <div style="font-size: 16pt; font-weight: bold; margin-top: 6px;">Trial Balance</div>
+                            <td style="border: none; text-align: center; vertical-align: middle; line-height: 1.6;">
+                                <div style="font-size: 14pt; font-weight: bold; margin-bottom: 4px;">สถาบันเทคโนโลยีพระจอมเกล้าเจ้าคุณทหารลาดกระบัง</div>
+                                <div style="font-size: 12pt; font-style: italic; margin-bottom: 12px;">King Mongkut's Institute of Technology Ladkrabang</div>
+                                <div style="font-size: 16pt; font-weight: bold; margin-bottom: 6px;">Trial Balance</div>
                                 <div style="font-size: 12pt;">
                                     ตั้งแต่ <t t-out="kmitl_date_from_th" /> ถึง <t t-out="kmitl_date_to_th" />
                                 </div>

--- a/accounting_kmitl_reports/security/ir.model.access.csv
+++ b/accounting_kmitl_reports/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_trial_balance_report_wizard_kmitl,access_trial_balance_report_wizard_kmitl,model_trial_balance_report_wizard_kmitl,base.group_user,1,1,1,1

--- a/accounting_kmitl_reports/views/menuitem.xml
+++ b/accounting_kmitl_reports/views/menuitem.xml
@@ -37,7 +37,7 @@
         id="menu_report_trial_balance_kmitl"
         name="งบทดลอง"
         parent="accounting_kmitl.menu_accounting_reports"
-        action="account_financial_report.action_trial_balance_wizard"
+        action="action_trial_balance_wizard_kmitl"
         sequence="5"
     />
     <menuitem

--- a/accounting_kmitl_reports/wizard/__init__.py
+++ b/accounting_kmitl_reports/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import trial_balance_wizard_kmitl

--- a/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl.py
+++ b/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl.py
@@ -1,0 +1,17 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class TrialBalanceReportWizardKmitl(models.TransientModel):
+    _name = "trial.balance.report.wizard.kmitl"
+    _inherit = "trial.balance.report.wizard"
+    _description = "KMITL Trial Balance Report Wizard"
+
+    def _print_report(self, report_type):
+        self.ensure_one()
+        data = self._prepare_report_data()
+        report = self.env.ref(
+            "accounting_kmitl_reports.action_report_trial_balance_kmitl"
+        )
+        return report.report_action(self, data=data)

--- a/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl.py
+++ b/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl.py
@@ -36,7 +36,9 @@ class TrialBalanceReportWizardKmitl(models.TransientModel):
     def _print_report(self, report_type):
         self.ensure_one()
         data = self._build_report_data()
-        report = self.env.ref(
-            "accounting_kmitl_reports.action_report_trial_balance_kmitl"
-        )
+        if report_type == "qweb-html":
+            xmlid = "accounting_kmitl_reports.action_report_trial_balance_kmitl_html"
+        else:
+            xmlid = "accounting_kmitl_reports.action_report_trial_balance_kmitl"
+        report = self.env.ref(xmlid)
         return report.report_action(self, data=data)

--- a/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl.py
+++ b/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl.py
@@ -8,9 +8,34 @@ class TrialBalanceReportWizardKmitl(models.TransientModel):
     _inherit = "trial.balance.report.wizard"
     _description = "KMITL Trial Balance Report Wizard"
 
+    def _build_report_data(self):
+        self.ensure_one()
+        return {
+            "wizard_name": self._name,
+            "wizard_id": self.id,
+            "date_from": self.date_from,
+            "date_to": self.date_to,
+            "only_posted_moves": self.target_move == "posted",
+            "hide_account_at_0": self.hide_account_at_0,
+            "foreign_currency": self.foreign_currency,
+            "company_id": self.company_id.id,
+            "account_ids": self.account_ids.ids or [],
+            "partner_ids": self.partner_ids.ids or [],
+            "journal_ids": self.journal_ids.ids or [],
+            "fy_start_date": self.fy_start_date,
+            "show_hierarchy": self.show_hierarchy,
+            "limit_hierarchy_level": self.limit_hierarchy_level,
+            "show_hierarchy_level": self.show_hierarchy_level,
+            "hide_parent_hierarchy_level": self.hide_parent_hierarchy_level,
+            "show_partner_details": self.show_partner_details,
+            "unaffected_earnings_account": self.unaffected_earnings_account.id,
+            "account_financial_report_lang": self.env.lang,
+            "grouped_by": self.grouped_by,
+        }
+
     def _print_report(self, report_type):
         self.ensure_one()
-        data = self._prepare_report_data()
+        data = self._build_report_data()
         report = self.env.ref(
             "accounting_kmitl_reports.action_report_trial_balance_kmitl"
         )

--- a/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl_view.xml
+++ b/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl_view.xml
@@ -78,11 +78,16 @@
                         attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}"
                     >
                         <button
-                            name="button_export_pdf"
-                            string="พิมพ์รายงาน (PDF)"
+                            name="button_export_html"
+                            string="ดู (HTML)"
                             type="object"
                             default_focus="1"
                             class="oe_highlight"
+                        />
+                        <button
+                            name="button_export_pdf"
+                            string="พิมพ์ (PDF)"
+                            type="object"
                         />
                         <button string="ยกเลิก" class="oe_link" special="cancel" />
                     </div>

--- a/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl_view.xml
+++ b/accounting_kmitl_reports/wizard/trial_balance_wizard_kmitl_view.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="trial_balance_wizard_kmitl_form" model="ir.ui.view">
+        <field name="name">trial.balance.report.wizard.kmitl.form</field>
+        <field name="model">trial.balance.report.wizard.kmitl</field>
+        <field name="arch" type="xml">
+            <form>
+                <group name="main_info">
+                    <field
+                        name="company_id"
+                        options="{'no_create': True}"
+                        groups="base.group_multi_company"
+                    />
+                </group>
+                <div
+                    attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}"
+                >
+                    <group name="filters">
+                        <group name="date_range">
+                            <field name="date_range_id" />
+                            <field name="date_from" />
+                            <field name="date_to" />
+                            <field name="fy_start_date" invisible="1" />
+                        </group>
+                        <group name="other_filters">
+                            <field name="target_move" widget="radio" />
+                            <field name="hide_account_at_0" />
+                        </group>
+                    </group>
+                    <label for="journal_ids" />
+                    <field
+                        name="journal_ids"
+                        widget="many2many_tags"
+                        nolabel="1"
+                        options="{'no_create': True}"
+                    />
+                    <group name="account_filter" col="4">
+                        <label for="account_ids" colspan="4" />
+                        <label for="account_code_from" string="From Code" />
+                        <div>
+                            <div class="o_row">
+                                <field
+                                    name="account_code_from"
+                                    class="oe_inline"
+                                    options="{'no_create': True}"
+                                />
+                                <span class="oe_inline">To</span>
+                                <field
+                                    name="account_code_to"
+                                    class="oe_inline"
+                                    options="{'no_create': True}"
+                                />
+                            </div>
+                        </div>
+                        <field
+                            name="account_ids"
+                            nolabel="1"
+                            widget="many2many_tags"
+                            options="{'no_create': True}"
+                            colspan="4"
+                        />
+                    </group>
+                </div>
+                <div
+                    attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', False)]}"
+                >
+                    <field
+                        name="not_only_one_unaffected_earnings_account"
+                        invisible="1"
+                    />
+                    <h4>
+                        Trial Balance can be computed only if selected company has
+                        only one unaffected earnings account.
+                    </h4>
+                </div>
+                <footer>
+                    <div
+                        attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}"
+                    >
+                        <button
+                            name="button_export_pdf"
+                            string="พิมพ์รายงาน (PDF)"
+                            type="object"
+                            default_focus="1"
+                            class="oe_highlight"
+                        />
+                        <button string="ยกเลิก" class="oe_link" special="cancel" />
+                    </div>
+                    <div
+                        attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', False)]}"
+                    >
+                        <button string="Cancel" class="oe_link" special="cancel" />
+                    </div>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_trial_balance_wizard_kmitl" model="ir.actions.act_window">
+        <field name="name">งบทดลอง</field>
+        <field name="res_model">trial.balance.report.wizard.kmitl</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="trial_balance_wizard_kmitl_form" />
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/thai_date_utils/models/thai_date_mixin.py
+++ b/thai_date_utils/models/thai_date_mixin.py
@@ -8,22 +8,42 @@ MONTHS_TH = [
     "กรกฎาคม", "สิงหาคม", "กันยายน", "ตุลาคม", "พฤศจิกายน", "ธันวาคม"
 ]
 
+MONTHS_TH_SHORT = [
+    "", "ม.ค.", "ก.พ.", "มี.ค.", "เม.ย.", "พ.ค.", "มิ.ย.",
+    "ก.ค.", "ส.ค.", "ก.ย.", "ต.ค.", "พ.ย.", "ธ.ค."
+]
+
 
 class ThaiDateMixin(models.AbstractModel):
     _name = 'thai.date.mixin'
     _description = 'Thai Date Format Utility Mixin'
 
-    def format_date_thai(self, dt):
-        if not dt:
-            return ""
+    def _coerce_to_datetime(self, dt):
         if isinstance(dt, str):
             try:
                 dt = datetime.fromisoformat(dt)
             except Exception:
-                return dt
+                return None
         if isinstance(dt, datetime) and not dt.tzinfo:
             dt = odoo_fields.Datetime.context_timestamp(self, dt)
+        return dt
+
+    def format_date_thai(self, dt):
+        if not dt:
+            return ""
+        dt = self._coerce_to_datetime(dt) or dt
+        if not hasattr(dt, "day"):
+            return dt
         day = dt.day
         month = MONTHS_TH[dt.month]
         year = dt.year + 543
         return f"{day} {month} พ.ศ. {year}"
+
+    def format_date_thai_short(self, dt):
+        """Return e.g. ``1 เม.ย. 2569`` (Buddhist year, abbreviated month)."""
+        if not dt:
+            return ""
+        dt = self._coerce_to_datetime(dt) or dt
+        if not hasattr(dt, "day"):
+            return dt
+        return f"{dt.day} {MONTHS_TH_SHORT[dt.month]} {dt.year + 543}"


### PR DESCRIPTION
## Summary

- Adds a KMITL-branded Trial Balance PDF that reuses the OCA `account_financial_report` data layer through a wizard (`trial.balance.report.wizard.kmitl`) and AbstractModel inheritance — the OCA module itself is untouched.
- New QWeb template renders a bilingual institute header (logo + Thai/English name), Thai abbreviated date range (e.g. `1 เม.ย. 2569`), and a 7-column table that splits Opening/Balance into Dr/Cr alongside Debit/Credit for the period; per-page `Remains` totals and an `X/Y` page footer.
- `thai_date_utils` gains a `format_date_thai_short` helper, and the existing `งบทดลอง` menu is re-pointed from the OCA wizard to the new KMITL wizard.

## Test plan

- [ ] Upgrade `accounting_kmitl_reports`; open **Accounting KMITL → Reports → งบทดลอง**, pick a date range, click **พิมพ์รายงาน (PDF)** and verify the rendered layout matches the KMITL sample.
- [ ] Confirm the institute header and `X/Y` page footer repeat on every page and the `Remains` row equals total Dr = total Cr for the period.