### PR TITLE
[16.0][IMP] kris_project: allocation template รหัสงบประมาณหน่วยงาน + ห้ามแก้ไข

### DIFF
--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -29,6 +29,18 @@ if self.state == 'draft' and self.warn_allocation_mismatch:
         <field name="active" eval="True"/>
     </record>
 
+    <record id="kris_excep_no_allocation_lines" model="exception.rule">
+        <field name="name">No revenue allocation lines.</field>
+        <field name="description">Please specify at least one revenue allocation line.</field>
+        <field name="sequence">25</field>
+        <field name="model">kris.project</field>
+        <field name="code">
+if self.state == 'draft' and not self.allocation_line_ids:
+    failed = True
+        </field>
+        <field name="active" eval="True"/>
+    </record>
+
     <record id="kris_excep_no_installments" model="exception.rule">
         <field name="name">There is no work period.</field>
         <field name="description">Please specify at least one work phase.</field>

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -30,12 +30,12 @@ if self.state == 'draft' and self.warn_allocation_mismatch:
     </record>
 
     <record id="kris_excep_no_allocation_lines" model="exception.rule">
-        <field name="name">ไม่มีรายการจัดสรรรายได้</field>
-        <field name="description">กรุณาระบุรายการจัดสรรรายได้อย่างน้อย 1 รายการ</field>
+        <field name="name">ไม่ได้ระบุรหัสงบประมาณหน่วยงาน</field>
+        <field name="description">กรุณาระบุรหัสงบประมาณหน่วยงานในรายการจัดสรรรายได้ทุกรายการ</field>
         <field name="sequence">25</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'draft' and not self.allocation_line_ids:
+if self.state == 'draft' and self.allocation_line_ids and any(not line.department_analytic_id for line in self.allocation_line_ids):
     failed = True
         </field>
         <field name="active" eval="True"/>

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -30,8 +30,8 @@ if self.state == 'draft' and self.warn_allocation_mismatch:
     </record>
 
     <record id="kris_excep_no_allocation_lines" model="exception.rule">
-        <field name="name">No revenue allocation lines.</field>
-        <field name="description">Please specify at least one revenue allocation line.</field>
+        <field name="name">ไม่มีรายการจัดสรรรายได้</field>
+        <field name="description">กรุณาระบุรายการจัดสรรรายได้อย่างน้อย 1 รายการ</field>
         <field name="sequence">25</field>
         <field name="model">kris.project</field>
         <field name="code">

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -424,6 +424,8 @@ class KrisProject(models.Model):
                     "sequence": tl.sequence,
                     "item_id": tl.item_id.id,
                     "estimated_amount": base_amount * tl.allocation_pct / 100.0,
+                    "department_budget_code_id": tl.department_budget_code_id.id,
+                    "is_locked": tl.is_locked,
                 },
             )
             for tl in self.allocation_template_id.line_ids

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -424,7 +424,7 @@ class KrisProject(models.Model):
                     "sequence": tl.sequence,
                     "item_id": tl.item_id.id,
                     "estimated_amount": base_amount * tl.allocation_pct / 100.0,
-                    "department_budget_code_id": tl.department_budget_code_id.id,
+                    "department_analytic_id": tl.department_analytic_id.id,
                     "is_locked": tl.is_locked,
                 },
             )

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -33,7 +33,7 @@ class KrisProjectAllocationLine(models.Model):
         store=True,
         readonly=True,
     )
-    department_budget_code_id = fields.Many2one(
+    department_analytic_id = fields.Many2one(
         comodel_name="account.analytic.account",
         string="รหัสงบประมาณหน่วยงาน",
         domain=[("root_plan_id.code", "=", "departments")],

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -33,6 +33,12 @@ class KrisProjectAllocationLine(models.Model):
         store=True,
         readonly=True,
     )
+    department_budget_code_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="รหัสงบประมาณหน่วยงาน",
+        domain=[("root_plan_id.code", "=", "departments")],
+    )
+    is_locked = fields.Boolean(string="ห้ามแก้ไข")
     allocation_pct = fields.Float(
         string="Allocation %",
         digits=(5, 2),

--- a/kris_project/models/kris_project_allocation_template.py
+++ b/kris_project/models/kris_project_allocation_template.py
@@ -47,3 +47,9 @@ class KrisProjectAllocationTemplateLine(models.Model):
     )
     sequence = fields.Integer(string="Sequence", default=10)
     allocation_pct = fields.Float(string="Allocation %", digits=(5, 2))
+    department_budget_code_id = fields.Many2one(
+        comodel_name="account.analytic.account",
+        string="รหัสงบประมาณหน่วยงาน",
+        domain=[("root_plan_id.code", "=", "departments")],
+    )
+    is_locked = fields.Boolean(string="ห้ามแก้ไข")

--- a/kris_project/models/kris_project_allocation_template.py
+++ b/kris_project/models/kris_project_allocation_template.py
@@ -47,7 +47,7 @@ class KrisProjectAllocationTemplateLine(models.Model):
     )
     sequence = fields.Integer(string="Sequence", default=10)
     allocation_pct = fields.Float(string="Allocation %", digits=(5, 2))
-    department_budget_code_id = fields.Many2one(
+    department_analytic_id = fields.Many2one(
         comodel_name="account.analytic.account",
         string="รหัสงบประมาณหน่วยงาน",
         domain=[("root_plan_id.code", "=", "departments")],

--- a/kris_project/views/kris_project_allocation_views.xml
+++ b/kris_project/views/kris_project_allocation_views.xml
@@ -69,7 +69,9 @@
                         <tree editable="bottom">
                             <field name="sequence" widget="handle"/>
                             <field name="item_id"/>
-                            <field name="department_analytic_id"/>
+                            <field name="department_analytic_id"
+                                attrs="{'required': [('is_locked', '=', True)]}"
+                            />
                             <field name="is_locked"/>
                             <field name="allocation_pct" string="Allocation %"/>
                         </tree>

--- a/kris_project/views/kris_project_allocation_views.xml
+++ b/kris_project/views/kris_project_allocation_views.xml
@@ -69,7 +69,7 @@
                         <tree editable="bottom">
                             <field name="sequence" widget="handle"/>
                             <field name="item_id"/>
-                            <field name="department_budget_code_id"/>
+                            <field name="department_analytic_id"/>
                             <field name="is_locked"/>
                             <field name="allocation_pct" string="Allocation %"/>
                         </tree>

--- a/kris_project/views/kris_project_allocation_views.xml
+++ b/kris_project/views/kris_project_allocation_views.xml
@@ -69,6 +69,8 @@
                         <tree editable="bottom">
                             <field name="sequence" widget="handle"/>
                             <field name="item_id"/>
+                            <field name="department_budget_code_id"/>
+                            <field name="is_locked"/>
                             <field name="allocation_pct" string="Allocation %"/>
                         </tree>
                     </field>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -253,6 +253,10 @@
                                 <tree editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="item_id"/>
+                                    <field name="department_budget_code_id"
+                                        attrs="{'readonly': [('is_locked', '=', True)]}"
+                                    />
+                                    <field name="is_locked" invisible="1"/>
                                     <field name="allocation_pct" string="Allocation %" readonly="1" sum="รวม"/>
                                     <field name="estimated_amount" sum="รวม"/>
                                     <field name="actual_amount" readonly="1" sum="รวม"/>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -253,7 +253,7 @@
                                 <tree editable="bottom">
                                     <field name="sequence" widget="handle"/>
                                     <field name="item_id"/>
-                                    <field name="department_budget_code_id"
+                                    <field name="department_analytic_id"
                                         attrs="{'readonly': [('is_locked', '=', True)]}"
                                     />
                                     <field name="is_locked" invisible="1"/>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -290,7 +290,9 @@
                             >
                                 <tree editable="bottom">
                                     <field name="sequence" widget="handle"/>
-                                    <field name="item_id"/>
+                                    <field name="item_id"
+                                        attrs="{'readonly': [('is_locked', '=', True)]}"
+                                    />
                                     <field name="department_analytic_id"
                                         attrs="{'readonly': [('is_locked', '=', True)]}"
                                     />


### PR DESCRIPTION
## Summary

เพิ่มฟิลด์ **รหัสงบประมาณหน่วยงาน** (analytic account, departments dimension) และตัวเลือก **ห้ามแก้ไข** ในแม่แบบจัดสรร (`kris.project.allocation.template`) เพื่อให้ตั้งค่ารหัสงบประมาณล่วงหน้าได้ และล็อกไม่ให้ผู้ใช้ปลายทางแก้ไขในหน้าฟอร์มโปรเจค

## Changes

### Models
- `kris.project.allocation.template.line` — เพิ่ม `department_analytic_id` (Many2one → `account.analytic.account` กรองด้วย `root_plan_id.code = 'departments'`) และ `is_locked` (Boolean)
- `kris.project.allocation.line` — เพิ่มฟิลด์เดียวกัน เพื่อเก็บค่าคัดลอกจาก template line
- `kris.project.action_apply_allocation_template` — คัดลอก `department_analytic_id` และ `is_locked` จาก template line ลงไปยัง allocation line ที่สร้างใหม่

### Views
- `kris_project_allocation_views.xml` — เพิ่ม 2 คอลัมน์ในตารางของฟอร์ม template หลัง `item_id`
- `kris_project_views.xml` (ส่วน "2. จัดสรรรายได้") — เพิ่ม `department_analytic_id` (attrs readonly เมื่อ `is_locked=True`) และซ่อน `is_locked` ไว้รองรับ attrs

## Behavior

- ใน template: ผู้ดูแลตั้ง `รหัสงบประมาณหน่วยงาน` ของแต่ละบรรทัด และเลือก `ห้ามแก้ไข` ได้
- เมื่อกดปุ่ม **Template** ในหน้า `kris.project` (เรียก `action_apply_allocation_template`): สร้าง allocation line พร้อมรหัสงบประมาณและสถานะล็อค
- บรรทัดที่ `is_locked = True` → ช่อง `รหัสงบประมาณหน่วยงาน` อยู่ในสถานะ readonly แก้ไขไม่ได้
- บรรทัดที่ `is_locked = False` → ผู้ใช้แก้ไขรหัสได้ตามปกติ

## Test plan
- [x] Restart Odoo และ upgrade module `kris_project`
- [x] เปิดฟอร์ม `kris.project.allocation.template` ตั้งรหัสงบประมาณหน่วยงาน + ติ๊กห้ามแก้ไขในบางบรรทัด
- [x] ในฟอร์ม `kris.project` ส่วน "2. จัดสรรรายได้" เลือก template แล้วกดปุ่ม Template
- [x] ตรวจสอบ: บรรทัดที่ห้ามแก้ไข → ช่องรหัสงบประมาณหน่วยงานเป็น readonly; บรรทัดที่ไม่ติ๊ก → แก้ไขได้