### PR TITLE
[FIX] hr_employee_academic_standing_thailand: clear academic fields on non-academic role

### DIFF
--- a/hr_employee_academic_standing_thailand/__manifest__.py
+++ b/hr_employee_academic_standing_thailand/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "HR Employee Academic Standing Thailand",
-    "version": "16.0.1.0.4",
+    "version": "16.0.1.0.5",
     "summary": """ HR Employee Academic Standing Thailand Summary """,
     "author": "nopparuts, Aginix Technologies",
     "website": "https://github.com/aginix/kmitl-odoo",

--- a/hr_employee_academic_standing_thailand/models/hr_employee.py
+++ b/hr_employee_academic_standing_thailand/models/hr_employee.py
@@ -4,6 +4,13 @@ from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
+ACADEMIC_ONLY_FIELDS = (
+    "academic_standing_id",
+    "rank_id",
+    "rank_nobility_id",
+    "profession_id",
+)
+
 
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
@@ -49,18 +56,19 @@ class HrEmployee(models.Model):
         "profession_id",
         "education_level_id",
         "role",
+        "job_id",
+        "position_level_relation_id",
     )
     def _compute_academic_standing_title(self):
         def get_value(value):
             return value + " " if value else ""
 
+        dr_education = self.env.ref(
+            "hr_employee_education_history.Q01", raise_if_not_found=False
+        )
+
         def get_academic_standing_for_academic_role(rec):
-            title_dr = False
-            if (
-                self.env.ref("hr_employee_education_history.Q01").id
-                == rec.education_level_id.id
-            ):
-                title_dr = True
+            title_dr = bool(dr_education and dr_education == rec.education_level_id)
 
             rec.academic_standing_title = (
                 "{academic}{rank}{dr}{profession}{rank_nobility}".format(
@@ -126,14 +134,22 @@ class HrEmployee(models.Model):
             if rec.role == "academic":
                 get_academic_standing_for_academic_role(rec)
             elif rec.role == "support":
-                rec.academic_standing_id = False
                 get_academic_standing_for_support_role(rec)
             else:
-                rec.academic_standing_id = False
-                rec.rank_id = False
-                rec.rank_nobility_id = False
-                rec.profession_id = False
                 rec.academic_standing_title = ""
                 rec.academic_standing_title_abbreviation = ""
                 rec.academic_standing_title_en = ""
                 rec.academic_standing_title_abbreviation_en = ""
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if "role" in vals and vals.get("role") != "academic":
+                for fname in ACADEMIC_ONLY_FIELDS:
+                    vals[fname] = False
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if "role" in vals and vals.get("role") != "academic":
+            vals = {**vals, **{fname: False for fname in ACADEMIC_ONLY_FIELDS}}
+        return super().write(vals)


### PR DESCRIPTION
[FIX] hr_employee_academic_standing_thailand: clear academic fields on non-academic role

- Extract ACADEMIC_ONLY_FIELDS constant for fields that only apply to academic-role employees
- Override create/write to clear academic fields when role is not academic
- Fix dr_education ref lookup to use raise_if_not_found=False, preventing errors when the external ID is missing
- Remove redundant field clearing from _compute_academic_standing_title (now handled at ORM level)
- Add job_id and position_level_relation_id as compute dependencies
- Bump version to 16.0.1.0.5