### PR TITLE
[16.0][FIX] agx_approval: AR number duplicates on copy + sort newest first

### DIFF
--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -12,7 +12,7 @@ class ApprovalRequest(models.Model):
         "mail.thread",
         "mail.activity.mixin",
     ]
-    _order = "name"
+    _order = "name desc"
 
     READONLY_STATES = {
         "to_verify": [("readonly", True)],
@@ -96,6 +96,7 @@ class ApprovalRequest(models.Model):
         string="Name",
         default="/",
         required=True,
+        copy=False,
         tracking=True,
         states=READONLY_STATES,
     )
@@ -168,6 +169,7 @@ class ApprovalRequest(models.Model):
         "approval.request.line",
         "request_id",
         string="Expense Lines",
+        copy=True,
     )
 
     has_period = fields.Boolean(
@@ -192,6 +194,7 @@ class ApprovalRequest(models.Model):
         ("rejected", "Rejected"),
     ],
         default="draft",
+        copy=False,
         string="state"
     )
 
@@ -207,7 +210,6 @@ class ApprovalRequest(models.Model):
         "budget.account",
         string="Budget Account",
         domain=lambda self: self._domain_budget_account_id(),
-        copy=False,
         tracking=True,
     )
 

--- a/agx_approval/models/approval_request_exception.py
+++ b/agx_approval/models/approval_request_exception.py
@@ -4,7 +4,7 @@ from odoo import api, models
 class ApprovalRequest(models.Model):
     _name = "approval.request"
     _inherit = ["approval.request", "base.exception"]
-    _order = "main_exception_id asc, name"
+    _order = "main_exception_id asc, name desc"
 
     @api.model
     def _reverse_field(self):


### PR DESCRIPTION
## Summary
- `copy=False` on `name` and `state` so a copied approval request gets a fresh sequence and starts in draft.
- `copy=True` on `line_ids` and drop `copy=False` on `budget_account_id` so the copy carries expense lines + budget account.
- `_order = "name desc"` on `approval.request` (and the `base.exception` extension) so list views, dropdowns, and search panels show the most recent AR at the top.

## Test plan
- [ ] Duplicate an approved/billed AR — copy starts in draft with a new AR number.
- [ ] Copy carries over expense lines and the chosen `budget_account_id`.
- [ ] List view, "Approval Request" search, and Many2one dropdowns show newest AR first.