### PR TITLE
[16.0][IMP] agx_approval: move PDF report from sarabun, drop HTML

### DIFF
--- a/agx_approval/__manifest__.py
+++ b/agx_approval/__manifest__.py
@@ -18,6 +18,8 @@
         "data/approval_sequence.xml",
         "data/approval_category_group.xml",
         "data/approval_category.xml",
+        "reports/paperformat_approval_request.xml",
+        "reports/report_approval_request.xml",
     ],
     "license": "LGPL-3",
 }

--- a/agx_approval/reports/paperformat_approval_request.xml
+++ b/agx_approval/reports/paperformat_approval_request.xml
@@ -21,19 +21,10 @@
         <field name="name">Approval Request Report</field>
         <field name="model">approval.request</field>
         <field name="report_type">qweb-pdf</field>
-        <field name="report_name">agx_approval_sarabun.report_approval_request_document</field>
+        <field name="report_name">agx_approval.report_approval_request_document</field>
         <field name="print_report_name">'Approval Request - %s' % (object.name)</field>
         <field name="paperformat_id" ref="paperformat_approval_request_report"/>
-        <field name="binding_model_id" />
-    </record>
-
-    <record id="report_approval_request" model="ir.actions.report">
-        <field name="name">Approval Request</field>
-        <field name="model">approval.request</field>
-        <field name="report_type">qweb-html</field>
-        <field name="report_name">agx_approval_sarabun.report_approval_request_document</field>
-        <field name="print_report_name">'Approval Request - %s' % (object.name)</field>
-        <field name="paperformat_id" ref="paperformat_approval_request_report"/>
-        <field name="binding_model_id" />
+        <field name="binding_model_id" ref="model_approval_request"/>
+        <field name="binding_type">report</field>
     </record>
 </odoo>

--- a/agx_approval/reports/report_approval_request.xml
+++ b/agx_approval/reports/report_approval_request.xml
@@ -26,35 +26,31 @@
                         <div style="height: 1px" />
                         <div class="page-header mt-5 mb-5">
                             <h3 class="text-center fw-bolder" style="line-height: 1.575;">
-                                บันทึกข้อความ
+                                ใบขออนุมัติ
                             </h3>
                         </div>
 
                         <!-- Document Info -->
                         <div class="row">
                             <div class="col-8">
-                                เลขที่เอกสาร
-                                <span class="ms-2 fw-normal" t-out="o.main_sarabun_document_id.name" />
+                                เลขที่
+                                <span class="ms-2 fw-normal" t-out="o.name" />
                             </div>
                             <div class="col">
                                 วันที่
-                                <span class="ms-2 fw-normal" t-esc="o.format_date_thai(o.main_sarabun_document_id.date)" />
+                                <span class="ms-2 fw-normal" t-field="o.date" />
                             </div>
                         </div>
                         <div class="row">
                             <div class="col">
                                 หน่วยงาน
-                                <span class="ms-2" t-out="o.main_sarabun_document_id.sender_display" />
+                                <span class="ms-2" t-field="o.department_id" />
                             </div>
                         </div>
                         <div class="row">
                             <div class="col">
-                                เรื่อง                                <span class="ms-2" t-out="o.main_sarabun_document_id.subject" />
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col">
-                                เรียน                                <span class="ms-2" t-out="o.main_sarabun_document_id.recipient" />
+                                เรื่อง
+                                <span class="ms-2" t-field="o.category_id" />
                             </div>
                         </div>
 
@@ -88,9 +84,9 @@
                         <div class="row" t-if="o.has_period">
                             <div class="col">
                                 ระยะเวลา
-                                <span class="fw-bolder text-decoration-underline" t-esc="o.format_date_thai(o.date_start)" />
+                                <span class="fw-bolder text-decoration-underline" t-field="o.date_start" />
                                 -
-                                <span class="fw-bolder text-decoration-underline" t-esc="o.format_date_thai(o.date_end)" />
+                                <span class="fw-bolder text-decoration-underline" t-field="o.date_end" />
                             </div>
                         </div>
 
@@ -134,20 +130,7 @@
                         <!-- Budget Details -->
                         <div class="my-4" />
                         <p>รายละเอียดงบประมาณ</p>
-                        <t t-call="agx_approval_sarabun.report_approval_request_budget" />
-
-                        <!-- Signature Section -->
-                        <div class="my-5" style="height: 10px" />
-                        <div class="my-5">
-                            <div class="my-2 d-inline-block">
-                                <div>ลงชื่อ                                    <t t-out="'.' * 80" />
- ผู้ขออนุมัติ</div>
-                                <div class="text-center my-2">
-                                    (                                    <span t-field="o.owner_id" />
- )
-                                </div>
-                            </div>
-                        </div>
+                        <t t-call="agx_approval.report_approval_request_budget" />
                     </div>
                 </t>
             </t>

--- a/agx_approval_sarabun/__manifest__.py
+++ b/agx_approval_sarabun/__manifest__.py
@@ -20,8 +20,6 @@
         "views/approval_request_views.xml",
         "views/sarabun_document_views.xml",
         "views/portal_templates.xml",
-        "reports/paperformat_approval_request.xml",
-        "reports/report_approval_request.xml",
     ],
     "assets": {
         "web.assets_frontend": [

--- a/agx_approval_sarabun/controllers/portal.py
+++ b/agx_approval_sarabun/controllers/portal.py
@@ -102,7 +102,7 @@ class ApprovalRequestPortal(CustomerPortal):
             return self._show_report(
                 model=approval_request_sudo,
                 report_type=report_type,
-                report_ref="agx_approval_sarabun.action_report_approval_request",
+                report_ref="agx_approval.action_report_approval_request",
                 download=download,
             )
 
@@ -149,7 +149,7 @@ class ApprovalRequestPortal(CustomerPortal):
 
         if report_type == "html":
             report = request.env.ref(
-                "agx_approval_sarabun.report_approval_request"
+                "agx_approval.action_report_approval_request"
             )
             html = request.env["ir.actions.report"]._render_qweb_html(
                 report.id, [approval_request_sudo.id]
@@ -163,7 +163,7 @@ class ApprovalRequestPortal(CustomerPortal):
             )
         elif report_type == "pdf":
             report = request.env.ref(
-                "agx_approval_sarabun.report_approval_request"
+                "agx_approval.action_report_approval_request"
             )
             pdf_content, _ = request.env["ir.actions.report"]._render_qweb_pdf(
                 report.id, [approval_request_sudo.id]

--- a/agx_approval_sarabun/models/approval_request.py
+++ b/agx_approval_sarabun/models/approval_request.py
@@ -87,5 +87,5 @@ class ApprovalRequest(models.Model):
     def _get_sarabun_report_action(self):
         """Delegate Sarabun report to Approval Request report."""
         return self.env.ref(
-            "agx_approval_sarabun.action_report_approval_request"
+            "agx_approval.action_report_approval_request"
         )


### PR DESCRIPTION
## Summary
- Move the Approval Request PDF report from `agx_approval_sarabun` into core `agx_approval` so it works without Sarabun installed.
- Decouple from Sarabun-only fields: replace `main_sarabun_document_id.*` header (เลขที่/วันที่/หน่วยงาน/เรื่อง/เรียน) with the AR's own `name`/`date`/`category_id`/`department_id`. Use `t-field="o.date"` instead of `format_date_thai()` from `thai.date.mixin`.
- Drop the qweb-html variant; only qweb-pdf remains. Update Sarabun portal controller and model refs to `agx_approval.action_report_approval_request`.
- Delete the now-empty `agx_approval_sarabun/reports/` directory and prune the entries from its manifest.

## Test plan
- [ ] Install `agx_approval` standalone — Print menu on AR form shows "Approval Request Report".
- [ ] Print AR — PDF renders with header / lines / budget table without Sarabun installed.
- [ ] Install `agx_approval_sarabun` on top — Sarabun routing still triggers the same report via the new ref.