### PR TITLE
[16.0][IMP] agx_approval: approval workflow + UX improvements

### DIFF
--- a/agx_approval/i18n/th.po
+++ b/agx_approval/i18n/th.po
@@ -730,16 +730,20 @@ msgstr "ขอการอนุมัติ"
 
 #. module: agx_approval
 #: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
-msgid "To Verify"
-msgstr "จองงบประมาณ"
+msgid "Verify Request"
+msgstr "ยืนยันคำขอ"
+
+#. module: agx_approval
+#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
+#: model_terms:ir.ui.view,arch_db:agx_approval.update_actual_amount_wizard_view_form
+msgid "Total"
+msgstr "รวม"
 
 #. module: agx_approval
 #: model:ir.model.fields,field_description:agx_approval.field_approval_request_line__total_amount
 #: model:ir.model.fields,field_description:agx_approval.field_approval_update_actual_amount_wizard_line__total_amount
-#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
-#: model_terms:ir.ui.view,arch_db:agx_approval.update_actual_amount_wizard_view_form
-msgid "Total"
-msgstr "จำนวนเงิน"
+msgid "Requested Amount"
+msgstr "ยอดขอเบิก"
 
 #. module: agx_approval
 #: model:ir.model.fields,field_description:agx_approval.field_approval_request__total_amount
@@ -838,11 +842,42 @@ msgstr "ยอดเบิกจริง"
 #. module: agx_approval
 #. odoo-python
 #: code:addons/agx_approval/models/approval_request.py:0
-#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
 #: model_terms:ir.ui.view,arch_db:agx_approval.update_actual_amount_wizard_view_form
 #, python-format
 msgid "Update actual amount"
 msgstr "แก้ไขยอดเบิกจริง"
+
+#. module: agx_approval
+#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
+msgid "Record Actual Disbursement"
+msgstr "ขอเบิกจริง"
+
+#. module: agx_approval
+#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
+msgid "Budget Reserved:"
+msgstr "จองงบแล้ว:"
+
+#. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_request__budget_commitment_amount
+msgid "Reserved Amount"
+msgstr "วงเงินที่จอง"
+
+#. module: agx_approval
+#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_form
+msgid ""
+"Use this to adjust the actual disbursement amount when it is lower than the "
+"approved amount. Values above the approved amount are not allowed."
+msgstr ""
+"ใช้ปุ่มนี้เพื่อปรับยอดเบิกจริงเมื่อยอดต่ำกว่ายอดที่ขออนุมัติ "
+"ไม่อนุญาตให้กรอกยอดที่สูงกว่ายอดที่ขออนุมัติ"
+
+#. module: agx_approval
+#. odoo-python
+#: code:addons/agx_approval/wizard/update_actual_amount_wizard.py:0
+#, python-format
+msgid ""
+"Actual amount cannot exceed the approved amount on the following line(s): %s"
+msgstr "ยอดเบิกจริงต้องไม่เกินยอดที่ขออนุมัติในรายการต่อไปนี้: %s"
 
 #. module: agx_approval
 #: model:ir.model,name:agx_approval.model_approval_update_actual_amount_wizard

--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -203,6 +203,13 @@ class ApprovalRequest(models.Model):
         help="Related budget commitment for this approval request",
     )
 
+    budget_commitment_amount = fields.Monetary(
+        related="budget_commitment_id.amount",
+        string="Reserved Amount",
+        currency_field="currency_id",
+        readonly=True,
+    )
+
     budget_account_id = fields.Many2one(
         "budget.account",
         string="Budget Account",
@@ -343,7 +350,6 @@ class ApprovalRequest(models.Model):
             line._update_analytic_distribution("sources")
     
     def action_to_verify(self):
-        # TODO: validate budget commitment before submit
         for record in self:
             if record.state != "draft":
                 raise UserError(_("Only draft requests can be verified."))
@@ -351,7 +357,6 @@ class ApprovalRequest(models.Model):
         return True
 
     def action_submit(self):
-        # TODO: validate budget commitment before submit
         for record in self:
             if record.state != "to_verify":
                 raise UserError(_("Only To Verify requests can be submitted."))
@@ -363,6 +368,15 @@ class ApprovalRequest(models.Model):
             if record.state != "submitted":
                 raise UserError(_("Only submitted requests can be validated."))
             record.state = "validated"
+        return True
+
+    def action_approve(self):
+        for record in self:
+            if record.state not in ("submitted", "validated"):
+                raise UserError(
+                    _("Only submitted or validated requests can be approved.")
+                )
+            record.state = "approved"
         return True
 
     def action_bill(self):
@@ -416,20 +430,6 @@ class ApprovalRequest(models.Model):
                     line.actual_amount = line.total_amount
         return result
 
-    # def write(self, values):
-    #     if (
-    #         "budget_commitment_id" in values
-    #         and values.get("budget_commitment_id") != self.budget_commitment_id.id
-    #     ):
-    #         self._log_budget_commitment_unlinked()
-
-    #     res = super().write(values)
-
-    #     if "budget_commitment_id" in values and values.get("budget_commitment_id"):
-    #         self._log_budget_commitment_linked()
-
-    #     return res
-
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -465,7 +465,7 @@ class ApprovalRequest(models.Model):
     def action_open_budget_commitment(self):
         self.ensure_one()
         if not self.budget_commitment_id:
-            raise UserError("ยังไม่มี Budget Commitment สำหรับเอกสารนี้")
+            raise UserError(_("ยังไม่มี Budget Commitment สำหรับเอกสารนี้"))
 
         return {
             "type": "ir.actions.act_window",

--- a/agx_approval/models/approval_request_line.py
+++ b/agx_approval/models/approval_request_line.py
@@ -49,7 +49,7 @@ class ApprovalRequestLine(models.Model):
     )
 
     total_amount = fields.Monetary(
-        string="Total",
+        string="Requested Amount",
         currency_field='currency_id',
         required=True,
     )

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -9,22 +9,18 @@
                 <header>
                     <field name="hide_reserve_budget_button" invisible="1" />
                     <field name="is_editable" invisible="1"/>
-                    <button
-                        name="action_reserve_budget"
-                        type="object" attrs="{'invisible':[('hide_reserve_budget_button', '=', True)]}"
-                        string="Reserve Budget"
-                        class="oe_highlight btn-success"
-                        groups="budget.group_budget_commitment"
-                    />
-                    <button name="action_to_verify" string="To Verify" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}" />
+                    <button name="action_reserve_budget" type="object" attrs="{'invisible':[('hide_reserve_budget_button', '=', True)]}" string="Reserve Budget" class="oe_highlight btn-success" groups="budget.group_budget_commitment" />
+                    <button name="action_to_verify" string="Verify Request" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}" />
                     <!-- <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'to_verify')]}" /> -->
+                    <button name="action_approve" string="อนุมัติ" type="object" class="oe_highlight" attrs="{'invisible': [('state', 'not in', ['submitted', 'validated'])]}" groups="agx_approval.group_approval_manager"/>
                     <button name="action_draft" string="Reset to draft" type="object" class="btn btn-secondary" attrs="{'invisible': [('state', 'not in', ['to_verify', 'submitted'])]}" groups="agx_approval.group_approval_manager"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'approved')]}" groups="agx_approval.group_approval_manager"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,to_verify,submitted,approved,billed" />
                 </header>
-                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
-                    attrs="{'invisible': [('exceptions_summary', '=', False)]}">
-                    <p><strong>Exception:</strong></p>
+                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('exceptions_summary', '=', False)]}">
+                    <p>
+                        <strong>Exception:</strong>
+                    </p>
                     <field name="exceptions_summary"/>
                 </div>
                 <sheet>
@@ -42,7 +38,7 @@
                             <field name="name" readonly="1"/>
                         </h1>
                     </div>
-                    
+
                     <group string="Approval Details">
                         <group>
                             <field name="date" readonly="1"/>
@@ -67,53 +63,37 @@
                         </group>
                     </group>
                     <group name="attachment" string="Attachment for Approval Request">
-                        <field name="attachment_ids"
-                            attrs="{'readonly': [('is_editable','=', False)]}"
-                            context="{'default_res_model': 'approval.request'}"
-                            widget="many2many_binary">
+                        <field name="attachment_ids" attrs="{'readonly': [('is_editable','=', False)]}" context="{'default_res_model': 'approval.request'}" widget="many2many_binary">
                         </field>
                     </group>
                     <group string="Budget">
+                        <div colspan="2" class="alert alert-success my-2" role="alert" attrs="{'invisible': [('budget_commitment_id', '=', False)]}">
+                            <i class="fa fa-check-circle me-1"/>
+                            <strong>Budget Reserved:</strong>
+                            <field name="budget_commitment_id" readonly="1" nolabel="1" class="oe_inline ms-1"/>
+                            <span class="mx-1">—</span>
+                            <field name="budget_commitment_amount" readonly="1" nolabel="1" widget="monetary" class="oe_inline"/>
+                            <span class="ms-1">฿</span>
+                        </div>
                         <field name="is_budget_editable" invisible="1"/>
                         <field name="budget_account_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
-                        <field name="budget_account_id" invisible="1" />
                         <field name="activity_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
-                        <field name="activity_analytic_id" invisible="1" />
                         <field name="department_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
-                        <field name="department_analytic_id" invisible="1" />
                         <field name="fund_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}"/>
-                        <field name="fund_analytic_id" widget="selection" invisible="1" />
                         <field name="source_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}"/>
-                        <field name="source_analytic_id" widget="selection" invisible="1" />
                         <field name="analytic_distribution" invisible="1"/>
                     </group>
-                    <button
-                        name="action_open_actual_amount_wizard"
-                        string="Update actual amount"
-                        type="object"
-                        class="btn btn-primary my-3"
-                        attrs="{'invisible': [('state', '!=', 'approved')]}"
-                    />
+                    <button name="action_open_actual_amount_wizard" string="Record Actual Disbursement" help="Use this to adjust the actual disbursement amount when it is lower than the approved amount. Values above the approved amount are not allowed." type="object" class="btn btn-primary my-3" attrs="{'invisible': [('state', '!=', 'approved')]}" />
                     <group name="warning_partner">
                         <group>
-                            <div
-                                colspan="2"
-                                class="alert alert-warning show"
-                                role="alert"
-                                attrs="{'invisible': [('payment_type', '!=', 'prepaid')]}"
-                            >
+                            <div colspan="2" class="alert alert-warning show" role="alert" attrs="{'invisible': [('payment_type', '!=', 'prepaid')]}">
                                 If vendor name not found, contact procurement staff to add the information.
                             </div>
                         </group>
                     </group>
                     <group name="warning_prepaid">
                         <group>
-                            <div
-                                colspan="2"
-                                class="alert alert-warning show"
-                                role="alert"
-                                attrs="{'invisible': [('payment_type', '!=', 'prepaid')]}"
-                            >
+                            <div colspan="2" class="alert alert-warning show" role="alert" attrs="{'invisible': [('payment_type', '!=', 'prepaid')]}">
                                 When payment type is Prepaid, please select the advance
                                 payer's name in the Partner field.
                             </div>
@@ -121,8 +101,7 @@
                     </group>
                     <notebook>
                         <page name="request_lines" string="Request Lines">
-                            <field name="line_ids"
-                                attrs="{'readonly': [('state', '!=', 'draft')]}">
+                            <field name="line_ids" attrs="{'readonly': [('state', '!=', 'draft')]}">
                                 <tree editable="bottom">
                                     <field name="allowed_product_ids" invisible="1"/>
                                     <field name="sequence" widget="handle"/>
@@ -130,9 +109,7 @@
                                     <field name="partner_id"/>
                                     <field name="product_id"/>
                                     <field name="total_amount" sum="Total"/>
-                                    <field name="actual_amount"
-                                        attrs="{'column_invisible': [('parent.state', 'not in', ['approved', 'billed'])]}"
-                                        readonly="1" sum="Total"/>
+                                    <field name="actual_amount" attrs="{'column_invisible': [('parent.state', 'not in', ['approved', 'billed'])]}" readonly="1" sum="Total"/>
                                 </tree>
                             </field>
                         </page>
@@ -153,11 +130,11 @@
         <field name="arch" type="xml">
             <tree string="Approval Request">
                 <field name="name" />
+                <field name="date" />
+                <field name="category_id" />
                 <field name="department_id" />
                 <field name="owner_id" />
-                <field name="state" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-danger="state == 'rejected'"/>
-                <field name="category_id" />
-                <field name="source_analytic_id" />
+                <field name="state" widget="badge" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-danger="state == 'rejected'"/>
             </tree>
         </field>
     </record>

--- a/agx_approval/wizard/update_actual_amount_wizard.py
+++ b/agx_approval/wizard/update_actual_amount_wizard.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class UpdateActualAmountWizard(models.TransientModel):
@@ -18,6 +19,14 @@ class UpdateActualAmountWizard(models.TransientModel):
     )
 
     def action_save(self):
+        over_limit = self.line_ids.filtered(
+            lambda l: l.actual_amount > l.total_amount
+        )
+        if over_limit:
+            raise UserError(_(
+                "Actual amount cannot exceed the approved amount on the "
+                "following line(s): %s"
+            ) % ", ".join(over_limit.mapped("product_id.name")))
         for line in self.line_ids:
             line.approval_line_id.actual_amount = line.actual_amount
         return {"type": "ir.actions.act_window_close"}
@@ -62,7 +71,7 @@ class UpdateActualAmountWizardLine(models.TransientModel):
 
     total_amount = fields.Monetary(
         related="approval_line_id.total_amount",
-        string="Total",
+        string="Requested Amount",
         currency_field="currency_id",
         readonly=True,
     )

--- a/agx_approval_sarabun/views/approval_request_views.xml
+++ b/agx_approval_sarabun/views/approval_request_views.xml
@@ -7,26 +7,19 @@
         <field name="arch" type="xml">
             <!-- Add button_box before oe_title -->
             <xpath expr="//div[@name='button_box']" position="inside">
-                    <field name="sarabun_document_count" invisible="1" />
-                    <button
-                        type="object"
-                        name="action_view_sarabun_documents"
-                        class="oe_stat_button"
-                        icon="fa-file-text-o"
-                        attrs="{'invisible': [('sarabun_document_count', '=', 0)]}"
-                        string="หนังสือ"
-                    />
+                <field name="sarabun_document_count" invisible="1" />
+                <button type="object" name="action_view_sarabun_documents" class="oe_stat_button" icon="fa-file-text-o" attrs="{'invisible': [('sarabun_document_count', '=', 0)]}" string="หนังสือ" />
             </xpath>
 
             <!-- Add Submit to Sarabun button after To Verify button -->
             <xpath expr="//button[@name='action_to_verify']" position="after">
-                <button
-                    name="action_submit_to_sarabun"
-                    string="สร้างเอกสาร"
-                    type="object"
-                    class="oe_highlight"
-                    attrs="{'invisible': ['|', ('state', '!=', 'submitted'), ('sarabun_document_count', '>', 0)]}"
-                />
+                <button name="action_submit_to_sarabun" string="สร้างเอกสาร" type="object" class="oe_highlight" attrs="{'invisible': ['|', ('state', '!=', 'submitted'), ('sarabun_document_count', '>', 0)]}" />
+            </xpath>
+
+            <!-- Sarabun routing replaces direct approval. Hide the manual
+                 Approve button to avoid double-approval paths. -->
+            <xpath expr="//button[@name='action_approve']" position="attributes">
+                <attribute name="invisible">1</attribute>
             </xpath>
         </field>
     </record>
@@ -36,8 +29,8 @@
         <field name="model">approval.request</field>
         <field name="inherit_id" ref="agx_approval.approval_request_view_tree" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='name']" position="before">
-                <field name="main_sarabun_document_id" optional="show" />
+            <xpath expr="//field[@name='state']" position="after">
+                <field name="main_sarabun_document_id" optional="hide" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Add `action_approve` method + button (submitted/validated → approved), gated to the manager group; hide it via inheritance in `agx_approval_sarabun` where the routing callback drives approval.
- Drop commented-out `write()` dead code.
- Rename buttons to keep English source + translate via .po: "Verify Request" → "ยืนยันคำขอ"; "Record Actual Disbursement" → "ขอเบิกจริง" with a tooltip explaining the use-case.
- Validate in `update_actual_amount_wizard.action_save` that actual_amount per line ≤ approved total_amount; raise UserError listing offending lines.
- Consolidate duplicate field rendering in the Budget group.
- Add a green "Budget Reserved: <commitment> — <amount> ฿" alert in the Budget group (auto-shows when a commitment is linked), backed by new related `budget_commitment_amount` field.
- Tree view: state rendered as badge with success/warning/muted/danger decorations.
- Wrap hardcoded Thai UserError in `action_open_budget_commitment` with `_()`.
- Rename `approval.request.line.total_amount` label from "Total" to "Requested Amount" (ยอดขอเบิก), separate from table-footer `sum="Total"` ("รวม").
- Add th.po entries for all new English source strings.

## Test plan
- [ ] Submit an AR → manager sees Approve button → click → state → approved.
- [ ] Install `agx_approval_sarabun` → Approve button hidden; routing still works.
- [ ] Open Update Actual Disbursement wizard → enter actual > total → save blocked with clear error message.
- [ ] Reserve budget on AR → green alert appears with commitment name + amount + ฿.
- [ ] AR list view: state column shows colored badges.
- [ ] Translations: Thai UI reads "ยืนยันคำขอ", "ขอเบิกจริง", "Budget Reserved" → "จองงบแล้ว", line column "ยอดขอเบิก".