### PR TITLE
[16.0][IMP] agx_approval_disbursement: copy AR attachments to DR

### DIFF
--- a/agx_approval_disbursement/models/approval_request.py
+++ b/agx_approval_disbursement/models/approval_request.py
@@ -104,6 +104,7 @@ class ApprovalRequest(models.Model):
         self.action_bill()
         vals = self._prepare_disbursement_request_vals()
         disbursement = self.env["disbursement.request"].create(vals)
+        self._copy_attachments_to_disbursement(disbursement)
 
         link = self._get_record_url()
         disbursement.message_post(
@@ -147,6 +148,25 @@ class ApprovalRequest(models.Model):
                 ("id", "in", self.disbursement_request_ids.ids)
             ]
         return action
+
+    def _copy_attachments_to_disbursement(self, disbursement):
+        """Clone AR attachments to the given DR.
+
+        Includes both the request-side attachment_ids (filtered to
+        non-evidence on this model) and the disbursement_attachment_ids
+        many2many that gathers DR-evidence files staged on the AR.
+
+        Each clone gets its own ir.attachment row pointing at the same
+        SHA1-hashed file in the Odoo filestore, so no binary is duplicated
+        on disk.
+        """
+        self.ensure_one()
+        attachments = self.attachment_ids | self.disbursement_attachment_ids
+        for attachment in attachments:
+            attachment.copy({
+                "res_model": "disbursement.request",
+                "res_id": disbursement.id,
+            })
 
     def _get_record_url(self):
         return "/web#id={}&model={}&view_type=form".format(self.id, self._name)


### PR DESCRIPTION
## Summary
- When `action_create_disbursement_request()` creates a DR from an AR, clone the AR's `attachment_ids` (non-evidence) and `disbursement_attachment_ids` (evidence M2M) onto the new DR.
- Each clone is a fresh `ir.attachment` row, but Odoo's filestore deduplicates by SHA1 hash so no binary content is duplicated on disk.

## Test plan
- [ ] Create AR, attach 2 files in Attachments + 1 evidence in disbursement_attachment_ids.
- [ ] Approve → Create Disbursement → DR shows all 3 attachments under its own Attachments.
- [ ] Verify filestore: only one physical file per unique content (check `du` on filestore directory before/after).