### PR TITLE
[16.0][IMP] disbursement: refactor budget logic + improve PDF

### DIFF
--- a/disbursement/__manifest__.py
+++ b/disbursement/__manifest__.py
@@ -13,6 +13,7 @@
         "finance_kmitl",
         "base_exception",
         "l10n_th_account_tax",
+        "l10n_th_amount_to_text",
         "base_fontawesome",
         "partner_type_aginix",
     ],

--- a/disbursement/models/budget_commitment.py
+++ b/disbursement/models/budget_commitment.py
@@ -1,6 +1,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class BudgetCommitment(models.Model):
@@ -24,10 +24,19 @@ class BudgetCommitment(models.Model):
 
     def action_view_disbursement_requests(self):
         self.ensure_one()
-        return {
+        action = {
+            "name": _("Disbursement Requests"),
             "res_model": "disbursement.request",
             "type": "ir.actions.act_window",
-            "view_mode": "form",
-            "view_type": "form",
-            "res_id": self.disbursement_request_ids[0].id,
         }
+        if len(self.disbursement_request_ids) == 1:
+            action.update({
+                "view_mode": "form",
+                "res_id": self.disbursement_request_ids.id,
+            })
+        else:
+            action.update({
+                "view_mode": "tree,form",
+                "domain": [("id", "in", self.disbursement_request_ids.ids)],
+            })
+        return action

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -366,23 +366,23 @@ class DisbursementRequest(models.Model):
                 rec.budget_account_id = budget.account_id
                 rec.analytic_distribution = budget.analytic_distribution
 
-    @api.constrains("analytic_distribution")
+    @api.constrains("analytic_distribution", "state")
     def _check_analytic_distribution_complete(self):
-        required_plan_codes = {"activities", "departments", "funds", "sources"}
-        # for rec in self:
-        #     if rec.state == "cancel":
-        #         continue
-        #     if not rec.analytic_distribution:
-        #         raise ValidationError(_("Analytic distribution is required."))
-        #     account_ids = [int(k) for k in rec.analytic_distribution.keys()]
-        #     accounts = self.env["account.analytic.account"].browse(account_ids)
-        #     present_codes = set(accounts.mapped("root_plan_id.code"))
-        #     missing = required_plan_codes - present_codes
-        #     if missing:
-        #         raise ValidationError(
-        #             _("Missing required analytic dimensions: %s")
-        #             % ", ".join(missing)
-        #         )
+        required_plan_codes = set(self._analytic_keys.keys())
+        for rec in self:
+            if rec.state in ("draft", "cancel"):
+                continue
+            if not rec.analytic_distribution:
+                raise ValidationError(_("Analytic distribution is required."))
+            account_ids = [int(k) for k in rec.analytic_distribution.keys()]
+            accounts = self.env["account.analytic.account"].browse(account_ids)
+            present_codes = set(accounts.mapped("root_plan_id.code"))
+            missing = required_plan_codes - present_codes
+            if missing:
+                raise ValidationError(
+                    _("Missing required analytic dimensions: %s")
+                    % ", ".join(sorted(missing))
+                )
 
     @api.model
     def _search_source_analytic_id(self, operator, value):
@@ -804,6 +804,22 @@ class DisbursementRequest(models.Model):
         consume line for the DR amount, leaving the BC open for other DRs.
         """
         self.ensure_one()
+        commitment = self._check_commitment_obligable()
+        first_reserve = self._get_commitment_reserve_line(commitment)
+        self.env["budget.commitment.line"].create(
+            self._prepare_budget_obligate_lines(commitment, first_reserve)
+        )
+        self.budget_consumed_amount = self.amount_total
+        self.budget_consumed_date = fields.Datetime.now()
+        self.message_post(
+            body=_("Budget obligated and consumed: %(amount)s on commitment %(name)s")
+            % {"amount": self.amount_total, "name": commitment.name},
+            subtype_xmlid="mail.mt_note",
+        )
+
+    def _check_commitment_obligable(self):
+        """Validate the linked commitment can absorb this DR's amount."""
+        self.ensure_one()
         if not self.budget_commitment_id:
             raise UserError(
                 _("Budget commitment is required before approval. "
@@ -826,6 +842,10 @@ class DisbursementRequest(models.Model):
                     "required": self.amount_total,
                 }
             )
+        return commitment
+
+    def _get_commitment_reserve_line(self, commitment):
+        """Return the first active reserve line on the commitment."""
         first_reserve = commitment.line_ids.filtered(
             lambda l: l.move_type == "reserve" and l.state == "posted"
         )[:1]
@@ -833,31 +853,23 @@ class DisbursementRequest(models.Model):
             raise UserError(
                 _("No active reserve line on commitment %s.") % commitment.name
             )
-        self.env["budget.commitment.line"].create([
-            {
-                "commitment_id": commitment.id,
-                "move_type": "obligate",
-                "account_id": first_reserve.account_id.id,
-                "analytic_distribution": first_reserve.analytic_distribution,
-                "amount": self.amount_total,
-                "name": _("Obligation: %s") % self.name,
-            },
-            {
-                "commitment_id": commitment.id,
-                "move_type": "consume",
-                "account_id": first_reserve.account_id.id,
-                "analytic_distribution": first_reserve.analytic_distribution,
-                "amount": self.amount_total,
-                "name": _("Consumption: %s") % self.name,
-            },
-        ])
-        self.budget_consumed_amount = self.amount_total
-        self.budget_consumed_date = fields.Datetime.now()
-        self.message_post(
-            body=_("Budget obligated and consumed: %(amount)s on commitment %(name)s")
-            % {"amount": self.amount_total, "name": commitment.name},
-            subtype_xmlid="mail.mt_note",
-        )
+        return first_reserve
+
+    def _prepare_budget_obligate_lines(self, commitment, reserve_line):
+        """Build the obligate + consume commitment lines for this DR."""
+        self.ensure_one()
+        common = {
+            "commitment_id": commitment.id,
+            "account_id": reserve_line.account_id.id,
+            "analytic_distribution": reserve_line.analytic_distribution,
+            "amount": self.amount_total,
+        }
+        return [
+            dict(common, move_type="obligate",
+                 name=_("Obligation: %s") % self.name),
+            dict(common, move_type="consume",
+                 name=_("Consumption: %s") % self.name),
+        ]
 
     def action_cancel(self):
         """Cancel the request.

--- a/disbursement/report/report_disbursement_request.xml
+++ b/disbursement/report/report_disbursement_request.xml
@@ -116,8 +116,8 @@
                         <t t-if="o.partner_type == 'single'">
                             <div class="row" t-if="o.partner_bank_id">
                                 <div class="col">
-                                    ธนาคาร <span class="ms-2" t-out="o.partner_bank_id.bank_id.name"/>
-                                    เลขที่บัญชี <span class="ms-2" t-out="o.partner_bank_id.acc_number"/>
+                                    ธนาคาร                                    <span class="ms-2" t-out="o.partner_bank_id.bank_id.name"/>
+                                    เลขที่บัญชี                                    <span class="ms-2" t-out="o.partner_bank_id.acc_number"/>
                                 </div>
                             </div>
                         </t>
@@ -143,8 +143,8 @@
                                             <td class="text-center" style="width: 8%" t-out="row_no"/>
                                             <td t-out="line.name"/>
                                             <td class="text-center" t-out="'{0:,.2f}'.format(line.quantity)"/>
-                                            <td class="text-end" t-out="'{0:,.2f}'.format(line.price_unit)"/>
-                                            <td class="text-end" t-out="'{0:,.2f}'.format(line.price_subtotal)"/>
+                                            <td class="text-end" t-out="'{0:,.2f} ฿'.format(line.price_unit)"/>
+                                            <td class="text-end" t-out="'{0:,.2f} ฿'.format(line.price_subtotal)"/>
                                         </tr>
                                         <t t-set="row_no" t-value="row_no + 1"/>
                                     </t>
@@ -159,15 +159,16 @@
                             <t t-foreach="partners" t-as="partner">
                                 <div class="row mt-3 mb-2">
                                     <div class="col">
-                                        <strong>ผู้รับเงิน: <span t-out="partner.name"/></strong>
+                                        <strong>ผู้รับเงิน:                                            <span t-out="partner.name"/>
+                                        </strong>
                                     </div>
                                 </div>
                                 <t t-set="partner_lines" t-value="o.line_ids.filtered(lambda l: l.partner_id == partner)"/>
                                 <t t-set="partner_bank" t-value="partner_lines[0].partner_bank_id if partner_lines else False"/>
                                 <div class="row mb-2" t-if="partner_bank">
                                     <div class="col">
-                                        ธนาคาร <span class="ms-2" t-out="partner_bank.bank_id.name"/>
-                                        เลขที่บัญชี <span class="ms-2" t-out="partner_bank.acc_number"/>
+                                        ธนาคาร                                        <span class="ms-2" t-out="partner_bank.bank_id.name"/>
+                                        เลขที่บัญชี                                        <span class="ms-2" t-out="partner_bank.acc_number"/>
                                     </div>
                                 </div>
                                 <table class="table table-bordered table-sm mb-4">
@@ -186,8 +187,8 @@
                                                 <td class="text-center" style="width: 8%" t-out="global_row_no"/>
                                                 <td t-out="line.name"/>
                                                 <td class="text-center" t-out="'{0:,.2f}'.format(line.quantity)"/>
-                                                <td class="text-end" t-out="'{0:,.2f}'.format(line.price_unit)"/>
-                                                <td class="text-end" t-out="'{0:,.2f}'.format(line.price_subtotal)"/>
+                                                <td class="text-end" t-out="'{0:,.2f} ฿'.format(line.price_unit)"/>
+                                                <td class="text-end" t-out="'{0:,.2f} ฿'.format(line.price_subtotal)"/>
                                             </tr>
                                             <t t-set="global_row_no" t-value="global_row_no + 1"/>
                                         </t>
@@ -200,20 +201,23 @@
                         <table class="table table-bordered table-sm mb-4">
                             <tbody>
                                 <tr>
-                                    <td colspan="2" rowspan="3" class="text-center align-middle">
-                                        (                                        <t t-esc="currency.with_context({'lang': 'th_TH'}).amount_to_text(o.amount_total)"/>
- )
+                                    <td rowspan="3" class="text-center align-middle" style="width: 50%">
+
+                                        <div class="mt-2">
+                                            (                                            <t t-esc="currency.with_context({'lang': 'th_TH'}).amount_to_text(o.amount_total)"/>
+)
+                                        </div>
                                     </td>
-                                    <td class="text-center" colspan="2">ราคาก่อนรวมภาษีมูลค่าเพิ่ม</td>
-                                    <td class="text-end" t-out="'{0:,.2f}'.format(o.amount_untaxed)"/>
+                                    <td class="text-center" style="width: 25%">ราคาก่อนรวมภาษีมูลค่าเพิ่ม</td>
+                                    <td class="text-end" style="width: 25%" t-out="'{0:,.2f} ฿'.format(o.amount_untaxed)"/>
                                 </tr>
                                 <tr>
-                                    <td class="text-center" colspan="2">ภาษีมูลค่าเพิ่ม (VAT 7%)</td>
-                                    <td class="text-end" t-out="'{0:,.2f}'.format(o.amount_tax)"/>
+                                    <td class="text-center">ภาษีมูลค่าเพิ่ม (VAT 7%)</td>
+                                    <td class="text-end" t-out="'{0:,.2f} ฿'.format(o.amount_tax)"/>
                                 </tr>
                                 <tr>
-                                    <td class="text-center" colspan="2">ราคาสุทธิ</td>
-                                    <td class="text-end" t-out="'{0:,.2f}'.format(o.amount_total)"/>
+                                    <td class="text-center">ราคาสุทธิ</td>
+                                    <td class="text-end" t-out="'{0:,.2f} ฿'.format(o.amount_total)"/>
                                 </tr>
                             </tbody>
                         </table>

--- a/disbursement_accounting_kmitl/i18n/th.po
+++ b/disbursement_accounting_kmitl/i18n/th.po
@@ -64,6 +64,12 @@ msgid "Bill Posted"
 msgstr "ตั้งหนี้ - ลงบัญชี"
 
 #. module: disbursement_accounting_kmitl
+#: model:ir.model.fields.selection,name:disbursement_accounting_kmitl.selection__disbursement_request__state__bills_posted
+#: model:ir.model.fields.selection,name:disbursement_accounting_kmitl.selection__disbursement_request__display_status__bills_posted
+msgid "Bills Posted"
+msgstr "ตั้งหนี้ครบ"
+
+#. module: disbursement_accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:disbursement_accounting_kmitl.view_disbursement_request_form_inherit_accounting
 msgid "Create Bill"
 msgstr "สร้างใบตั้งหนี้"


### PR DESCRIPTION
## Summary
- Re-enable analytic dimension validation constraint (was commented out); blocks DR transitions when one of the 4 required analytic dimensions is missing, except in draft/cancel states.
- Extract helpers from the 62-line `_action_approve_budget`: `_check_commitment_obligable`, `_get_commitment_reserve_line`, `_prepare_budget_obligate_lines`.
- Fix `budget_commitment.action_view_disbursement_requests` to open a list view when more than one DR is linked (instead of always opening the first record).
- Add `l10n_th_amount_to_text` dep for Thai amount-to-text on the DR PDF.
- DR PDF: append "฿" to every monetary cell, add Thai amount reading in totals, tighten the totals layout to 2:1:1 column ratio.
- Add missing Thai translation for "Bills Posted" state value in `disbursement_accounting_kmitl/i18n/th.po`.

## Test plan
- [ ] Submit DR with incomplete analytic dimensions → constraint blocks with clear error.
- [ ] Approve DR → budget obligated + consumed correctly (regression test extracted helpers).
- [ ] Open a budget commitment linked to multiple DRs → smart button opens list view.
- [ ] Print DR PDF → every money cell shows "฿", totals row shows Thai reading.
- [ ] DR with state=bills_posted → status displays in Thai.