### PR TITLE
[16.0][REF] accounting_kmitl: drop unused budget fields on account.move

### DIFF
--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -32,26 +32,6 @@ msgid "Submitted"
 msgstr "ส่งอนุมัติ"
 
 #. module: accounting_kmitl
-#: model:ir.model.fields,field_description:accounting_kmitl.field_account_move__budget_commitment_id
-msgid "Budget Commitment"
-msgstr "ผูกพันงบประมาณ"
-
-#. module: accounting_kmitl
-#: model:ir.model.fields,field_description:accounting_kmitl.field_account_move__budget_account_id
-msgid "Budget Account"
-msgstr "บัญชีงบประมาณ"
-
-#. module: accounting_kmitl
-#: model:ir.model.fields,help:accounting_kmitl.field_account_move__budget_commitment_id
-msgid "Related budget commitment for this journal entry"
-msgstr "ผูกพันงบประมาณที่เกี่ยวข้องกับรายการบันทึกบัญชีนี้"
-
-#. module: accounting_kmitl
-#: model:ir.model.fields,help:accounting_kmitl.field_account_move__budget_account_id
-msgid "Budget account to be used for commitment"
-msgstr "บัญชีงบประมาณที่ใช้สำหรับการผูกพัน"
-
-#. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
 msgid "Submit"
 msgstr "ยืนยัน"

--- a/accounting_kmitl/models/account_move.py
+++ b/accounting_kmitl/models/account_move.py
@@ -6,31 +6,12 @@ from odoo.exceptions import UserError, ValidationError
 
 class AccountMove(models.Model):
     _name = "account.move"
-    _inherit = ["account.move", "budget.commitment.mixin",
-                "analytic.distribution.mixin"]
-
-    # Budget commitment mixin configuration
-    _commitment_id_field = "budget_commitment_id"
-    _commitment_account_id_field = "budget_account_id"
+    _inherit = ["account.move", "analytic.distribution.mixin"]
 
     # --- State ---
     state = fields.Selection(
         selection_add=[("submitted", "Submitted"), ("posted",)],
         ondelete={"submitted": "set default"},
-    )
-
-    # --- Budget fields ---
-    budget_commitment_id = fields.Many2one(
-        "budget.commitment",
-        string="Budget Commitment",
-        copy=False,
-        help="Related budget commitment for this journal entry",
-    )
-    budget_account_id = fields.Many2one(
-        "budget.account",
-        string="Budget Account",
-        domain=[("budgetable", "=", True), ("budget_type", "=", "expense")],
-        help="Budget account to be used for commitment",
     )
 
     # --- Compute ---
@@ -70,22 +51,6 @@ class AccountMove(models.Model):
             move.state = "draft"
         return True
 
-    def action_view_budget_commitment(self):
-        """View related budget commitment."""
-        self.ensure_one()
-        if not self.budget_commitment_id:
-            raise UserError(
-                _("No budget commitment linked to this journal entry")
-            )
-        return {
-            "type": "ir.actions.act_window",
-            "name": _("Budget Commitment"),
-            "res_model": "budget.commitment",
-            "res_id": self.budget_commitment_id.id,
-            "view_mode": "form",
-            "target": "current",
-        }
-
     # --- Budget validation ---
     def _check_analytic_distribution_complete(self):
         """Validate that all required analytic dimensions are present."""
@@ -124,30 +89,6 @@ class AccountMove(models.Model):
                         tax_inv.tax_invoice_number = ref
                 if not tax_inv.tax_invoice_date:
                     tax_inv.tax_invoice_date = move.date
-
-    # --- Onchange ---
-    @api.onchange("budget_commitment_id")
-    def _onchange_budget_commitment_id(self):
-        """Auto-populate budget account and analytic distribution
-        from budget commitment."""
-        if self.budget_commitment_id:
-            self.budget_account_id = self.budget_commitment_id.account_id
-            commitment = self.budget_commitment_id
-            analytic_accounts = {}
-            if commitment.activity_analytic_id:
-                analytic_accounts[commitment.activity_analytic_id.id] = 100
-                self.activity_analytic_id = commitment.activity_analytic_id
-            if commitment.department_analytic_id:
-                analytic_accounts[commitment.department_analytic_id.id] = 100
-                self.department_analytic_id = commitment.department_analytic_id
-            if commitment.fund_analytic_id:
-                analytic_accounts[commitment.fund_analytic_id.id] = 100
-                self.fund_analytic_id = commitment.fund_analytic_id
-            if commitment.source_analytic_id:
-                analytic_accounts[commitment.source_analytic_id.id] = 100
-                self.source_analytic_id = commitment.source_analytic_id
-            if analytic_accounts:
-                self.analytic_distribution = analytic_accounts
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -12,8 +12,10 @@
                 <attribute name="statusbar_visible">draft,submitted,posted</attribute>
             </xpath>
 
-            <!-- Submit and Reset to Draft buttons -->
-            <xpath expr="//button[@name='action_post'][2]" position="after">
+            <!-- Submit and Reset to Draft buttons.
+                 Anchor on the second action_post button (the "Confirm" variant
+                 for non-entry move types) via the unique attrs discriminator. -->
+            <xpath expr="//button[@name='action_post' and contains(@attrs, 'display_inactive_currency_warning')]" position="after">
                 <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
                 <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'submitted')]}"/>
             </xpath>
@@ -46,27 +48,15 @@
             <xpath expr="//page[@id='invoice_tab']/.." position="before">
                 <group name="budget_root" string="Budget">
                     <group name="budget_info">
-                        <field name="budget_commitment_id" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                         <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
                     </group>
                     <group name="analytic_dimensions">
-                        <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                        <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                        <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                        <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
-                        <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
+                        <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
+                        <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
+                        <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
+                        <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                     </group>
                 </group>
-            </xpath>
-
-            <!-- Budget commitment button in header button box -->
-            <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="action_view_budget_commitment" type="object" class="oe_stat_button" icon="fa-calculator" attrs="{'invisible': [('budget_commitment_id', '=', False)]}">
-                    <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_text">View</span>
-                        <span class="o_stat_text">Budget Commitment</span>
-                    </div>
-                </button>
             </xpath>
 
         </field>

--- a/disbursement_accounting_kmitl/models/disbursement_request.py
+++ b/disbursement_accounting_kmitl/models/disbursement_request.py
@@ -204,8 +204,6 @@ class DisbursementRequest(models.Model):
             "currency_id": self.currency_id.id,
             "company_id": self.company_id.id,
             "invoice_line_ids": invoice_lines,
-            "budget_commitment_id": self.budget_commitment_id.id,
-            "budget_account_id": self.budget_account_id.id,
             "analytic_distribution": self.analytic_distribution,
         }
 

--- a/finance_kmitl/data/kmitl_payment_type_data.xml
+++ b/finance_kmitl/data/kmitl_payment_type_data.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    NOTE: Override accounts below are matched by KMITL chart-of-accounts code
+    "2150000006" (deposit liability). If this code is absent in the installed
+    chart, the override_account_id field is left empty (graceful no-op).
+    Admins can manually set the override account on each kmitl.payment.type
+    record after install via the Settings menu.
+-->
 <odoo noupdate="1">
 
     <record id="payment_type_normal_inbound" model="kmitl.payment.type">

--- a/finance_kmitl/models/account_payment.py
+++ b/finance_kmitl/models/account_payment.py
@@ -125,32 +125,3 @@ class AccountPayment(models.Model):
             "kmitl_payment_type_id",
         )
 
-    # --- Budget commitment (delegates to account.move via _inherits) ---
-
-    @api.onchange("budget_commitment_id")
-    def _onchange_budget_commitment_id(self):
-        """Auto-populate budget account and analytic distribution
-        from budget commitment.
-
-        Note: budget fields live on account.move and are accessed here
-        via _inherits delegation. The onchange must be defined on
-        account.payment because _inherits does not cascade onchange handlers.
-        """
-        if self.budget_commitment_id:
-            self.budget_account_id = self.budget_commitment_id.account_id
-            commitment = self.budget_commitment_id
-            analytic_accounts = {}
-            if commitment.activity_analytic_id:
-                analytic_accounts[commitment.activity_analytic_id.id] = 100
-                self.activity_analytic_id = commitment.activity_analytic_id
-            if commitment.department_analytic_id:
-                analytic_accounts[commitment.department_analytic_id.id] = 100
-                self.department_analytic_id = commitment.department_analytic_id
-            if commitment.fund_analytic_id:
-                analytic_accounts[commitment.fund_analytic_id.id] = 100
-                self.fund_analytic_id = commitment.fund_analytic_id
-            if commitment.source_analytic_id:
-                analytic_accounts[commitment.source_analytic_id.id] = 100
-                self.source_analytic_id = commitment.source_analytic_id
-            if analytic_accounts:
-                self.analytic_distribution = analytic_accounts

--- a/finance_kmitl/models/bank_payment_export_line.py
+++ b/finance_kmitl/models/bank_payment_export_line.py
@@ -11,7 +11,12 @@ class BankPaymentExportLine(models.Model):
     # -------------------------------------------------------------------------
     @api.model
     def _domain_payment_id(self):
-        method_manual_out = self.env.ref("account.account_payment_method_manual_out")
+        method_manual_out = self.env.ref(
+            "account.account_payment_method_manual_out",
+            raise_if_not_found=False,
+        )
+        if not method_manual_out:
+            return "[('id', '=', 0)]"
         domain = (
             "[('export_status', '=', 'draft'), "
             "('state', '=', 'submitted'), "

--- a/finance_kmitl/views/account_payment_views.xml
+++ b/finance_kmitl/views/account_payment_views.xml
@@ -79,13 +79,11 @@
                 <notebook>
                     <page string="Budget" name="budget">
                         <group string="Budget" name="budget_info">
-                            <field name="budget_commitment_id" attrs="{'readonly': [('state', '!=', 'draft')]}" />
                             <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
-                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
-                            <field name="budget_account_id" options="{'no_create': True}" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '!=', 'draft')]}"/>
+                            <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                         </group>
                     </page>
                 </notebook>

--- a/finance_kmitl/wizards/account_payment_register.py
+++ b/finance_kmitl/wizards/account_payment_register.py
@@ -7,26 +7,19 @@ class AccountPaymentRegister(models.TransientModel):
     _inherit = "account.payment.register"
 
     def _create_payments(self):
-        """Propagate budget and analytic data from source invoices to payments."""
+        """Propagate analytic distribution from source invoices to payments."""
         payments = super()._create_payments()
         active_model = self._context.get("active_model")
         active_ids = self._context.get("active_ids", [])
         if active_model == "account.move" and active_ids:
             source_move = self.env["account.move"].browse(active_ids)[:1]
-            vals = {}
             if source_move.analytic_distribution:
-                vals["analytic_distribution"] = source_move.analytic_distribution
-            if source_move.budget_commitment_id:
-                vals["budget_commitment_id"] = source_move.budget_commitment_id.id
-            if source_move.budget_account_id:
-                vals["budget_account_id"] = source_move.budget_account_id.id
-            if vals:
+                distribution = source_move.analytic_distribution
                 for payment in payments:
-                    payment.write(vals)
-                    if vals.get("analytic_distribution"):
-                        payment.move_id.line_ids.write(
-                            {"analytic_distribution": vals["analytic_distribution"]}
-                        )
+                    payment.write({"analytic_distribution": distribution})
+                    payment.move_id.line_ids.write(
+                        {"analytic_distribution": distribution}
+                    )
         return payments
 
     def _post_payments(self, to_process, edit_mode=False):


### PR DESCRIPTION
## Summary
Remove `budget_commitment_id` and `budget_account_id` from `account.move` and the downstream `account.payment` delegation. The `analytic_distribution` JSON already carries all required dimensions across the DR → bill → payment flow, so the two convenience fields were duplicate state with no remaining consumers.

**accounting_kmitl:**
- Drop `budget.commitment.mixin` inheritance, field definitions, smart button, and onchange.
- Prune stale .po entries.
- Replace fragile `//button[@name='action_post'][2]` selector with a stable `contains(@attrs, 'display_inactive_currency_warning')` match.

**finance_kmitl:**
- Drop the `_inherits`-delegated onchange on `account.payment`.
- Remove the two fields from the payment Budget tab.
- Stop propagating the keys in `account.payment.register._create_payments`.
- Safe `env.ref(..., raise_if_not_found=False)` in `bank_payment_export_line._domain_payment_id`.
- Document the hardcoded deposit account code with an XML comment in `kmitl_payment_type_data.xml`.

**disbursement_accounting_kmitl:**
- Stop passing the removed keys when preparing the vendor bill from a DR.

## Test plan
- [ ] Fresh install of accounting_kmitl + finance_kmitl + disbursement_accounting_kmitl → upgrade succeeds, no broken view errors.
- [ ] Approve DR → bill is created without the removed fields → analytic_distribution still propagates correctly to lines.
- [ ] Register payment from bill → payment carries analytic_distribution.
- [ ] account.move form: no more "Budget Commitment" smart button or budget fields, but analytic dimensions remain editable.
- [ ] account.payment form: Budget tab still shows analytic dimensions, no commitment selector.