### PR TITLE
[16.0][IMP] app_menu: reorder root menus on Apps drawer

### DIFF
--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -6,7 +6,7 @@
         id="menu_accounting_root"
         name="Accounting"
         web_icon="accounting_kmitl,static/description/icon.png"
-        sequence="55"
+        sequence="7"
         groups="accounting_kmitl.group_accounting_kmitl_user"
     />
 

--- a/advance_payment/views/advance_payment_menus.xml
+++ b/advance_payment/views/advance_payment_menus.xml
@@ -2,7 +2,7 @@
 <odoo>
     <menuitem id="menu_advance_payment_root"
         name="สัญญายืมเงิน"
-        sequence="50"
+        sequence="6"
         web_icon="advance_payment,static/description/icon.png"
         groups="advance_payment.group_advance_payment_user"/>
 

--- a/agx_approval/views/approval_menus.xml
+++ b/agx_approval/views/approval_menus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- Root Menu -->
-    <menuitem id="approval_root_menu" name="Approval" action="action_approval_dashboard" web_icon="agx_approval,static/description/icon.png" groups="agx_approval.group_approval_user"/>
+    <menuitem id="approval_root_menu" name="Approval" sequence="4" action="action_approval_dashboard" web_icon="agx_approval,static/description/icon.png" groups="agx_approval.group_approval_user"/>
     <!-- My Approvals Tab -->
     <menuitem id="approval_approvals_menu" name="My Approvals" sequence="10" parent="approval_root_menu" />
     <menuitem id="approval_new_request_menu" name="New Request" sequence="10" parent="approval_approvals_menu" action="action_approval_dashboard"/>

--- a/agx_sarabun/views/sarabun_menus.xml
+++ b/agx_sarabun/views/sarabun_menus.xml
@@ -3,7 +3,7 @@
     <!-- Main Menu -->
     <menuitem id="menu_sarabun_root"
         name="e-Sarabun"
-        sequence="50"
+        sequence="2"
         web_icon="agx_sarabun,static/description/icon.png"
         groups="group_sarabun_user"/>
 

--- a/budget/views/budget_menus.xml
+++ b/budget/views/budget_menus.xml
@@ -3,7 +3,7 @@
     <menuitem
         id="budget_root_menu"
         name="Budgeting"
-        sequence="10"
+        sequence="1"
         groups="budget.group_budget_user"
         web_icon="budget,static/description/icon.png">
 

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -242,7 +242,7 @@
     </record>
 
     <!-- Root menu for Disbursement app -->
-    <menuitem id="menu_disbursement_root" name="Disbursement" sequence="45" web_icon="disbursement,static/description/icon.png"/>
+    <menuitem id="menu_disbursement_root" name="Disbursement" sequence="5" web_icon="disbursement,static/description/icon.png"/>
 
     <!-- Disbursement Requests submenu -->
     <menuitem id="menu_disbursement_request" name="Disbursement Requests" parent="menu_disbursement_root" action="action_disbursement_request" sequence="10" groups="disbursement.group_disbursement_user"/>

--- a/finance_kmitl/views/menuitem.xml
+++ b/finance_kmitl/views/menuitem.xml
@@ -6,7 +6,7 @@
         id="menu_payment_root"
         name="Finance"
         web_icon="finance_kmitl,static/description/icon.png"
-        sequence="60"
+        sequence="8"
         groups="finance_kmitl.group_finance_kmitl_user_in,finance_kmitl.group_finance_kmitl_user_out"
     />
 

--- a/procurement_plan/views/procurement_plan_menus.xml
+++ b/procurement_plan/views/procurement_plan_menus.xml
@@ -12,7 +12,7 @@
         <field name="target">main</field>
     </record>
 
-    <menuitem id="procurement_plan_root_menu" name="Procurement Plan" sequence="10" web_icon="procurement_plan,static/description/logo.png" groups="procurement_plan.group_procurement_plan_user">
+    <menuitem id="procurement_plan_root_menu" name="Procurement Plan" sequence="3" web_icon="procurement_plan,static/description/logo.png" groups="procurement_plan.group_procurement_plan_user">
         <menuitem
             id="action_procurement_plan_menu_action"
             name="Procurement Plan"


### PR DESCRIPTION
## Summary
ตั้ง `sequence` 1-8 ให้ root menu ของแต่ละ module เพื่อให้แสดงบนสุดของหน้า Apps drawer ตามลำดับ:
Budgeting → e-Sarabun → Procurement Plan → Approval → Disbursement → สัญญายืมเงิน → Accounting → Finance

## Test plan
- [ ] Upgrade ทั้ง 8 modules
- [ ] เข้าหน้า Apps drawer ด้วย user ที่มีสิทธิ์เห็นครบทุก module และยืนยันลำดับตามที่กำหนด