### PR TITLE
[16.0][IMP] accounting_kmitl: account.move form cleanup + payment method config

### DIFF
--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -7,6 +7,7 @@
     "website": "https://www.kmitl.ac.th",
     "license": "AGPL-3",
     "depends": [
+        "account_operating_unit",
         "base_tier_validation",
         "budget",
         "l10n_th_account_tax",

--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -15,6 +15,7 @@
     "data": [
         "security/security.xml",
         "views/account_move_views.xml",
+        "views/account_payment_method_views.xml",
         "views/menuitem.xml",
         "data/tier_definition.xml",
     ],

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -27,9 +27,24 @@ msgid "Status"
 msgstr "สถานะ"
 
 #. module: accounting_kmitl
+#: model:ir.model.fields.selection,name:account.selection__account_move__state__draft
+msgid "Draft"
+msgstr "ฉบับร่าง"
+
+#. module: accounting_kmitl
 #: model:ir.model.fields.selection,name:accounting_kmitl.selection__account_move__state__submitted
 msgid "Submitted"
-msgstr "ส่งอนุมัติ"
+msgstr "ยืนยันแล้ว"
+
+#. module: accounting_kmitl
+#: model:ir.model.fields.selection,name:account.selection__account_move__state__posted
+msgid "Posted"
+msgstr "บันทึกแล้ว"
+
+#. module: accounting_kmitl
+#: model:ir.model.fields.selection,name:account.selection__account_move__state__cancel
+msgid "Cancelled"
+msgstr "ยกเลิกแล้ว"
 
 #. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
@@ -43,18 +58,13 @@ msgstr "ตั้งค่าเป็นฉบับร่าง"
 
 #. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
-msgid "Budget"
-msgstr "งบประมาณ"
+msgid "Accounting Dimensions"
+msgstr "มิติทางบัญชี"
 
 #. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
-msgid "View"
-msgstr "ดู"
-
-#. module: accounting_kmitl
-#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
-msgid "Budget Commitment"
-msgstr "ผูกพันงบประมาณ"
+msgid "Additional Information"
+msgstr "ข้อมูลเพิ่มเติม"
 
 #. module: accounting_kmitl
 #: code:addons/accounting_kmitl/models/account_move.py:0

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -131,6 +131,12 @@ msgid "Journal Entries"
 msgstr "รายการบันทึกบัญชี"
 
 #. module: accounting_kmitl
+#: model:ir.ui.menu,name:accounting_kmitl.menu_journal_items_all
+#: model:ir.actions.act_window,name:accounting_kmitl.action_account_move_lines_all
+msgid "Journal Items"
+msgstr "บรรทัดรายการบัญชี"
+
+#. module: accounting_kmitl
 #: model:ir.ui.menu,name:accounting_kmitl.menu_accounting_reports
 msgid "Reports"
 msgstr "รายงาน"

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -47,7 +47,7 @@
                 <group name="budget_root" string="Budget">
                     <group name="budget_info">
                         <field name="budget_commitment_id" attrs="{'readonly': [('state', '=', 'posted')]}"/>
-                        <field name="analytic_distribution" widget="analytic_distribution" readonly="1"/>
+                        <field name="analytic_distribution" widget="analytic_distribution" invisible="1"/>
                     </group>
                     <group name="analytic_dimensions">
                         <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': ['|', ('budget_commitment_id', '!=', False), ('state', '=', 'posted')]}"/>
@@ -69,6 +69,70 @@
                 </button>
             </xpath>
 
+        </field>
+    </record>
+
+    <!-- Hide operating_unit_id from account.move form view -->
+    <record id="view_move_form_hide_operating_unit" model="ir.ui.view">
+        <field name="name">account.move.form.hide.operating.unit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account_operating_unit.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@id='header_right_group']/field[@name='operating_unit_id'][not(@invisible)]" position="replace"/>
+            <xpath expr="//field[@name='line_ids']/tree//field[@name='operating_unit_id']" position="replace"/>
+            <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='operating_unit_id']" position="replace"/>
+        </field>
+    </record>
+
+    <!-- Hide operating_unit_id from account.move invoice tree view -->
+    <record id="view_invoice_tree_hide_operating_unit" model="ir.ui.view">
+        <field name="name">account.invoice.tree.hide.operating.unit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account_operating_unit.view_invoice_tree"/>
+        <field name="arch" type="xml">
+            <field name="operating_unit_id" position="replace"/>
+        </field>
+    </record>
+
+    <!-- Hide operating_unit_id from account.move invoice search/filter -->
+    <record id="view_account_invoice_filter_hide_operating_unit" model="ir.ui.view">
+        <field name="name">account.invoice.select.hide.operating.unit</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account_operating_unit.view_account_invoice_filter"/>
+        <field name="arch" type="xml">
+            <field name="operating_unit_id" position="replace"/>
+            <filter name="operating_unit_grouped" position="replace"/>
+        </field>
+    </record>
+
+    <!-- Hide operating_unit_id from account.move.line form view -->
+    <record id="view_move_line_form_hide_operating_unit" model="ir.ui.view">
+        <field name="name">account.move.line.form.hide.operating.unit</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account_operating_unit.view_move_line_form"/>
+        <field name="arch" type="xml">
+            <field name="operating_unit_id" position="replace"/>
+        </field>
+    </record>
+
+    <!-- Hide operating_unit_id from account.move.line tree view -->
+    <record id="view_move_line_tree_hide_operating_unit" model="ir.ui.view">
+        <field name="name">account.move.line.tree.hide.operating.unit</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account_operating_unit.view_move_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="operating_unit_id" position="replace"/>
+        </field>
+    </record>
+
+    <!-- Hide operating_unit_id from account.move.line search/filter -->
+    <record id="view_account_move_line_filter_hide_operating_unit" model="ir.ui.view">
+        <field name="name">account.move.line.filter.hide.operating.unit</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account_operating_unit.view_account_move_line_filter"/>
+        <field name="arch" type="xml">
+            <field name="operating_unit_id" position="replace"/>
+            <filter name="operating_unit_grouped" position="replace"/>
         </field>
     </record>
 

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -62,7 +62,7 @@
             <!-- Move narration field out of other_tab_entry page to main form, wrapped in a new group -->
             <xpath expr="//page[@id='invoice_tab']/.." position="before">
                 <group name="narration_group" string="Additional Information">
-                    <field name="narration" widget="text" placeholder="Add an internal note..." nolabel="1" colspan="2"/>
+                    <field name="narration" placeholder="Add an internal note..." nolabel="1" colspan="2"/>
                 </group>
             </xpath>
             <xpath expr="//page[@id='other_tab_entry']/field[@name='narration']" position="replace"/>

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -46,17 +46,38 @@
 
             <!-- Budget fields on main form (before invoice_tab notebook) -->
             <xpath expr="//page[@id='invoice_tab']/.." position="before">
-                <group name="budget_root" string="Budget">
-                    <group name="budget_info">
-                        <field name="analytic_distribution" widget="analytic_distribution" invisible="1"/>
-                    </group>
+                <group name="budget_root" string="Accounting Dimensions">
                     <group name="analytic_dimensions">
                         <field name="activity_analytic_id" domain="[('plan_id.code', '=', 'activities')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                         <field name="department_analytic_id" domain="[('plan_id.code', '=', 'departments')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                         <field name="fund_analytic_id" domain="[('plan_id.code', '=', 'funds')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                         <field name="source_analytic_id" domain="[('plan_id.code', '=', 'sources')]" options="{'no_create': True}" required="1" attrs="{'readonly': [('state', '=', 'posted')]}"/>
                     </group>
+                    <group name="budget_info">
+                        <field name="analytic_distribution" widget="analytic_distribution" invisible="1"/>
+                    </group>
                 </group>
+            </xpath>
+
+            <!-- Move narration field out of other_tab_entry page to main form, wrapped in a new group -->
+            <xpath expr="//page[@id='invoice_tab']/.." position="before">
+                <group name="narration_group" string="Additional Information">
+                    <field name="narration" widget="text" placeholder="Add an internal note..." nolabel="1" colspan="2"/>
+                </group>
+            </xpath>
+            <xpath expr="//page[@id='other_tab_entry']/field[@name='narration']" position="replace"/>
+
+            <!-- Show reversed_entry_id only when it has a value -->
+            <xpath expr="//page[@id='other_tab_entry']//field[@name='reversed_entry_id']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('move_type', '!=', 'entry'), ('reversed_entry_id', '=', False)]}</attribute>
+            </xpath>
+
+            <!-- Hide fiscal_position_id on both other_tab (invoice/bill) and other_tab_entry (journal entry) -->
+            <xpath expr="//page[@id='other_tab']//field[@name='fiscal_position_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//page[@id='other_tab_entry']//field[@name='fiscal_position_id']" position="attributes">
+                <attribute name="invisible">1</attribute>
             </xpath>
 
         </field>

--- a/accounting_kmitl/views/account_payment_method_views.xml
+++ b/accounting_kmitl/views/account_payment_method_views.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- account.payment.method -->
+    <record id="view_account_payment_method_tree" model="ir.ui.view">
+        <field name="name">account.payment.method.tree</field>
+        <field name="model">account.payment.method</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="code"/>
+                <field name="payment_type"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_account_payment_method_form" model="ir.ui.view">
+        <field name="name">account.payment.method.form</field>
+        <field name="model">account.payment.method</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="code"/>
+                        <field name="payment_type"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_account_payment_method" model="ir.actions.act_window">
+        <field name="name">Payment Methods</field>
+        <field name="res_model">account.payment.method</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- account.payment.method.line -->
+    <record id="view_account_payment_method_line_tree" model="ir.ui.view">
+        <field name="name">account.payment.method.line.tree</field>
+        <field name="model">account.payment.method.line</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="payment_type"/>
+                <field name="available_payment_method_ids" invisible="1"/>
+                <field name="payment_method_id"/>
+                <field name="journal_id"/>
+                <field name="payment_account_id"/>
+                <field name="company_id" invisible="1"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_account_payment_method_line_form" model="ir.ui.view">
+        <field name="name">account.payment.method.line.form</field>
+        <field name="model">account.payment.method.line</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="sequence"/>
+                            <field name="payment_type"/>
+                            <field name="available_payment_method_ids" invisible="1"/>
+                            <field name="payment_method_id"/>
+                        </group>
+                        <group>
+                            <field name="journal_id"/>
+                            <field name="payment_account_id"/>
+                            <field name="company_id" invisible="1"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_account_payment_method_line" model="ir.actions.act_window">
+        <field name="name">Payment Method Lines</field>
+        <field name="res_model">account.payment.method.line</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+</odoo>

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -81,5 +81,19 @@
         action="account.action_tax_form"
         sequence="30"
     />
+    <menuitem
+        id="menu_config_payment_methods"
+        name="Payment Methods"
+        parent="menu_accounting_config"
+        action="action_account_payment_method"
+        sequence="40"
+    />
+    <menuitem
+        id="menu_config_payment_method_lines"
+        name="Payment Method Lines"
+        parent="menu_accounting_config"
+        action="action_account_payment_method_line"
+        sequence="50"
+    />
 
 </odoo>

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -44,6 +44,22 @@
         sequence="20"
     />
 
+    <!-- All Journal Items (account.move.line) under Journal Entries -->
+    <record id="action_account_move_lines_all" model="ir.actions.act_window">
+        <field name="name">Journal Items</field>
+        <field name="res_model">account.move.line</field>
+        <field name="view_mode">tree,pivot,graph,kanban,form</field>
+        <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+        <field name="context">{'search_default_group_by_move': 1, 'create': 0}</field>
+    </record>
+    <menuitem
+        id="menu_journal_items_all"
+        name="Journal Items"
+        parent="menu_journal_entries"
+        action="action_account_move_lines_all"
+        sequence="10"
+    />
+
     <!-- Reports submenu (placeholder — extend ผ่านโมดูล report ในอนาคต) -->
     <menuitem
         id="menu_accounting_reports"


### PR DESCRIPTION
## Summary

- Clean up `account.move` form: hide `operating_unit_id` (account.move + account.move.line, all views), hide `fiscal_position_id`, hide `analytic_distribution`, show `reversed_entry_id` only when it has a value, and move `narration` to a new "Additional Information" group on the main form with a plain text widget.
- Rename the analytic-dimensions group label from "Budget" to "Accounting Dimensions" so the wording matches its content.
- Add Configuration menus + views for `account.payment.method` and `account.payment.method.line` under KMITL Accounting > Configuration.
- Add `account_operating_unit` to depends so its views can be inherited.
- Refresh Thai translations: rename state values (Draft/Submitted/Posted/Cancelled), add new strings (Additional Information, Accounting Dimensions), drop obsolete budget-commitment entries.

## Test plan

- [ ] Upgrade `accounting_kmitl`; verify `account_operating_unit` gets installed as a new dependency.
- [ ] Open Accounting > Customers > Invoices: no Operating Unit column / search / Group By.
- [ ] Open an invoice form: no Operating Unit field in header, no Operating Unit column in invoice lines / journal items.
- [ ] Open Accounting > Accounting > Journal Items: no Operating Unit anywhere (tree, search, line form).
- [ ] Open a journal entry: confirm \`narration\` shows as a plain textbox under "Additional Information" group, and \`reversed_entry_id\` only appears for reversed entries.
- [ ] Verify \`fiscal_position_id\` is gone from both invoice "Other Info" and journal entry "Other Info" pages.
- [ ] Navigate to Accounting > Configuration > Payment Methods and Payment Method Lines: verify both menus open tree/form views.
- [ ] Switch UI to Thai: confirm state badges show ฉบับร่าง / ยืนยันแล้ว / บันทึกแล้ว / ยกเลิกแล้ว and group labels show "มิติทางบัญชี" and "ข้อมูลเพิ่มเติม".