### PR TITLE
[16.0][IMP] disbursement: mask bank account number in PDF

### DIFF
--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -922,6 +922,19 @@ class DisbursementRequest(models.Model):
         self.ensure_one()
         return f"Disbursement Request-{self.name}"
 
+    @api.model
+    def _get_masked_acc_number(self, acc_number):
+        """Mask a bank account number, keeping the first 3 and last 4 digits."""
+        acc = acc_number or ""
+        digit_positions = [i for i, c in enumerate(acc) if c.isdigit()]
+        if len(digit_positions) <= 7:
+            return acc
+        keep = set(digit_positions[:3]) | set(digit_positions[-4:])
+        return "".join(
+            c if (not c.isdigit() or i in keep) else "X"
+            for i, c in enumerate(acc)
+        )
+
     def open_preview(self):
         """Open preview in portal."""
         self.ensure_one()

--- a/disbursement/report/report_disbursement_request.xml
+++ b/disbursement/report/report_disbursement_request.xml
@@ -117,7 +117,7 @@
                             <div class="row" t-if="o.partner_bank_id">
                                 <div class="col">
                                     ธนาคาร                                    <span class="ms-2" t-out="o.partner_bank_id.bank_id.name"/>
-                                    เลขที่บัญชี                                    <span class="ms-2" t-out="o.partner_bank_id.acc_number"/>
+                                    เลขที่บัญชี                                    <span class="ms-2" t-out="o._get_masked_acc_number(o.partner_bank_id.acc_number)"/>
                                 </div>
                             </div>
                         </t>
@@ -168,7 +168,7 @@
                                 <div class="row mb-2" t-if="partner_bank">
                                     <div class="col">
                                         ธนาคาร                                        <span class="ms-2" t-out="partner_bank.bank_id.name"/>
-                                        เลขที่บัญชี                                        <span class="ms-2" t-out="partner_bank.acc_number"/>
+                                        เลขที่บัญชี                                        <span class="ms-2" t-out="o._get_masked_acc_number(partner_bank.acc_number)"/>
                                     </div>
                                 </div>
                                 <table class="table table-bordered table-sm mb-4">


### PR DESCRIPTION
## Summary
- Add `_get_masked_acc_number` helper on `disbursement.request` that keeps the first 3 and last 4 digits visible and replaces the rest with `X` (matches the masking used in `agx_approval`).
- Update `report_disbursement_request.xml` to render the masked account number in both single-partner and multi-partner sections.

## Test plan
- [ ] Upgrade `disbursement` module
- [ ] Print PDF for a single-partner request with `partner_bank_id` → verify masked output (e.g. `123XXXXX6789`)
- [ ] Print PDF for a multi-partner request → verify each partner section shows masked output
- [ ] Verify short account numbers (≤7 digits) remain unmasked