### PR TITLE
[16.0][FIX] kris_project, agx_approval: add titles to icons for a11y

### DIFF
--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -68,7 +68,7 @@
                     </group>
                     <group string="Budget">
                         <div colspan="2" class="alert alert-success my-2" role="alert" attrs="{'invisible': [('budget_commitment_id', '=', False)]}">
-                            <i class="fa fa-check-circle me-1"/>
+                            <i class="fa fa-check-circle me-1" title="Budget Reserved"/>
                             <strong>Budget Reserved:</strong>
                             <field name="budget_commitment_id" readonly="1" nolabel="1" class="oe_inline ms-1"/>
                             <span class="mx-1">—</span>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -422,6 +422,7 @@
                                         name="action_delete"
                                         type="object"
                                         icon="fa-trash"
+                                        title="Delete"
                                         attrs="{'invisible': [('project_state', 'in', ['done', 'cancel'])]}"
                                     />
                                 </tree>


### PR DESCRIPTION
Resolves Odoo accessibility warnings requiring icon-only elements to have a title in their tag, parents, or descendants.

- `kris_project`: add `title="Delete"` to the icon-only (`fa-trash`) delete button in the kris.project form view.
- `agx_approval`: add `title="Budget Reserved"` to the `fa-check-circle` icon in the approval.request form view.