### PR TITLE
[16.0][ADD] hr_employee_name_detail_kmitl: show employee detail in m2o autocomplete

### DIFF
--- a/hr_employee_name_detail_kmitl/README.rst
+++ b/hr_employee_name_detail_kmitl/README.rst
@@ -2,19 +2,29 @@
 HR Employee Name Detail KMITL
 =============================
 
-This module enriches ``hr.employee`` many2one fields so that, once an employee
-is selected, the academic standing title, work email, department (faculty /
-department) and KID are shown as extra lines below the input.
+This module shows extra employee information (academic standing title, work
+email, department as *faculty / department*, and KID) on ``hr.employee``
+many2one fields once an employee is selected.
 
-The behaviour mirrors the partner ``show_address`` pattern: it is gated by the
-``show_employee_detail`` context flag, so the regular display name is unchanged
-everywhere else.
+Two presentations are provided.
 
-Usage
-=====
+Styled detail card (recommended)
+=================================
 
-Add the context flag and ``always_reload`` option on any ``hr.employee``
-many2one field where the detail should appear::
+The ``employee_detail_many2one`` widget renders the detail as an icon-prefixed
+card below the field::
+
+    <field name="employee_id" widget="employee_detail_many2one"/>
+
+No context flag is needed: the widget reads the employee fields directly, so
+empty values are skipped without shifting the layout.
+
+Plain text extra lines
+======================
+
+For places where a custom widget is not desired, ``name_get`` can append the
+same information as plain extra lines (the partner ``show_address`` pattern),
+gated by the ``show_employee_detail`` context flag::
 
     <field name="employee_id"
            context="{'show_employee_detail': 1}"

--- a/hr_employee_name_detail_kmitl/README.rst
+++ b/hr_employee_name_detail_kmitl/README.rst
@@ -1,0 +1,21 @@
+=============================
+HR Employee Name Detail KMITL
+=============================
+
+This module enriches ``hr.employee`` many2one fields so that, once an employee
+is selected, the academic standing title, work email, department (faculty /
+department) and KID are shown as extra lines below the input.
+
+The behaviour mirrors the partner ``show_address`` pattern: it is gated by the
+``show_employee_detail`` context flag, so the regular display name is unchanged
+everywhere else.
+
+Usage
+=====
+
+Add the context flag and ``always_reload`` option on any ``hr.employee``
+many2one field where the detail should appear::
+
+    <field name="employee_id"
+           context="{'show_employee_detail': 1}"
+           options="{'always_reload': True, 'highlight_first_line': True}"/>

--- a/hr_employee_name_detail_kmitl/__init__.py
+++ b/hr_employee_name_detail_kmitl/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hr_employee_name_detail_kmitl/__manifest__.py
+++ b/hr_employee_name_detail_kmitl/__manifest__.py
@@ -8,6 +8,7 @@
     "category": "Human Resources",
     "depends": [
         "hr",
+        "hr_department_code_tracking",
         "hr_employee_academic_standing_thailand",
         "hr_employee_kmitl_kid",
     ],

--- a/hr_employee_name_detail_kmitl/__manifest__.py
+++ b/hr_employee_name_detail_kmitl/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "HR Employee Name Detail KMITL",
+    "version": "16.0.1.0.0",
+    "summary": """ Show academic standing, email, department and KID
+        under hr.employee many2one fields """,
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl-odoo",
+    "category": "Human Resources",
+    "depends": [
+        "hr",
+        "hr_employee_academic_standing_thailand",
+        "hr_employee_kmitl_kid",
+    ],
+    "data": [],
+    "application": False,
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/hr_employee_name_detail_kmitl/__manifest__.py
+++ b/hr_employee_name_detail_kmitl/__manifest__.py
@@ -12,6 +12,13 @@
         "hr_employee_kmitl_kid",
     ],
     "data": [],
+    "assets": {
+        "web.assets_backend": [
+            "hr_employee_name_detail_kmitl/static/src/**/*.js",
+            "hr_employee_name_detail_kmitl/static/src/**/*.xml",
+            "hr_employee_name_detail_kmitl/static/src/**/*.scss",
+        ],
+    },
     "application": False,
     "installable": True,
     "auto_install": False,

--- a/hr_employee_name_detail_kmitl/models/__init__.py
+++ b/hr_employee_name_detail_kmitl/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_employee

--- a/hr_employee_name_detail_kmitl/models/hr_employee.py
+++ b/hr_employee_name_detail_kmitl/models/hr_employee.py
@@ -1,0 +1,33 @@
+from odoo import _, models
+
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    def name_get(self):
+        """Append academic standing, email, department and KID as extra lines
+        when the ``show_employee_detail`` context flag is set.
+
+        The Many2OneField widget splits ``display_name`` on newlines: the first
+        line is the displayed value, the rest are rendered as muted extra lines
+        below the input (same mechanism as the partner ``show_address`` flag).
+        Use together with ``options="{'always_reload': True}"`` on the field so
+        ``name_get`` is re-evaluated with the field context.
+        """
+        res = super().name_get()
+        if not self.env.context.get("show_employee_detail"):
+            return res
+        names = dict(res)
+        result = []
+        for employee in self:
+            lines = [names.get(employee.id, "")]
+            if employee.academic_standing_title:
+                lines.append(employee.academic_standing_title)
+            if employee.work_email:
+                lines.append(employee.work_email)
+            if employee.department_id:
+                lines.append(employee.department_id.complete_name)
+            if employee.kid and employee.kid != _("New"):
+                lines.append("KID: %s" % employee.kid)
+            result.append((employee.id, "\n".join(lines)))
+        return result

--- a/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
+++ b/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
@@ -42,10 +42,12 @@ export class EmployeeDetailMany2OneField extends Many2OneField {
             const [dept = {}] = await this.orm.read(
                 "hr.department",
                 [record.department_id[0]],
-                ["complete_name"],
+                ["complete_name", "code"],
                 { context: this.context }
             );
-            department = dept.complete_name;
+            department = dept.code
+                ? `[${dept.code || '-'}] ${dept.complete_name}`
+                : dept.complete_name;
         }
         this.detail.data = {
             academic_standing_title: record.academic_standing_title,

--- a/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
+++ b/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { Many2OneField } from "@web/views/fields/many2one/many2one_field";
+
+import { onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
+
+// Fields read from the selected employee to build the detail card.
+const DETAIL_FIELDS = ["academic_standing_title", "work_email", "department_id", "kid"];
+
+/**
+ * Many2one widget for ``hr.employee`` that renders the academic standing title,
+ * work email, department (faculty / department) and KID as an icon-prefixed
+ * detail card below the field, instead of plain ``name_get`` extra lines.
+ *
+ * Usage: ``<field name="employee_id" widget="employee_detail_many2one"/>``
+ */
+export class EmployeeDetailMany2OneField extends Many2OneField {
+    setup() {
+        super.setup();
+        this.detail = useState({ data: null });
+        onWillStart(() => this.loadDetail(this.props.value));
+        onWillUpdateProps((nextProps) => {
+            const prevId = this.props.value && this.props.value[0];
+            const nextId = nextProps.value && nextProps.value[0];
+            if (prevId !== nextId) {
+                this.loadDetail(nextProps.value);
+            }
+        });
+    }
+
+    async loadDetail(value) {
+        if (!value) {
+            this.detail.data = null;
+            return;
+        }
+        const records = await this.orm.read(this.relation, [value[0]], DETAIL_FIELDS, {
+            context: this.context,
+        });
+        const record = records[0] || {};
+        this.detail.data = {
+            academic_standing_title: record.academic_standing_title,
+            work_email: record.work_email,
+            department: record.department_id ? record.department_id[1] : false,
+            kid: record.kid,
+        };
+    }
+
+    get employeeDetail() {
+        return this.detail.data;
+    }
+}
+
+EmployeeDetailMany2OneField.template =
+    "hr_employee_name_detail_kmitl.EmployeeDetailMany2OneField";
+
+registry.category("fields").add("employee_detail_many2one", EmployeeDetailMany2OneField);

--- a/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
+++ b/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
@@ -34,14 +34,23 @@ export class EmployeeDetailMany2OneField extends Many2OneField {
             this.detail.data = null;
             return;
         }
-        const records = await this.orm.read(this.relation, [value[0]], DETAIL_FIELDS, {
+        const [record = {}] = await this.orm.read(this.relation, [value[0]], DETAIL_FIELDS, {
             context: this.context,
         });
-        const record = records[0] || {};
+        let department = false;
+        if (record.department_id) {
+            const [dept = {}] = await this.orm.read(
+                "hr.department",
+                [record.department_id[0]],
+                ["complete_name"],
+                { context: this.context }
+            );
+            department = dept.complete_name;
+        }
         this.detail.data = {
             academic_standing_title: record.academic_standing_title,
             work_email: record.work_email,
-            department: record.department_id ? record.department_id[1] : false,
+            department,
             kid: record.kid,
         };
     }

--- a/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.scss
+++ b/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.scss
@@ -1,0 +1,17 @@
+.o_employee_detail {
+    margin-top: 2px;
+    font-size: 0.85em;
+    line-height: 1.5;
+    color: $text-muted;
+
+    .o_employee_detail_line {
+        display: flex;
+        align-items: baseline;
+        gap: 5px;
+
+        > i {
+            flex: 0 0 auto;
+            opacity: 0.75;
+        }
+    }
+}

--- a/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.xml
+++ b/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="hr_employee_name_detail_kmitl.EmployeeDetailCard" owl="1">
+        <div class="o_employee_detail" t-if="employeeDetail">
+            <div class="o_employee_detail_line" t-if="employeeDetail.academic_standing_title">
+                <i class="fa fa-fw fa-graduation-cap" title="ตำแหน่งทางวิชาการ"/>
+                <span t-esc="employeeDetail.academic_standing_title"/>
+            </div>
+            <div class="o_employee_detail_line" t-if="employeeDetail.work_email">
+                <i class="fa fa-fw fa-envelope-o" title="อีเมล"/>
+                <span t-esc="employeeDetail.work_email"/>
+            </div>
+            <div class="o_employee_detail_line" t-if="employeeDetail.department">
+                <i class="fa fa-fw fa-building-o" title="สังกัด"/>
+                <span t-esc="employeeDetail.department"/>
+            </div>
+            <div class="o_employee_detail_line" t-if="employeeDetail.kid">
+                <i class="fa fa-fw fa-id-card-o" title="KID"/>
+                <span>KID: <t t-esc="employeeDetail.kid"/></span>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="hr_employee_name_detail_kmitl.EmployeeDetailMany2OneField" owl="1">
+        <t t-if="props.readonly">
+            <t t-if="!props.canOpen">
+                <span>
+                    <span t-esc="displayName"/>
+                    <t t-call="hr_employee_name_detail_kmitl.EmployeeDetailCard"/>
+                </span>
+            </t>
+            <t t-else="">
+                <a
+                    t-if="props.value"
+                    t-attf-class="o_form_uri #{classFromDecoration}"
+                    t-att-href="props.value ? `#id=${props.value[0]}&amp;model=${relation}` : '#'"
+                    t-on-click.prevent="onClick"
+                >
+                    <span t-esc="displayName"/>
+                    <t t-call="hr_employee_name_detail_kmitl.EmployeeDetailCard"/>
+                </a>
+            </t>
+        </t>
+        <t t-else="">
+            <div class="o_field_many2one_selection">
+                <Many2XAutocomplete t-props="Many2XAutocompleteProps"/>
+                <t t-if="hasExternalButton">
+                    <button
+                        type="button"
+                        class="btn btn-secondary fa o_external_button"
+                        t-att-class="(props.openTarget === 'current' and !env.inDialog )? 'fa-arrow-right' : 'fa-external-link'"
+                        tabindex="-1"
+                        draggable="false"
+                        aria-label="Internal link"
+                        data-tooltip="Internal link"
+                        t-on-click="onExternalBtnClick"
+                    />
+                </t>
+                <button
+                    t-if="hasBarcodeButton"
+                    t-on-click="onBarcodeBtnClick"
+                    type="button"
+                    class="btn ms-3 o_barcode"
+                    tabindex="-1"
+                    draggable="false"
+                    aria-label="Scan barcode"
+                    title="Scan barcode"
+                    data-tooltip="Scan barcode"
+                />
+            </div>
+            <t t-call="hr_employee_name_detail_kmitl.EmployeeDetailCard"/>
+        </t>
+    </t>
+
+</templates>

--- a/kris_project/__manifest__.py
+++ b/kris_project/__manifest__.py
@@ -13,6 +13,7 @@
         "base_exception",
         "tracking_manager",
         "account_analytic_kmitl",
+        "hr_employee_name_detail_kmitl",
     ],
     "data": [
         "data/sequence.xml",

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -170,6 +170,7 @@
                             <field
                                 name="manager_id"
                                 required="1"
+                                widget="employee_detail_many2one"
                                 attrs="{'readonly': [('can_edit', '=', False)]}"
                             />
 


### PR DESCRIPTION
Adds a new module `hr_employee_name_detail_kmitl` that enriches `hr.employee` many2one fields: once an employee is selected, the academic standing title, work email, department (faculty / department) and KID appear as extra lines below the input. The behaviour reuses the partner `show_address` pattern — it overrides `name_get` gated by the `show_employee_detail` context flag, so the regular display name is unchanged everywhere else. To enable it on a field, add `context="{'show_employee_detail': 1}"` together with `options="{'always_reload': True, 'highlight_first_line': True}"`.