### PR TITLE
[16.0][FIX] kris_project: viewer access control & dashboard access

### DIFF
--- a/kris_project/models/kris_project_dashboard.py
+++ b/kris_project/models/kris_project_dashboard.py
@@ -151,7 +151,9 @@ class KrisProjectDashboard(models.Model):
         # --- filter_options ---
         categories = self.env["kris.project.category"].search([])
         types = self.env["kris.project.type"].search([])
-        fiscal_years = self.env["account.fiscal.year"].search(
+        # sudo: read access to account.fiscal.year is limited to accounting
+        # groups; KRIS officers/viewers need it only as dashboard filter options.
+        fiscal_years = self.env["account.fiscal.year"].sudo().search(
             [], order="date_from desc"
         )
 

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -99,6 +99,7 @@
                         type="object"
                         class="btn-primary"
                         states="draft"
+                        groups="kris_project.group_kris_project_officer"
                     />
                     <button
                         name="action_done"
@@ -112,6 +113,7 @@
                         string="Cancel"
                         type="object"
                         states="draft,in_progress,done"
+                        groups="kris_project.group_kris_project_officer"
                     />
                     <button
                         name="action_draft"
@@ -284,6 +286,7 @@
                             </group>
                             <div class="mb-3"
                                 attrs="{'invisible': [('can_edit', '=', False)]}"
+                                groups="kris_project.group_kris_project_officer"
                             >
                                 <field
                                     name="allocation_template_id"
@@ -341,6 +344,7 @@
                             </div>
                             <div class="mb-3"
                                 attrs="{'invisible': [('can_edit', '=', False)]}"
+                                groups="kris_project.group_kris_project_officer"
                             >
                                 <button
                                     name="action_add_installment"

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -461,19 +461,24 @@
         <field name="name">kris.project.tree</field>
         <field name="model">kris.project</field>
         <field name="arch" type="xml">
-            <tree decoration-danger="main_exception_id">
+            <tree
+                decoration-danger="main_exception_id"
+                decoration-muted="state == 'cancel'"
+            >
+                <field name="currency_id" invisible="1"/>
                 <field name="name"/>
                 <field name="project_name"/>
-                <field name="contract_number" optional="show"/>
+                <field name="contract_number" optional="hide"/>
                 <field name="project_category_id" optional="show"/>
-                <field name="project_type_id" optional="show"/>
+                <field name="project_type_id" optional="hide"/>
                 <field name="manager_id" optional="show"/>
-                <field name="user_id" optional="show"/>
+                <field name="user_id" widget="many2one_avatar_user" optional="hide"/>
                 <field name="department_analytic_id" optional="show"/>
-                <field name="client_name" optional="show"/>
+                <field name="client_name" optional="hide"/>
                 <field name="account_fiscal_year_id" optional="show"/>
                 <field name="project_value" sum="รวม" optional="show"/>
                 <field name="total_received_amount" sum="รวม" optional="show"/>
+                <field name="revenue_remaining" sum="รวม" optional="hide"/>
                 <field name="main_exception_id" optional="hide"/>
                 <field name="state" widget="badge"
                     decoration-info="state == 'draft'"
@@ -494,10 +499,14 @@
         <field name="model">kris.project</field>
         <field name="arch" type="xml">
             <search>
-                <field name="name" string="Project Number"/>
+                <field name="name" string="Project"
+                    filter_domain="['|', '|', '|', ('name', 'ilike', self), ('project_name', 'ilike', self), ('contract_number', 'ilike', self), ('client_name', 'ilike', self)]"/>
                 <field name="project_name" string="Project Name"/>
-                 <field name="client_name"/>
+                <field name="contract_number"/>
+                <field name="client_name"/>
                 <field name="manager_id"/>
+                <field name="department_analytic_id"/>
+                <field name="user_id"/>
                 <field name="project_category_id"/>
                 <field name="project_type_id"/>
                 <separator/>
@@ -516,14 +525,22 @@
                     string="My Project"
                     domain="[('user_id', '=', uid)]"
                 />
+                <separator/>
+                <filter name="contract_start" string="Contract Start Date" date="date_contract_start"/>
                 <!-- Group By -->
                 <group expand="0" string="จัดกลุ่มตาม">
                     <filter name="group_category" string="Project Category" context="{'group_by': 'project_category_id'}"/>
                     <filter name="group_type" string="Project Type" context="{'group_by': 'project_type_id'}"/>
+                    <filter name="group_manager" string="Project Manager" context="{'group_by': 'manager_id'}"/>
                     <filter name="group_state" string="State" context="{'group_by': 'state'}"/>
                     <filter name="group_fiscal_year" string="Fiscal Year" context="{'group_by': 'account_fiscal_year_id'}"/>
                     <filter name="group_department" string="Department" context="{'group_by': 'department_analytic_id'}"/>
                 </group>
+                <searchpanel>
+                    <field name="account_fiscal_year_id" icon="fa-calendar" enable_counters="1"/>
+                    <field name="project_category_id" icon="fa-folder" enable_counters="1"/>
+                    <field name="department_analytic_id" icon="fa-building-o" enable_counters="1"/>
+                </searchpanel>
             </search>
         </field>
     </record>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -107,6 +107,7 @@
                         type="object"
                         class="btn-primary"
                         states="in_progress"
+                        groups="kris_project.group_kris_project_officer"
                     />
                     <button
                         name="action_cancel"
@@ -399,6 +400,7 @@
                             <separator string="Revenue Record"/>
                             <div class="mb-3"
                                 attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"
+                                groups="kris_project.group_kris_project_officer"
                             >
                                 <button
                                     name="action_add_receipt"
@@ -428,6 +430,7 @@
                                         icon="fa-trash"
                                         title="Delete"
                                         attrs="{'invisible': [('project_state', 'in', ['done', 'cancel'])]}"
+                                        groups="kris_project.group_kris_project_officer"
                                     />
                                 </tree>
                             </field>


### PR DESCRIPTION
## Summary

Tightens access control for the **viewer** role on `kris.project` and fixes a dashboard access error, plus improves the project list/search views.

## Changes

**Access control (fix)**
- Dashboard failed to load for KRIS officers/viewers because `account.fiscal.year` read access is restricted to accounting groups. The dashboard now reads fiscal years with `sudo()` since they are only used as filter options.
- Hide all write / state-change / delete actions from users with only viewer access by gating them with `group_kris_project_officer`: **Confirm**, **Done**, **Cancel**, **Apply Template** (with its template selector), **Add Installment**, **Add Revenue**, and the receipt **delete** button. Officers and managers are unaffected.

**View improvements**
- **Tree:** add an invisible `currency_id` so monetary columns format correctly, mute cancelled rows, curate the default optional columns, show the responsible-user avatar, and add a `revenue_remaining` column.
- **Search:** unified search across project number / name / contract / client, added contract / department / user search fields, a contract-start-date filter, group-by manager, and a search panel for fiscal year / category / department.

## How to test

1. Assign a test user **only** to *KRIS Project / Viewer* (no Officer/Manager).
2. As that viewer, open the **KRIS Project dashboard** → it loads without an access error and the fiscal-year filter is populated.
3. Open any project form as the viewer and confirm **none** of these buttons appear: Confirm, Done, Cancel, Apply Template (and the template selector), Add Installment, Add Revenue, and the 🗑️ delete icon on the Revenue tab.
4. Switch the user to *Officer* (or *Manager*) and confirm all those buttons reappear and work as before.
5. On the project list, confirm monetary columns show the currency, cancelled rows are greyed out, and the search bar / search panel filters behave correctly.

---

## สรุป (ภาษาไทย)

ปรับสิทธิ์การเข้าถึงของบทบาท **viewer** บน `kris.project` ให้รัดกุมขึ้น แก้ปัญหา dashboard เปิดไม่ได้ และปรับปรุงหน้า list/search ของโครงการ

### การเปลี่ยนแปลง

**การควบคุมสิทธิ์ (แก้บั๊ก)**
- เดิม dashboard เปิดไม่ได้สำหรับ officer/viewer เพราะสิทธิ์อ่าน `account.fiscal.year` ถูกจำกัดไว้เฉพาะกลุ่มบัญชี ตอนนี้ดึงปีงบประมาณด้วย `sudo()` เนื่องจากใช้เป็นแค่ตัวเลือกตัวกรองเท่านั้น
- ซ่อนปุ่มที่เป็นการเขียน / เปลี่ยนสถานะ / ลบข้อมูล ออกจากผู้ใช้ที่มีสิทธิ์ viewer อย่างเดียว โดย gate ด้วย `group_kris_project_officer` ได้แก่ **ยืนยัน (Confirm)**, **เสร็จสิ้น (Done)**, **ยกเลิก (Cancel)**, **นำแม่แบบมาใช้ (Apply Template)** (รวมช่องเลือกแม่แบบ), **เพิ่มงวด (Add Installment)**, **เพิ่มรายรับ (Add Revenue)** และปุ่ม **ลบ** รายการรายรับ — ส่วน officer และ manager ใช้งานได้ตามเดิม

**ปรับปรุงหน้าจอ**
- **Tree:** เพิ่ม `currency_id` แบบซ่อนเพื่อให้คอลัมน์จำนวนเงินแสดงสกุลเงินถูกต้อง, ทำให้แถวที่ยกเลิกดูจางลง, คัดเลือกคอลัมน์ที่แสดงโดยปริยาย, แสดง avatar ผู้รับผิดชอบ และเพิ่มคอลัมน์ `revenue_remaining`
- **Search:** ค้นหารวมจากเลขโครงการ / ชื่อ / เลขสัญญา / ลูกค้า, เพิ่มฟิลด์ค้นหาเลขสัญญา / ส่วนงาน / ผู้ใช้, เพิ่มตัวกรองวันที่เริ่มสัญญา, จัดกลุ่มตามผู้จัดการ และเพิ่ม search panel สำหรับปีงบ / หมวดหมู่ / ส่วนงาน

### วิธีทดสอบ

1. กำหนดให้ผู้ใช้ทดสอบมีสิทธิ์ *KRIS Project / Viewer* **เท่านั้น** (ไม่ใส่ Officer/Manager)
2. เข้าสู่ระบบด้วย viewer แล้วเปิด **KRIS Project dashboard** → ต้องโหลดได้โดยไม่มี error และมีตัวกรองปีงบประมาณ
3. เปิดฟอร์มโครงการด้วย viewer แล้วตรวจว่า **ไม่เห็น** ปุ่มเหล่านี้: ยืนยัน, เสร็จสิ้น, ยกเลิก, นำแม่แบบมาใช้ (และช่องเลือกแม่แบบ), เพิ่มงวด, เพิ่มรายรับ และไอคอนลบ 🗑️ ในแท็บรายรับ
4. เปลี่ยนผู้ใช้เป็น *Officer* (หรือ *Manager*) → ปุ่มทั้งหมดต้องกลับมาแสดงและใช้งานได้ตามปกติ
5. ที่หน้า list ของโครงการ → ตรวจว่าคอลัมน์จำนวนเงินแสดงสกุลเงิน, แถวที่ยกเลิกเป็นสีจาง และแถบค้นหา / search panel ทำงานถูกต้อง
