### PR TITLE
[16.0][FIX] kris_project: fix project_duration inclusive count & remove department_id from form

### DIFF
--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -388,7 +388,7 @@ class KrisProject(models.Model):
             if rec.date_contract_start and rec.date_contract_end:
                 rec.project_duration = (
                     rec.date_contract_end - rec.date_contract_start
-                ).days
+                ).days + 1
             else:
                 rec.project_duration = 0
 

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -110,14 +110,6 @@ class KrisProject(models.Model):
         string="Project Manager",
         tracking=True,
     )
-    department_id = fields.Many2one(
-        comodel_name="hr.department",
-        string="Leader Department",
-        compute="_compute_department_id",
-        store=True,
-        readonly=True,
-        tracking=True,
-    )
     # --- Financial fields ---
     project_value = fields.Monetary(
         string="Project Value",
@@ -376,11 +368,6 @@ class KrisProject(models.Model):
             diff = rec.project_value - rec.total_received_amount
             rec.revenue_remaining = max(0.0, diff)
             rec.over_revenue = max(0.0, -diff)
-
-    @api.depends("manager_id", "manager_id.department_id")
-    def _compute_department_id(self):
-        for rec in self:
-            rec.department_id = rec.manager_id.department_id
 
     @api.depends("date_contract_start", "date_contract_end")
     def _compute_project_duration(self):

--- a/kris_project/models/kris_project_dashboard.py
+++ b/kris_project/models/kris_project_dashboard.py
@@ -126,8 +126,8 @@ class KrisProjectDashboard(models.Model):
         )
         for project in projects:
             department_name = (
-                project.department_id.complete_name
-                if project.department_id
+                project.department_analytic_id.name
+                if project.department_analytic_id
                 else _("(ไม่ระบุ)")
             )
             for line in project.allocation_line_ids:

--- a/kris_project/models/kris_project_dashboard.py
+++ b/kris_project/models/kris_project_dashboard.py
@@ -126,7 +126,7 @@ class KrisProjectDashboard(models.Model):
         )
         for project in projects:
             department_name = (
-                project.department_analytic_id.name
+                project.department_analytic_id.complete_name
                 if project.department_analytic_id
                 else _("(ไม่ระบุ)")
             )

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -171,7 +171,7 @@
                                 required="1"
                                 attrs="{'readonly': [('can_edit', '=', False)]}"
                             />
-                            <field name="department_id" readonly="1"/>
+
                             <field
                                 name="user_id"
                                 widget="many2one_avatar_user"


### PR DESCRIPTION
## Summary

- **Fix `project_duration` inclusive day counting**: The duration calculation now adds `+1` to the date difference so both start and end dates are counted inclusively. For example, a project running from `2026-06-01` to `2026-06-13` previously returned `12` but now correctly returns `13`.
- **Remove `department_id` field from form view**: The `department_id` read-only field has been removed from the `kris.project` form view as it is no longer needed in the UI.

## Changes

| File | Change |
|------|--------|
| `kris_project/models/kris_project.py` | `_compute_project_duration`: changed `.days` to `.days + 1` |
| `kris_project/views/kris_project_views.xml` | Removed `<field name="department_id" readonly="1"/>` |

## Test plan

- [ ] Open a `kris.project` form and confirm `department_id` field is no longer visible
- [ ] Set `date_contract_start = 2026-06-01` and `date_contract_end = 2026-06-13`, verify `project_duration = 13`
- [ ] Verify `project_duration = 1` when start and end date are the same day