### PR TITLE
[16.0][IMP] kris_project: installment partial state, multi-receipt & allocation guards

### DIFF
--- a/kris_project/__manifest__.py
+++ b/kris_project/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KRIS Project",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "category": "KMITL",
     "summary": "Academic service and research project revenue tracking for KRIS",
     "author": "Aginix Technologies",

--- a/kris_project/i18n/th.po
+++ b/kris_project/i18n/th.po
@@ -1484,6 +1484,12 @@ msgid "Department"
 msgstr "ส่วนงาน"
 
 #. module: kris_project
+#: model:ir.model.fields,field_description:kris_project.field_kris_project_allocation_line__department_analytic_id
+#: model:ir.model.fields,field_description:kris_project.field_kris_project_allocation_template_line__department_analytic_id
+msgid "Department Budget Code"
+msgstr "รหัสงบประมาณหน่วยงาน"
+
+#. module: kris_project
 #: model:ir.model.fields,field_description:kris_project.field_kris_project__extra_analytic_id
 msgid "Extra Payee"
 msgstr "ผู้รับค่า Extra"

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -249,6 +249,11 @@ class KrisProject(models.Model):
         compute="_compute_totals",
         store=True,
     )
+    total_extra_received = fields.Monetary(
+        string="Total Extra Received",
+        compute="_compute_totals",
+        store=True,
+    )
     # --- Standard fields ---
     company_id = fields.Many2one(
         comodel_name="res.company",
@@ -358,6 +363,7 @@ class KrisProject(models.Model):
         "installment_ids.amount",
         "receipt_ids.amount",
         "receipt_ids.net_amount",
+        "receipt_ids.extra_income",
         "project_value",
     )
     def _compute_totals(self):
@@ -365,6 +371,7 @@ class KrisProject(models.Model):
             rec.total_installment_amount = sum(rec.installment_ids.mapped("amount"))
             rec.total_received_amount = sum(rec.receipt_ids.mapped("amount"))
             rec.total_net_received = sum(rec.receipt_ids.mapped("net_amount"))
+            rec.total_extra_received = sum(rec.receipt_ids.mapped("extra_income"))
             diff = rec.project_value - rec.total_received_amount
             rec.revenue_remaining = max(0.0, diff)
             rec.over_revenue = max(0.0, -diff)
@@ -403,6 +410,10 @@ class KrisProject(models.Model):
 
     def action_add_receipt(self):
         self.ensure_one()
+        if self.state in ("done", "cancel"):
+            raise UserError(
+                _("Cannot record revenue on a project that is done or cancelled.")
+            )
         return {
             "name": _("Revenue Record"),
             "type": "ir.actions.act_window",
@@ -414,6 +425,10 @@ class KrisProject(models.Model):
 
     def action_add_installment(self):
         self.ensure_one()
+        if not self.can_edit:
+            raise UserError(
+                _("Installments can only be added while the project is in draft.")
+            )
         return {
             "name": _("Add Installment"),
             "type": "ir.actions.act_window",
@@ -425,6 +440,10 @@ class KrisProject(models.Model):
 
     def action_apply_allocation_template(self):
         self.ensure_one()
+        if not self.can_edit:
+            raise UserError(
+                _("Allocation can only be changed while the project is in draft.")
+            )
         if not self.allocation_template_id:
             raise UserError(_("Please select an allocation template first."))
         base_amount = self.maintenance_deduction_amount

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -36,7 +36,7 @@ class KrisProjectAllocationLine(models.Model):
     )
     department_analytic_id = fields.Many2one(
         comodel_name="account.analytic.account",
-        string="รหัสงบประมาณหน่วยงาน",
+        string="Department Budget Code",
         domain=[("root_plan_id.code", "=", "departments")],
     )
     is_locked = fields.Boolean(string="ห้ามแก้ไข")

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -2,6 +2,7 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -97,5 +98,22 @@ class KrisProjectAllocationLine(models.Model):
                         "ผลรวมประมาณการจัดสรรต้องไม่เกินมูลค่าหักค่าบำรุง (%.2f บาท)"
                     )
                     % base
+                )
+
+    @api.constrains("estimated_amount", "actual_amount")
+    def _check_actual_not_exceed_estimated(self):
+        prec = self.env["decimal.precision"].precision_get("Account")
+        for line in self:
+            if (
+                float_compare(
+                    line.actual_amount, line.estimated_amount, precision_digits=prec
+                )
+                > 0
+            ):
+                raise ValidationError(
+                    _(
+                        "ยอดจัดสรรจริงของ %s (%.2f บาท) เกินประมาณการ (%.2f บาท)"
+                    )
+                    % (line.name or "", line.actual_amount, line.estimated_amount)
                 )
 

--- a/kris_project/models/kris_project_allocation_template.py
+++ b/kris_project/models/kris_project_allocation_template.py
@@ -49,7 +49,7 @@ class KrisProjectAllocationTemplateLine(models.Model):
     allocation_pct = fields.Float(string="Allocation %", digits=(5, 2))
     department_analytic_id = fields.Many2one(
         comodel_name="account.analytic.account",
-        string="รหัสงบประมาณหน่วยงาน",
+        string="Department Budget Code",
         domain=[("root_plan_id.code", "=", "departments")],
     )
     is_locked = fields.Boolean(string="ห้ามแก้ไข")

--- a/kris_project/models/kris_project_exception.py
+++ b/kris_project/models/kris_project_exception.py
@@ -53,6 +53,11 @@ class KrisProject(models.Model):
         self.write({"state": "done", "ignore_exception": False})
 
     def action_cancel(self):
+        for rec in self:
+            if rec.state == "cancel":
+                raise UserError(
+                    _("This project is already cancelled.")
+                )
         if self.detect_exceptions() and not self.ignore_exception:
             return self.with_context(
                 kris_exception_action="action_cancel"

--- a/kris_project/models/kris_project_installment.py
+++ b/kris_project/models/kris_project_installment.py
@@ -2,6 +2,7 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -35,10 +36,13 @@ class KrisProjectInstallment(models.Model):
     state = fields.Selection(
         selection=[
             ("pending", "รอรับเงิน"),
+            ("partial", "รับบางส่วน"),
             ("received", "รับเงินแล้ว"),
         ],
         string="State",
-        default="pending",
+        compute="_compute_state",
+        store=True,
+        readonly=True,
     )
     deduction_guarantee = fields.Monetary(
         string="Guarantee Deduction",
@@ -72,6 +76,16 @@ class KrisProjectInstallment(models.Model):
         inverse_name="installment_id",
         string="Allocation",
     )
+    receipt_ids = fields.One2many(
+        comodel_name="kris.project.receipt",
+        inverse_name="installment_id",
+        string="Receipts",
+    )
+    received_total = fields.Monetary(
+        string="Received Total",
+        compute="_compute_state",
+        store=True,
+    )
     currency_id = fields.Many2one(
         comodel_name="res.currency",
         related="project_id.currency_id",
@@ -99,6 +113,19 @@ class KrisProjectInstallment(models.Model):
                 max_seq = max(project.installment_ids.mapped("sequence") or [0])
                 vals["sequence"] = max_seq + 10
         return super().create(vals_list)
+
+    @api.depends("amount", "receipt_ids.amount")
+    def _compute_state(self):
+        prec = self.env["decimal.precision"].precision_get("Account")
+        for rec in self:
+            total = sum(rec.receipt_ids.mapped("amount"))
+            rec.received_total = total
+            if float_compare(total, 0.0, precision_digits=prec) <= 0:
+                rec.state = "pending"
+            elif float_compare(total, rec.amount, precision_digits=prec) >= 0:
+                rec.state = "received"
+            else:
+                rec.state = "partial"
 
     @api.depends("amount", "deduction_guarantee", "deduction_advance")
     def _compute_received_from_employer(self):

--- a/kris_project/models/kris_project_receipt.py
+++ b/kris_project/models/kris_project_receipt.py
@@ -1,6 +1,7 @@
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -88,3 +89,19 @@ class KrisProjectReceipt(models.Model):
     def _compute_net_amount(self):
         for rec in self:
             rec.net_amount = rec.amount - rec.equipment_cost_in_installment
+
+    @api.constrains("extra_income", "project_id")
+    def _check_extra_income_total(self):
+        for rec in self:
+            project = rec.project_id
+            if not project:
+                continue
+            total_extra = sum(project.receipt_ids.mapped("extra_income"))
+            if total_extra > project.extra_value + 1e-9:
+                raise ValidationError(
+                    _(
+                        "ยอดค่า Extra ที่รับจริงรวมทุกใบ (%.2f บาท) "
+                        "เกินจากยอดค่า Extra โครงการ (%.2f บาท)"
+                    )
+                    % (total_extra, project.extra_value)
+                )

--- a/kris_project/models/kris_project_receipt_allocation.py
+++ b/kris_project/models/kris_project_receipt_allocation.py
@@ -1,4 +1,6 @@
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
 
 
 class KrisProjectReceiptAllocation(models.Model):
@@ -33,3 +35,21 @@ class KrisProjectReceiptAllocation(models.Model):
         related="receipt_id.currency_id",
         readonly=True,
     )
+
+    @api.constrains("amount", "allocation_line_id")
+    def _check_actual_not_exceed_estimated(self):
+        prec = self.env["decimal.precision"].precision_get("Account")
+        for alloc_line in self.mapped("allocation_line_id"):
+            actual = sum(alloc_line.receipt_allocation_ids.mapped("amount"))
+            if (
+                float_compare(
+                    actual, alloc_line.estimated_amount, precision_digits=prec
+                )
+                > 0
+            ):
+                raise ValidationError(
+                    _(
+                        "ยอดจัดสรรจริงของ %s (%.2f บาท) เกินประมาณการ (%.2f บาท)"
+                    )
+                    % (alloc_line.name or "", actual, alloc_line.estimated_amount)
+                )

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -53,6 +53,7 @@
                         <field name="due_date"/>
                         <field name="state" widget="badge"
                             decoration-info="state == 'pending'"
+                            decoration-warning="state == 'partial'"
                             decoration-success="state == 'received'"
                         />
                     </group>
@@ -372,8 +373,8 @@
                                     <field name="due_date"/>
                                     <field name="state" widget="badge"
                                         decoration-info="state == 'pending'"
+                                        decoration-warning="state == 'partial'"
                                         decoration-success="state == 'received'"
-                                        invisible="1"
                                     />
                                     <field name="currency_id" invisible="1"/>
                                 </tree>

--- a/kris_project/wizard/kris_project_receipt_wizard.py
+++ b/kris_project/wizard/kris_project_receipt_wizard.py
@@ -72,12 +72,13 @@ class KrisProjectReceiptWizard(models.TransientModel):
             ]
         return res
 
-    @api.depends("project_id", "project_id.receipt_ids.installment_id")
+    @api.depends("project_id", "project_id.installment_ids.state")
     def _compute_available_installment_ids(self):
         for wiz in self:
-            used_ids = wiz.project_id.receipt_ids.mapped("installment_id").ids
+            # Allow splitting a single installment across multiple receipts:
+            # only fully received installments are removed from the choices.
             available = wiz.project_id.installment_ids.filtered(
-                lambda i: i.id not in used_ids
+                lambda i: i.state != "received"
             )
             wiz.available_installment_ids = available
 


### PR DESCRIPTION
## Summary

จากการ review โมดูล `kris_project` พบช่องโหว่เชิง workflow และการคำนวณเงิน 5 จุดหลัก:

- **`installment.state` เป็น manual ล้วน** ไม่มีอะไร auto-set ทำให้ไม่สอดคล้องกับยอดที่รับจริง
- **รับเงินงวดเดียวแบบแบ่งจ่ายหลายครั้งไม่ได้** (wizard บังคับ 1 งวด:1 receipt)
- **ไม่มีการบล็อก over-allocation ต่อ allocator** สามารถจัดสรรเกิน estimated ได้
- **`receipt.extra_income` ลอย** เก็บค่าแต่ไม่ถูกรวม/ตรวจที่ไหนเลย
- **action หลายตัวขาด state guard ระดับ Python** กันแค่ view (เรียกผ่าน RPC ได้)

## Changes

### `kris_project_installment.py`
- เพิ่ม selection `("partial", "รับบางส่วน")` ใน state
- เปลี่ยน `state` เป็น `compute="_compute_state", store=True, readonly=True` — ห้ามแก้มือ
- เพิ่ม `receipt_ids` (One2many) และ `received_total` (Monetary, stored)
- `_compute_state` ใช้ `float_compare` เทียบยอด receipt สะสมกับ `amount` งวด

### `kris_project_receipt_wizard.py`
- `_compute_available_installment_ids` เปลี่ยนเป็นกรองออกเฉพาะงวด `state == 'received'` → รับแบบแบ่งจ่ายได้

### `kris_project_allocation.py`
- เพิ่ม constraint `_check_actual_not_exceed_estimated`: `actual_amount` ต่อ allocator ห้ามเกิน `estimated_amount`

### `kris_project_receipt_allocation.py`
- เพิ่ม constraint คู่กัน (fires เมื่อแก้ receipt allocation โดยตรง) เพื่อครอบทุกทางเข้า

### `kris_project_receipt.py`
- เพิ่ม constraint `_check_extra_income_total`: extra รับสะสมทุกใบห้ามเกิน `project.extra_value`

### `kris_project.py`
- เพิ่ม `total_extra_received` (Monetary, stored) — `sum(receipt_ids.extra_income)`
- เพิ่ม `receipt_ids.extra_income` ใน `@api.depends` ของ `_compute_totals`
- `action_add_receipt`: guard ห้ามตอน `done`/`cancel`
- `action_add_installment`: guard ต้อง `can_edit` (draft)
- `action_apply_allocation_template`: guard ต้อง `can_edit` (draft)

### `kris_project_exception.py`
- `action_cancel`: guard ห้ามกดซ้ำตอน `state == cancel` แล้ว

### `kris_project_views.xml`
- เพิ่ม `decoration-warning="state == 'partial'"` ทั้งในฟอร์มงวดและ tree ในแท็บของโครงการ
- เปิดให้คอลัมน์ state ในแท็บงวดแสดงผล (เดิม `invisible="1"`)

## Test plan

- [ ] อัปเกรดโมดูล `kris_project` (stored computed จะ recompute ให้ระเบียนเดิมอัตโนมัติ)
- [ ] สร้างโครงการ → งวด amount=100,000 → confirm → เพิ่ม receipt 40,000 ผูกงวด ⇒ งวดเป็น `partial` (badge สีส้ม)
- [ ] เพิ่ม receipt อีก 60,000 งวดเดิม ⇒ งวดเป็น `received`; ลบ receipt ⇒ ถอยกลับ `partial`/`pending` เอง
- [ ] ใน wizard เลือกงวด partial ได้, งวด received ไม่ปรากฏในตัวเลือก
- [ ] จัดสรร allocator เกิน estimated ⇒ ValidationError
- [ ] receipt extra_income รวมเกิน project.extra_value ⇒ ValidationError
- [ ] เรียก action_apply_allocation_template ตอน state=in_progress ผ่าน RPC ⇒ UserError
- [ ] Regression: confirm/done/cancel/exception popup ทำงานปกติ, dashboard โหลดได้