### PR TITLE
[16.0][IMP] procurement_plan: reserve budget on appropriation; PR from plan

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -8,3 +8,9 @@ This map is seeded lazily — modules are listed here as they get a `CONTEXT.md`
 
 - [KRIS Project](./kris_project/CONTEXT.md) — revenue tracking for projects run under the KRIS unit (operating unit `99`); external academic-service and research work channelled through KRIS.
 - [Budget](./budget/CONTEXT.md) — appropriation, reservation and disbursement tracking; appropriated pool (`budget.move`) consumed through a reserve→obligate→consume commitment pipeline (`budget.commitment`).
+- [Procurement Plan](./procurement_plan/CONTEXT.md) — annual procurement planning; each plan is created from an appropriation, reserves its budget at that moment, and is realised through one purchase request + installment disbursements.
+
+## Relationships
+
+- **Budget → Procurement Plan**: posting a `budget.appropriation` line creates a `procurement.plan` and reserves its `budget.commitment` for the full amount (ADR-0005).
+- **Procurement Plan → Budget**: the plan's single purchase request and its installment disbursement requests draw that one shared commitment down (obligate+consume per งวด) (ADR-0004, ADR-0006).

--- a/budget/CONTEXT.md
+++ b/budget/CONTEXT.md
@@ -51,7 +51,7 @@ The per-commitment cap (`commitment.amount`) — the amount a request was approv
 _Avoid_: budget, reserved amount
 
 **Reserve (จองงบ)**:
-Earmarking pool against a commitment the moment it is approved (e.g. a procurement plan reserves its full amount at once). A `reserve` ledger line.
+Earmarking pool against a commitment. For a procurement plan this fires the moment its source budget **appropriation is posted** — the plan reserves its full `total_price` at once (not when the plan is later made *ready*; see ADR-0005). A `reserve` ledger line.
 _Avoid_: allocate, commit
 
 **Obligate (ผูกพัน)**:
@@ -63,5 +63,5 @@ The actual disbursement — money leaves the pool for good. A `consume` ledger l
 _Avoid_: spend, pay, disburse (pick "consume" in code, "เบิกจ่าย" in UI)
 
 **Reserved (b) / Obligated (c) / Disbursed (d) / Used (e) / Remaining (f)**:
-The disbursement waterfall for an account: `b` = reserved-but-not-yet-obligated (`total_reserved − total_obligated`); `c` = obligated-but-not-yet-disbursed (`total_obligated − total_consumed`); `d` = disbursed (`total_consumed`); `e` = total locked = `b + c + d = total_reserved`; `f` = `Current Budget (a) − e`. When obligate and consume fire together (PO), `c` stays ~0; when separated in time (procurement instalments), `c` carries the standing obligation.
+The disbursement waterfall for an account: `b` = reserved-but-not-yet-obligated (`total_reserved − total_obligated`); `c` = obligated-but-not-yet-disbursed (`total_obligated − total_consumed`); `d` = disbursed (`total_consumed`); `e` = total locked = `b + c + d = total_reserved`; `f` = `Current Budget (a) − e`. Both KMITL flows fire obligate and consume **together** — the PO flow, and the procurement-plan flow (per งวด at each disbursement request) — so `c` stays ~0 in practice. The not-yet-disbursed remainder of a reserved procurement plan therefore sits in `b` (reserved-but-not-obligated), **not** `c`. `c` only carries a standing balance if some flow posts an obligate without an immediate matching consume (a capability the ledger supports but no current flow uses).
 _Avoid_: spent (ambiguous between c, d, e)

--- a/budget/docs/adr/0001-obligate-consume-separate-primitives.md
+++ b/budget/docs/adr/0001-obligate-consume-separate-primitives.md
@@ -1,10 +1,12 @@
 # Obligate and consume are separate ledger primitives
 
-`budget.commitment` records reserve / obligate / consume as separate `budget.commitment.line` entries (`move_type`), and **obligate and consume are independent primitives applied at different times**. This supports the procurement-plan flow: a plan is reserved in full on approval, then obligated per installment (งวดงาน, at contract signing) and consumed later (actual payment/posting).
+`budget.commitment` records reserve / obligate / consume as separate `budget.commitment.line` entries (`move_type`). The ledger **supports** posting obligate and consume independently at different times — but that is a capability, not how the current flows behave.
 
-The PO / disbursement flow deliberately fires obligate + consume together in one step. That is why the dashboard's **"ผูกพัน (c)" column is ~0 for PO-driven commitments** while it carries a real standing balance for procurement plans — both paths call the same two primitives, they just time them differently.
+In practice **both** KMITL flows fire obligate + consume **together** in one step: the PO / disbursement flow, and the procurement-plan flow (which obligates+consumes per งวด at each disbursement request — see the clarification below). That is why the dashboard's **"ผูกพัน (c)" column is ~0** for both — both call the same two primitives at the same moment.
+
+> **Clarification (2026-06, per direct user requirement):** the procurement-plan disbursement does obligate **and** consume together, equal to the submitted amount (ส่งเบิกเท่าไร ผูกพัน+ตัดงบเท่านั้น). It does **not** obligate-at-contract and consume-later. So `(c)` is ~0 for procurement plans too; the not-yet-disbursed remainder of a reserved plan sits in `(b)` reserved.
 
 ## Consequences
 
-- `(c)` being 0 for a PO-driven commitment is expected, not a bug.
-- Splitting the disbursement flow so obligate (contract) and consume (payment) can occur at different times is a Phase 2 change; the primitive split lands first.
+- `(c)` being ~0 is expected for **both** PO-driven and procurement-plan commitments, not a bug.
+- Splitting obligate (at ส่งเบิก/submit) from consume (at approve) was considered for the procurement-plan flow but **rejected per user requirement**: budget is obligated+consumed together at the disbursement request.

--- a/budget/docs/adr/0004-procurement-plan-shared-commitment.md
+++ b/budget/docs/adr/0004-procurement-plan-shared-commitment.md
@@ -1,12 +1,14 @@
 # Procurement plan owns a shared commitment drawn down by downstream documents
 
+> **Superseded in part by [ADR-0005](./0005-reserve-on-appropriation-posting.md):** the reserve no longer fires when the plan is made *ready*, but when the plan's source budget **appropriation is posted**. Everything else below — the shared commitment, per-DR draw-down, release and cancellation rules — still holds.
+
 When a `procurement.plan` is made **ready** it reserves ONE `budget.commitment` for its full `total_price`, linked via `procurement_plan_id`. Downstream plan-driven PR → PO → DR **draw this single commitment down** (obligate + consume) rather than each reserving its own — which is what prevents double-reservation (a plan reserving *and* its PR reserving would lock the same money twice).
 
-Discriminator: a PR with `use_procurement_plan` links `plan.budget_commitment_ids` instead of calling `_create_budget_commitment`; a PR/approval **without** a plan keeps its own per-document commitment (unchanged).
+Discriminator: a PR with `use_procurement_plan` links `plan.budget_commitment_ids` instead of calling `_create_budget_commitment`; a PR/approval **without** a plan keeps its own per-document commitment (unchanged). → **superseded by [ADR-0006](./0006-plan-driven-pr-created-from-plan.md)**: the link is now the create-from-plan action, not the `use_procurement_plan` flag.
 
 ## Consequences
 
-- **Reserve timing:** on `ready`; blocks on insufficient budget unless `budget.allow_negative` is set.
+- **Reserve timing:** ~~on `ready`~~ — **superseded by ADR-0005**: fires when the source appropriation is posted. Still blocks on insufficient budget unless `budget.allow_negative` is set.
 - **Release:** on `on_hold` / `reset_to_draft` the plan cancels its commitment **only while untouched**; if any obligate/consume draw exists, the commitment is kept and a note is posted (never strand in-flight spend).
 - **Cancellation:** cancelling one downstream DR reverses **only its own** obligate/consume lines — attributed via `res_model`/`res_id` stamped on the lines (`disbursement.request`) — leaving the shared reservation open for sibling DRs. Full-commitment cancel is kept only for sole-owner, non-plan commitments (D4). This relies on the Phase 1 fix that keeps reversals postable after a commitment auto-reaches `done`.
 

--- a/budget/docs/adr/0005-reserve-on-appropriation-posting.md
+++ b/budget/docs/adr/0005-reserve-on-appropriation-posting.md
@@ -1,0 +1,17 @@
+# Reserve fires when the budget appropriation is posted, not when the plan is made ready
+
+A `procurement.plan` reserves its full `total_price` against a `budget.commitment` the moment its source `budget.appropriation` is **posted** (`action_post`) — not when the plan is later moved to `ready`. The reservation is created in the appropriation's `action_post` override **after** `super()` has posted the appropriation move, so the pool is appropriated (and therefore available) before it is locked. `_reserve_plan_commitment` stays idempotent, so the (now operational-only) `ready` step never double-reserves.
+
+The plan's `ready` step — gated on the five ETA fields + procurement method — no longer touches the ledger. Its sole remaining job is to be the **operational gate that unlocks creating the plan's purchase request**.
+
+Supersedes the *"Reserve timing: on `ready`"* consequence of [ADR-0004](./0004-procurement-plan-shared-commitment.md). The shared-commitment, per-DR draw-down, release and cancellation decisions in ADR-0004 still stand.
+
+## Why
+
+- Thai practice: once budget is appropriated/approved the money is earmarked **immediately**; a plan must never sit appropriated-but-unreserved.
+- Decouples money (reserved at allocation) from operations (ETA readiness), so the ETA gate can govern PR creation without doing double duty as the reservation trigger.
+
+## Consequences
+
+- Reserve still blocks on insufficient budget unless `budget.allow_negative` is set.
+- Reservation must run *after* the appropriation move is posted; reserving inside `budget_move_line_vals` (before the move posts) would fail the availability check because the pool is not yet appropriated.

--- a/budget/docs/adr/0005-reserve-on-appropriation-posting.md
+++ b/budget/docs/adr/0005-reserve-on-appropriation-posting.md
@@ -2,7 +2,7 @@
 
 A `procurement.plan` reserves its full `total_price` against a `budget.commitment` the moment its source `budget.appropriation` is **posted** (`action_post`) — not when the plan is later moved to `ready`. The reservation is created in the appropriation's `action_post` override **after** `super()` has posted the appropriation move, so the pool is appropriated (and therefore available) before it is locked. `_reserve_plan_commitment` stays idempotent, so the (now operational-only) `ready` step never double-reserves.
 
-The plan's `ready` step — gated on the five ETA fields + procurement method — no longer touches the ledger. Its sole remaining job is to be the **operational gate that unlocks creating the plan's purchase request**.
+The plan's `ready` step — gated on the five ETA fields + procurement method — no longer *creates* the reservation. It keeps an idempotent `_reserve_plan_commitment()` call only as a backward-compatible safety net (a no-op once the plan already holds a commitment, covering plans whose appropriation was posted before this change). Its real job is now to be the **operational gate that unlocks creating the plan's purchase request**.
 
 Supersedes the *"Reserve timing: on `ready`"* consequence of [ADR-0004](./0004-procurement-plan-shared-commitment.md). The shared-commitment, per-DR draw-down, release and cancellation decisions in ADR-0004 still stand.
 

--- a/budget/docs/adr/0006-plan-driven-pr-created-from-plan.md
+++ b/budget/docs/adr/0006-plan-driven-pr-created-from-plan.md
@@ -1,0 +1,19 @@
+# Plan-driven purchase requests are created from the plan, one active at a time
+
+A purchase request that spends a procurement plan is **created from the plan** (a "สร้าง PR" action on `procurement.plan`), not by ticking `use_procurement_plan` and picking a plan on the PR form. The action prefills budget account, analytic distribution, fiscal year, procurement method and title, links the plan's **existing** `budget.commitment`, and moves the plan to `in_progress`. A plan allows **at most one active PR** (state ≠ `rejected`); if that PR is rejected the plan returns to `ready` so a new one can be created.
+
+The "สร้าง PR" button shows while the plan is `new` or `ready` (and has no active PR); pressing it on a `new` plan raises a `UserError` telling the officer to complete the ETA fields and press *Ready* first — the ETA gate.
+
+Supersedes the discriminator in [ADR-0004](./0004-procurement-plan-shared-commitment.md): the link is no longer the `use_procurement_plan` flag on the PR but the create-from-plan action. The shared-commitment draw-down model itself is unchanged.
+
+## Why
+
+- One plan = one procurement = one PR. The in-form selector let many PRs point at one plan, and let users pick a plan that was not yet reserved (the dropdown filtered `state='new'` while the commitment only existed from `ready` — a live inconsistency).
+- Creating from the plan guarantees the PR is backed by an existing reservation and carries the plan's dimensions, letting us drop the onchange prefill.
+
+## Consequences
+
+- `use_procurement_plan`, the in-form `procurement_plan_id` selector and `_onchange_procurement_plan_id` are removed.
+- Budget fields (budget account + analytic dimensions) stay **read-only** on a plan-driven PR so they cannot diverge from the plan; the existing `is_budget_editable=False` lock is kept, re-keyed from `use_procurement_plan` to `procurement_plan_id`.
+- Plan-driven PRs do not call `action_reserve_budget` (they never reserve — see the terminology note in `procurement_plan/CONTEXT.md`); non-plan PRs keep their own per-document reserve flow unchanged.
+- A rejected PR must bounce the plan `in_progress → ready`; full consumption auto-closes the plan to `done`.

--- a/budget/docs/adr/0006-plan-driven-pr-created-from-plan.md
+++ b/budget/docs/adr/0006-plan-driven-pr-created-from-plan.md
@@ -4,16 +4,17 @@ A purchase request that spends a procurement plan is **created from the plan** (
 
 The "สร้าง PR" button shows while the plan is `new` or `ready` (and has no active PR); pressing it on a `new` plan raises a `UserError` telling the officer to complete the ETA fields and press *Ready* first — the ETA gate.
 
-Supersedes the discriminator in [ADR-0004](./0004-procurement-plan-shared-commitment.md): the link is no longer the `use_procurement_plan` flag on the PR but the create-from-plan action. The shared-commitment draw-down model itself is unchanged.
+Refines the discriminator in [ADR-0004](./0004-procurement-plan-shared-commitment.md): the `use_procurement_plan` flag is **kept** as the internal discriminator — the purchase order, the make-PO wizard, the `purchase.request.approval` model and the over-budget exception rule all read it — but the user can no longer set it. The in-form checkbox + plan dropdown are removed; the flag and `procurement_plan_id` are populated only by the create-from-plan action. The shared-commitment draw-down model itself is unchanged.
 
 ## Why
 
 - One plan = one procurement = one PR. The in-form selector let many PRs point at one plan, and let users pick a plan that was not yet reserved (the dropdown filtered `state='new'` while the commitment only existed from `ready` — a live inconsistency).
-- Creating from the plan guarantees the PR is backed by an existing reservation and carries the plan's dimensions, letting us drop the onchange prefill.
+- Creating from the plan guarantees the PR is backed by an existing reservation and carries the plan's dimensions; the existing prefill onchange now fires from the create-from-plan context defaults instead of a manual toggle.
 
 ## Consequences
 
-- `use_procurement_plan`, the in-form `procurement_plan_id` selector and `_onchange_procurement_plan_id` are removed.
-- Budget fields (budget account + analytic dimensions) stay **read-only** on a plan-driven PR so they cannot diverge from the plan; the existing `is_budget_editable=False` lock is kept, re-keyed from `use_procurement_plan` to `procurement_plan_id`.
-- Plan-driven PRs do not call `action_reserve_budget` (they never reserve — see the terminology note in `procurement_plan/CONTEXT.md`); non-plan PRs keep their own per-document reserve flow unchanged.
-- A rejected PR must bounce the plan `in_progress → ready`; full consumption auto-closes the plan to `done`.
+- The in-form selector is removed: the `use_procurement_plan` checkbox and the `procurement_plan_id` dropdown no longer appear on the PR form. Both fields stay on the form as invisible so the prefill onchange still fires from the create-from-plan context defaults.
+- `use_procurement_plan` is **retained** as the cross-module discriminator (purchase order, make-PO wizard, `purchase.request.approval`, over-budget exception rule), set automatically by the create-from-plan action.
+- Budget fields (budget account + analytic dimensions) stay **read-only** on a plan-driven PR via the existing `is_budget_editable=False` lock (keyed on `use_procurement_plan`), unchanged.
+- Plan-driven PRs reuse `action_reserve_budget` only to advance `to_verify → to_approve`; its plan branch links the existing reservation and never creates a second commitment (see the terminology note in `procurement_plan/CONTEXT.md`).
+- A rejected plan PR detaches from (never cancels) the shared reservation and bounces the plan `in_progress → ready`; full consumption auto-closes the plan to `done`.

--- a/procurement_plan/CONTEXT.md
+++ b/procurement_plan/CONTEXT.md
@@ -1,0 +1,25 @@
+# Procurement Plan
+
+Annual procurement planning (แผนจัดซื้อจัดจ้าง) for KMITL. A plan is born from an approved budget appropriation, reserves its full amount against the budget pipeline at that moment, and is realised through exactly one purchase request and a series of installment disbursements.
+
+## Language
+
+**Procurement Plan (แผนจัดซื้อจัดจ้าง)**:
+A single planned procurement, created when a `budget.appropriation` line is posted. Owns one `budget.commitment` (its reservation) and at most one *active* purchase request. Carries the financial dimensions via `analytic_distribution`.
+_Avoid_: purchase plan, procurement request
+
+**Installment (งวดงาน, `procurement.plan.payment`)**:
+A planned disbursement tranche of a plan. Actual budget consumption happens งวด-by-งวด through disbursement requests; the installment rows are the *plan*, not the ledger.
+_Avoid_: payment, period
+
+**Reserve (จองงบ)**:
+The plan's full-amount earmark, created the moment its source appropriation is posted — i.e. when the plan reaches state `new`. The single act of จองงบ; nothing downstream reserves again. See [budget » Reserve](../budget/CONTEXT.md).
+_Avoid_: allocate
+
+**Ready (the ETA gate)**:
+The operational checkpoint — all five ETA fields + procurement method filled — that **unlocks creating the plan's purchase request**. It does not touch budget (the reserve already happened at `new`).
+_Avoid_: confirmed, approved
+
+**Reserve Budget (the PR `action_reserve_budget` button)**:
+A misnomer for plan-driven PRs: it does **not** จองงบ. The reservation already exists on the plan; a plan-driven PR only *links* it. Reserving (จองงบ) is exclusively the appropriation→`new` event.
+_Avoid_: using "reserve budget" to mean จองงบ for plan-driven PRs

--- a/procurement_plan/__manifest__.py
+++ b/procurement_plan/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Procurement Plan",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",

--- a/procurement_plan/controllers/main.py
+++ b/procurement_plan/controllers/main.py
@@ -8,7 +8,7 @@ class ProcurementPlanDashboardController(http.Controller):
     STATE_LABELS = {
         "draft": "ฉบับร่าง",
         "new": "ยังไม่เริ่ม",
-        "on_hold": "รอดำเนินการ",
+        "on_hold": "ชะลอโครงการ",
         "in_progress": "กำลังดำเนินการ",
         "done": "เสร็จสิ้น",
         "cancel": "ยกเลิก",

--- a/procurement_plan/i18n/th.po
+++ b/procurement_plan/i18n/th.po
@@ -432,7 +432,7 @@ msgstr "ตุลาคม"
 #. module: procurement_plan
 #: model:ir.model.fields.selection,name:procurement_plan.selection__procurement_plan__state__on_hold
 msgid "On Hold"
-msgstr ""
+msgstr "ชะลอโครงการ"
 
 #. module: procurement_plan
 #: model:ir.model.fields,field_description:procurement_plan.field_procurement_plan__payment_ids
@@ -509,7 +509,7 @@ msgstr "จัดทำ พ.1"
 #. module: procurement_plan
 #: model:ir.model.fields.selection,name:procurement_plan.selection__procurement_plan__state__ready model_terms:ir.ui.view,arch_db:procurement_plan.view_procurement_plan_form
 msgid "Ready"
-msgstr "ยังไม่ดำเนินการ"
+msgstr "รอดำเนินการ"
 
 #. module: procurement_plan
 #. odoo-python

--- a/procurement_plan/models/budget_commitment.py
+++ b/procurement_plan/models/budget_commitment.py
@@ -22,6 +22,18 @@ class BudgetCommitment(models.Model):
         states=READONLY_STATES,
     )
 
+    def _sync_state(self):
+        """When a plan's commitment is fully consumed it reaches ``done``;
+        propagate that to the owning procurement plan so it auto-closes once
+        every installment has been disbursed (ADR-0005 / done-when-consumed)."""
+        super()._sync_state()
+        for commitment in self.filtered(
+            lambda c: c.state == "done" and c.procurement_plan_id
+        ):
+            plan = commitment.procurement_plan_id
+            if plan.state == "in_progress":
+                plan.action_done()
+
     def action_view_procurement_plan(self):
         self.ensure_one()
         if not self.procurement_plan_id:

--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -275,7 +275,7 @@ class ProcurementPlan(models.Model):
             return
         if not self.budget_account_id:
             raise UserError(
-                _("กรุณาระบุรหัสงบประมาณก่อนตั้งสถานะพร้อมดำเนินการ")
+                _("กรุณาระบุรหัสงบประมาณก่อนตั้งสถานะรอดำเนินการ")
             )
         if self.total_price <= 0:
             raise UserError(

--- a/procurement_plan/views/procurement_plan_views.xml
+++ b/procurement_plan/views/procurement_plan_views.xml
@@ -13,6 +13,11 @@
                 <field name="amount" optional="hide" />
                 <field name="unit" optional="hide" />
                 <field name="total_price" sum="รวมทั้งหมด" widget="monetary" />
+                <field name="budget_account_id" optional="hide" />
+                <field name="department_analytic_id" optional="show" />
+                <field name="source_analytic_id" optional="show" />
+                <field name="fund_analytic_id" optional="hide" />
+                <field name="activity_analytic_id" optional="hide" />
                 <field name="procurement_method_id" optional="show" />
                 <field name="state" widget="badge" decoration-info="state == 'in_progress'" decoration-success="state == 'done'" decoration-warning="state in ('new', 'on_hold')" decoration-muted="state == 'draft'" />
             </tree>
@@ -121,16 +126,28 @@
         <field name="arch" type="xml">
             <search>
                 <field name="name" filter_domain="['|', ('name','ilike',self), ('description','ilike',self)]" />
+                <field name="budget_account_id" />
+                <field name="department_analytic_id" />
+                <field name="source_analytic_id" />
+                <field name="fund_analytic_id" />
+                <field name="activity_analytic_id" />
+                <field name="procurement_method_id" />
                 <separator/>
                 <filter name="current_fy" string="ปีงบประมาณปัจจุบัน" domain="[('account_fiscal_year_id.date_from', '&lt;=', context_today()), ('account_fiscal_year_id.date_to', '&gt;=', context_today())]" />
                 <separator/>
                 <group expand="1" string="Group By">
                     <filter string="ปีงบประมาณ" name="group_by_fiscal_year" context="{'group_by': 'account_fiscal_year_id'}" />
+                    <filter string="ส่วนงาน" name="group_by_department" context="{'group_by': 'department_analytic_id'}" />
+                    <filter string="แหล่งเงิน" name="group_by_source" context="{'group_by': 'source_analytic_id'}" />
+                    <filter string="กองทุน" name="group_by_fund" context="{'group_by': 'fund_analytic_id'}" />
+                    <filter string="กิจกรรม" name="group_by_activity" context="{'group_by': 'activity_analytic_id'}" />
+                    <filter string="รหัสงบประมาณ" name="group_by_budget_account" context="{'group_by': 'budget_account_id'}" />
                     <filter string="วิธีการจัดซื้อจัดจ้าง" name="group_by_procurement_method" context="{'group_by': 'procurement_method_id'}" />
                     <filter string="สถานะ" name="group_by_state" context="{'group_by': 'state'}" />
                 </group>
                 <searchpanel>
                     <field name="state" icon="fa-calendar" select="multi" enable_counters="1" />
+                    <field name="department_analytic_id" icon="fa-sitemap" select="multi" />
                     <field name="source_analytic_id" icon="fa-money" select="multi" />
                     <field name="fund_analytic_id" icon="fa-university" select="multi" />
                     <field name="procurement_method_id" icon="fa-calendar" select="multi" />

--- a/procurement_plan/views/procurement_plan_views.xml
+++ b/procurement_plan/views/procurement_plan_views.xml
@@ -6,7 +6,7 @@
         <field name="name">view.procurement.plan.tree</field>
         <field name="model">procurement.plan</field>
         <field name="arch" type="xml">
-            <tree decoration-info="state == 'in_progress'" decoration-success="state == 'done'" decoration-warning="state in ('new', 'on_hold')" decoration-muted="state == 'draft'">
+            <tree create="false" decoration-info="state == 'in_progress'" decoration-success="state == 'done'" decoration-warning="state in ('new', 'on_hold')" decoration-muted="state == 'draft'">
                 <field name="account_fiscal_year_id" />
                 <field name="name" />
                 <field name="description" />
@@ -29,7 +29,7 @@
         <field name="name">view.procurement.plan.form</field>
         <field name="model">procurement.plan</field>
         <field name="arch" type="xml">
-            <form string="Procurement Plan">
+            <form string="Procurement Plan" create="false">
                 <header>
                     <field name="state" widget="statusbar" statusbar_visible="draft,new,ready,in_progress,done" />
                     <button name="action_ready" string="Ready" type="object" class="btn-primary" states="new" />

--- a/procurement_plan/views/procurement_plan_views.xml
+++ b/procurement_plan/views/procurement_plan_views.xml
@@ -133,6 +133,7 @@
                 <field name="activity_analytic_id" />
                 <field name="procurement_method_id" />
                 <separator/>
+                <filter name="hide_draft_cancel" string="ซ่อนร่าง/ยกเลิก" domain="[('state', 'not in', ('draft', 'cancel'))]" />
                 <filter name="current_fy" string="ปีงบประมาณปัจจุบัน" domain="[('account_fiscal_year_id.date_from', '&lt;=', context_today()), ('account_fiscal_year_id.date_to', '&gt;=', context_today())]" />
                 <separator/>
                 <group expand="1" string="Group By">
@@ -146,6 +147,7 @@
                     <filter string="สถานะ" name="group_by_state" context="{'group_by': 'state'}" />
                 </group>
                 <searchpanel>
+                    <field name="account_fiscal_year_id" icon="fa-calendar" select="multi" enable_counters="1" />
                     <field name="state" icon="fa-calendar" select="multi" enable_counters="1" />
                     <field name="department_analytic_id" icon="fa-sitemap" select="multi" />
                     <field name="source_analytic_id" icon="fa-money" select="multi" />
@@ -162,8 +164,8 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">procurement.plan</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('state', '!=', 'cancel')]</field>
-        <field name="context">{}</field>
+        <field name="domain">[]</field>
+        <field name="context">{'search_default_hide_draft_cancel': 1}</field>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
                 There is no examples click here to add new Procurement Plan.

--- a/procurement_plan_budget/__manifest__.py
+++ b/procurement_plan_budget/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Procurement Plan Budget Appropriation",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",

--- a/procurement_plan_budget/models/budget_appropriation.py
+++ b/procurement_plan_budget/models/budget_appropriation.py
@@ -28,7 +28,17 @@ class BudgetAppropriation(models.Model):
 
     def action_post(self):
         super().action_post()
+        self._reserve_procurement_plans()
         self._log_message_on_linked_documents()
+
+    def _reserve_procurement_plans(self):
+        """Reserve each created procurement plan's budget the moment the
+        appropriation is posted (ADR-0005). super().action_post() has already
+        posted the appropriation move, so the pool is available to lock.
+        ``_reserve_plan_commitment`` is idempotent and skips plans that already
+        hold an active commitment."""
+        for line in self.line_ids.filtered(lambda l: l.procurement_plan_id):
+            line.procurement_plan_id._reserve_plan_commitment()
 
     def _log_message_on_linked_documents(self):
         procurement_lines = self.line_ids.filtered(lambda l: l.procurement_plan_id)

--- a/procurement_plan_budget/models/budget_appropriation_line.py
+++ b/procurement_plan_budget/models/budget_appropriation_line.py
@@ -21,6 +21,20 @@ class BudgetAppropriationLine(models.Model):
     procurement_plan_id = fields.Many2one(comodel_name="procurement.plan")
 
     def _prepare_procurement_plan_vals(self):
+        # The line's own analytic_distribution holds at most the line-level
+        # dimensions; department/source live on the appropriation header (related
+        # fields) and never sync into it. Build the full 4D distribution from the
+        # convenience fields so the plan — and its reservation — carry every
+        # dimension, not just activity/fund.
+        distribution = dict(self.analytic_distribution or {})
+        for dimension in (
+            self.department_analytic_id,
+            self.source_analytic_id,
+            self.activity_analytic_id,
+            self.fund_analytic_id,
+        ):
+            if dimension:
+                distribution[str(dimension.id)] = 100
         return {
             "account_fiscal_year_id": self.account_fiscal_year_id.id,
             "description": self.description,
@@ -29,7 +43,7 @@ class BudgetAppropriationLine(models.Model):
             "total_price": self.balance,
             "user_id": self.appropriation_id.user_id.id,
             "budget_account_id": self.account_id.id,
-            "analytic_distribution": self.analytic_distribution,
+            "analytic_distribution": distribution or False,
         }
 
     def _create_procurement_plan(self):

--- a/procurement_plan_budget/models/budget_appropriation_line.py
+++ b/procurement_plan_budget/models/budget_appropriation_line.py
@@ -48,7 +48,10 @@ class BudgetAppropriationLine(models.Model):
             procurement_plan_id = self._create_procurement_plan()
             account_id = procurement_plan_id.analytic_account_id
 
-            distribution = vals['analytic_distribution']
+            # analytic_distribution may be empty/False when the line carries no
+            # dimensions; start from a fresh dict so item assignment never hits a
+            # bool, and copy to avoid mutating the source field value.
+            distribution = dict(vals.get('analytic_distribution') or {})
             distribution[str(account_id.id)] = 100
             vals['analytic_distribution'] = distribution
             vals['procurement_plan_id'] = procurement_plan_id.id

--- a/procurement_plan_portal/__manifest__.py
+++ b/procurement_plan_portal/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Procurement Plan Portal",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "",
     "website": "",
     "category": "",

--- a/procurement_plan_portal/controllers/main.py
+++ b/procurement_plan_portal/controllers/main.py
@@ -260,8 +260,8 @@ class ProcurementPlanPortal(http.Controller):
         # State label map
         state_labels = {
             "new": "ยังไม่เริ่ม",
-            "on_hold": "รอดำเนินการ",
-            "ready": "พร้อม",
+            "on_hold": "ชะลอโครงการ",
+            "ready": "รอดำเนินการ",
             "in_progress": "กำลังดำเนินการ",
             "done": "เสร็จสิ้น",
             "cancel": "ยกเลิก",

--- a/procurement_plan_portal/views/templates.xml
+++ b/procurement_plan_portal/views/templates.xml
@@ -222,10 +222,10 @@
                                                     <span class="badge text-bg-secondary">ยังไม่เริ่ม</span>
                                                 </t>
                                                 <t t-elif="plan.state == 'on_hold'">
-                                                    <span class="badge text-bg-warning">รอดำเนินการ</span>
+                                                    <span class="badge text-bg-warning">ชะลอโครงการ</span>
                                                 </t>
                                                 <t t-elif="plan.state == 'ready'">
-                                                    <span class="badge text-bg-info">พร้อม</span>
+                                                    <span class="badge text-bg-info">รอดำเนินการ</span>
                                                 </t>
                                                 <t t-elif="plan.state == 'in_progress'">
                                                     <span class="badge text-bg-primary">กำลังดำเนินการ</span>
@@ -371,8 +371,8 @@
                                 <div class="btn-group" role="group" aria-label="สถานะการดำเนินงาน">
                                     <label t-attf-class="btn #{'btn-secondary' if plan.state == 'draft' else 'btn-outline-secondary'}">แบบร่าง</label>
                                     <label t-attf-class="btn #{'btn-secondary' if plan.state == 'new' else 'btn-outline-secondary'}">ยังไม่เริ่ม</label>
-                                    <label t-attf-class="btn #{'btn-warning' if plan.state == 'on_hold' else 'btn-outline-secondary'}">รอดำเนินการ</label>
-                                    <label t-attf-class="btn #{'btn-info' if plan.state == 'ready' else 'btn-outline-secondary'}">พร้อม</label>
+                                    <label t-attf-class="btn #{'btn-warning' if plan.state == 'on_hold' else 'btn-outline-secondary'}">ชะลอโครงการ</label>
+                                    <label t-attf-class="btn #{'btn-info' if plan.state == 'ready' else 'btn-outline-secondary'}">รอดำเนินการ</label>
                                     <label t-attf-class="btn #{'btn-primary' if plan.state == 'in_progress' else 'btn-outline-secondary'}">กำลังดำเนินการ</label>
                                     <label t-attf-class="btn #{'btn-success' if plan.state == 'done' else 'btn-outline-secondary'}">เสร็จสิ้น</label>
                                     <label t-attf-class="btn #{'btn-danger' if plan.state == 'cancel' else 'btn-outline-secondary'}">ยกเลิก</label>

--- a/purchase_request_budget_procurement/__manifest__.py
+++ b/purchase_request_budget_procurement/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Purchase Request Budget Procurement",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.1.0",
     "category": "KMITL",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/purchase_request_budget_procurement/models/purchase_request.py
+++ b/purchase_request_budget_procurement/models/purchase_request.py
@@ -125,7 +125,7 @@ class PurchaseRequest(models.Model):
                 raise UserError(
                     _(
                         "แผนจัดซื้อจัดจ้างยังไม่ได้จองงบประมาณ "
-                        "(แผนต้องอยู่สถานะพร้อมดำเนินการ)"
+                        "(แผนต้องอยู่สถานะรอดำเนินการ)"
                     )
                 )
             self.budget_commitment_id = commitment.id
@@ -209,7 +209,7 @@ class PurchaseRequest(models.Model):
             return
         plan.write({"state": "ready"})
         plan.message_post(
-            body=_("ใบขอซื้อ %s ถูกปฏิเสธ แผนกลับสู่สถานะพร้อมดำเนินการ")
+            body=_("ใบขอซื้อ %s ถูกปฏิเสธ แผนกลับสู่สถานะรอดำเนินการ")
             % self.display_name
         )
 
@@ -269,12 +269,12 @@ class ProcurementPlan(models.Model):
             raise UserError(
                 _(
                     "กรุณากรอกแผนการดำเนินงาน (ETA) ให้ครบ แล้วกด "
-                    "'พร้อมดำเนินการ' ก่อนสร้างใบขอซื้อ"
+                    "'รอดำเนินการ' ก่อนสร้างใบขอซื้อ"
                 )
             )
         if self.state != "ready":
             raise UserError(
-                _("สร้างใบขอซื้อได้เฉพาะแผนที่อยู่สถานะพร้อมดำเนินการเท่านั้น")
+                _("สร้างใบขอซื้อได้เฉพาะแผนที่อยู่สถานะรอดำเนินการเท่านั้น")
             )
         if self.purchase_request_ids.filtered(lambda r: r.state != "rejected"):
             raise UserError(

--- a/purchase_request_budget_procurement/models/purchase_request.py
+++ b/purchase_request_budget_procurement/models/purchase_request.py
@@ -152,6 +152,67 @@ class PurchaseRequest(models.Model):
             return True
         return super()._cancel_budget_commitment()
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record in records.filtered(lambda r: r.procurement_plan_id):
+            record._link_to_procurement_plan()
+        return records
+
+    def _link_to_procurement_plan(self):
+        """A plan-driven PR (created from the plan, ADR-0006) enforces one active
+        PR per plan, links the plan's already-reserved shared commitment, and
+        starts the plan. Reservation itself happened at appropriation post."""
+        self.ensure_one()
+        plan = self.procurement_plan_id
+        if not self.use_procurement_plan:
+            self.use_procurement_plan = True
+        active_others = plan.purchase_request_ids.filtered(
+            lambda r: r.id != self.id and r.state != "rejected"
+        )
+        if active_others:
+            raise UserError(
+                _(
+                    "แผนจัดซื้อจัดจ้าง %s มีใบขอซื้อที่ยังดำเนินการอยู่แล้ว "
+                    "(1 แผน ต่อ 1 ใบขอซื้อ)"
+                )
+                % plan.display_name
+            )
+        if not self.budget_commitment_id:
+            commitment = plan.budget_commitment_ids.filtered(
+                lambda c: c.state in ("reserved", "partial")
+            )[:1]
+            if commitment:
+                self.budget_commitment_id = commitment.id
+        if plan.state == "ready":
+            plan.action_in_progress()
+
+    def button_rejected(self):
+        res = super().button_rejected()
+        for record in self:
+            record._reopen_plan_on_reject()
+        return res
+
+    def _reopen_plan_on_reject(self):
+        """When the single plan-driven PR is rejected, return the plan to
+        ``ready`` so a replacement PR can be created — but only while no draw-down
+        has started and no other active PR exists (ADR-0006, decision ข)."""
+        self.ensure_one()
+        plan = self.procurement_plan_id
+        if not plan or plan.state != "in_progress":
+            return
+        active_others = plan.purchase_request_ids.filtered(
+            lambda r: r.id != self.id and r.state != "rejected"
+        )
+        consumed = any(c.total_consumed for c in plan.budget_commitment_ids)
+        if active_others or consumed:
+            return
+        plan.write({"state": "ready"})
+        plan.message_post(
+            body=_("ใบขอซื้อ %s ถูกปฏิเสธ แผนกลับสู่สถานะพร้อมดำเนินการ")
+            % self.display_name
+        )
+
 
 class ProcurementPlan(models.Model):
     _inherit = "procurement.plan"
@@ -179,4 +240,67 @@ class ProcurementPlan(models.Model):
             "res_model": "purchase.request",
             "view_mode": "tree,form",
             "domain": [("id", "in", self.purchase_request_ids.ids)],
+        }
+
+    can_create_purchase_request = fields.Boolean(
+        compute="_compute_can_create_purchase_request"
+    )
+
+    @api.depends("state", "purchase_request_ids.state")
+    def _compute_can_create_purchase_request(self):
+        """Show the create-PR button while the plan is new/ready and has no
+        active PR. New plans still show it (with an ETA-gate error on click) so
+        officers discover the next step."""
+        for rec in self:
+            active = rec.purchase_request_ids.filtered(
+                lambda r: r.state != "rejected"
+            )
+            rec.can_create_purchase_request = (
+                rec.state in ("new", "ready") and not active
+            )
+
+    def action_create_purchase_request(self):
+        """Create the plan's single purchase request (ADR-0006). Opens a PR form
+        pre-filled from the plan via context defaults; the existing onchange
+        builds the budget lines. The plan must be ready (ETA gate) and hold an
+        active reservation."""
+        self.ensure_one()
+        if self.state == "new":
+            raise UserError(
+                _(
+                    "กรุณากรอกแผนการดำเนินงาน (ETA) ให้ครบ แล้วกด "
+                    "'พร้อมดำเนินการ' ก่อนสร้างใบขอซื้อ"
+                )
+            )
+        if self.state != "ready":
+            raise UserError(
+                _("สร้างใบขอซื้อได้เฉพาะแผนที่อยู่สถานะพร้อมดำเนินการเท่านั้น")
+            )
+        if self.purchase_request_ids.filtered(lambda r: r.state != "rejected"):
+            raise UserError(
+                _("แผนนี้มีใบขอซื้อที่ยังดำเนินการอยู่แล้ว (1 แผน ต่อ 1 ใบขอซื้อ)")
+            )
+        commitment = self.budget_commitment_ids.filtered(
+            lambda c: c.state in ("reserved", "partial")
+        )[:1]
+        if not commitment:
+            raise UserError(
+                _("แผนยังไม่ได้จองงบประมาณ ไม่สามารถสร้างใบขอซื้อได้")
+            )
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("สร้างใบขอซื้อจากแผน"),
+            "res_model": "purchase.request",
+            "view_mode": "form",
+            "target": "current",
+            "context": {
+                "default_use_procurement_plan": True,
+                "default_procurement_plan_id": self.id,
+                "default_budget_commitment_id": commitment.id,
+                "default_budget_account_id": self.budget_account_id.id,
+                "default_account_fiscal_year_id": self.account_fiscal_year_id.id,
+                "default_procurement_method_id": self.procurement_method_id.id,
+                "default_analytic_distribution": self.analytic_distribution,
+                "default_title": self.description,
+            },
         }

--- a/purchase_request_budget_procurement/models/purchase_request.py
+++ b/purchase_request_budget_procurement/models/purchase_request.py
@@ -234,13 +234,20 @@ class ProcurementPlan(models.Model):
 
     def action_view_purchase_requests(self):
         self.ensure_one()
-        return {
-            "name": "Purchase Request",
+        action = {
+            "name": _("ใบขอซื้อ (พ.1)"),
             "type": "ir.actions.act_window",
             "res_model": "purchase.request",
-            "view_mode": "tree,form",
             "domain": [("id", "in", self.purchase_request_ids.ids)],
         }
+        # One plan normally holds a single PR — open it straight in form view.
+        if len(self.purchase_request_ids) == 1:
+            action.update(
+                {"view_mode": "form", "res_id": self.purchase_request_ids.id}
+            )
+        else:
+            action["view_mode"] = "tree,form"
+        return action
 
     can_create_purchase_request = fields.Boolean(
         compute="_compute_can_create_purchase_request"

--- a/purchase_request_budget_procurement/views/procurement_plan_views.xml
+++ b/purchase_request_budget_procurement/views/procurement_plan_views.xml
@@ -12,11 +12,8 @@
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <field name="can_create_purchase_request" invisible="1" />
-                <field name="purchase_request_count" invisible="1" />
                 <button name="action_view_purchase_requests" type="object" class="oe_stat_button" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_request_count', '=', 0)]}">
-                    <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_text">Purchase Requests</span>
-                    </div>
+                    <field name="purchase_request_count" widget="statinfo" string="ใบ พ.1" />
                 </button>
             </xpath>
         </field>

--- a/purchase_request_budget_procurement/views/procurement_plan_views.xml
+++ b/purchase_request_budget_procurement/views/procurement_plan_views.xml
@@ -22,4 +22,13 @@
         </field>
     </record>
 
+    <!-- Plans a พ.1 can be created from (new + ready). Linked from the info
+         alert on the purchase request form so users land on a filtered list. -->
+    <record id="action_procurement_plan_ready_for_pr" model="ir.actions.act_window">
+        <field name="name">แผนจัดซื้อจัดจ้าง</field>
+        <field name="res_model">procurement.plan</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('state', 'in', ['new', 'ready'])]</field>
+    </record>
+
 </odoo>

--- a/purchase_request_budget_procurement/views/procurement_plan_views.xml
+++ b/purchase_request_budget_procurement/views/procurement_plan_views.xml
@@ -7,7 +7,11 @@
         <field name="model">procurement.plan</field>
         <field name="inherit_id" ref="procurement_plan.view_procurement_plan_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="action_create_purchase_request" type="object" string="สร้างใบขอซื้อ" class="btn-primary" attrs="{'invisible': [('can_create_purchase_request', '=', False)]}" />
+            </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <field name="can_create_purchase_request" invisible="1" />
                 <field name="purchase_request_count" invisible="1" />
                 <button name="action_view_purchase_requests" type="object" class="oe_stat_button" icon="fa-shopping-cart" attrs="{'invisible': [('purchase_request_count', '=', 0)]}">
                     <div class="o_field_widget o_stat_info">

--- a/purchase_request_budget_procurement/views/purchase_request_views.xml
+++ b/purchase_request_budget_procurement/views/purchase_request_views.xml
@@ -45,6 +45,20 @@
                      the prefill onchange still fires from the create context. -->
                 <field name="use_procurement_plan" invisible="1" />
                 <field name="procurement_plan_analytic_id" invisible="1" />
+                <!-- Discoverability: tell users where plan-driven พ.1 come from,
+                     shown only on a fresh, non-plan-linked draft. Direct (non-plan)
+                     PRs are still created here as usual. -->
+                <div
+                    class="alert alert-info"
+                    role="alert"
+                    attrs="{'invisible': ['|', ('procurement_plan_id', '!=', False), ('state', '!=', 'draft')]}"
+                >
+                    <i class="fa fa-info-circle me-1" />
+                    ต้องการจัดทำใบ พ.1 จาก<b>แผนจัดซื้อจัดจ้าง</b>?
+                    ให้ไปที่เมนู <b>แผนจัดซื้อจัดจ้าง</b> เลือกแผนที่อยู่สถานะ
+                    <b>"รอดำเนินการ"</b> แล้วกดปุ่ม <b>"สร้างใบขอซื้อ"</b>
+                    — ไม่สามารถเลือกแผนจากในใบ พ.1 นี้ได้
+                </div>
             </xpath>
         </field>
     </record>

--- a/purchase_request_budget_procurement/views/purchase_request_views.xml
+++ b/purchase_request_budget_procurement/views/purchase_request_views.xml
@@ -40,19 +40,11 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_edit_only')]" position="before">
                 <h2>Purchase Request Form</h2>
-                <group string="Procurement Plan">
-                    <field
-                        name="use_procurement_plan"
-                        attrs="{'readonly': [('is_editable','=', False)]}"
-                    />
-                    <field
-                        name="procurement_plan_id"
-                        options="{'no_create_edit': True, 'no_create': True}"
-                        domain="[('state', '=', 'new')]"
-                        attrs="{'invisible': [('use_procurement_plan', '=', False)], 'required': [('use_procurement_plan', '=', True)], 'readonly': [('is_editable','=', False)]}"
-                    />
-                    <field name="procurement_plan_analytic_id" invisible="1" />
-                </group>
+                <!-- Plan-driven PRs are created from the procurement plan only
+                     (ADR-0006). The selector is gone; these stay invisible so
+                     the prefill onchange still fires from the create context. -->
+                <field name="use_procurement_plan" invisible="1" />
+                <field name="procurement_plan_analytic_id" invisible="1" />
             </xpath>
         </field>
     </record>

--- a/purchase_request_budget_procurement/views/purchase_request_views.xml
+++ b/purchase_request_budget_procurement/views/purchase_request_views.xml
@@ -55,9 +55,17 @@
                 >
                     <i class="fa fa-info-circle me-1" />
                     ต้องการจัดทำใบ พ.1 จาก<b>แผนจัดซื้อจัดจ้าง</b>?
-                    ให้ไปที่เมนู <b>แผนจัดซื้อจัดจ้าง</b> เลือกแผนที่อยู่สถานะ
-                    <b>"รอดำเนินการ"</b> แล้วกดปุ่ม <b>"สร้างใบขอซื้อ"</b>
+                    เลือกแผน แล้วกดปุ่ม <b>"สร้างใบขอซื้อ"</b> จากหน้าแผน
+                    (แผนต้องอยู่สถานะ <b>"รอดำเนินการ"</b>)
                     — ไม่สามารถเลือกแผนจากในใบ พ.1 นี้ได้
+                    <div class="mt-2">
+                        <a
+                            href="/web#action=purchase_request_budget_procurement.action_procurement_plan_ready_for_pr"
+                            class="btn btn-sm btn-primary"
+                        >
+                            <i class="fa fa-external-link me-1" />ไปที่แผนจัดซื้อจัดจ้าง
+                        </a>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Reworks the procurement-plan budget flow so a plan reserves its full budget when its budget appropriation is posted (ADR-0005) instead of at "ready", and auto-closes once its commitment is fully consumed. A plan's purchase request is now created only from the plan via a new button — one active PR per plan, budget fields pre-filled and locked, and rejecting it returns the plan to "ready"; disbursement keeps the existing obligate+consume-per-installment behaviour unchanged. Documents the agreed reserve→obligate→consume timing in ADRs 0001/0004/0005/0006 plus the budget and procurement_plan CONTEXT glossaries. Touches procurement_plan, procurement_plan_budget and purchase_request_budget_procurement (version-bumped to 16.0.1.1.0).

## วิธีทดสอบ

**เตรียมระบบ**
- [ ] อัปเกรดโมดูล `procurement_plan`, `procurement_plan_budget`, `purchase_request_budget_procurement`

**1. จองงบเมื่อ Post ใบจัดสรรงบประมาณ (ADR-0005)**
- [ ] สร้างแผนจัดซื้อจัดจ้าง ระบุรหัสงบประมาณ + วงเงินรวม (total) > 0 — แผนยังอยู่สถานะ `new`
- [ ] สร้างใบจัดสรรงบประมาณ (budget.appropriation) ที่มีบรรทัดผูกกับแผนนี้ แล้วกด **Post**
- [ ] ⇒ แผนถูกจองงบทันทีโดยไม่ต้องรอ `ready`: เกิด `budget.commitment` สถานะ `reserved` วงเงิน = `total_price` ของแผน

**2. ตั้งพร้อมดำเนินการไม่จองซ้ำ (idempotent)**
- [ ] กรอก ETA ครบทั้ง 5 ช่อง + วิธีจัดซื้อ แล้วกด **พร้อมดำเนินการ** ⇒ แผนเป็น `ready` โดย**ไม่เกิด** commitment ซ้ำ (ยังมีใบจองเดียว)
- [ ] (กรณีกรอก ETA ไม่ครบ) กดพร้อมดำเนินการ ⇒ ขึ้น UserError "กรุณาระบุแผนการดำเนินงานให้เสร็จสิ้นทั้งหมด"

**3. สร้างใบขอซื้อจากแผน (ADR-0006)**
- [ ] แผนสถานะ `new`: ปุ่ม **สร้างใบขอซื้อ** แสดงอยู่ แต่กดแล้วขึ้น UserError ให้กรอก ETA แล้วกดพร้อมดำเนินการก่อน
- [ ] แผนสถานะ `ready`: กดปุ่ม **สร้างใบขอซื้อ** ⇒ เปิดฟอร์ม PR ที่ prefill รหัสงบประมาณ / มิติ analytic / ปีงบประมาณ / วิธีจัดซื้อ / ชื่อเรื่อง และผูก `budget.commitment` เดิมของแผน (ไม่สร้างใบจองใหม่)
- [ ] บันทึก PR ⇒ แผนเปลี่ยนเป็น `in_progress` และปุ่มสร้างใบขอซื้อหายไป
- [ ] ในฟอร์ม PR ช่องงบประมาณ (budget account + มิติ analytic) เป็น **read-only**

**4. 1 แผน ต่อ 1 ใบขอซื้อ**
- [ ] ขณะที่ยังมี PR ที่ active อยู่ (สถานะ ≠ rejected) ลองสร้าง PR ใบที่สอง ⇒ UserError "...มีใบขอซื้อที่ยังดำเนินการอยู่แล้ว (1 แผน ต่อ 1 ใบขอซื้อ)"

**5. ปฏิเสธใบขอซื้อ → แผนกลับสู่พร้อมดำเนินการ**
- [ ] กด **Reject** PR (โดยยัง**ไม่มี**การเบิกจ่าย/consume และไม่มี PR active อื่น) ⇒ แผนกลับจาก `in_progress` เป็น `ready` พร้อม message log "ใบขอซื้อ ... ถูกปฏิเสธ แผนกลับสู่สถานะพร้อมดำเนินการ" และสร้าง PR ใหม่ได้
- [ ] (กรณีมีการ consume ไปแล้ว) Reject ⇒ แผน**ไม่**กลับสู่ ready

**6. ปิดแผนอัตโนมัติเมื่อใช้งบครบ**
- [ ] เดินเอกสารเบิกจ่าย (obligate + consume ตามงวด) จน commitment ถูก consume เต็มจำนวน ⇒ commitment เป็น `done` และแผน **auto เปลี่ยนเป็น `done`** เอง

**7. นำตัวเลือกผูกแผนออกจากฟอร์ม PR**
- [ ] เปิดฟอร์ม Purchase Request ปกติ ⇒ ไม่มี checkbox "use_procurement_plan" และ dropdown เลือกแผนแล้ว (ผูกแผนได้จากปุ่มในแผนเท่านั้น)

**8. Regression**
- [ ] การเบิกจ่ายแบบ obligate + consume per installment ทำงานเหมือนเดิม
- [ ] Reset to draft / On hold ของแผน ยังปล่อยคืนงบ (release commitment) ตามเดิม
