### PR TITLE
[16.0][FIX] kmitl_project_purchase_request: pre-fill analytic dimensions from project

### DIFF
--- a/kmitl_project_purchase_request/models/purchase_request.py
+++ b/kmitl_project_purchase_request/models/purchase_request.py
@@ -21,6 +21,35 @@ class PurchaseRequest(models.Model):
         tracking=True,
     )
 
+    project_analytic_id = fields.Many2one(
+        "account.analytic.account",
+        compute="_compute_project_analytic_id",
+        inverse="_inverse_project_analytic",
+        domain=[("root_plan_id.code", "=", "kmitl_project")],
+        store=False,
+        string="โครงการ/กิจกรรม (Analytic)",
+    )
+
+    @api.depends("analytic_distribution")
+    def _compute_project_analytic_id(self):
+        for rec in self:
+            account_ids = [int(a) for a in rec.analytic_distribution or {}]
+            accounts = self.env["account.analytic.account"].browse(account_ids)
+            rec.project_analytic_id = accounts.filtered(
+                lambda a: a.plan_id.code == "kmitl_project"
+            )[:1]
+
+    def _inverse_project_analytic(self):
+        for rec in self:
+            dist = dict(rec.analytic_distribution or {})
+            account_ids = [int(k) for k in dist.keys()]
+            accounts = self.env["account.analytic.account"].browse(account_ids)
+            for acc in accounts.filtered(lambda a: a.plan_id.code == "kmitl_project"):
+                dist.pop(str(acc.id), None)
+            if rec.project_analytic_id:
+                dist[str(rec.project_analytic_id.id)] = 100
+            rec.analytic_distribution = dist or False
+
     def _domain_budget_account_id(self):
         # Standalone PRs must not draw directly on a project budget code — those
         # are reserved through projects (ADR-0007). Project-driven PRs prefill the

--- a/kmitl_project_purchase_request/views/kmitl_project_views.xml
+++ b/kmitl_project_purchase_request/views/kmitl_project_views.xml
@@ -21,6 +21,21 @@
         </field>
     </record>
 
+    <!-- Expose the project's own analytic account in the budget section -->
+    <record id="view_kmitl_project_form_analytic_account" model="ir.ui.view">
+        <field name="name">view.kmitl.project.form.analytic.account</field>
+        <field name="model">kmitl.project</field>
+        <field name="inherit_id" ref="kmitl_project.view_kmitl_project_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='analytic_account_id']" position="attributes">
+                <attribute name="invisible">0</attribute>
+                <attribute name="string">โครงการ/กิจกรรม (Analytic)</attribute>
+                <attribute name="readonly">1</attribute>
+                <attribute name="attrs">{'invisible': [('analytic_account_id', '=', False)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <!-- Projects a พ.1 can be created from (reserved: new + in_progress).
          Linked from the info alert on the purchase request form. -->
     <record id="action_kmitl_project_for_pr" model="ir.actions.act_window">

--- a/kmitl_project_purchase_request/views/purchase_request_views.xml
+++ b/kmitl_project_purchase_request/views/purchase_request_views.xml
@@ -31,7 +31,7 @@
         <field name="model">purchase.request</field>
         <field name="inherit_id" ref="purchase_request_budget.view_purchase_request_form" />
         <field name="arch" type="xml">
-            <xpath expr="//group[@string='Budget Details']/field[@name='product_id']" position="before">
+            <xpath expr="//field[@name='source_analytic_id']" position="after">
                 <field
                     name="project_analytic_id"
                     attrs="{'readonly': [('is_budget_editable', '=', False)]}"

--- a/kmitl_project_purchase_request/views/purchase_request_views.xml
+++ b/kmitl_project_purchase_request/views/purchase_request_views.xml
@@ -25,6 +25,22 @@
         </field>
     </record>
 
+    <!-- Budget Details - add project_analytic_id dimension to the budget group -->
+    <record id="view_purchase_request_form_kmitl_project_budget" model="ir.ui.view">
+        <field name="name">view.purchase.request.form (KMITL Project Budget)</field>
+        <field name="model">purchase.request</field>
+        <field name="inherit_id" ref="purchase_request_budget.view_purchase_request_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@string='Budget Details']/field[@name='product_id']" position="before">
+                <field
+                    name="project_analytic_id"
+                    attrs="{'readonly': [('is_budget_editable', '=', False)]}"
+                    options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"
+                />
+            </xpath>
+        </field>
+    </record>
+
     <!-- Discoverability: tell users where project-driven พ.1 come from, shown only
          on a fresh, non-project-linked draft. Project พ.1 are created from the
          project page (mirrors the procurement-plan alert). -->


### PR DESCRIPTION
## Summary

- Add `project_analytic_id` field on `purchase.request` (computed from `analytic_distribution`, plan code `kmitl_project`) with its own compute/inverse, so the kmitl_project dimension is pre-filled when a PR is created from a project via `action_create_purchase_request`
- Show `project_analytic_id` in the **Budget Details** group on the purchase request form (readonly when budget is locked)
- Expose `analytic_account_id` in the **งบประมาณ** group on the `kmitl.project` form so users can see the project's own analytic dimension after confirmation

## Test plan

- [ ] Open a confirmed project (state: new/in_progress) that has a reserved commitment and click **สร้างใบขอซื้อ**
- [ ] Verify the new PR form pre-fills department, activity, fund, source, and project analytic dimensions from the project's `analytic_distribution`
- [ ] Confirm `project_analytic_id` appears in the Budget Details section and is readonly
- [ ] Open a confirmed project and verify the analytic account is visible in the budget group (hidden before confirmation)