### PR TITLE
[16.0][FIX] accounting_kmitl: drop legacy account.move tier definitions

### DIFF
--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Accounting",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "KMITL/Accounting",
     "summary": "งานบัญชี KMITL: ตั้งหนี้, ล้างหนี้, สมุดรายวัน, รายงานบัญชี",
     "author": "KMITL",
@@ -17,7 +17,6 @@
         "views/account_move_views.xml",
         "views/account_payment_method_views.xml",
         "views/menuitem.xml",
-        "data/tier_definition.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/accounting_kmitl/data/tier_definition.xml
+++ b/accounting_kmitl/data/tier_definition.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-
-    <!-- Tier validation moved to disbursement.request; remove legacy
-         account.move tier definitions that previously gated bill posting. -->
-    <delete model="tier.definition" id="tier_definition_account_move_accountant"/>
-    <delete model="tier.definition" id="tier_definition_account_move_head_accountant"/>
-
-</odoo>


### PR DESCRIPTION
## Problem

On every install/upgrade Odoo logs two warnings:

```
WARNING odoo.tools.convert: Skipping deletion for missing XML ID `'tier_definition_account_move_accountant'`
ValueError: External ID not found in the system: accounting_kmitl.tier_definition_account_move_accountant
```
(same for `tier_definition_account_move_head_accountant`)

## Root cause

`accounting_kmitl/data/tier_definition.xml` only held two `<delete>` tags for
the old `tier.definition` records that PR #759 retired when bill posting moved
from per-bill tier validation to the DR-driven flow.

Those records no longer exist on any instance — fresh installs never create
them, and instances upgraded after #759 already deleted them. So the
`<delete id="...">` tags raise *External ID not found* on each run, which Odoo
catches and logs as a warning (`odoo/tools/convert.py:_tag_delete`). The deletes
are pure noise now.

## Fix

- Remove `accounting_kmitl/data/tier_definition.xml`.
- Drop its entry from `__manifest__.py`.
- Bump version `16.0.1.0.0` → `16.0.1.0.1` so the change is picked up on upgrade.

No `env.ref()` usages reference these XML IDs (verified); only stale comment
references remain in `i18n/th.po`, which regenerate on the next PO export.

## Deploy note

Run `-u accounting_kmitl` on affected instances; once the file is no longer in
the manifest the `<delete>` tags stop loading and the warnings disappear.