### PR TITLE
[16.0][FIX] kmitl_project_purchase_request: remove onchange that wiped analytic dimensions

### DIFF
--- a/kmitl_project/models/kmitl_project.py
+++ b/kmitl_project/models/kmitl_project.py
@@ -316,6 +316,7 @@ class KmitlProject(models.Model):
         "kmitl_project_id",
         string="ผูกพันงบประมาณ",
         readonly=True,
+        copy=False,
     )
     budget_commitment_count = fields.Integer(
         string="จำนวนผูกพันงบประมาณ",

--- a/kmitl_project_purchase_request/models/purchase_request.py
+++ b/kmitl_project_purchase_request/models/purchase_request.py
@@ -63,13 +63,15 @@ class PurchaseRequest(models.Model):
             if rec.use_project:
                 rec.is_budget_editable = False
 
-    @api.onchange("use_project", "kmitl_project_id")
-    def _onchange_kmitl_project_id(self):
-        if self.use_project and self.kmitl_project_id:
-            self.account_fiscal_year_id = self.kmitl_project_id.account_fiscal_year_id.id
-            self.budget_account_id = self.kmitl_project_id.budget_account_id.id
-            self.analytic_distribution = self.kmitl_project_id.analytic_distribution
-            self.title = self.kmitl_project_id.name
+    # No _onchange to prefill from the project on purpose. A project-driven พ.1 is
+    # only ever opened through action_create_purchase_request, which already passes
+    # the whole budget context (fiscal year, budget account, analytic_distribution,
+    # title) as context defaults — and _link_to_project re-writes it server-side on
+    # create. analytic_distribution inherits the core analytic.mixin field whose
+    # compute (_compute_analytic_distribution) is a no-op: re-assigning it inside the
+    # new-record onchange cascade makes Odoo recompute it to False, wiping the
+    # dimension fields on the unsaved form (they reappear only after save). Letting
+    # default_get drive the prefill keeps the value stable and the dimensions visible.
 
     def action_view_kmitl_project(self):
         self.ensure_one()


### PR DESCRIPTION
## Summary

- Removes `_onchange_kmitl_project_id` which triggered Odoo to recompute `analytic_distribution` to `False` on the unsaved form, wiping all analytic dimension fields (departments, funds, activities, etc.) before save.
- Project-driven พ.1 records are always created via `action_create_purchase_request`, which passes fiscal year, budget account, analytic distribution, and title as `context` defaults; `_link_to_project` then re-writes them server-side on create — making the onchange redundant and harmful.
- Prefill via `default_get` keeps `analytic_distribution` stable so dimension fields remain visible throughout the new-record form session.

## Test plan

- [ ] Create a พ.1 from a KMITL project via the project action button
- [ ] Confirm fiscal year, budget account, title, and all analytic dimension fields are pre-filled and remain visible on the unsaved form
- [ ] Save and confirm values are persisted correctly