### PR TITLE
[16.0][FIX] disbursement: translate display_status statusbar labels to Thai

### DIFF
--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -1010,13 +1010,11 @@ msgid "Approved"
 msgstr "อนุมัติแล้ว"
 
 #. module: disbursement
-#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__bill_draft
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Bill Draft"
 msgstr "รอตั้งหนี้"
 
 #. module: disbursement
-#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__bill_posted
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Bill Posted"
 msgstr "ตั้งหนี้แล้ว"
@@ -1037,7 +1035,6 @@ msgid "Disbursement Head"
 msgstr "หัวหน้าหน่วยงาน"
 
 #. module: disbursement
-#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__done
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Done"
 msgstr "เสร็จสิ้น"
@@ -1104,13 +1101,11 @@ msgid "Payment Count"
 msgstr "จำนวนการจ่ายเงิน"
 
 #. module: disbursement
-#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__payment_draft
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Payment Draft"
 msgstr "รอจ่ายเงิน"
 
 #. module: disbursement
-#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__payment_posted
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Payment Posted"
 msgstr "จ่ายเงินแล้ว"

--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -212,6 +212,7 @@ msgid "Cancel"
 msgstr "ยกเลิก"
 
 #. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__display_status__cancel
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__cancel
 msgid "Cancelled"
 msgstr "ยกเลิกแล้ว"
@@ -380,6 +381,7 @@ msgid "Download"
 msgstr ""
 
 #. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__display_status__draft
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__draft
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Draft"
@@ -738,6 +740,7 @@ msgid "Submit"
 msgstr "ยืนยัน"
 
 #. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__display_status__submitted
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__submitted
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Submitted"
@@ -817,6 +820,7 @@ msgid "Validate"
 msgstr "ตรวจสอบ"
 
 #. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__display_status__verified
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__verified
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Verified"
@@ -1134,6 +1138,7 @@ msgid "Sign"
 msgstr "ลงนาม"
 
 #. module: disbursement
+#: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__display_status__signed
 #: model:ir.model.fields.selection,name:disbursement.selection__disbursement_request__state__signed
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search
 msgid "Signed"


### PR DESCRIPTION
## Context

After installing the disbursement modules, the form statusbar showed a mix of English and Thai labels:

`DRAFT  SUBMITTED  SIGNED  VERIFIED  อนุมัติแล้ว  ตั้งหนี้แล้ว`

## Root cause

The statusbar is bound to the computed `display_status` field (`disbursement_request_views.xml:47`), **not** `state`. In Odoo 16, selection-label translations are keyed per field+value (`selection__disbursement_request__<field>__<value>`), and `display_status` defines its own selection list that duplicates the `state` labels — so it needs its own translation entries.

In `disbursement/i18n/th.po`, only `display_status__approved` had a Thai entry. The values `draft`, `submitted`, `signed`, `verified`, `cancel` had no `display_status__*` translation and fell back to the English source string. The `bill_*` / `payment_*` / `done` values are translated by the sub-modules, which is why `ตั้งหนี้แล้ว` rendered correctly.

## Fix

Add a `display_status` selection reference line to each of the 5 already-translated `state` msgid blocks in `th.po`, reusing the existing Thai strings (mirroring how the `Pre-approval` / `Approved` blocks already merge `pipeline_status` + `display_status` references). No new translation strings introduced.

## Verification

1. Upgrade `disbursement` with Thai active.
2. Open a Disbursement Request form — statusbar reads fully in Thai: `ฉบับร่าง  ยืนยันแล้ว  ลงนามแล้ว  ตรวจสอบแล้ว  อนุมัติแล้ว  ตั้งหนี้แล้ว …`