### PR TITLE
[16.0][IMP] agx_approval: add fiscal year field to approval requests

### DIFF
--- a/agx_approval/__manifest__.py
+++ b/agx_approval/__manifest__.py
@@ -1,11 +1,18 @@
 {
     "name": "Aginix Approval",
-    "version": "16.0.1.0.6",
+    "version": "16.0.1.0.7",
     "category": "Accounting",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "license": "LGPL-3",
-    "depends": ["account", "hr", "budget_product", "budget", "base_exception"],
+    "depends": [
+        "account",
+        "hr",
+        "budget_product",
+        "budget",
+        "base_exception",
+        "account_fiscal_year_enhance",
+    ],
     "data": [
         "security/security.xml",
         "security/ir.model.access.csv",

--- a/agx_approval/i18n/th.po
+++ b/agx_approval/i18n/th.po
@@ -352,6 +352,11 @@ msgid "Expense Lines"
 msgstr ""
 
 #. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_request__account_fiscal_year_id
+msgid "Fiscal Year"
+msgstr "ปีงบประมาณ"
+
+#. module: agx_approval
 #: model:ir.model.fields,field_description:agx_approval.field_approval_request__message_follower_ids
 msgid "Followers"
 msgstr ""

--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -1,5 +1,6 @@
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError
+from odoo.osv import expression
 
 
 class ApprovalRequest(models.Model):
@@ -271,6 +272,15 @@ class ApprovalRequest(models.Model):
         search="_search_source_analytic_id",
     )
 
+    account_fiscal_year_id = fields.Many2one(
+        comodel_name="account.fiscal.year",
+        string="Fiscal Year",
+        tracking=True,
+        store=True,
+        compute="_compute_date_range_fy",
+        search="_search_date_range_fy",
+    )
+
     _analytic_keys = {
         "activities": "activity_analytic_id",
         "departments": "department_analytic_id",
@@ -331,6 +341,41 @@ class ApprovalRequest(models.Model):
                 (query, [[str(account_id) for account_id in account_ids]]),
             )
         ]
+
+    @api.depends("date", "company_id")
+    def _compute_date_range_fy(self):
+        for rec in self:
+            date = fields.Date.to_date(rec.date)
+            company = rec.company_id
+            rec.account_fiscal_year_id = (
+                company and company.find_daterange_fy(date) or False
+            )
+
+    @api.model
+    def _search_date_range_fy(self, operator, value):
+        if operator in ("=", "!=", "in", "not in"):
+            date_range_domain = [("id", operator, value)]
+        else:
+            date_range_domain = [("name", operator, value)]
+
+        date_ranges = self.env["account.fiscal.year"].search(date_range_domain)
+
+        domain = [("id", "=", -1)]
+        for date_range in date_ranges:
+            domain = expression.OR(
+                [
+                    domain,
+                    [
+                        "&",
+                        ("date", ">=", date_range.date_from),
+                        ("date", "<=", date_range.date_to),
+                        "|",
+                        ("company_id", "=", False),
+                        ("company_id", "=", date_range.company_id.id),
+                    ],
+                ]
+            )
+        return domain
 
     @api.onchange("analytic_distribution")
     def _onchange_analytic_distribution(self):

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -81,6 +81,7 @@
                         <field name="department_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
                         <field name="fund_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}"/>
                         <field name="source_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}"/>
+                        <field name="account_fiscal_year_id" readonly="1" options="{'no_open': True}"/>
                         <field name="analytic_distribution" invisible="1"/>
                     </group>
                     <button name="action_open_actual_amount_wizard" string="Record Actual Disbursement" help="Use this to adjust the actual disbursement amount when it is lower than the approved amount. Values above the approved amount are not allowed." type="object" class="btn btn-primary my-3" attrs="{'invisible': [('state', '!=', 'approved')]}" />
@@ -143,6 +144,7 @@
                 <field name="category_id" />
                 <field name="department_id" />
                 <field name="owner_id" />
+                <field name="account_fiscal_year_id" options="{'no_open': True}" />
                 <field name="state" widget="badge" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-danger="state == 'rejected'"/>
             </tree>
         </field>
@@ -156,6 +158,7 @@
                 <field name="name" />
                 <field name="department_id" />
                 <field name="category_id" />
+                <field name="account_fiscal_year_id" />
                 <filter name="filter_draft" string="Draft" domain="[('state', '=', 'draft')]" />
                 <filter name="filter_submitted" string="Submitted" domain="[('state', '=', 'submitted')]" />
                 <filter name="filter_validated" string="Validated" domain="[('state', '=', 'validated')]" />


### PR DESCRIPTION
## What

Add `account_fiscal_year_id` to `approval.request`, mirroring the existing field on `disbursement.request`.

## Why

Approval requests (AR) flow into disbursement requests (DR), which already carry a fiscal-year dimension. Adding the same field to AR keeps the two consistent and lets approvals be searched/grouped by fiscal year.

## Changes

- **models/approval_request.py**
  - New `account_fiscal_year_id` — a stored computed `Many2one` to `account.fiscal.year`, derived from the record's own `date` + `company_id` via `_compute_date_range_fy` (uses `company.find_daterange_fy()`).
  - `_search_date_range_fy` — date-range search, copied verbatim from `disbursement.request`.
- **__manifest__.py** — add `account_fiscal_year_enhance` dependency (provides `find_daterange_fy` and, transitively, the `account.fiscal.year` model); bump version to `16.0.1.0.7`.
- **views/approval_request_views.xml** — show the field readonly in the form (Budget group), plus tree and search views.
- **i18n/th.po** — Thai translation (`Fiscal Year` → `ปีงบประมาณ`), matching disbursement.

## Notes

- The field is read-only at ORM level (stored compute, no inverse) and self-contained — it does not affect DR/advance-payment creation flows (those enumerate fields explicitly and DR computes its own fiscal year) and the procurement side does not reference `approval.request`.
- On `-u agx_approval` the stored field is back-filled for existing records from their `date`.