### PR TITLE
[16.0][FIX] budget reservation picker close + PR project field readonly

### DIFF
--- a/budget/static/src/reservation_picker/budget_reservation_picker.js
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.js
@@ -25,6 +25,7 @@ export class BudgetReservationPicker extends BudgetDashboard {
     setup() {
         super.setup();
         this.notification = useService("notification");
+        this.actionService = useService("action");
         const ctx = (this.props.action && this.props.action.context) || {};
         this.resModel = ctx.res_model;
         this.resId = ctx.res_id;

--- a/kmitl_project_purchase_request/views/purchase_request_views.xml
+++ b/kmitl_project_purchase_request/views/purchase_request_views.xml
@@ -34,8 +34,8 @@
             <xpath expr="//field[@name='source_analytic_id']" position="after">
                 <field
                     name="project_analytic_id"
-                    attrs="{'readonly': [('is_budget_editable', '=', False)]}"
-                    options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"
+                    readonly="1"
+                    options="{'no_open': True}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Two fixes bundled in this workspace:

- **budget**: The reservation picker's `close()` calls `this.actionService.doAction()` to close the dialog, but the action service was never registered (the parent `BudgetDashboard` sets up only `orm`, and the picker added only `notification`), so selecting a budget and confirming crashed with `Cannot read properties of undefined (reading 'doAction')`; this registers the `action` service in `setup()`.
- **kmitl_project_purchase_request**: `project_analytic_id` is a display field derived from `analytic_distribution` (written server-side from the project in `_link_to_project`), so it is now unconditionally read-only instead of editable when the budget is editable.