### PR TITLE
[16.0][FIX] procurement_plan: fix false insufficient-budget block on appropriation

### DIFF
--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -287,6 +287,11 @@ class ProcurementPlan(models.Model):
             "department_analytic_id": self.department_analytic_id.id or False,
             "fund_analytic_id": self.fund_analytic_id.id or False,
             "source_analytic_id": self.source_analytic_id.id or False,
+            # The source appropriation is tagged with this plan's own
+            # procurement_plan dimension; the check must carry it too, otherwise
+            # the engine pins procurement_plan empty and excludes the very
+            # appropriation being drawn from (→ false "insufficient budget").
+            "procurement_plan_analytic_id": self.analytic_account_id.id or False,
         }
         allow_negative = (
             self.env["ir.config_parameter"]


### PR DESCRIPTION
## Problem

Posting a `budget.appropriation` that allocates budget to a procurement plan was blocked with "งบประมาณไม่เพียงพอ" (insufficient budget) — at the very step meant to fund the plan.

## Root cause

The posted appropriation move line is tagged with the plan's own `procurement_plan` analytic dimension, but `procurement.plan._reserve_plan_commitment()` ran the availability check with only 4 dimensions (account + activity/department/fund/source), omitting `procurement_plan_analytic_id`. The availability engine then pins every unused controlled dimension to empty, excluding the very appropriation being drawn from, so `available = 0` and the reservation was rejected.

## Fix

Carry the plan's own `procurement_plan_analytic_id` in the check's `analytic_data` so it matches both the appropriation it draws from and the commitment being created (whose distribution already includes that dimension).