### PR TITLE
[16.0][IMP] multiple: replace department_id (hr.department) with department_analytic_id

### DIFF
--- a/account_asset_batch/models/account_asset_batch.py
+++ b/account_asset_batch/models/account_asset_batch.py
@@ -74,12 +74,12 @@ class AccountAssetBatch(models.Model):
         string="Lines"
     )
 
-    department_id = fields.Many2one(
-        "hr.department",
+    department_analytic_id = fields.Many2one(
+        "account.analytic.account",
         string="Department",
         store=True,
         readonly=False,
-        default=lambda self: self.env.user.employee_id.department_id,
+        domain=[("root_plan_id.code", "=", "departments")],
     )
 
     asset_count = fields.Integer(
@@ -217,7 +217,6 @@ class AccountAssetBatch(models.Model):
                         "date_start": batch.date,
                         "account_fiscal_year_id": batch.account_fiscal_year_id.id,
                         "operating_unit_id": batch.operating_unit_id.id,
-                        "department_id": batch.department_id.id,
                         "purchase_id": batch.purchase_id.id if batch.purchase_id else False,
                         "gpsc_id": line.gpsc_id.id,
                         "profile_id": line.profile_id.id,

--- a/account_asset_batch/models/purchase_order.py
+++ b/account_asset_batch/models/purchase_order.py
@@ -31,6 +31,6 @@ class PurchaseOrder(models.Model):
             "default_purchase_id": self.id,
             "create": True,
             "default_account_fiscal_year_id": self.account_fiscal_year_id.id,
-            "default_department_id": self.department_id.id,
+            "default_department_analytic_id": self.department_analytic_id.id,
         }
         return action

--- a/account_asset_batch/views/account_asset_batch_views.xml
+++ b/account_asset_batch/views/account_asset_batch_views.xml
@@ -10,7 +10,7 @@
                 <field name="account_fiscal_year_id" optional="show" />
                 <field name="contract_number" optional="show" />
                 <field name="purchase_id" optional="show" />
-                <field name="department_id" optional="hide" />
+                <field name="department_analytic_id" optional="hide" />
                 <field name="operating_unit_id" optional="hide" />
                 <field
                     name="state"
@@ -111,7 +111,7 @@
                         />
                         <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
                         <field
-                            name="department_id"
+                            name="department_analytic_id"
                             attrs="{'readonly': [('is_editable','=', False)]}"
                         />
                         <field name="company_id" groups="base.group_multi_company" />

--- a/account_asset_depreciation_report/report/asset_depreciation_report_xlsx.py
+++ b/account_asset_depreciation_report/report/asset_depreciation_report_xlsx.py
@@ -81,7 +81,7 @@ class AssetDepreciationReportXlsx(models.AbstractModel):
         }
         source_of_asset_name = source_of_asset_labels.get(wizard.source_of_asset, "ทั้งหมด")
         source_name = wizard.source_analytic_id.name if wizard.source_analytic_id else "ทั้งหมด"
-        dept_name = wizard.department_id.complete_name if wizard.department_id else "ทุกหน่วยงาน"
+        dept_name = wizard.department_analytic_id.complete_name if wizard.department_analytic_id else "ทุกหน่วยงาน"
 
         info_rows = [
             f"ประเภท: {profile_name}",
@@ -203,7 +203,7 @@ class AssetDepreciationReportXlsx(models.AbstractModel):
             sheet.write(row, 8, depr_before, num_fmt)
             sheet.write(row, 9, depr_this_month, num_fmt)
             sheet.write(row, 10, depr_carry, num_fmt)
-            sheet.write(row, 11, asset.department_id.complete_name if asset.department_id else "", data_fmt)
+            sheet.write(row, 11, asset.department_analytic_id.complete_name if asset.department_analytic_id else "", data_fmt)
 
             total_purchase += asset.purchase_value or 0.0
             total_depr_year += depr_year

--- a/account_asset_depreciation_report/views/asset_depreciation_report_wizard_views.xml
+++ b/account_asset_depreciation_report/views/asset_depreciation_report_wizard_views.xml
@@ -14,7 +14,7 @@
                     </group>
                     <group>
                         <field name="source_analytic_id" required="1" />
-                        <field name="department_id" />
+                        <field name="department_analytic_id" />
                         <div colspan="2" class="alert alert-warning show" role="alert">
                             Leave department empty to export data for all departments.
                         </div>

--- a/account_asset_depreciation_report/wizard/asset_depreciation_report_wizard.py
+++ b/account_asset_depreciation_report/wizard/asset_depreciation_report_wizard.py
@@ -37,9 +37,10 @@ class AssetDepreciationReportWizard(models.TransientModel):
         string="Funding Source",
         domain=[("root_plan_id.code", "=", "sources")],
     )
-    department_id = fields.Many2one(
-        "hr.department",
+    department_analytic_id = fields.Many2one(
+        "account.analytic.account",
         string="Department",
+        domain=[("root_plan_id.code", "=", "departments")],
     )
     data = fields.Binary(string="Report", readonly=True)
     filename = fields.Char(string="Filename", readonly=True)
@@ -60,8 +61,8 @@ class AssetDepreciationReportWizard(models.TransientModel):
         domain = [("state", "in", ["open", "close"])]
         if self.profile_id:
             domain.append(("profile_id", "=", self.profile_id.id))
-        if self.department_id:
-            domain.append(("department_id", "=", self.department_id.id))
+        if self.department_analytic_id:
+            domain.append(("department_analytic_id", "=", self.department_analytic_id.id))
         if self.source_analytic_id:
             domain.append(("source_analytic_id", "=", self.source_analytic_id.id))
 

--- a/account_asset_kmitl/models/account_asset.py
+++ b/account_asset_kmitl/models/account_asset.py
@@ -56,12 +56,6 @@ class AccountAsset(models.Model):
         tracking=True
     )
 
-    department_id = fields.Many2one(
-        "hr.department",
-        string="Department",
-        tracking=True
-    )
-    
     source_analytic_id = fields.Many2one(
         "account.analytic.account",
         string="แหล่งเงิน",

--- a/account_asset_kmitl/views/account_asset_views.xml
+++ b/account_asset_kmitl/views/account_asset_views.xml
@@ -26,7 +26,7 @@
                             <field name="employee_id" />
                             <field name="asset_location_id" />
                             <field name="location" />
-                            <field name="department_id" />
+                            <field name="department_analytic_id" />
                         </group>
                         <group>
                             <field name="asset_serial_number" />

--- a/advance_payment/data/advance_payment_exception_data.xml
+++ b/advance_payment/data/advance_payment_exception_data.xml
@@ -33,17 +33,6 @@
         <field name="active" eval="True"/>
     </record>
 
-    <record id="excep_missing_department" model="exception.rule">
-        <field name="name">ไม่ได้ระบุหน่วยงาน</field>
-        <field name="description">กรุณาระบุหน่วยงานก่อนส่งขออนุมัติ</field>
-        <field name="sequence">31</field>
-        <field name="model">advance.payment</field>
-        <field name="exception_type">by_domain</field>
-        <field name="domain">[('department_id', '=', False)]</field>
-        <field name="is_blocking" eval="True"/>
-        <field name="active" eval="True"/>
-    </record>
-
     <record id="excep_missing_analytic" model="exception.rule">
         <field name="name">ไม่ได้ระบุมิติทางบัญชีครบถ้วน</field>
         <field name="description">กรุณาระบุส่วนงาน แหล่งเงิน กองทุน และด้าน/แผนงาน/กิจกรรม ให้ครบถ้วน</field>

--- a/advance_payment/models/advance_payment.py
+++ b/advance_payment/models/advance_payment.py
@@ -28,7 +28,6 @@ class AdvancePayment(models.Model):
         "bank_id",
         "reference",
         "requested_by",
-        "department_id",
     }
 
     READONLY_STATES = {
@@ -76,13 +75,6 @@ class AdvancePayment(models.Model):
         related="requested_by.partner_id",
         string="Requestor Partner",
         store=False,
-    )
-
-    department_id = fields.Many2one(
-        comodel_name="hr.department",
-        string="Department",
-        default=lambda self: self.env.user.employee_id.department_id,
-        states=READONLY_STATES,
     )
 
     is_reference_visible = fields.Boolean(
@@ -299,8 +291,6 @@ class AdvancePayment(models.Model):
     def _onchange_requested_by(self):
         if self.bank_id and self.bank_id.partner_id != self.requested_by.partner_id:
             self.bank_id = False
-        if self.requested_by:
-            self.department_id = self.requested_by.employee_id.department_id
 
     @api.depends("analytic_distribution")
     def _compute_analytic_ids(self):

--- a/advance_payment/views/advance_payment_views.xml
+++ b/advance_payment/views/advance_payment_views.xml
@@ -131,7 +131,7 @@
                                 groups="advance_payment.group_advance_payment_manager" />
                             <field name="requested_by" readonly="1"
                                 groups="!advance_payment.group_advance_payment_manager" />
-                            <field name="department_id"
+                            <field name="department_analytic_id"
                                 attrs="{'readonly': [('is_locked_by_reference', '=', True)]}" />
                             <field name="requested_by_partner_id" invisible="1" />
                             <field name="bank_id"

--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -84,15 +84,6 @@ class ApprovalRequest(models.Model):
         states=READONLY_STATES,
     )
 
-    department_id = fields.Many2one(
-        string="Department",
-        comodel_name="hr.department",
-        default=lambda self: self.env.user.employee_id.department_id,
-        required=True,
-        tracking=True,
-        states=READONLY_STATES,
-    )
-
     name = fields.Char(
         string="Name",
         default="/",
@@ -305,10 +296,6 @@ class ApprovalRequest(models.Model):
                 if analytic:
                     distribution[str(analytic.id)] = 100
             self.analytic_distribution = distribution or False
-
-    @api.onchange("owner_id")
-    def _onchange_owner_id(self):
-        self.department_id = self.owner_id.employee_id.department_id
 
     @api.model
     def _search_source_analytic_id(self, operator, value):

--- a/agx_approval/reports/report_approval_request.xml
+++ b/agx_approval/reports/report_approval_request.xml
@@ -44,7 +44,7 @@
                         <div class="row">
                             <div class="col">
                                 หน่วยงาน
-                                <span class="ms-2" t-field="o.department_id" />
+                                <span class="ms-2" t-field="o.department_analytic_id" />
                             </div>
                         </div>
                         <div class="row">
@@ -60,7 +60,7 @@
                             ผู้ขออนุมัติ
                             <span t-field="o.owner_id" class="fw-bolder text-decoration-underline" />
                             <span class="ms-2">สังกัด</span>
-                            <span t-field="o.department_id" class="fw-bolder text-decoration-underline" />
+                            <span t-field="o.department_analytic_id" class="fw-bolder text-decoration-underline" />
                         </p>
 
                         <div class="row">

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -46,7 +46,7 @@
                             <field name="category_id" attrs="{'readonly': [('id', '!=', False)]}" />
                             <field name="payment_type" required="1" widget="radio" options="{'horizontal': true}"/>
                             <field name="owner_id" />
-                            <field name="department_id" readonly="1"/>
+                            <field name="department_analytic_id" readonly="1"/>
                             <field name="user_id" readonly="1"/>
                             <field name="has_period" invisible="1" />
                             <field name="has_city" invisible="1" />
@@ -142,7 +142,7 @@
                 <field name="name" />
                 <field name="date" />
                 <field name="category_id" />
-                <field name="department_id" />
+                <field name="department_analytic_id" />
                 <field name="owner_id" />
                 <field name="account_fiscal_year_id" options="{'no_open': True}" />
                 <field name="state" widget="badge" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-danger="state == 'rejected'"/>
@@ -156,7 +156,7 @@
         <field name="arch" type="xml">
             <search string="Approval Request">
                 <field name="name" />
-                <field name="department_id" />
+                <field name="department_analytic_id" />
                 <field name="category_id" />
                 <field name="account_fiscal_year_id" />
                 <filter name="filter_draft" string="Draft" domain="[('state', '=', 'draft')]" />

--- a/agx_approval_advance_payment/models/approval_request.py
+++ b/agx_approval_advance_payment/models/approval_request.py
@@ -68,7 +68,6 @@ class ApprovalRequest(models.Model):
         loan_type = self.env.ref("advance_payment.loan_type_other")
         return {
             "requested_by": self.owner_id.id,
-            "department_id": self.department_id.id,
             "loan_reason": self.description or "",
             "loan_amount": self.total_amount,
             "loan_type_id": loan_type.id,

--- a/agx_approval_sarabun/models/approval_request.py
+++ b/agx_approval_sarabun/models/approval_request.py
@@ -21,6 +21,21 @@ class ApprovalRequest(models.Model):
         copy=False,
     )
 
+    master_department_name = fields.Char(
+        compute="_compute_master_department_name",
+    )
+
+    @api.depends("department_analytic_id")
+    def _compute_master_department_name(self):
+        for rec in self:
+            dept = rec.department_analytic_id
+            if dept and dept.parent_path:
+                root_id = int(dept.parent_path.split("/")[0])
+                root = self.env["account.analytic.account"].browse(root_id)
+                rec.master_department_name = root.name
+            else:
+                rec.master_department_name = False
+
     def _compute_access_url(self):
         """Compute the access URL for portal access."""
         super()._compute_access_url()

--- a/agx_approval_sarabun/reports/report_approval_request.xml
+++ b/agx_approval_sarabun/reports/report_approval_request.xml
@@ -95,7 +95,7 @@
                             />
                             <span class="ms-2">สังกัด</span>
                             <span
-                                t-field="o.department_id"
+                                t-field="o.department_analytic_id"
                                 class="fw-bolder text-decoration-underline"
                             />
                         </p>
@@ -269,7 +269,7 @@
                 <div>ลงชื่อ <t t-out="'.' * 80" /></div>
                 <div class="text-center">( <span t-field="o.owner_id" /> )</div>
                 <div class="text-center">
-                    คณบดี <span t-out="o.department_id.master_department_id.name" />
+                    คณบดี <span t-out="o.master_department_name" />
                 </div>
             </div>
         </div>

--- a/agx_approval_sarabun/views/portal_templates.xml
+++ b/agx_approval_sarabun/views/portal_templates.xml
@@ -47,7 +47,7 @@
                                 <span t-field="req.date"/>
                             </td>
                             <td>
-                                <span t-field="req.department_id"/>
+                                <span t-field="req.department_analytic_id"/>
                             </td>
                             <td>
                                 <span t-field="req.category_id"/>

--- a/agx_construction/__manifest__.py
+++ b/agx_construction/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "license": "LGPL-3",
-    "depends": ["base", "hr", "mail", "purchase_request_sarabun"],
+    "depends": ["base", "mail", "purchase_request_sarabun", "account_analytic_plan_code"],
     "data": [
         "security/ir.model.access.csv",
         "wizard/construction_project_end_wizard_views.xml",

--- a/agx_construction/models/construction_project.py
+++ b/agx_construction/models/construction_project.py
@@ -16,9 +16,10 @@ class ConstructionProject(models.Model):
 
     ref = fields.Char(string="Reference", default="/", readonly=True, copy=False)
 
-    department_id = fields.Many2one(
-        comodel_name="hr.department",
+    department_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
         string="Department",
+        domain=[("root_plan_id.code", "=", "departments")],
         states=READONLY_STATES,
     )
 

--- a/agx_construction/views/construction_project_views.xml
+++ b/agx_construction/views/construction_project_views.xml
@@ -7,7 +7,7 @@
             <tree string="Construction Projects">
                 <field name="ref"/>
                 <field name="name"/>
-                <field name="department_id"/>
+                <field name="department_analytic_id"/>
                 <field name="date_end"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state in ('in_progress', 'ended')" decoration-danger="state == 'cancelled'"/>
             </tree>
@@ -36,7 +36,7 @@
                     <group>
                         <group>
                             <field name="ref"/>
-                            <field name="department_id"/>
+                            <field name="department_analytic_id"/>
                             <field name="date_end" attrs="{'invisible': [('state', '!=', 'ended')]}"/>
                         </group>
                     </group>
@@ -82,9 +82,9 @@
             <search string="Construction Projects">
                 <field name="name"/>
                 <field name="ref"/>
-                <field name="department_id"/>
+                <field name="department_analytic_id"/>
                 <group expand="0" string="Group By">
-                    <filter string="Department" name="group_department" context="{'group_by': 'department_id'}"/>
+                    <filter string="Department" name="group_department" context="{'group_by': 'department_analytic_id'}"/>
                 </group>
             </search>
         </field>

--- a/purchase_order_kmitl/__manifest__.py
+++ b/purchase_order_kmitl/__manifest__.py
@@ -11,7 +11,7 @@
         "purchase_invoice_plan_kmitl",
         "purchase_invoice_plan",
         "account_fiscal_year",
-        "hr",
+        "account_analytic_plan_code",
         "purchase_operating_unit",
         "purchase_request_department",
         "purchase_order_link_purchase_request",

--- a/purchase_order_kmitl/models/purchase_order.py
+++ b/purchase_order_kmitl/models/purchase_order.py
@@ -44,11 +44,12 @@ class PurchaseOrder(models.Model):
         string="Date End"
     )
 
-    department_id = fields.Many2one(
-        comodel_name="hr.department",
+    department_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
         string="Department",
+        domain=[("root_plan_id.code", "=", "departments")],
         states=READONLY_STATES,
-        tracking=True
+        tracking=True,
     )
 
     payment_type = fields.Selection(

--- a/purchase_order_kmitl/views/purchase_order_views.xml
+++ b/purchase_order_kmitl/views/purchase_order_views.xml
@@ -30,7 +30,7 @@
                 />
             </xpath>
             <xpath expr="//field[@name='company_id']" position="after">
-                <field name="department_id" />
+                <field name="department_analytic_id" />
             </xpath>
             <xpath
                 expr="//button[@name='action_rfq_send' and @states='draft']"
@@ -156,7 +156,7 @@
                             widget="res_partner_many2one"
                             context="{'res_partner_search_mode': 'supplier', 'show_vat': True}"
                         />
-                        <field name="department_id" readonly="1" />
+                        <field name="department_analytic_id" readonly="1" />
                         <field name="payment_type" readonly="1" />
                     </group>
                 </group>

--- a/purchase_order_kmitl/wizards/purchase_request_line_make_purchase_order.py
+++ b/purchase_order_kmitl/wizards/purchase_request_line_make_purchase_order.py
@@ -13,6 +13,6 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
     def _prepare_purchase_order(self, picking_type, group_id, company, origin):
         vals = super()._prepare_purchase_order(picking_type, group_id, company, origin)
         vals.update({
-            "department_id": self.item_ids.request_id.department_id.id,
+            "department_analytic_id": self.item_ids.request_id.department_analytic_id.id,
         })
         return vals

--- a/purchase_request_advance_payment/models/purchase_request.py
+++ b/purchase_request_advance_payment/models/purchase_request.py
@@ -41,7 +41,6 @@ class PurchaseRequest(models.Model):
         loan_type = self.env.ref("advance_payment.loan_type_procurement")
         return {
             "requested_by": self.requested_by.id,
-            "department_id": self.department_id.id,
             "reference": "purchase.request,%s" % self.id,
             "loan_amount": self.get_estimated_cost_currency(),
             "loan_type_id": loan_type.id,

--- a/purchase_request_sequence_kmitl/__manifest__.py
+++ b/purchase_request_sequence_kmitl/__manifest__.py
@@ -6,7 +6,7 @@
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",
-    'depends': ['hr_department_short_name', 'purchase_request_department'],
+    'depends': ['account_analytic_kmitl', 'purchase_request_department'],
     'data': [],
     'installable': True,
     'auto_install': False,

--- a/purchase_request_sequence_kmitl/models/purchase_request.py
+++ b/purchase_request_sequence_kmitl/models/purchase_request.py
@@ -6,6 +6,15 @@ from odoo.exceptions import UserError, ValidationError
 class PurchaseRequest(models.Model):
     _inherit = 'purchase.request'
 
+    def _get_department_from_distribution(self, analytic_distribution):
+        if not analytic_distribution:
+            return self.env["account.analytic.account"]
+        account_ids = [int(k) for k in analytic_distribution]
+        return self.env["account.analytic.account"].search(
+            [("id", "in", account_ids), ("root_plan_id.code", "=", "departments")],
+            limit=1,
+        )
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -13,11 +22,13 @@ class PurchaseRequest(models.Model):
             fy_id = self.env["account.fiscal.year"].browse(vals.get("account_fiscal_year_id"))
             fiscal_year = fy_id.name[-2:] if fy_id else fields.Date.today().strftime("%y")
 
-            department = self.env["hr.department"].browse(vals.get("department_id"))
-            short_name = department.short_name
+            dept_account = self._get_department_from_distribution(
+                vals.get("analytic_distribution")
+            )
+            short_name = dept_account.code
 
             if not short_name:
-                raise ValidationError(_("Department short name is missing."))
+                raise ValidationError(_("Department analytic code is missing."))
 
             seq_code = f"purchase.request.{fiscal_year}.{short_name}"
 

--- a/purchase_request_sequence_kmitl/models/purchase_request.py
+++ b/purchase_request_sequence_kmitl/models/purchase_request.py
@@ -6,14 +6,18 @@ from odoo.exceptions import UserError, ValidationError
 class PurchaseRequest(models.Model):
     _inherit = 'purchase.request'
 
-    def _get_department_from_distribution(self, analytic_distribution):
-        if not analytic_distribution:
-            return self.env["account.analytic.account"]
-        account_ids = [int(k) for k in analytic_distribution]
-        return self.env["account.analytic.account"].search(
-            [("id", "in", account_ids), ("root_plan_id.code", "=", "departments")],
-            limit=1,
-        )
+    def _get_department_from_distribution(self, analytic_distribution, department_analytic_id=None):
+        if analytic_distribution:
+            account_ids = [int(k) for k in analytic_distribution]
+            account = self.env["account.analytic.account"].search(
+                [("id", "in", account_ids), ("root_plan_id.code", "=", "departments")],
+                limit=1,
+            )
+            if account:
+                return account
+        if department_analytic_id:
+            return self.env["account.analytic.account"].browse(department_analytic_id)
+        return self.env["account.analytic.account"]
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -23,7 +27,8 @@ class PurchaseRequest(models.Model):
             fiscal_year = fy_id.name[-2:] if fy_id else fields.Date.today().strftime("%y")
 
             dept_account = self._get_department_from_distribution(
-                vals.get("analytic_distribution")
+                vals.get("analytic_distribution"),
+                vals.get("department_analytic_id"),
             )
             short_name = dept_account.code
 

--- a/purchase_sequence_kmitl/__manifest__.py
+++ b/purchase_sequence_kmitl/__manifest__.py
@@ -6,7 +6,7 @@
     "category": "KMITL",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    'depends': ['purchase_order_kmitl', 'hr_department_short_name'],
+    'depends': ['purchase_order_kmitl', 'account_analytic_kmitl'],
     'data': [
 
     ],

--- a/purchase_sequence_kmitl/models/purchase_order.py
+++ b/purchase_sequence_kmitl/models/purchase_order.py
@@ -6,14 +6,18 @@ from odoo.exceptions import UserError, ValidationError
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    def _get_department_from_distribution(self, analytic_distribution):
-        if not analytic_distribution:
-            return self.env["account.analytic.account"]
-        account_ids = [int(k) for k in analytic_distribution]
-        return self.env["account.analytic.account"].search(
-            [("id", "in", account_ids), ("root_plan_id.code", "=", "departments")],
-            limit=1,
-        )
+    def _get_department_from_distribution(self, analytic_distribution, department_analytic_id=None):
+        if analytic_distribution:
+            account_ids = [int(k) for k in analytic_distribution]
+            account = self.env["account.analytic.account"].search(
+                [("id", "in", account_ids), ("root_plan_id.code", "=", "departments")],
+                limit=1,
+            )
+            if account:
+                return account
+        if department_analytic_id:
+            return self.env["account.analytic.account"].browse(department_analytic_id)
+        return self.env["account.analytic.account"]
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -23,7 +27,8 @@ class PurchaseOrder(models.Model):
             fiscal_year = fy_id.name[-2:] if fy_id else fields.Date.today().strftime("%y")
 
             dept_account = self._get_department_from_distribution(
-                vals.get("analytic_distribution")
+                vals.get("analytic_distribution"),
+                vals.get("department_analytic_id"),
             )
             short_name = dept_account.code
 

--- a/purchase_sequence_kmitl/models/purchase_order.py
+++ b/purchase_sequence_kmitl/models/purchase_order.py
@@ -6,6 +6,15 @@ from odoo.exceptions import UserError, ValidationError
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
+    def _get_department_from_distribution(self, analytic_distribution):
+        if not analytic_distribution:
+            return self.env["account.analytic.account"]
+        account_ids = [int(k) for k in analytic_distribution]
+        return self.env["account.analytic.account"].search(
+            [("id", "in", account_ids), ("root_plan_id.code", "=", "departments")],
+            limit=1,
+        )
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
@@ -13,12 +22,13 @@ class PurchaseOrder(models.Model):
             fy_id = self.env["account.fiscal.year"].browse(vals.get("account_fiscal_year_id"))
             fiscal_year = fy_id.name[-2:] if fy_id else fields.Date.today().strftime("%y")
 
-            department = self.env["hr.department"].browse(vals.get("department_id"))
-
-            short_name = department.short_name
+            dept_account = self._get_department_from_distribution(
+                vals.get("analytic_distribution")
+            )
+            short_name = dept_account.code
 
             if not short_name:
-                raise ValidationError(_("Department short name is missing."))
+                raise ValidationError(_("Department analytic code is missing."))
 
             seq_code = f"purchase.{fiscal_year}.{short_name}"
 

--- a/stock_inventory_department/__manifest__.py
+++ b/stock_inventory_department/__manifest__.py
@@ -6,7 +6,7 @@
      "category": "KMITL",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    'depends': ['stock_inventory'],
+    'depends': ['stock_inventory', 'account_analytic_plan_code'],
     "data": [
         "views/stock_inventory_views.xml"
     ],

--- a/stock_inventory_department/models/stock_inventory.py
+++ b/stock_inventory_department/models/stock_inventory.py
@@ -6,7 +6,8 @@ from odoo.exceptions import UserError, ValidationError
 class StockInventory(models.Model):
     _inherit = 'stock.inventory'
 
-    department_id = fields.Many2one(
-        comodel_name="hr.department",
+    department_analytic_id = fields.Many2one(
+        comodel_name="account.analytic.account",
         string="Department",
+        domain=[("root_plan_id.code", "=", "departments")],
     )

--- a/stock_inventory_department/views/stock_inventory_views.xml
+++ b/stock_inventory_department/views/stock_inventory_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock_inventory.view_inventory_group_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='owner_id']" position="after">
-              <field name="department_id" />
+              <field name="department_analytic_id" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary

โมดูลที่เกี่ยวข้องกับงบประมาณและการเงินควรใช้โครงสร้างหน่วยงานตามรหัสงบประมาณ (analytic account dimension `departments`) ไม่ใช่โครงสร้าง HR (`hr.department`) PR นี้ลบ `department_id` ออกจากโมดูล Group A (Budget/Finance) ทั้งหมด และแทนที่ด้วย `department_analytic_id`

## Modules Changed

### Phase 1 — Models that already had both fields (remove `department_id`, keep `department_analytic_id`)

- **`account_asset_kmitl`**: Remove redundant `department_id` field; `department_analytic_id` was already stored and computed from `analytic_distribution`
- **`advance_payment`**: Remove `department_id` field, remove from `_PROTECTED_FIELDS`, remove `_onchange_requested_by` logic that set it, remove redundant `excep_missing_department` exception rule (already covered by `excep_missing_analytic`)
- **`agx_approval`**: Remove `department_id` field and `_onchange_owner_id`; update form/tree/search views and report templates
- **`agx_approval_sarabun`**: Replace `o.department_id` in report/portal; add `master_department_name` computed field that walks `department_analytic_id.parent_path` to root analytic account (replaces `department_id.master_department_id.name` for คณบดี signature line)

### Phase 2 — Bridge modules cleaned

- **`agx_approval_advance_payment`**: Remove `department_id` from advance payment vals (`analytic_distribution` already carries it)
- **`purchase_request_advance_payment`**: Same

### Phase 3 — Models with only `department_id` (replaced)

- **`agx_construction`**: Replace `department_id` with `department_analytic_id`; remove `hr` manifest dependency → `account_analytic_plan_code`
- **`account_asset_batch`**: Replace `department_id` with `department_analytic_id`; remove from asset creation vals (analytic_distribution already carries it); update `default_department_analytic_id` context on PO action
- **`account_asset_depreciation_report`**: Replace wizard filter field and asset domain filter; update XLSX report columns
- **`purchase_order_kmitl`**: Replace field; update `make_purchase_order` wizard to read `department_analytic_id` from PR; replace `hr` manifest dependency → `account_analytic_plan_code`
- **`stock_inventory_department`**: Replace field; add `account_analytic_plan_code` manifest dependency

### Phase 4 — Sequence modules (special handling)

- **`purchase_request_sequence_kmitl`**: Switch from `hr.department.short_name` to analytic account `code` extracted from `analytic_distribution`; replace `hr_department_short_name` manifest dependency → `account_analytic_kmitl`
- **`purchase_sequence_kmitl`**: Same pattern for PO sequences

## Not Changed

- `budget/`, `budget_report/`, `procurement_plan/`, `kmitl_project/`, `budget_appropriation_summary_dashboard/` — already fully migrated to analytic accounts
- `agx_sarabun/` — `sender_department_id` must remain `hr.department` for routing logic
- `purchase_request_approval/` — `requesting_department_id` kept as-is (feeds `sender_department_id` on sarabun document)
- All `hr_*` modules — pure HR
- Purchase committee modules — employee-based `department_id` (Group D)

## Technical Notes

- Analytic account `code` matches `hr.department.short_name` — existing sequences (e.g. `PR/68/ENG/0001`) continue to work
- `master_department_name` computed field in `agx_approval_sarabun` uses `parent_path.split("/")[0]` to find the root analytic account, mirroring the existing HR `master_department_id` logic