### PR TITLE
[16.0][ADD] kmitl_user_access_gate: revoke app access for users without linked hr.employee

### DIFF
--- a/kmitl_user_access_gate/README.rst
+++ b/kmitl_user_access_gate/README.rst
@@ -1,0 +1,20 @@
+=====================
+KMITL User Access Gate
+=====================
+
+When a user authenticates (e.g. via LDAP) but has no linked ``hr.employee``,
+they have not yet been allocated permissions. This module revokes all of their
+groups on login so they see no apps until an admin provisions them.
+
+How it works
+============
+
+On login, ``res.users._update_last_login`` checks each user:
+
+* the main admin (``base.user_admin``) and the superuser are always exempt;
+* users with a linked ``hr.employee`` keep their access;
+* portal/public users (share users) are left untouched;
+* any remaining **internal** user without an employee has all groups cleared.
+
+Once an admin links an employee and assigns groups, those groups are preserved
+on subsequent logins.

--- a/kmitl_user_access_gate/__init__.py
+++ b/kmitl_user_access_gate/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/kmitl_user_access_gate/__manifest__.py
+++ b/kmitl_user_access_gate/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "KMITL – User Access Gate (no employee → no apps)",
+    "summary": "Revoke all app access from internal users without a linked employee",
+    "version": "16.0.1.0.0",
+    "category": "Tools",
+    "author": "KMITL, Aginix",
+    "website": "https://www.kmitl.ac.th",
+    "license": "LGPL-3",
+    "depends": ["hr"],
+    "installable": True,
+    "application": False,
+}

--- a/kmitl_user_access_gate/models/__init__.py
+++ b/kmitl_user_access_gate/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/kmitl_user_access_gate/models/res_users.py
+++ b/kmitl_user_access_gate/models/res_users.py
@@ -1,0 +1,35 @@
+from odoo import SUPERUSER_ID, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _update_last_login(self):
+        res = super()._update_last_login()
+        self._revoke_access_if_no_employee()
+        return res
+
+    def _revoke_access_if_no_employee(self):
+        """Internal users with no linked hr.employee have not been allocated
+        permissions yet: strip all their groups so they see no apps until an
+        admin provisions them. The main admin and superuser are exempt.
+
+        Only internal users (members of base.group_user) are touched, so portal
+        and public users — which legitimately have no employee — keep their
+        access. This also makes the operation idempotent: a stripped user is no
+        longer internal, so subsequent logins skip them.
+        """
+        internal = self.env.ref("base.group_user")
+        admin = self.env.ref("base.user_admin", raise_if_not_found=False)
+        exempt_ids = {SUPERUSER_ID}
+        if admin:
+            exempt_ids.add(admin.id)
+        for user in self:
+            if user.id in exempt_ids:
+                continue
+            if user.employee_ids:
+                continue
+            if internal not in user.groups_id:
+                # portal/public or already-stripped users: leave untouched
+                continue
+            user.sudo().write({"groups_id": [(5, 0, 0)]})

--- a/kmitl_user_access_gate/tests/__init__.py
+++ b/kmitl_user_access_gate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_access_gate

--- a/kmitl_user_access_gate/tests/test_access_gate.py
+++ b/kmitl_user_access_gate/tests/test_access_gate.py
@@ -1,0 +1,48 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUserAccessGate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Users = cls.env["res.users"]
+        cls.internal_group = cls.env.ref("base.group_user")
+        cls.portal_group = cls.env.ref("base.group_portal")
+
+    def _create_user(self, login, group):
+        return self.Users.create(
+            {
+                "name": login,
+                "login": login,
+                "groups_id": [(6, 0, group.ids)],
+            }
+        )
+
+    def test_internal_user_without_employee_is_stripped(self):
+        user = self._create_user("gate_internal", self.internal_group)
+        self.assertTrue(user.groups_id)
+        user._update_last_login()
+        self.assertFalse(user.groups_id, "Groups should be cleared")
+
+    def test_user_with_employee_keeps_access(self):
+        user = self._create_user("gate_with_emp", self.internal_group)
+        self.env["hr.employee"].create({"name": "Emp", "user_id": user.id})
+        before = user.groups_id
+        user._update_last_login()
+        self.assertEqual(user.groups_id, before, "Groups should be preserved")
+
+    def test_admin_without_employee_keeps_access(self):
+        admin = self.env.ref("base.user_admin")
+        admin.employee_ids.unlink()
+        before = admin.groups_id
+        admin._update_last_login()
+        self.assertEqual(admin.groups_id, before, "Admin must stay exempt")
+
+    def test_portal_user_without_employee_keeps_access(self):
+        user = self._create_user("gate_portal", self.portal_group)
+        before = user.groups_id
+        user._update_last_login()
+        self.assertEqual(
+            user.groups_id, before, "Portal users must not be stripped"
+        )


### PR DESCRIPTION
## ปัญหา

ระบบเชื่อมกับ LDAP (`auth_ldap`) เมื่อ user login ผ่าน LDAP ครั้งแรก ระบบจะสร้าง `res.users` ให้อัตโนมัติ แต่ไม่มี `hr.employee` เชื่อมอยู่ ทำให้ user เหล่านั้นเป็น Internal User ที่มองเห็น app ทุกตัว ทั้งที่ยังไม่ได้รับการจัดสรรสิทธิ

## การแก้ไข

สร้าง module ใหม่ `kmitl_user_access_gate` ที่ทำงานดังนี้:

- **Hook at login:** override `_update_last_login()` (pattern เดียวกับ `hr_recruitment_kmitl`)
- **ตรวจสอบ:** ถ้า user เป็น Internal User (`base.group_user`) แต่ไม่มี `hr.employee` เชื่ออยู่ → ล้าง groups ทั้งหมด (`[(5, 0, 0)]`)
- **ผล:** user login ได้ แต่เห็น backend ว่างเปล่า ไม่มี app ใดเลย จนกว่า admin จะ link employee และมอบสิทธิ
- **Idempotent:** user ที่ถูกล้าง group แล้วจะไม่ใช่ Internal User อีก → login ครั้งต่อไปข้ามไป

## ข้อยกเว้น

| กรณี | พฤติกรรม |
|------|----------|
| `base.user_admin` + superuser | ยกเว้นเสมอ |
| user ที่มี `hr.employee` เชื่ออยู่ | groups ไม่ถูกแตะ |
| Portal / Public user (ThaiD ฯลฯ) | ไม่ใช่ Internal User → ข้ามไป |

## ไฟล์ที่เพิ่ม

```
kmitl_user_access_gate/
├── __init__.py
├── __manifest__.py          # depends: ['hr']
├── README.rst
├── models/
│   ├── __init__.py
│   └── res_users.py         # _update_last_login + _revoke_access_if_no_employee
└── tests/
    ├── __init__.py
    └── test_access_gate.py  # 4 test cases
```

## Test Plan

- [ ] Internal user ที่ไม่มี employee → login แล้ว `groups_id` ว่าง, ไม่เห็น app ใด
- [ ] User ที่มี employee + groups → login แล้ว groups คงเดิม
- [ ] `base.user_admin` (ไม่มี employee) → login แล้ว access ปกติ
- [ ] Portal user (ไม่มี employee) → login แล้ว portal access คงเดิม
- [ ] LDAP user ใหม่ → สร้างได้, login ครั้งแรกเห็น empty backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)