### PR TITLE
[16.0][IMP] kmitl_project: select budget code via reservation picker

### DIFF
--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Budgeting",
-    "version": "16.0.1.3.0",
+    "version": "16.0.1.4.0",
     "summary": """ KMITL Budgeting""",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget/models/budget_controller.py
+++ b/budget/models/budget_controller.py
@@ -54,6 +54,17 @@ class BudgetController(models.AbstractModel):
         "kmitl_project": "kmitl_project_analytic_id",
         "procurement_plan": "procurement_plan_analytic_id",
     }
+    # "Ownership tag" dimensions: they identify the document that owns a
+    # reservation (a project / a procurement plan) and ride on its reserve lines,
+    # but the appropriation pool a project draws from is *untagged* (floating,
+    # ADR-0007). So they are pinned absent on the appropriation (current) side
+    # only; on the usage side a floating check must count every reserve drawing
+    # from the pool whatever its owner, else it ignores other documents' reserves
+    # and overstates what is available — letting projects over-reserve the pool.
+    _POOL_TAG_COLUMNS = (
+        "kmitl_project_analytic_id",
+        "procurement_plan_analytic_id",
+    )
 
     # ------------------------------------------------------------------
     # Public API
@@ -232,32 +243,43 @@ class BudgetController(models.AbstractModel):
             else "="
         )
 
-    def _absent_dim_leaves(self, dims):
+    def _absent_dim_leaves(self, dims, include_pool_tags=True):
         """Require controlled dimensions NOT used by this reservation to be empty.
 
         Without this, a combination that omits a dimension would match
         appropriation/usage carrying *any* value there (cross-dimension leak).
         ``kmitl_project`` and ``procurement_plan`` are mutually exclusive, so the
         unused one is correctly required to be empty.
+
+        ``include_pool_tags=False`` leaves the ownership tags
+        (:attr:`_POOL_TAG_COLUMNS`) unpinned — used on the *usage* side so a
+        floating-pool check counts every reserve drawing from the (untagged)
+        pool whatever document owns it; they stay pinned on the appropriation
+        side. The four real dimensions are pinned either way.
         """
+        skip = () if include_pool_tags else self._POOL_TAG_COLUMNS
         return [
             (column, "=", False)
             for column in self._DIM_COLUMNS.values()
-            if column not in dims
+            if column not in dims and column not in skip
         ]
 
-    def _control_scope(self, controls, dims):
+    def _control_scope(self, controls, dims, include_pool_tags=True):
         """Subtree leaves over the control node on every axis.
 
         ``child_of`` rolls usage/appropriation up to the control node so sibling
         draws cannot double-spend a shared pool; flat analytic dimensions fall
-        back to an exact match. Unused dimensions are pinned empty.
+        back to an exact match. Unused dimensions are pinned empty, except the
+        ownership tags when ``include_pool_tags=False`` (see
+        :meth:`_absent_dim_leaves`).
         """
         dim_op = self._analytic_hier_op()
         leaves = [("account_id", "child_of", controls["account"].id)]
         for column in dims:
             leaves.append((column, dim_op, controls["dims"][column].id))
-        return leaves + self._absent_dim_leaves(dims)
+        return leaves + self._absent_dim_leaves(
+            dims, include_pool_tags=include_pool_tags
+        )
 
     def _sum_current(self, controls, dims, fiscal_year_id, company_id):
         """Σ posted appropriation/entry balance over the control-node subtree."""
@@ -275,7 +297,11 @@ class BudgetController(models.AbstractModel):
             ("account_fiscal_year_id", "=", fiscal_year_id),
             ("company_id", "=", company_id),
         ]
-        domain += self._control_scope(controls, dims)
+        # Count every reserve drawing from the pool regardless of which project /
+        # plan owns it: the floating appropriation is untagged, so pinning the
+        # ownership tags here would drop other documents' reserves and overstate
+        # availability (the over-reservation bug).
+        domain += self._control_scope(controls, dims, include_pool_tags=False)
         groups = self.env["budget.commitment.line"].read_group(
             domain, ["amount"], []
         )

--- a/budget/models/budget_dashboard.py
+++ b/budget/models/budget_dashboard.py
@@ -649,6 +649,22 @@ class BudgetDashboard(models.AbstractModel):
         }
 
     @api.model
+    def get_selectable_roots(self, account_domain):
+        """Root expense categories that contain at least one account matching
+        ``account_domain``.
+
+        The reservation picker scopes its ประเภทงบ dropdown to these, so a host
+        never opens on — or switches to — a category with nothing selectable.
+        Root resolution lives here, next to the dashboard's other ``parent_path``
+        helpers, reusing :meth:`_root_category_map` rather than reparsing
+        ``parent_path`` in the client.
+        """
+        if not account_domain:
+            return []
+        account_ids = self.env["budget.account"].search(account_domain).ids
+        return list(set(self._root_category_map(account_ids).values()))
+
+    @api.model
     def get_overview_departments(self):
         """Department (ส่วนงาน) options for the overview multi-select filter.
 

--- a/budget/static/src/reservation_picker/budget_reservation_picker.js
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.js
@@ -91,28 +91,21 @@ export class BudgetReservationPicker extends BudgetDashboard {
         // Scope the ประเภทงบ (budget category) dropdown to the categories that
         // actually contain a code the host may pick (its account_domain), so a
         // host never lands on — nor can switch to — a category with nothing
-        // selectable. With no account_domain (e.g. budget.commitment) every
+        // selectable. Root resolution stays server-side (parent_path is a budget
+        // backend concern). With no account_domain (e.g. budget.commitment) every
         // expense category stays, as before.
         if (this.accountDomain) {
-            const accounts = await this.orm.searchRead(
-                "budget.account",
-                this.accountDomain,
-                ["parent_path"]
-            );
             const rootIds = new Set(
-                accounts
-                    .map((a) => parseInt((a.parent_path || "").split("/")[0]))
-                    .filter((id) => id)
+                await this.orm.call("budget.dashboard", "get_selectable_roots", [
+                    this.accountDomain,
+                ])
             );
             this.rootAccounts = this.rootAccounts.filter((acc) =>
                 rootIds.has(acc.id)
             );
             // A context-provided root that is no longer offered is dropped so the
             // default below re-picks a category that has something to select.
-            if (
-                this.state.rootAccountId &&
-                !this.rootAccounts.some((acc) => acc.id === this.state.rootAccountId)
-            ) {
+            if (this.state.rootAccountId && !rootIds.has(this.state.rootAccountId)) {
                 this.state.rootAccountId = false;
             }
         }

--- a/budget/static/src/reservation_picker/budget_reservation_picker.js
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.js
@@ -88,6 +88,34 @@ export class BudgetReservationPicker extends BudgetDashboard {
 
     async onWillStart() {
         await super.onWillStart();
+        // Scope the ประเภทงบ (budget category) dropdown to the categories that
+        // actually contain a code the host may pick (its account_domain), so a
+        // host never lands on — nor can switch to — a category with nothing
+        // selectable. With no account_domain (e.g. budget.commitment) every
+        // expense category stays, as before.
+        if (this.accountDomain) {
+            const accounts = await this.orm.searchRead(
+                "budget.account",
+                this.accountDomain,
+                ["parent_path"]
+            );
+            const rootIds = new Set(
+                accounts
+                    .map((a) => parseInt((a.parent_path || "").split("/")[0]))
+                    .filter((id) => id)
+            );
+            this.rootAccounts = this.rootAccounts.filter((acc) =>
+                rootIds.has(acc.id)
+            );
+            // A context-provided root that is no longer offered is dropped so the
+            // default below re-picks a category that has something to select.
+            if (
+                this.state.rootAccountId &&
+                !this.rootAccounts.some((acc) => acc.id === this.state.rootAccountId)
+            ) {
+                this.state.rootAccountId = false;
+            }
+        }
         // Force a single budget category (no "all") — default to the first.
         if (!this.state.rootAccountId && this.rootAccounts.length) {
             this.state.rootAccountId = this.rootAccounts[0].id;

--- a/budget/tests/test_budget_controller.py
+++ b/budget/tests/test_budget_controller.py
@@ -167,6 +167,34 @@ class TestBudgetController(TransactionCase):
         # no fund specified must NOT leak the fund-A appropriation
         self.assertEqual(self._available(self.dimleaf, {}), 0.0)
 
+    def test_floating_pool_counts_tagged_owner_reserves(self):
+        """A floating-pool check (no ownership tag) must count a reserve that
+        DOES carry one (a project's reserve).
+
+        Project appropriation is untagged (kmitl_project absent); a project's
+        reserve carries its kmitl_project tag. If the tagged reserve were
+        excluded from ``used``, every project would see the full pool and could
+        over-reserve it (ADR-0007). Here 100k pool − a 60k tagged reserve = 40k.
+        """
+        Plan = self.env["account.analytic.plan"]
+        proj_plan = Plan.search(
+            [("code", "=", "kmitl_project")], limit=1
+        ) or Plan.create({"name": "Project", "code": "kmitl_project"})
+        project = self.env["account.analytic.account"].create(
+            {"name": "Proj X", "code": "CTRL_PRJ", "plan_id": proj_plan.id}
+        )
+        self._appropriate(self.dimleaf, 100_000, fund=self.fund_a)
+        self._reserve(
+            self.dimleaf,
+            60_000,
+            dist={str(self.fund_a.id): 100.0, str(project.id): 100.0},
+        )
+        # the 4D floating check (fund only, no kmitl_project) still sees the
+        # tagged reserve as used
+        self.assertEqual(
+            self._available(self.dimleaf, {str(self.fund_a.id): 100.0}), 40_000
+        )
+
     def _reserve_multi(self, account_amounts):
         first = account_amounts[0][0]
         return self.env["budget.commitment"].create(

--- a/kmitl_project/__manifest__.py
+++ b/kmitl_project/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KMITL Project",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "Project",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/kmitl_project/models/kmitl_project.py
+++ b/kmitl_project/models/kmitl_project.py
@@ -12,7 +12,13 @@ class KmitlProject(models.Model):
     _description = "KMITL Project"
     _order = "id desc"
     _rec_names_search = ["name", "key"]
-    _inherit = ["mail.thread", "mail.activity.mixin", "analytic.mixin", "portal.mixin"]
+    _inherit = [
+        "mail.thread",
+        "mail.activity.mixin",
+        "analytic.mixin",
+        "portal.mixin",
+        "budget.commitment.mixin",
+    ]
 
     READONLY_STATES = {
         "draft": [("readonly", False)],
@@ -294,7 +300,6 @@ class KmitlProject(models.Model):
 
     budget_account_id = fields.Many2one(comodel_name="budget.account",
         string="รหัสงบประมาณ",
-        required=True,
         index=True,
         tracking=True,
         domain="[('budgetable', '=', True), ('budget_type', '=', 'expense'),"
@@ -504,11 +509,31 @@ class KmitlProject(models.Model):
         it on demand (kmitl.project, unlike procurement.plan, has no auto-create on
         write) and let the inverse fold it into ``analytic_distribution``."""
         self.ensure_one()
-        if self.analytic_account_id:
-            return
-        self.analytic_account_id = self._create_analytic_account_from_values(
-            {"name": self.name, "code": self.key or self.name}
-        ).id
+        if not self.analytic_account_id:
+            self.analytic_account_id = self._create_analytic_account_from_values(
+                {"name": self.name, "code": self.key or self.name}
+            ).id
+        # Fold the kmitl_project dimension into analytic_distribution — in both
+        # branches, independent of the create-branch inverse-flush ordering. The
+        # reservation picker rewrites analytic_distribution wholesale (the four
+        # budget dimensions) on (re-)selection, dropping this dimension; refold it
+        # so the reservation always carries the kmitl_project dimension.
+        self._update_analytic_distribution("kmitl_project")
+
+    def _reservation_account_domain(self):
+        """Budget codes selectable in the reservation picker for this project.
+
+        Mirrors the ``budget_account_id`` field domain: budgetable expense codes
+        flagged ``is_project`` whose ``project_type`` matches this project. The
+        picker offers only these (other codes still show, but are not selectable),
+        and the mixin re-checks the chosen code against this same domain
+        server-side in ``apply_reservation_selection`` — so a code outside these
+        conditions can be neither picked nor written."""
+        self.ensure_one()
+        return super()._reservation_account_domain() + [
+            ("is_project", "=", True),
+            ("project_type", "=", self.project_type),
+        ]
 
     def _reserve_project_commitment(self):
         """Reserve one shared budget.commitment for the project's full

--- a/kmitl_project/views/kmitl_project_views.xml
+++ b/kmitl_project/views/kmitl_project_views.xml
@@ -124,11 +124,15 @@
                             <group name="budget" string="งบประมาณ">
                                 <field name="budget_amount" required="1"/>
                                 <field name="budget_remaining" attrs="{'invisible': [('state', '=', 'draft')]}"/>
-                                <field name="budget_account_id" required="1" widget="helper_text" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" />
-                                <field name="activity_analytic_id" required="1" widget="helper_text" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" />
-                                <field name="fund_analytic_id" required="1" widget="selection" />
-                                <field name="department_analytic_id" required="1" widget="helper_text" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" />
-                                <field name="source_analytic_id" required="1" widget="selection" />
+                                <button name="action_open_reservation_picker" type="object"
+                                    string="เลือกงบประมาณจากผังงบ (ดูยอดคงเหลือ)"
+                                    class="btn btn-primary" icon="fa-sitemap" colspan="2"
+                                    attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                                <field name="budget_account_id" readonly="1" widget="helper_text" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" />
+                                <field name="activity_analytic_id" readonly="1" widget="helper_text" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" />
+                                <field name="fund_analytic_id" readonly="1" widget="selection" />
+                                <field name="department_analytic_id" readonly="1" widget="helper_text" options="{'no_create_edit': True, 'no_create': True, 'no_open': True}" />
+                                <field name="source_analytic_id" readonly="1" widget="selection" />
                                 <field name="analytic_account_id" invisible="1" />
                                 <field name="analytic_distribution" invisible="1" />
                             </group>


### PR DESCRIPTION
## kmitl_project — reservation picker

Replaces the `budget_account_id` dropdown on `kmitl.project` with the budget module's reservation picker (via `budget.commitment.mixin`), so a project picks its รหัสงบประมาณ by navigating the floating budget pools by ส่วนงาน/กิจกรรม/กองทุน with live balances, constrained to budgetable expense project codes matching the project type — enforced both in the picker (selectable rows) and server-side in `apply_reservation_selection`. The picker writes back the code plus its four dimensions; the budget fields become readonly and `budget_account_id` is no longer field-required (confirm still gates a missing code), and `_ensure_analytic_account` refolds the `kmitl_project` dimension so the reservation always carries it.

## budget — picker scoping + over-reservation fix

The shared reservation picker scopes its ประเภทงบ (budget category) dropdown to only the categories that contain a code matching the host's `account_domain` (root resolution done server-side via a new `budget.dashboard.get_selectable_roots` reusing `_root_category_map`); hosts without an `account_domain` keep every expense category.

Fixes a project over-reservation bug in the availability engine: the ownership-tag dimensions (`kmitl_project`, `procurement_plan`) were pinned to `False` on both sides of `available = current − used`, so the used sum excluded every project's (tagged) reserve against the untagged floating pool, letting projects over-reserve into the negative. They are now pinned on the appropriation side only; the usage side counts all reserves drawing from the pool (matching the dashboard's Remaining(f)). The four real dimensions stay pinned on both sides, so the cross-dimension guard is unchanged; procurement and PR/PO/transfer are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)