### PR TITLE
[16.0][FIX] hr_employee_academic_standing_thailand: mirror fields to public model

### DIFF
--- a/hr_employee_academic_standing_thailand/__manifest__.py
+++ b/hr_employee_academic_standing_thailand/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "HR Employee Academic Standing Thailand",
-    "version": "16.0.1.0.5",
+    "version": "16.0.1.0.6",
     "summary": """ HR Employee Academic Standing Thailand Summary """,
     "author": "nopparuts, Aginix Technologies",
     "website": "https://github.com/aginix/kmitl-odoo",

--- a/hr_employee_academic_standing_thailand/models/__init__.py
+++ b/hr_employee_academic_standing_thailand/models/__init__.py
@@ -1,4 +1,5 @@
 from . import hr_employee
+from . import hr_employee_public
 from . import hr_employee_academic_standing
 from . import resource_rank
 from . import resource_rank_agency

--- a/hr_employee_academic_standing_thailand/models/hr_employee_public.py
+++ b/hr_employee_academic_standing_thailand/models/hr_employee_public.py
@@ -1,0 +1,39 @@
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = "hr.employee.public"
+
+    academic_standing_id = fields.Many2one(
+        related="employee_id.academic_standing_id",
+        readonly=True,
+    )
+    rank_id = fields.Many2one(
+        related="employee_id.rank_id",
+        readonly=True,
+    )
+    rank_nobility_id = fields.Many2one(
+        related="employee_id.rank_nobility_id",
+        readonly=True,
+    )
+    profession_id = fields.Many2one(
+        related="employee_id.profession_id",
+        readonly=True,
+    )
+
+    academic_standing_title = fields.Char(
+        related="employee_id.academic_standing_title",
+        readonly=True,
+    )
+    academic_standing_title_abbreviation = fields.Char(
+        related="employee_id.academic_standing_title_abbreviation",
+        readonly=True,
+    )
+    academic_standing_title_en = fields.Char(
+        related="employee_id.academic_standing_title_en",
+        readonly=True,
+    )
+    academic_standing_title_abbreviation_en = fields.Char(
+        related="employee_id.academic_standing_title_abbreviation_en",
+        readonly=True,
+    )


### PR DESCRIPTION
Non-HR users hit `ValueError: Invalid field 'academic_standing_id' on model 'hr.employee.public'` when an `hr.employee` record was read without HR access (e.g. via the kris_project dashboard accessing `manager_id.name`), because Odoo's prefetch delegates the read to `hr.employee.public`, which lacked the stored fields this module adds.

This mirrors all eight stored fields — the four academic Many2one fields (`academic_standing_id`, `rank_id`, `rank_nobility_id`, `profession_id`) and the four computed-stored academic standing title fields — onto `hr.employee.public` via `related` fields, following the existing sibling-module pattern (e.g. `hr_employee_role`, `hr_employee_education_history`).