### PR TITLE
[16.0][IMP] agx_approval: select budget code via reservation picker

### DIFF
--- a/agx_approval/__manifest__.py
+++ b/agx_approval/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Aginix Approval",
-    "version": "16.0.1.0.7",
+    "version": "16.0.1.0.8",
     "category": "Accounting",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -231,6 +231,29 @@ class ApprovalRequest(models.Model):
     def _domain_budget_account_id(self):
         return [("purchase_ok", "=", True), ("product_id", "!=", False)]
 
+    def _reservation_account_domain(self):
+        """Budget codes selectable in the reservation picker for this request.
+
+        Mirror the budget_account_id field domain (purchasable, product-backed
+        codes) on top of the mixin's budgetable/expense baseline, so the picker
+        cannot offer — and apply_reservation_selection cannot write — a code the
+        request rejects.
+        """
+        return super()._reservation_account_domain() + self._domain_budget_account_id()
+
+    def apply_reservation_selection(self, selections, dims=None):
+        """Picker write-back: set the budget code + dimensions, then push the
+        distribution onto the request lines (the analytic_distribution onchange
+        does not fire on an ORM write)."""
+        res = super().apply_reservation_selection(selections, dims=dims)
+        if (
+            self.analytic_distribution
+            and self.line_ids
+            and "analytic_distribution" in self.line_ids._fields
+        ):
+            self.line_ids.update({"analytic_distribution": self.analytic_distribution})
+        return res
+
     activity_analytic_id = fields.Many2one(
         "account.analytic.account",
         string="กิจกรรม",

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -76,11 +76,15 @@
                             <span class="ms-1">฿</span>
                         </div>
                         <field name="is_budget_editable" invisible="1"/>
-                        <field name="budget_account_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
-                        <field name="activity_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
-                        <field name="department_analytic_id" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
-                        <field name="fund_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}"/>
-                        <field name="source_analytic_id" widget="selection" attrs="{'readonly': [('is_budget_editable', '=', False)], 'required': [('state', '=', 'to_verify')]}"/>
+                        <button name="action_open_reservation_picker" type="object"
+                            string="Select budget from chart (view balances)"
+                            class="btn btn-primary mb-2" icon="fa-sitemap" colspan="2"
+                            attrs="{'invisible': [('is_budget_editable', '=', False)]}"/>
+                        <field name="budget_account_id" readonly="1" attrs="{'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
+                        <field name="activity_analytic_id" readonly="1" attrs="{'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
+                        <field name="department_analytic_id" readonly="1" attrs="{'required': [('state', '=', 'to_verify')]}" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
+                        <field name="fund_analytic_id" widget="selection" readonly="1" attrs="{'required': [('state', '=', 'to_verify')]}"/>
+                        <field name="source_analytic_id" widget="selection" readonly="1" attrs="{'required': [('state', '=', 'to_verify')]}"/>
                         <field name="account_fiscal_year_id" readonly="1" options="{'no_open': True}"/>
                         <field name="analytic_distribution" invisible="1"/>
                     </group>


### PR DESCRIPTION
## Context

PR #833 gave `kmitl_project` an interactive **budget reservation picker** (a tree of budget codes showing remaining balances) instead of typing the budget code + 4 analytic dimensions by hand; the same pattern was then applied to `purchase_request` (`purchase_request_budget`). This PR brings the identical picker UX to `approval.request`.

`approval.request` (module `agx_approval`) already inherits `budget.commitment.mixin` + `analytic.mixin` and declares every field the picker needs (`budget_account_id`, the 4 computed dimensions, `analytic_distribution`, `account_fiscal_year_id`, `is_budget_editable`, `action_reserve_budget`). Today those budget fields are typed in directly — this PR swaps that manual entry for the picker, exactly as the two precedents did.

## Changes (all in `agx_approval`)

**`models/approval_request.py`** — two overrides (mirroring `purchase_request_budget`):
- `_reservation_account_domain()` = `super() + _domain_budget_account_id()`, so the picker offers — and `apply_reservation_selection` writes — only purchasable, product-backed budgetable expense codes (re-checked server-side).
- `apply_reservation_selection()` re-syncs `analytic_distribution` onto the request lines (the onchange does not fire on an ORM `write`), preserving the prior direct-edit behavior.

**`views/approval_request_views.xml`** — Budget group:
- Add the `action_open_reservation_picker` button (gated on `is_budget_editable`).
- Make `budget_account_id` + the 4 analytic dimension fields `readonly="1"` (picker-only); `required` in `to_verify` is kept.

**`__manifest__.py`** — version `16.0.1.0.7` → `16.0.1.0.8`.

## Notes

- The picker only **selects** a code; reservation still happens via the existing **Reserve Budget** button — that flow and `hide_reserve_budget_button` are unchanged.
- The button is gated on `is_budget_editable` (not a literal `state=='draft'`) so it shows precisely when budget editing is allowed — in `draft` and, for `budget.group_budget_commitment` users with no active commitment, in `to_verify`.
- **No `budget` module changes** — the picker JS, `get_selectable_roots`, and the floating-pool controller fix from #833 are already in the tree. Sibling views (`agx_approval_disbursement`, `agx_approval_advance_payment`, `agx_approval_sarabun`) do not render the budget fields, so no changes there.
- Button label is an English source string; the Thai translation will be added via i18n `.po` in a follow-up.

## Testing

- [ ] Upgrade `agx_approval`; the form parses and the Budget group shows the picker button.
- [ ] On a `draft` request, the picker opens, the category dropdown is scoped, and only `budgetable/expense/purchase_ok/product_id` codes are selectable.
- [ ] Picking a code fills `budget_account_id` + the 4 readonly dimension fields and syncs the lines' distribution.
- [ ] `apply_reservation_selection` with an out-of-domain code raises `UserError`.
- [ ] The existing **Reserve Budget** flow still builds the commitment and advances to `submitted`.