### PR TITLE
[16.0][FIX] hr_employee_kmitl_kid: unique KID for existing employees on install

### DIFF
--- a/hr_employee_kmitl_kid/__init__.py
+++ b/hr_employee_kmitl_kid/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/hr_employee_kmitl_kid/__manifest__.py
+++ b/hr_employee_kmitl_kid/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "HR Employee KMITL KID",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "summary": """ HR Employee KMITL KID Summary """,
     "author": "nopparuts, Aginix Technologies",
     "website": "https://github.com/aginix/kmitl-odoo",
@@ -9,6 +9,7 @@
         "hr",
     ],
     "data": ["data/ir_sequence.xml", "views/hr_view_employee_form_views.xml"],
+    "post_init_hook": "post_init_hook",
     "application": True,
     "installable": True,
     "auto_install": False,

--- a/hr_employee_kmitl_kid/hooks.py
+++ b/hr_employee_kmitl_kid/hooks.py
@@ -1,0 +1,20 @@
+from odoo import SUPERUSER_ID, api
+
+
+def post_init_hook(cr, registry):
+    """Seed the KID sequence past the values back-filled onto existing employees.
+
+    ``HrEmployee.init`` assigns existing rows ``K00001 .. K0000N`` (N = number
+    of pre-existing employees). The sequence created by ``data/ir_sequence.xml``
+    starts at 1, so without this the next employee would be assigned ``K00001``
+    again and hit the unique constraint. Advance it to ``N + 1``.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    sequence = env.ref(
+        "hr_employee_kmitl_kid.sequence_hr_employee_kmitl_kid",
+        raise_if_not_found=False,
+    )
+    if not sequence:
+        return
+    count = env["hr.employee"].with_context(active_test=False).search_count([])
+    sequence.sudo().number_next_actual = count + 1

--- a/hr_employee_kmitl_kid/models/hr_employee.py
+++ b/hr_employee_kmitl_kid/models/hr_employee.py
@@ -19,6 +19,33 @@ class HrEmployee(models.Model):
 
     _sql_constraints = [("unique_kid", "unique(kid)", "KID already exists!")]
 
+    def init(self):
+        super().init()
+        # When this module is installed on a table that already holds employees
+        # (e.g. Odoo demo employees), the new required ``kid`` column is filled
+        # with the same default placeholder on every existing row. That would
+        # violate the ``unique(kid)`` constraint, which is added right after
+        # this method. Give each conflicting/empty row a unique KID first. This
+        # is a no-op on upgrades, where existing rows already hold unique KIDs.
+        self.env.cr.execute(
+            """
+            WITH conflicting AS (
+                SELECT id, row_number() OVER (ORDER BY id) AS rn
+                FROM hr_employee
+                WHERE kid IS NULL
+                   OR kid IN (
+                       SELECT kid FROM hr_employee
+                       WHERE kid IS NOT NULL
+                       GROUP BY kid HAVING count(*) > 1
+                   )
+            )
+            UPDATE hr_employee e
+            SET kid = 'K' || lpad(c.rn::text, 5, '0')
+            FROM conflicting c
+            WHERE e.id = c.id
+            """
+        )
+
     @api.model_create_multi
     def create(self, vals):
         for val in vals:


### PR DESCRIPTION
Installing `hr_employee_kmitl_kid` on a populated `hr_employee` table (e.g. a database with demo employees) crashed with `could not create unique index "hr_employee_unique_kid" ... Key (kid)=(New) is duplicated` — the new required `kid` column was filled with the same default value on every existing row, breaking the `unique(kid)` constraint (the `create()` override only assigns KIDs to new records).

This back-fills existing/duplicate rows with unique KIDs in `init()` before the deferred constraint is added (a no-op on upgrades), and advances the sequence past them in a `post_init_hook` so newly created employees don't collide.