### PR TITLE
[16.0][IMP] budget, account_analytic_kmitl: search accounts by complete_name

### DIFF
--- a/account_analytic_kmitl/__manifest__.py
+++ b/account_analytic_kmitl/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Account Analytic",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.2.2",
     "summary": """ KMITL Account Analytic""",
     "category": "KMITL/Accounting",
     "author": "Aginix Technologies",

--- a/account_analytic_kmitl/models/account_analytic_account.py
+++ b/account_analytic_kmitl/models/account_analytic_account.py
@@ -1,8 +1,46 @@
-from odoo import fields, models
+import re
+
+from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class AccountAnalyticAccount(models.Model):
     _inherit = "account.analytic.account"
+    # Search the hierarchical complete_name (e.g. "parent / child") so users can
+    # find children by typing the parent's name. The stored complete_name from
+    # account_analytic_parent already includes the account's own name as suffix.
+    _rec_names_search = ["complete_name", "code"]
+
+    @api.model
+    def _name_search(
+        self, name="", args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        # name_get displays records as "[code] complete_name". When users edit
+        # that text in an autocomplete (e.g. deleting the last hierarchy segment
+        # to look for siblings), the leftover "[code]" prefix is not part of any
+        # single stored field, so the default search matches nothing. Detect the
+        # prefix, drop it, and search the code and the remaining hierarchical
+        # name independently (OR) so siblings under the same parent are found.
+        if name and operator not in expression.NEGATIVE_TERM_OPERATORS:
+            match = re.match(r"^\s*\[(?P<code>[^\]]*)\]\s*(?P<rest>.*)$", name)
+            if match:
+                code = match.group("code").strip()
+                rest = match.group("rest").strip()
+                subdomains = []
+                if rest:
+                    subdomains.append([("complete_name", operator, rest)])
+                if code:
+                    subdomains.append([("code", operator, code)])
+                if subdomains:
+                    domain = expression.AND(
+                        [list(args or []), expression.OR(subdomains)]
+                    )
+                    return self._search(
+                        domain, limit=limit, access_rights_uid=name_get_uid
+                    )
+        return super()._name_search(
+            name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
+        )
 
     department_analytic_ids = fields.Many2many(
         comodel_name="account.analytic.account",

--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Budgeting",
-    "version": "16.0.1.4.0",
+    "version": "16.0.1.4.1",
     "summary": """ KMITL Budgeting""",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget/models/budget_account.py
+++ b/budget/models/budget_account.py
@@ -1,7 +1,9 @@
 import logging
+import re
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.osv import expression
 
 from .budget_tree import BudgetTree
 
@@ -38,7 +40,10 @@ class BudgetAccount(models.Model):
     _description = "Budget Account"
     _parent_store = True
     _order = "code"
-    _rec_names_search = ["name", "code"]
+    # Search the hierarchical complete_name (e.g. "parent / child") so users can
+    # find children by typing the parent's name. complete_name already includes
+    # the account's own name as suffix, so "name" is covered too.
+    _rec_names_search = ["complete_name", "code"]
 
     _inherit = ["mail.thread"]
 
@@ -184,6 +189,37 @@ class BudgetAccount(models.Model):
     def _check_parent_id(self):
         if not self._check_recursion():
             raise ValidationError(_("You cannot create recursive budget account."))
+
+    @api.model
+    def _name_search(
+        self, name="", args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        # name_get displays records as "[code] complete_name". When users edit
+        # that text in an autocomplete (e.g. deleting the last hierarchy segment
+        # to look for siblings), the leftover "[code]" prefix is not part of any
+        # single stored field, so the default search matches nothing. Detect the
+        # prefix, drop it, and search the code and the remaining hierarchical
+        # name independently (OR) so siblings under the same parent are found.
+        if name and operator not in expression.NEGATIVE_TERM_OPERATORS:
+            match = re.match(r"^\s*\[(?P<code>[^\]]*)\]\s*(?P<rest>.*)$", name)
+            if match:
+                code = match.group("code").strip()
+                rest = match.group("rest").strip()
+                subdomains = []
+                if rest:
+                    subdomains.append([("complete_name", operator, rest)])
+                if code:
+                    subdomains.append([("code", operator, code)])
+                if subdomains:
+                    domain = expression.AND(
+                        [list(args or []), expression.OR(subdomains)]
+                    )
+                    return self._search(
+                        domain, limit=limit, access_rights_uid=name_get_uid
+                    )
+        return super()._name_search(
+            name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
+        )
 
     def name_get(self):
         res = []


### PR DESCRIPTION
Searching analytic accounts and budget accounts only matched a record's own `name` or `code`, so typing a parent's name never surfaced its children. This adds `complete_name` to `_rec_names_search` on both `account.analytic.account` and `budget.account` so the hierarchical "parent / child" name is searchable everywhere (budget_appropriation and all other dropdowns). It also overrides `_name_search` on both models to strip the leading `[code]` prefix that `name_get` displays, so when a user edits an autocomplete entry — e.g. deletes the last hierarchy segment — siblings under the same parent are found instead of nothing. Manifest versions bumped: account_analytic_kmitl 16.0.1.2.2, budget 16.0.1.4.1.