### PR TITLE
[16.0][IMP] kmitl_project: issue a running number as the analytic code

### DIFF
--- a/kmitl_project/CONTEXT.md
+++ b/kmitl_project/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: strategic plan (that names the `project.strategic.plan` it aligns to, n
 The full amount a project earmarks from its floating budget code. Reserved as one shared `budget.commitment` when the project is confirmed (`draft→new`); drawn down by the project's purchase requests and disbursements. See [budget » Reserve / Floating Budget](../budget/CONTEXT.md).
 _Avoid_: allocation, cost
 
+**Project Number (เลขที่รันโครงการ, `key`)**:
+A sequential running number that identifies a Project. Minted once, when the project is first confirmed (`draft→new`), and stable for the project's life — a later reset-to-draft never re-issues or clears it. Stamped with the project's **fiscal year** (`account_fiscal_year_id`), which is therefore frozen once a Project Number exists. Reused as the `code` of the project's analytic account.
+_Avoid_: Project Code (รหัสโครงการ) — a distinct approval-time identifier, **not yet implemented**; do not conflate it with the Project Number even though both currently share the `key` field.
+
 **Project Budget Remaining (งบประมาณคงเหลือ)**:
 A project's reserved `budget_amount` minus what has actually been **consumed (เบิกจ่าย)** from its commitment — the project money still available to spend. It is the project's own reservation-vs-spend, **not** the budget account's disbursement *Remaining (f)*, and **not** the พ.1 planning headroom (`budget_amount − Σ estimated_cost`) that caps how many purchase requests a project may raise.
 _Avoid_: remaining (unqualified — clashes with [budget » Remaining (f)](../budget/CONTEXT.md))

--- a/kmitl_project/__manifest__.py
+++ b/kmitl_project/__manifest__.py
@@ -21,6 +21,7 @@
         "report/paperformat.xml",
         "report/report_kmitl_project.xml",
         "data/account.analytic.plan.csv",
+        "data/sequence.xml",
         "data/kmitl_project_exception_data.xml",
         "data/project.evaluation.csv",
         "data/project.fight.csv",

--- a/kmitl_project/data/sequence.xml
+++ b/kmitl_project/data/sequence.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="procurement_plan_seq" model="ir.sequence">
-            <field name="name">Procurement Plan</field>
-            <field name="code">procurement.plan</field>
-            <field name="prefix">PROP/%(year_be)s/</field>
+        <record id="kmitl_project_seq" model="ir.sequence">
+            <field name="name">KMITL Project</field>
+            <field name="code">kmitl.project</field>
+            <field name="prefix">PROJ/%(year_be)s/</field>
             <field name="padding">4</field>
             <field name="number_next">1</field>
             <field name="number_increment">1</field>

--- a/kmitl_project/docs/adr/0001-project-number-on-key.md
+++ b/kmitl_project/docs/adr/0001-project-number-on-key.md
@@ -1,0 +1,15 @@
+# `key` carries the Project Number, not yet the รหัสโครงการ
+
+A `kmitl.project` needs a stable running number for identification and as its analytic-account `code`. We issue it from an `ir.sequence` (`kmitl.project`, prefix `PROJ/%(year_be)s/`, 4-digit, `no_gap`) and store it in the **existing `key` field**, rather than adding a new field. It is minted once, at the `draft→new` confirmation (alongside the analytic and the budget commitment), and is sticky — a later reset-to-draft never re-issues or clears it. The number is stamped with the project's **fiscal year** (the sequence is drawn on `account_fiscal_year_id.date_to`, not the confirmation calendar date), so it always reads as its ปีงบประมาณ; consequently `account_fiscal_year_id` is frozen once `key` exists (view + a server-side write guard).
+
+The real **รหัสโครงการ** — the institutional project code issued at *approval* — is **deferred**. When it lands it will be a separate field; `key` is the running number only. The two are intentionally distinct (see CONTEXT.md » Project Number).
+
+## Why
+
+- Reusing `key` avoids a new field and any view churn: `key` was already displayed and already wired as the analytic `code` source and the `budget.commitment` `ref` — it was simply never populated. The previous fallback (`code = self.key or self.name`) therefore always resolved to the **project name**, which is the bug this fixes.
+- Fiscal-year stamping (vs the `procurement_plan` calendar-date pattern) makes the number unambiguous for a government fiscal-year process and makes freezing the fiscal year meaningful: a project confirmed in Sept 2568 for FY2569 reads `PROJ/2569/...`, not `PROJ/2568/...`.
+
+## Consequences
+
+- `key` is overloaded until the approval-time รหัสโครงการ ships; the glossary flags this so the two are never conflated. Repurposing `key` later would require a migration — hence this record.
+- The counter is a single global `no_gap` sequence; the fiscal year only stamps the prefix and does not reset the count (same as `procurement_plan`).

--- a/kmitl_project/models/kmitl_project.py
+++ b/kmitl_project/models/kmitl_project.py
@@ -96,7 +96,14 @@ class KmitlProject(models.Model):
         "res.company", required=True, default=lambda self: self.env.company
     )
     location = fields.Text(string="สถานที่/พื้นที่ดำเนินโครงการ", copy=True, tracking=True)
-    key = fields.Char(tracking=True, readonly=True)
+    key = fields.Char(
+        string="เลขที่รันโครงการ",
+        tracking=True,
+        readonly=True,
+        copy=False,
+        help="เลขที่รันของโครงการ ออกให้ครั้งเดียวเมื่อยืนยันโครงการ (draft→new) "
+        "และคงเดิมตลอดอายุโครงการ ใช้เป็นรหัส (code) ของบัญชีวิเคราะห์โครงการ",
+    )
     account_fiscal_year_id = fields.Many2one(
         "account.fiscal.year",
         string="Fiscal year",
@@ -503,15 +510,47 @@ class KmitlProject(models.Model):
             }
         )
 
+    def _ensure_project_number(self):
+        """Issue the project's running number (``key``) once, when it is first
+        confirmed (``draft→new``). Idempotent — a later reset-to-draft keeps the
+        number, never re-issues it. Stamped with the project's fiscal year (not the
+        confirmation calendar date) by drawing the sequence on the fiscal year's
+        end date, so the number always reads as its ปีงบประมาณ. Becomes the analytic
+        account's ``code``."""
+        self.ensure_one()
+        if self.key:
+            return
+        self.key = self.env["ir.sequence"].next_by_code(
+            "kmitl.project",
+            sequence_date=self.account_fiscal_year_id.date_to,
+        )
+
+    def write(self, vals):
+        """Freeze the fiscal year once a running number exists: the number, the
+        budget commitment and the analytic are all minted against
+        ``account_fiscal_year_id`` at confirmation, so it must not drift afterwards
+        (e.g. on the reset-to-draft edit path)."""
+        if "account_fiscal_year_id" in vals:
+            for rec in self:
+                if rec.key and rec.account_fiscal_year_id.id != vals[
+                    "account_fiscal_year_id"
+                ]:
+                    raise UserError(
+                        _("ไม่สามารถเปลี่ยนปีงบประมาณได้ เนื่องจากโครงการมีเลขที่รันแล้ว (%s)")
+                        % rec.key
+                    )
+        return super().write(vals)
+
     def _ensure_analytic_account(self):
         """A confirmed project tracks its own ``kmitl_project`` analytic dimension so
         its reservation and downstream spend are attributable to the project. Create
         it on demand (kmitl.project, unlike procurement.plan, has no auto-create on
         write) and let the inverse fold it into ``analytic_distribution``."""
         self.ensure_one()
+        self._ensure_project_number()
         if not self.analytic_account_id:
             self.analytic_account_id = self._create_analytic_account_from_values(
-                {"name": self.name, "code": self.key or self.name}
+                {"name": self.name, "code": self.key}
             ).id
         # Fold the kmitl_project dimension into analytic_distribution — in both
         # branches, independent of the create-branch inverse-flush ordering. The


### PR DESCRIPTION
A `kmitl.project` previously created its analytic account with the **project name** as the `code`, because the `key` field that was meant to be the identifier was never populated. This issues a fiscal-year-stamped running number (`PROJ/<year_be>/0001`, 4-digit BE year drawn on the project's fiscal year) into `key` once at `draft → new`, sticky across reset-to-draft, and uses it as the analytic `code` (the analytic name stays the project name). The fiscal year is now frozen once the running number exists (the UI already locked it after save; this adds a server-side guard). The `procurement_plan` sequence is also widened to a 4-digit BE year for consistency. Glossary (`CONTEXT.md`) and an ADR document the decision, including that the real รหัสโครงการ at approval remains a separate, deferred identifier.