### PR TITLE
[16.0][IMP] account_kmitl: journal & account master data (xmlids, de-hardcode, ใบสำคัญ journals)

### DIFF
--- a/account_asset_kmitl/data/account_asset_profile.xml
+++ b/account_asset_kmitl/data/account_asset_profile.xml
@@ -2,21 +2,9 @@
 <odoo>
     <record id="asset_profile_001" model="account.asset.profile">
         <field name="name">ครุภัณฑ์สำนักงาน</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010004').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010004"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -32,21 +20,9 @@
 
     <record id="asset_profile_002" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ยานพาหนะและขนส่ง</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1252000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1252000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010005').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1252000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1252000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010005"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -62,21 +38,9 @@
 
     <record id="asset_profile_003" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ไฟฟ้าและวิทยุ</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1253000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1253000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010006"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -92,21 +56,9 @@
 
     <record id="asset_profile_004" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ไฟฟ้าและวิทยุ-เครื่องกำเนิดไฟฟ้า</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1253000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1253000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1253000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010006"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -122,21 +74,9 @@
 
     <record id="asset_profile_005" model="account.asset.profile">
         <field name="name">ครุภัณฑ์โฆษณาและเผยแพร่</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1254000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1254000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010007').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1254000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1254000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010007"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -152,21 +92,9 @@
 
     <record id="asset_profile_006" model="account.asset.profile">
         <field name="name">ครุภัณฑ์การเกษตร-เครื่องมือและอุปกรณ์</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1255000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1255000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010008"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -182,21 +110,9 @@
 
     <record id="asset_profile_007" model="account.asset.profile">
         <field name="name">ครุภัณฑ์การเกษตร-เครื่องจักรกล</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1255000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1255000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1255000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010008"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -212,21 +128,9 @@
 
     <record id="asset_profile_008" model="account.asset.profile">
         <field name="name">ครุภัณฑ์โรงงาน-เครื่องมือและอุปกรณ์</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1256000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1256000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010009"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -242,21 +146,9 @@
 
     <record id="asset_profile_009" model="account.asset.profile">
         <field name="name">ครุภัณฑ์โรงงาน-เครื่องจักรกล</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1256000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1256000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1256000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010009"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -272,21 +164,9 @@
 
     <record id="asset_profile_010" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ก่อสร้าง-เครื่องมือและอุปกรณ์</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1257000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1257000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010010"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -302,21 +182,9 @@
 
     <record id="asset_profile_011" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ก่อสร้าง-เครื่องจักรกล</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1257000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1257000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1257000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010010"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -332,21 +200,9 @@
 
     <record id="asset_profile_012" model="account.asset.profile">
         <field name="name">ครุภัณฑ์สำรวจ</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1258000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1258000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010011').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1258000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1258000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010011"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -362,21 +218,9 @@
 
     <record id="asset_profile_013" model="account.asset.profile">
         <field name="name">ครุภัณฑ์วิทยาศาสตร์และการแพทย์</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1259000001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1259000003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010012').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1259000001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1259000003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010012"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -392,21 +236,9 @@
 
     <record id="asset_profile_014" model="account.asset.profile">
         <field name="name">ครุภัณฑ์คอมพิวเตอร์</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251100001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251100003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010013').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251100001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251100003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010013"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -422,21 +254,9 @@
 
     <record id="asset_profile_015" model="account.asset.profile">
         <field name="name">ครุภัณฑ์กีฬา/กายภาพ</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251400001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251400003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010016').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251400001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251400003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010016"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -452,21 +272,9 @@
 
     <record id="asset_profile_016" model="account.asset.profile">
         <field name="name">ครุภัณฑ์สนาม</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251700001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251700003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010019').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251700001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251700003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010019"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -482,21 +290,9 @@
 
     <record id="asset_profile_017" model="account.asset.profile">
         <field name="name">ครุภัณฑ์งานบ้านงานครัว</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251300001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251300003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010015').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251300001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251300003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010015"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -512,21 +308,9 @@
 
     <record id="asset_profile_018" model="account.asset.profile">
         <field name="name">ครุภัณฑ์การศึกษา</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251200001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251200003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010014').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251200001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251200003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010014"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
@@ -542,21 +326,9 @@
 
     <record id="asset_profile_019" model="account.asset.profile">
         <field name="name">ครุภัณฑ์ดนตรี/นาฏศิลป์</field>
-        <field
-            name="account_asset_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251500001').code)])"
-        />
-        <field
-            name="account_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1251500003').code)])"
-        />
-        <field
-            name="account_expense_depreciation_id"
-            model="base"
-            eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010017').code)])"
-        />
+        <field name="account_asset_id" ref="account_kmitl.account_1251500001"/>
+        <field name="account_depreciation_id" ref="account_kmitl.account_1251500003"/>
+        <field name="account_expense_depreciation_id" ref="account_kmitl.account_5105010017"/>
         <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>

--- a/account_asset_kmitl/data/account_asset_profile.xml
+++ b/account_asset_kmitl/data/account_asset_profile.xml
@@ -17,11 +17,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010004').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -51,11 +47,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010005').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -85,11 +77,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -119,11 +107,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010006').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -153,11 +137,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010007').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -187,11 +167,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -221,11 +197,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010008').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -255,11 +227,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -289,11 +257,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010009').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -323,11 +287,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -357,11 +317,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010010').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -391,11 +347,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010011').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -425,11 +377,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010012').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -459,11 +407,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010013').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -493,11 +437,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010016').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -527,11 +467,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010019').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -561,11 +497,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010015').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -595,11 +527,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010014').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>
@@ -629,11 +557,7 @@
             model="base"
             eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_5105010017').code)])"
         />
-        <field
-            name="journal_id"
-            model="base"
-            eval="obj().env['account.journal'].search([('code', '=', 'JV')])"
-        />
+        <field name="journal_id" ref="account_kmitl.journal_jv" />
         <field name="barcode_type">qr</field>
         <field name="barcode_width">150</field>
         <field name="method">linear-limit</field>

--- a/account_kmitl/__manifest__.py
+++ b/account_kmitl/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "KMITL - Accounting",
-    "version": "16.0.1.0.3",
+    "version": "16.0.1.0.4",
     "category": "Accounting/Localizations/Account Charts",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/account_kmitl/__manifest__.py
+++ b/account_kmitl/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "KMITL - Accounting",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.0.3",
     "category": "Accounting/Localizations/Account Charts",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/account_kmitl/__manifest__.py
+++ b/account_kmitl/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "KMITL - Accounting",
-    "version": "16.0.1.0.4",
+    "version": "16.0.1.0.5",
     "category": "Accounting/Localizations/Account Charts",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/account_kmitl/data/account.account.template.csv
+++ b/account_kmitl/data/account.account.template.csv
@@ -9,6 +9,7 @@
 "a_1111100000","เงินสดย่อย","1111100000","asset_current","account_kmitl.chart","False"
 "a_1111100004","เงินสดย่อย","1111100004","asset_current","account_kmitl.chart","False"
 "a_1112000000","เงินฝากธนาคาร","1112000000","asset_current","account_kmitl.chart","False"
+"a_1112000006","ใบสำคัญจ่ายลูกหนี้เงินยืม (สำเนา)","1112000006","asset_cash","account_kmitl.chart","True"
 "a_1112110000","เงินฝากธนาคาร - เงินงบประมาณ-ออมทรัพย์","1112110000","asset_current","account_kmitl.chart","False"
 "a_1112110001","ธ.กรุงไทย สาขาลาดกระบัง บ/ช 69293-9","1112110001","asset_cash","account_kmitl.chart","True"
 "a_1112110002","ธ.กรุงไทย สาขาลาดกระบัง บ/ช 70392-2","1112110002","asset_cash","account_kmitl.chart","True"

--- a/account_kmitl/hooks.py
+++ b/account_kmitl/hooks.py
@@ -4,71 +4,79 @@ from odoo import SUPERUSER_ID, api
 
 _logger = logging.getLogger(__name__)
 
+# Journal master data. ``account`` is the account code used as the journal's
+# default account (resolved after the chart is loaded); ``None`` when the
+# journal has no default account.
+JOURNALS = [
+    {"xmlid": "journal_jv", "code": "JV", "name": "สมุดรายวันทั่วไป", "type": "general", "sequence": 10, "account": None},
+    {"xmlid": "journal_pv", "code": "PV", "name": "สมุดรายวันจ่าย", "type": "bank", "sequence": 20, "account": "1112210004"},
+    {"xmlid": "journal_rv", "code": "RV", "name": "สมุดรายวันรับ", "type": "bank", "sequence": 30, "account": "1112210004"},
+    {"xmlid": "journal_sv", "code": "SV", "name": "สมุดรายวันขาย", "type": "sale", "sequence": 40, "account": "4000000000"},
+    {"xmlid": "journal_uv", "code": "UV", "name": "สมุดรายวันซื้อ", "type": "purchase", "sequence": 50, "account": "5000000000"},
+]
+
+# Account used as payment_account_id on the bank journals' payment method lines.
+BANK_PAYMENT_ACCOUNT_CODE = "1112210004"
+
 
 def _create_journals(env, company):
-    """Create KMITL journals after chart of accounts is loaded."""
+    """Create KMITL journals after the chart of accounts is loaded.
+
+    Journals are created here (not via XML data files) because a bank journal
+    created before the chart exists would auto-create a stray liquidity account
+    and break ``chart._load``. Each journal is registered with a stable external
+    id so other modules can reference it via ``ref``. Idempotent: existing
+    journals are reused rather than duplicated.
+    """
     Account = env["account.account"]
+    Journal = env["account.journal"]
 
     def get_account(code):
-        return Account.search([("code", "=", code), ("company_id", "=", company.id)], limit=1)
+        account = Account.search(
+            [("code", "=", code), ("company_id", "=", company.id)], limit=1
+        )
+        if not account:
+            _logger.warning(
+                "account_kmitl: account code %s not found for company %s; "
+                "leaving journal default account empty.",
+                code,
+                company.display_name,
+            )
+        return account
 
-    journals_data = [
-        {
-            "name": "สมุดรายวันทั่วไป",
-            "code": "JV",
-            "type": "general",
-            "company_id": company.id,
-            "sequence": 10,
-        },
-        {
-            "name": "สมุดรายวันจ่าย",
-            "code": "PV",
-            "type": "bank",
-            "company_id": company.id,
-            "default_account_id": get_account("1112210004").id or False,
-            "sequence": 20,
-        },
-        {
-            "name": "สมุดรายวันรับ",
-            "code": "RV",
-            "type": "bank",
-            "company_id": company.id,
-            "default_account_id": get_account("1112210004").id or False,
-            "sequence": 30,
-        },
-        {
-            "name": "สมุดรายวันขาย",
-            "code": "SV",
-            "type": "sale",
-            "company_id": company.id,
-            "default_account_id": get_account("4000000000").id or False,
-            "sequence": 40,
-        },
-        {
-            "name": "สมุดรายวันซื้อ",
-            "code": "UV",
-            "type": "purchase",
-            "company_id": company.id,
-            "default_account_id": get_account("5000000000").id or False,
-            "sequence": 50,
-        },
-    ]
-
-    Journal = env["account.journal"]
-    for data in journals_data:
-        existing = Journal.search(
+    for data in JOURNALS:
+        journal = Journal.search(
             [("code", "=", data["code"]), ("company_id", "=", company.id)], limit=1
         )
-        if not existing:
-            Journal.create(data)
+        if not journal:
+            vals = {
+                "name": data["name"],
+                "code": data["code"],
+                "type": data["type"],
+                "company_id": company.id,
+                "sequence": data["sequence"],
+            }
+            if data["account"]:
+                vals["default_account_id"] = get_account(data["account"]).id or False
+            journal = Journal.create(vals)
+        env["ir.model.data"]._update_xmlids(
+            [
+                {
+                    "xml_id": "account_kmitl.%s" % data["xmlid"],
+                    "record": journal,
+                    "noupdate": True,
+                }
+            ]
+        )
 
     # Set payment_account_id on bank journal payment method lines
-    payment_account = get_account("1112210004")
+    payment_account = get_account(BANK_PAYMENT_ACCOUNT_CODE)
     if payment_account:
+        bank_codes = [j["code"] for j in JOURNALS if j["type"] == "bank"]
         bank_journals = Journal.search(
             [
                 ("company_id", "=", company.id),
-                ("code", "in", ("PV", "RV")),
+                ("code", "in", bank_codes),
             ]
         )
         payment_method_lines = (
@@ -80,7 +88,7 @@ def _create_journals(env, company):
 
 def _deactivate_default_journals(env, company):
     """Deactivate all non-KMITL journals created by the chart of accounts loader."""
-    kmitl_codes = ("JV", "PV", "RV", "SV", "UV")
+    kmitl_codes = tuple(j["code"] for j in JOURNALS)
     journals_to_deactivate = env["account.journal"].search(
         [
             ("company_id", "=", company.id),

--- a/account_kmitl/hooks.py
+++ b/account_kmitl/hooks.py
@@ -18,6 +18,25 @@ JOURNALS = [
 # Account used as payment_account_id on the bank journals' payment method lines.
 BANK_PAYMENT_ACCOUNT_CODE = "1112210004"
 
+# Account codes other modules reference. The chart loader assigns real accounts a
+# company-prefixed external id (``account_kmitl.1_a_<code>``); we publish a stable,
+# company-independent ``account_kmitl.account_<code>`` for each so downstream data
+# files can use ``ref`` instead of brittle search-by-code. Keep in sync with the
+# codes used in the data files listed below.
+REFERENCED_ACCOUNTS = [
+    # account_asset_kmitl asset profiles (data/account_asset_profile.xml)
+    "1251000001", "1251000003", "1251100001", "1251100003", "1251200001", "1251200003",
+    "1251300001", "1251300003", "1251400001", "1251400003", "1251500001", "1251500003",
+    "1251700001", "1251700003", "1252000001", "1252000003", "1253000001", "1253000003",
+    "1254000001", "1254000003", "1255000001", "1255000003", "1256000001", "1256000003",
+    "1257000001", "1257000003", "1258000001", "1258000003", "1259000001", "1259000003",
+    "5105010004", "5105010005", "5105010006", "5105010007", "5105010008", "5105010009",
+    "5105010010", "5105010011", "5105010012", "5105010013", "5105010014", "5105010015",
+    "5105010016", "5105010017", "5105010019",
+    # kmitl_demo partners (data/res.partner.xml)
+    "1126000001", "2110000001", "2110000099",
+]
+
 
 def _create_journals(env, company):
     """Create KMITL journals after the chart of accounts is loaded.
@@ -84,6 +103,44 @@ def _create_journals(env, company):
             + bank_journals.outbound_payment_method_line_ids
         )
         payment_method_lines.payment_account_id = payment_account
+
+
+def _register_account_xmlids(env, company):
+    """Publish stable, company-independent external ids for the accounts that
+    other modules reference (e.g. account_asset_kmitl asset profiles,
+    kmitl_demo partners).
+
+    The chart loader assigns real accounts a company-coupled xmlid
+    (``account_kmitl.1_a_<code>``). Downstream modules should not hard-code the
+    company prefix, so we publish ``account_kmitl.account_<code>`` pointing at the
+    same record. Idempotent: ``_update_xmlids`` upserts on (module, name), so
+    re-running reuses existing rows. Missing codes are logged, never fatal.
+    """
+    Account = env["account.account"]
+
+    data_list = []
+    for code in REFERENCED_ACCOUNTS:
+        account = Account.search(
+            [("code", "=", code), ("company_id", "=", company.id)], limit=1
+        )
+        if not account:
+            _logger.warning(
+                "account_kmitl: account code %s not found for company %s; "
+                "skipping external id account_kmitl.account_%s.",
+                code,
+                company.display_name,
+                code,
+            )
+            continue
+        data_list.append(
+            {
+                "xml_id": "account_kmitl.account_%s" % code,
+                "record": account,
+                "noupdate": True,
+            }
+        )
+    if data_list:
+        env["ir.model.data"]._update_xmlids(data_list)
 
 
 def _deactivate_default_journals(env, company):
@@ -182,5 +239,6 @@ def post_init_hook(cr, registry):
     _purge_generic_accounting_demo(env, company)
     env.ref("account_kmitl.chart")._load(company)
     _create_journals(env, company)
+    _register_account_xmlids(env, company)
     _deactivate_default_journals(env, company)
     _create_withholding_taxes(env, company)

--- a/account_kmitl/hooks.py
+++ b/account_kmitl/hooks.py
@@ -11,8 +11,8 @@ JOURNALS = [
     {"xmlid": "journal_jv", "code": "JV", "name": "สมุดรายวันทั่วไป", "type": "general", "sequence": 10, "account": None},
     {"xmlid": "journal_pv", "code": "PV", "name": "สมุดรายวันจ่าย", "type": "bank", "sequence": 20, "account": "1112210004"},
     {"xmlid": "journal_rv", "code": "RV", "name": "สมุดรายวันรับ", "type": "bank", "sequence": 30, "account": "1112210004"},
-    {"xmlid": "journal_sv", "code": "SV", "name": "สมุดรายวันขาย", "type": "sale", "sequence": 40, "account": "4000000000"},
-    {"xmlid": "journal_uv", "code": "UV", "name": "สมุดรายวันซื้อ", "type": "purchase", "sequence": 50, "account": "5000000000"},
+    {"xmlid": "journal_ar", "code": "AR", "name": "สมุดรายวันขาย", "type": "sale", "sequence": 40, "account": "4000000000"},
+    {"xmlid": "journal_ap", "code": "AP", "name": "สมุดรายวันซื้อ", "type": "purchase", "sequence": 50, "account": "5000000000"},
 ]
 
 # Account used as payment_account_id on the bank journals' payment method lines.

--- a/account_kmitl/hooks.py
+++ b/account_kmitl/hooks.py
@@ -6,17 +6,18 @@ _logger = logging.getLogger(__name__)
 
 # Journal master data. ``account`` is the account code used as the journal's
 # default account (resolved after the chart is loaded); ``None`` when the
-# journal has no default account.
+# journal has no default account. Bank journals also point their payment method
+# lines at that same default account.
 JOURNALS = [
-    {"xmlid": "journal_jv", "code": "JV", "name": "สมุดรายวันทั่วไป", "type": "general", "sequence": 10, "account": None},
-    {"xmlid": "journal_pv", "code": "PV", "name": "สมุดรายวันจ่าย", "type": "bank", "sequence": 20, "account": "1112210004"},
-    {"xmlid": "journal_rv", "code": "RV", "name": "สมุดรายวันรับ", "type": "bank", "sequence": 30, "account": "1112210004"},
-    {"xmlid": "journal_ar", "code": "AR", "name": "สมุดรายวันขาย", "type": "sale", "sequence": 40, "account": "4000000000"},
-    {"xmlid": "journal_ap", "code": "AP", "name": "สมุดรายวันซื้อ", "type": "purchase", "sequence": 50, "account": "5000000000"},
+    {"xmlid": "journal_jv", "code": "JV", "name": "ใบสำคัญทั่วไป", "type": "general", "sequence": 10, "account": None},
+    {"xmlid": "journal_pv", "code": "PV", "name": "ใบสำคัญจ่าย", "type": "bank", "sequence": 20, "account": "1112210004"},
+    {"xmlid": "journal_pvr", "code": "PVR", "name": "ใบสำคัญส่งคืนลูกหนี้เงินยืม", "type": "bank", "sequence": 30, "account": "1112000006"},
+    {"xmlid": "journal_rv", "code": "RV", "name": "ใบสำคัญรับ", "type": "bank", "sequence": 40, "account": "1112210004"},
+    {"xmlid": "journal_par", "code": "PAR", "name": "ใบสำคัญจ่ายลูกหนี้เงินยืม", "type": "bank", "sequence": 50, "account": "1112110004"},
+    {"xmlid": "journal_car", "code": "CAR", "name": "ใบสำคัญล้างลูกหนี้เงินยืม", "type": "general", "sequence": 60, "account": None},
+    {"xmlid": "journal_ar", "code": "AR", "name": "ใบสำคัญลูกหนี้", "type": "sale", "sequence": 70, "account": "4000000000"},
+    {"xmlid": "journal_ap", "code": "AP", "name": "ใบสำคัญซื้อ", "type": "purchase", "sequence": 80, "account": "5000000000"},
 ]
-
-# Account used as payment_account_id on the bank journals' payment method lines.
-BANK_PAYMENT_ACCOUNT_CODE = "1112210004"
 
 # Account codes other modules reference. The chart loader assigns real accounts a
 # company-prefixed external id (``account_kmitl.1_a_<code>``); we publish a stable,
@@ -67,6 +68,7 @@ def _create_journals(env, company):
         journal = Journal.search(
             [("code", "=", data["code"]), ("company_id", "=", company.id)], limit=1
         )
+        account = get_account(data["account"]) if data["account"] else Account.browse()
         if not journal:
             vals = {
                 "name": data["name"],
@@ -75,9 +77,12 @@ def _create_journals(env, company):
                 "company_id": company.id,
                 "sequence": data["sequence"],
             }
-            if data["account"]:
-                vals["default_account_id"] = get_account(data["account"]).id or False
+            if account:
+                vals["default_account_id"] = account.id
             journal = Journal.create(vals)
+        elif account and not journal.default_account_id:
+            # Backfill a default account added after the journal was created.
+            journal.default_account_id = account.id
         env["ir.model.data"]._update_xmlids(
             [
                 {
@@ -88,21 +93,21 @@ def _create_journals(env, company):
             ]
         )
 
-    # Set payment_account_id on bank journal payment method lines
-    payment_account = get_account(BANK_PAYMENT_ACCOUNT_CODE)
-    if payment_account:
-        bank_codes = [j["code"] for j in JOURNALS if j["type"] == "bank"]
-        bank_journals = Journal.search(
-            [
-                ("company_id", "=", company.id),
-                ("code", "in", bank_codes),
-            ]
-        )
-        payment_method_lines = (
-            bank_journals.inbound_payment_method_line_ids
-            + bank_journals.outbound_payment_method_line_ids
-        )
-        payment_method_lines.payment_account_id = payment_account
+    # Point each bank journal's payment method lines at its own default account.
+    bank_codes = [j["code"] for j in JOURNALS if j["type"] == "bank"]
+    bank_journals = Journal.search(
+        [
+            ("company_id", "=", company.id),
+            ("code", "in", bank_codes),
+        ]
+    )
+    for journal in bank_journals:
+        if journal.default_account_id:
+            lines = (
+                journal.inbound_payment_method_line_ids
+                + journal.outbound_payment_method_line_ids
+            )
+            lines.payment_account_id = journal.default_account_id
 
 
 def _register_account_xmlids(env, company):

--- a/account_kmitl/migrations/16.0.1.0.3/post-migration.py
+++ b/account_kmitl/migrations/16.0.1.0.3/post-migration.py
@@ -1,0 +1,15 @@
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.account_kmitl.hooks import _create_journals
+
+
+def migrate(cr, version):
+    """Backfill external ids for journals created before xmlids were added.
+
+    ``post_init_hook`` only runs on install, so existing databases have the 5
+    KMITL journals without any ``ir.model.data`` entry. ``_create_journals`` is
+    idempotent: it finds the existing journals (the chart is already loaded on a
+    live database) and registers their xmlids without re-creating them.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _create_journals(env, env.ref("base.main_company"))

--- a/account_kmitl/migrations/16.0.1.0.3/post-migration.py
+++ b/account_kmitl/migrations/16.0.1.0.3/post-migration.py
@@ -2,14 +2,30 @@ from odoo import SUPERUSER_ID, api
 
 from odoo.addons.account_kmitl.hooks import _create_journals
 
+# Journals renamed in this version. Existing installs created them under the
+# old codes; renaming preserves their entries and avoids creating duplicates.
+LEGACY_CODE_RENAMES = {"SV": "AR", "UV": "AP"}
+
 
 def migrate(cr, version):
-    """Backfill external ids for journals created before xmlids were added.
+    """Rename legacy journal codes and backfill external ids on existing DBs.
 
-    ``post_init_hook`` only runs on install, so existing databases have the 5
-    KMITL journals without any ``ir.model.data`` entry. ``_create_journals`` is
-    idempotent: it finds the existing journals (the chart is already loaded on a
-    live database) and registers their xmlids without re-creating them.
+    ``post_init_hook`` only runs on install, so existing databases still have
+    the journals under their old codes (and without any ``ir.model.data``
+    entry). Rename them first, then let the idempotent ``_create_journals``
+    find the renamed journals and register their xmlids without re-creating.
     """
     env = api.Environment(cr, SUPERUSER_ID, {})
-    _create_journals(env, env.ref("base.main_company"))
+    company = env.ref("base.main_company")
+
+    Journal = env["account.journal"]
+    for old_code, new_code in LEGACY_CODE_RENAMES.items():
+        journal = Journal.search(
+            [("code", "=", old_code), ("company_id", "=", company.id)], limit=1
+        )
+        if journal and not Journal.search_count(
+            [("code", "=", new_code), ("company_id", "=", company.id)]
+        ):
+            journal.code = new_code
+
+    _create_journals(env, company)

--- a/account_kmitl/migrations/16.0.1.0.4/post-migration.py
+++ b/account_kmitl/migrations/16.0.1.0.4/post-migration.py
@@ -1,0 +1,15 @@
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.account_kmitl.hooks import _register_account_xmlids
+
+
+def migrate(cr, version):
+    """Backfill company-independent account external ids on existing DBs.
+
+    ``post_init_hook`` only runs on install, so existing databases have the real
+    accounts but no ``account_kmitl.account_<code>`` external ids. Re-run the
+    idempotent registration to publish them before downstream modules reload
+    their data files with ``ref="account_kmitl.account_..."``.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _register_account_xmlids(env, env.ref("base.main_company"))

--- a/account_kmitl/migrations/16.0.1.0.5/post-migration.py
+++ b/account_kmitl/migrations/16.0.1.0.5/post-migration.py
@@ -1,0 +1,48 @@
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.account_kmitl.hooks import JOURNALS, _create_journals
+
+# Account added in this version; needed as the PVR journal's default account.
+NEW_ACCOUNT_TEMPLATE_XMLID = "account_kmitl.a_1112000006"
+
+
+def migrate(cr, version):
+    """Add the new journals/account and rename journal names on existing DBs.
+
+    ``chart._load`` and ``post_init_hook`` only run on install, so upgrades must
+    replicate their effects: instantiate the newly added account from its
+    (freshly loaded) template, create the new journals (PVR/PAR/CAR) while
+    backfilling default and payment accounts via the idempotent
+    ``_create_journals``, and rename the existing journals to the new
+    "ใบสำคัญ" names.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    company = env.ref("base.main_company")
+    Account = env["account.account"]
+    Journal = env["account.journal"]
+
+    # Instantiate the newly added account from its template.
+    template = env.ref(NEW_ACCOUNT_TEMPLATE_XMLID, raise_if_not_found=False)
+    if template and not Account.search_count(
+        [("code", "=", template.code), ("company_id", "=", company.id)]
+    ):
+        Account.create(
+            {
+                "code": template.code,
+                "name": template.name,
+                "account_type": template.account_type,
+                "reconcile": template.reconcile,
+                "company_id": company.id,
+            }
+        )
+
+    # Create the new journals, backfill default/payment accounts, register xmlids.
+    _create_journals(env, company)
+
+    # Rename existing journals to the new "ใบสำคัญ" names.
+    for data in JOURNALS:
+        journal = Journal.search(
+            [("code", "=", data["code"]), ("company_id", "=", company.id)], limit=1
+        )
+        if journal and journal.name != data["name"]:
+            journal.name = data["name"]

--- a/kmitl_demo/data/res.partner.xml
+++ b/kmitl_demo/data/res.partner.xml
@@ -15,8 +15,8 @@
             <field name="phone">+66 2 678 9012</field>
             <field name="email">info@moderntech.co.th</field>
             <field name="website">www.moderntech.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_002" model="res.partner">
@@ -32,8 +32,8 @@
             <field name="phone">+66 2 258 7410</field>
             <field name="email">contact@compsystem.co.th</field>
             <field name="website">www.compsystem.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_003" model="res.partner">
@@ -49,8 +49,8 @@
             <field name="phone">+66 2 538 9123</field>
             <field name="email">sales@digitalsolution.co.th</field>
             <field name="website">www.digitalsolution.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_004" model="res.partner">
@@ -66,8 +66,8 @@
             <field name="phone">+66 2 275 8456</field>
             <field name="email">order@thaistationery.co.th</field>
             <field name="website">www.thaistationery.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_005" model="res.partner">
@@ -82,8 +82,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 2 643 2178</field>
             <field name="email">info@officesupply.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_006" model="res.partner">
@@ -99,8 +99,8 @@
             <field name="phone">+66 2 254 7890</field>
             <field name="email">contract@construction-maint.co.th</field>
             <field name="website">www.construction-maint.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_007" model="res.partner">
@@ -115,8 +115,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 2 589 3456</field>
             <field name="email">service@engineering-service.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_008" model="res.partner">
@@ -132,8 +132,8 @@
             <field name="phone">+66 2 561 2345</field>
             <field name="email">sales@scienceinstrument.co.th</field>
             <field name="website">www.scienceinstrument.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_009" model="res.partner">
@@ -149,8 +149,8 @@
             <field name="phone">+66 2 617 8901</field>
             <field name="email">info@labequipment.co.th</field>
             <field name="website">www.labequipment.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <record id="vendor_demo_010" model="res.partner">
@@ -166,8 +166,8 @@
             <field name="phone">+66 2 743 5678</field>
             <field name="email">contact@consulting-training.co.th</field>
             <field name="website">www.consulting-training.co.th</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000001').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000001"/>
         </record>
 
         <!-- Individual Vendors -->
@@ -183,8 +183,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 81 234 5678</field>
             <field name="email">dr.somchai.w@gmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
 
         </record>
 
@@ -200,8 +200,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 89 567 1234</field>
             <field name="email">prasit.tech@hotmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_013" model="res.partner">
@@ -216,8 +216,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 82 345 6789</field>
             <field name="email">somying.research@yahoo.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_014" model="res.partner">
@@ -232,8 +232,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 86 456 7890</field>
             <field name="email">vipa.consult@outlook.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_015" model="res.partner">
@@ -248,8 +248,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 91 567 8901</field>
             <field name="email">anucha.trainer@gmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_016" model="res.partner">
@@ -264,8 +264,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 84 678 9012</field>
             <field name="email">pimjai.design@gmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_017" model="res.partner">
@@ -280,8 +280,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 85 789 0123</field>
             <field name="email">dr.veera.eng@hotmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_018" model="res.partner">
@@ -296,8 +296,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 92 890 1234</field>
             <field name="email">surachai.repair@gmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_019" model="res.partner">
@@ -312,8 +312,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 83 901 2345</field>
             <field name="email">napa.programmer@outlook.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
 
         <record id="vendor_demo_020" model="res.partner">
@@ -328,8 +328,8 @@
             <field name="country_id" ref="base.th"/>
             <field name="phone">+66 87 012 3456</field>
             <field name="email">thana.accountant@gmail.com</field>
-            <field name="property_account_receivable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_1126000001').code)])"/>
-            <field name="property_account_payable_id" model="base" eval="obj().env['account.account'].search([('code', '=', obj().env.ref('account_kmitl.a_2110000099').code)])"/>
+            <field name="property_account_receivable_id" ref="account_kmitl.account_1126000001"/>
+            <field name="property_account_payable_id" ref="account_kmitl.account_2110000099"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
## Why

The KMITL journals and referenced accounts were created/looked up in fragile ways:

1. **No external ids** — journals and accounts had no stable `ir.model.data` rows, so other modules looked them up by code (`account_asset_kmitl` did `eval="...search([('code','=','JV')])"` in 19 places; the chart's company-coupled `account_kmitl.1_a_<code>` xmlid was hard to reference).
2. **Hardcoded values** — default-account codes were inline magic strings and code lists were duplicated.
3. **Silent failures** — a missing account code silently produced `False` with no log.

This PR also brings the journal master data in line with the required set (8 journals, "ใบสำคัญ…" naming) and standard AR/AP codes.

## What changed

**Journals (`account_kmitl/hooks.py`)** — single `JOURNALS` constant as the source of truth; stable xmlids (`account_kmitl.journal_<code>`) registered via `ir.model.data._update_xmlids`; `_create_journals` is idempotent (reuses existing journals, backfills a missing default account); a warning is logged when an account code is missing; each bank journal's payment method lines point at **its own** default account. Final set:

| Name | Type | Code | Default account | xmlid |
|------|------|------|-----------------|-------|
| ใบสำคัญทั่วไป | general | JV | — | `journal_jv` |
| ใบสำคัญจ่าย | bank | PV | 1112210004 | `journal_pv` |
| ใบสำคัญส่งคืนลูกหนี้เงินยืม | bank | PVR | 1112000006 *(new)* | `journal_pvr` |
| ใบสำคัญรับ | bank | RV | 1112210004 | `journal_rv` |
| ใบสำคัญจ่ายลูกหนี้เงินยืม | bank | PAR | 1112110004 | `journal_par` |
| ใบสำคัญล้างลูกหนี้เงินยืม | general | CAR | — | `journal_car` |
| ใบสำคัญลูกหนี้ | sale | AR | 4000000000 | `journal_ar` |
| ใบสำคัญซื้อ | purchase | AP | 5000000000 | `journal_ap` |

Sale/purchase codes were renamed `SV → AR` / `UV → AP`; all journals were renamed from `สมุดรายวัน…` to `ใบสำคัญ…`.

**Accounts (`account_kmitl/hooks.py`, `data/account.account.template.csv`)** — publish stable, company-independent `account_kmitl.account_<code>` xmlids for the accounts other modules reference (`_register_account_xmlids`); add account `1112000006` (ใบสำคัญจ่ายลูกหนี้เงินยืม (สำเนา), asset_cash) used as PVR's default account.

**`account_asset_kmitl/data/account_asset_profile.xml`** — replace the 19 eval/search-by-code `journal_id` lookups with `ref="account_kmitl.journal_jv"`; account references use the published `account_kmitl.account_<code>` xmlids.

**`kmitl_demo/data/res.partner.xml`** — use the published account xmlids instead of search-by-code.

**Migrations (`account_kmitl/migrations/`)** — `post_init_hook`/`chart._load` only run on install, so upgrades replicate their effects for existing databases:
- `16.0.1.0.3` — rename legacy journal codes (SV→AR, UV→AP) and backfill journal xmlids.
- `16.0.1.0.4` — backfill the published account xmlids.
- `16.0.1.0.5` — instantiate account `1112000006` from its template, create the new journals (PVR/PAR/CAR) with default/payment accounts, and rename existing journals to the `ใบสำคัญ…` names.

Manifest version bumped to `16.0.1.0.5`.

## Notes
- Journal names are kept in Thai in the hook by design: `account.journal.name` is **not** `translate=True` in Odoo core, so it cannot be translated via `.po` — it is non-translatable master data.
- Journals must stay created in the hook (after `chart._load`): a bank journal created from an XML data file before the chart loads would auto-create a stray liquidity account and break `chart._load`.
- Code is the prefix of journal-entry names: entries already posted keep their old names; new entries use the new codes.

## Testing
- [ ] Fresh install of `account_kmitl` then `account_asset_kmitl` on a clean DB — 8 journals created with the correct names/codes/types/default accounts; `env.ref("account_kmitl.journal_*")` and `account_kmitl.account_*` resolve; all 19 asset profiles point at JV.
- [ ] Upgrade an existing DB (5 journals as สมุดรายวัน…, codes JV/PV/RV/SV/UV) — migrations rename codes, instantiate account 1112000006, create PVR/PAR/CAR, backfill default/payment accounts and xmlids, and rename all journals to ใบสำคัญ… without duplicates.