### PR TITLE
[16.0][FIX] budget: reserve against document fiscal year, not today

### DIFF
--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -567,12 +567,16 @@ class ApprovalRequest(models.Model):
 
         amount = sum(self.line_ids.mapped("total_amount"))
 
+        # ปีงบยึดตามเอกสาร: check/reserve against this request's own fiscal year
+        # (account_fiscal_year_id, derived from its date), not today() — otherwise a
+        # request whose FY differs from today is checked against the wrong year.
         check_result = self._check_budget_availability(
             amount=amount,
             activity_analytic_id=self.activity_analytic_id.id,
             department_analytic_id=self.department_analytic_id.id,
             fund_analytic_id=self.fund_analytic_id.id,
             source_analytic_id=self.source_analytic_id.id,
+            account_fiscal_year_id=self.account_fiscal_year_id.id,
         )
 
         if not check_result["is_sufficient"]:
@@ -591,6 +595,7 @@ class ApprovalRequest(models.Model):
                 ref=self.name,
                 description=f"Approval Request: {self.name}",
                 auto_reserve=True,
+                account_fiscal_year_id=self.account_fiscal_year_id.id,
             )
             self.message_post(
                 body=_("Budget reserved: %s for amount %s") % (commitment.name, amount)

--- a/budget/static/src/reservation_picker/budget_reservation_picker.xml
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.xml
@@ -4,9 +4,14 @@
     <t t-name="budget.BudgetReservationPicker" owl="1">
         <div class="o_budget_dashboard o_budget_reservation_picker d-flex flex-column">
             <div class="o_bd_controls">
+                <!-- ปีงบยึดตามเอกสาร (ทาง A): the year is fixed to the host's
+                     account_fiscal_year_id (passed as default_fiscal_year_id), so the
+                     grid can only ever show — and a reservation can only ever pick — a
+                     code budgeted in the document's own fiscal year. Locked, not
+                     switchable, to avoid showing a year the reserve check would reject. -->
                 <div class="o_bd_filter">
                     <label>ปีงบประมาณ</label>
-                    <select t-on-change="onFiscalYearChange">
+                    <select disabled="disabled" title="ปีงบประมาณยึดตามเอกสาร">
                         <t t-foreach="fiscalYears" t-as="fy" t-key="fy.id">
                             <option t-att-value="fy.id" t-att-selected="fy.id === state.fiscalYearId">
                                 <t t-esc="fy.name"/>

--- a/purchase_request_budget/models/purchase_request.py
+++ b/purchase_request_budget/models/purchase_request.py
@@ -204,12 +204,16 @@ class PurchaseRequest(models.Model):
 
         amount = sum(self.line_ids.mapped("estimated_cost"))
 
+        # ปีงบยึดตามเอกสาร: check/reserve against this request's own fiscal year
+        # (account_fiscal_year_id), not today() — otherwise a request whose FY differs
+        # from today is checked against the wrong year.
         check_result = self._check_budget_availability(
             amount=amount,
             activity_analytic_id=self.activity_analytic_id.id,
             department_analytic_id=self.department_analytic_id.id,
             fund_analytic_id=self.fund_analytic_id.id,
             source_analytic_id=self.source_analytic_id.id,
+            account_fiscal_year_id=self.account_fiscal_year_id.id,
         )
 
         if not check_result["is_sufficient"]:
@@ -228,6 +232,7 @@ class PurchaseRequest(models.Model):
                 ref=self.name,
                 description=f"Purchase Request: {self.name}",
                 auto_reserve=True,
+                account_fiscal_year_id=self.account_fiscal_year_id.id,
             )
             self.message_post(
                 body=_("Budget reserved: %s for amount %s") % (commitment.name, amount)


### PR DESCRIPTION
The reservation picker let the fiscal year be switched independently of the host document, while the reserve action checked availability against today's fiscal year — so a code budgeted only in a future year showed remaining in the grid yet failed with "insufficient funds" (reserving the current year worked only because today matched the grid default). This locks the picker's fiscal-year selector to the host's `account_fiscal_year_id` and passes that year to `_check_budget_availability` and `_create_budget_commitment` in the approval-request and purchase-request reserve actions, so both the availability check and the created commitment use the document's own fiscal year (1 document = 1 fiscal year). To reserve a different year, set the document's date into that year so its fiscal year recomputes.