### PR TITLE
[16.0][FIX] purchase_request_dashboard: default source to งบประมาณเงินรายได้

### DIFF
--- a/purchase_request_dashboard/controllers/main.py
+++ b/purchase_request_dashboard/controllers/main.py
@@ -71,7 +71,8 @@ class PurchaseRequestDashboardController(http.Controller):
         if not fiscal_year_id and fiscal_years:
             fiscal_year_id = fiscal_years[0].id
         if not source_id and sources:
-            source_id = sources[0].id
+            default_source = sources.filtered(lambda s: s.code == "2")
+            source_id = (default_source[:1] or sources[:1]).id
 
         # Fetch and filter records
         domain = []


### PR DESCRIPTION
## Summary

- เปลี่ยน default filter **แหล่งเงิน** บนหน้า Purchase Request Dashboard จาก **งบประมาณแผ่นดิน** (code `1`) เป็น **งบประมาณเงินรายได้** (code `2`)
- แก้ไขใน controller (`purchase_request_dashboard/controllers/main.py`) เนื่องจาก default ถูกกำหนดฝั่ง backend ก่อนส่งให้ frontend
- มี fallback กลับไปยังตัวแรกของ sources หาก code `2` ไม่พบในระบบ (ป้องกัน environment ที่ data ต่างกัน)

## Test plan

- [ ] เปิดหน้า Dashboard ของ Purchase Request ตรวจว่า dropdown "แหล่งเงิน" เลือก **งบประมาณเงินรายได้** เป็น default
- [ ] เปลี่ยน filter เป็น "งบประมาณแผ่นดิน" และกลับมา ดูว่า charts/summary boxes อัปเดตตามปกติ
- [ ] ตรวจว่าลำดับ option ใน dropdown ยังเรียงตาม code เหมือนเดิม