### PR TITLE
[16.0][FIX] kmitl_project_purchase_request: purchase users can create พ.1

### DIFF
--- a/kmitl_project_purchase_request/__manifest__.py
+++ b/kmitl_project_purchase_request/__manifest__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KMITL Project Purchase Request",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "KMITL",
     "summary": "Create purchase requests (พ.1) from a KMITL project's reserved budget",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
-    "depends": ["kmitl_project", "purchase_request_budget"],
+    "depends": ["kmitl_project", "purchase_request_budget", "purchase"],
     "data": [
+        "security/ir.model.access.csv",
+        "security/security.xml",
         "views/purchase_request_views.xml",
         "views/kmitl_project_views.xml",
     ],

--- a/kmitl_project_purchase_request/models/purchase_request.py
+++ b/kmitl_project_purchase_request/models/purchase_request.py
@@ -115,7 +115,9 @@ class PurchaseRequest(models.Model):
                 )
             self.budget_commitment_id = commitment.id
             if project.state == "new":
-                project.button_in_progress()
+                # Purchasing/budget staff have read — not write — on the project;
+                # advancing it is a system side-effect of reserving, so elevate it.
+                project.sudo().button_in_progress()
             self.button_to_approve()
             return {
                 "type": "ir.actions.act_window",
@@ -177,7 +179,10 @@ class PurchaseRequest(models.Model):
                 {"analytic_distribution": project.analytic_distribution}
             )
         if project.state == "new":
-            project.button_in_progress()
+            # The PR creator (purchase request user) has read — not write — on the
+            # project; advancing it to in_progress is a system side-effect of
+            # creating the พ.1, so elevate just this state write.
+            project.sudo().button_in_progress()
 
 
 class KmitlProject(models.Model):

--- a/kmitl_project_purchase_request/security/ir.model.access.csv
+++ b/kmitl_project_purchase_request/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_kmitl_project_purchase_request_user,kmitl.project purchasing read (PR user),kmitl_project.model_kmitl_project,purchase_request.group_purchase_request_user,1,0,0,0
+access_kmitl_project_purchase_user,kmitl.project purchasing read (purchase user),kmitl_project.model_kmitl_project,purchase.group_purchase_user,1,0,0,0

--- a/kmitl_project_purchase_request/security/security.xml
+++ b/kmitl_project_purchase_request/security/security.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <!-- Hotfix: let purchasing staff (purchase request user / purchase user)
+             create พ.1 from a project. The model access above grants them read on
+             kmitl.project; this rule lets them read every project (ANDed with the
+             global company / operating-unit rules) instead of being narrowed to
+             "own projects" when they also hold a kmitl.project user group.
+
+             Read only — they never gain write. The new→in_progress advance that a
+             พ.1 triggers on the project is elevated server-side (purchase_request.py),
+             so purchasing staff cannot otherwise edit or change a project's state. -->
+        <record id="kmitl_project_purchase_read_rule" model="ir.rule">
+            <field name="name">KMITL Project: purchasing read (สร้าง พ.1)</field>
+            <field name="model_id" ref="kmitl_project.model_kmitl_project"/>
+            <field name="groups" eval="[(4, ref('purchase_request.group_purchase_request_user')), (4, ref('purchase.group_purchase_user'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Purchasing staff (purchase request user / purchase user) were fully locked out of `kmitl.project`, so they could neither open a project nor use the **"สร้างใบขอซื้อ"** button to raise a พ.1. This grants those two groups read-only access to `kmitl.project` — model access plus an all-projects record rule, so users who also hold a project-user group aren't narrowed to "own projects". The `new→in_progress` advance that a พ.1 triggers on create/reserve is elevated server-side with `sudo()`, so purchasing staff need no write access on projects and cannot otherwise edit them or change their state. The manifest registers the new security files, adds the `purchase` dependency (for `purchase.group_purchase_user`), and bumps the version to `16.0.1.0.1`.
