### PR TITLE
[16.0][IMP] procurement_plan: reliable analytic_distribution on reserve & PR

### DIFF
--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -298,6 +298,14 @@ class ProcurementPlan(models.Model):
                 self.account_fiscal_year_id.id,
                 self.company_id.id,
             )
+        # Refold this plan's own procurement_plan dimension into
+        # analytic_distribution before snapshotting it onto the commitment in
+        # _prepare_plan_commitment_vals. It is normally folded in via the
+        # analytic_account_id inverse at action_new; refolding here makes the
+        # reservation robust to any edit or state-ordering change in between, so
+        # the reserve line always carries the ownership tag (see
+        # budget.controller _POOL_TAG_COLUMNS).
+        self._update_analytic_distribution("procurement_plan")
         commitment = self.env["budget.commitment"].create(
             self._prepare_plan_commitment_vals()
         )

--- a/procurement_plan/tests/__init__.py
+++ b/procurement_plan/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_procurement_plan_analytic
+from . import test_reserve_distribution

--- a/procurement_plan/tests/test_reserve_distribution.py
+++ b/procurement_plan/tests/test_reserve_distribution.py
@@ -1,0 +1,152 @@
+from datetime import date
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReserveDistribution(TransactionCase):
+    """The plan's reservation commitment must carry the plan's own
+    procurement_plan analytic dimension (the ownership tag) in
+    analytic_distribution, so the reserve line stays attributable to the plan
+    (see budget.controller _POOL_TAG_COLUMNS)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        # No appropriation is set up here; allow the reserve without availability.
+        env["ir.config_parameter"].sudo().set_param("budget.allow_negative", "True")
+
+        cls.activity_account = env["account.analytic.account"].create(
+            {
+                "name": "Test Activity",
+                "plan_id": env.ref(
+                    "account_analytic_kmitl.analytic_plan_activities"
+                ).id,
+            }
+        )
+        cls.department_account = env["account.analytic.account"].create(
+            {
+                "name": "Test Department",
+                "plan_id": env.ref(
+                    "account_analytic_kmitl.analytic_plan_departments"
+                ).id,
+            }
+        )
+        cls.fund_account = env["account.analytic.account"].create(
+            {
+                "name": "Test Fund",
+                "plan_id": env.ref("account_analytic_kmitl.analytic_plan_funds").id,
+            }
+        )
+        cls.source_account = env["account.analytic.account"].create(
+            {
+                "name": "Test Source",
+                "plan_id": env.ref(
+                    "account_analytic_kmitl.analytic_plan_sources"
+                ).id,
+            }
+        )
+
+        cls.fiscal_year = env["account.fiscal.year"].search([], limit=1)
+        if not cls.fiscal_year:
+            cls.fiscal_year = env["account.fiscal.year"].create(
+                {
+                    "name": "FY-TEST",
+                    "date_from": date(2025, 10, 1),
+                    "date_to": date(2026, 9, 30),
+                    "company_id": env.company.id,
+                }
+            )
+
+        cls.budget_account = env["budget.account"].create(
+            {
+                "code": "TESTPPRES",
+                "name": "Test Procurement Plan Code",
+                "budget_type": "expense",
+                "budgetable": True,
+            }
+        )
+
+    def _financial_dims(self):
+        return {
+            str(self.activity_account.id): 100,
+            str(self.department_account.id): 100,
+            str(self.fund_account.id): 100,
+            str(self.source_account.id): 100,
+        }
+
+    def _make_new_plan(self):
+        """Create a plan and confirm it (draft->new): action_new mints the plan's
+        own analytic account and folds it into analytic_distribution."""
+        plan = self.env["procurement.plan"].create(
+            {
+                "description": "Test Plan",
+                "amount": 1,
+                "unit": "ชุด",
+                "total_price": 1000.0,
+                "account_fiscal_year_id": self.fiscal_year.id,
+                "budget_account_id": self.budget_account.id,
+                "purchase_request_eta": "1",
+                "procurement_announcement_eta": "2",
+                "approval_signing_eta": "3",
+                "contract_order_signing_eta": "4",
+                "acceptance_eta": "5",
+                "analytic_distribution": self._financial_dims(),
+            }
+        )
+        plan.action_new()
+        return plan
+
+    def _reserve_line(self, plan):
+        commitment = plan.budget_commitment_ids.filtered(
+            lambda c: c.state != "cancel"
+        )[:1]
+        self.assertTrue(commitment, "a reservation commitment should exist")
+        return commitment.line_ids.filtered(
+            lambda l: l.move_type == "reserve"
+        )[:1]
+
+    def test_reservation_carries_procurement_plan_tag(self):
+        """After reserve, the reserve line carries the plan's own procurement_plan
+        dimension plus the four financial dimensions."""
+        plan = self._make_new_plan()
+        self.assertTrue(
+            plan.analytic_account_id,
+            "action_new should mint the plan's own analytic account",
+        )
+        plan.action_ready()
+
+        dist = self._reserve_line(plan).analytic_distribution or {}
+        self.assertIn(
+            str(plan.analytic_account_id.id),
+            dist,
+            "reserve line must carry the plan's own procurement_plan dimension",
+        )
+        for account in (
+            self.activity_account,
+            self.department_account,
+            self.fund_account,
+            self.source_account,
+        ):
+            self.assertIn(str(account.id), dist)
+
+    def test_refold_restores_dropped_tag(self):
+        """If analytic_distribution loses the procurement_plan dimension between
+        action_new and reserve (e.g. a wholesale rewrite by a picker), the
+        reserve step refolds it so the reserve line still carries the tag."""
+        plan = self._make_new_plan()
+        own_account = plan.analytic_account_id
+        self.assertTrue(own_account)
+
+        # Simulate a wholesale rewrite that drops the plan's own dimension.
+        plan.analytic_distribution = self._financial_dims()
+        self.assertNotIn(str(own_account.id), plan.analytic_distribution)
+
+        plan.action_ready()
+
+        self.assertIn(
+            str(own_account.id),
+            self._reserve_line(plan).analytic_distribution or {},
+            "the reserve step must refold the dropped procurement_plan dimension",
+        )

--- a/purchase_request_budget_procurement/models/purchase_request.py
+++ b/purchase_request_budget_procurement/models/purchase_request.py
@@ -60,8 +60,13 @@ class PurchaseRequest(models.Model):
                 self.account_fiscal_year_id = self.procurement_plan_id.account_fiscal_year_id.id
                 self.procurement_method_id = self.procurement_plan_id.procurement_method_id.id
                 self.budget_account_id = self.procurement_plan_id.budget_account_id.id
-                self.analytic_distribution = self.procurement_plan_id.analytic_distribution
                 self.title = _("%s") % self.procurement_plan_id.description
+                # Do NOT assign analytic_distribution here. It is the core
+                # analytic.mixin field whose compute is a no-op; re-assigning it
+                # inside the new-record onchange cascade makes Odoo recompute it to
+                # False, wiping the dimensions on the unsaved form. It is prefilled
+                # by default_get (default_analytic_distribution) and written
+                # server-side on create in _link_to_procurement_plan instead.
         else:
             self.procurement_plan_id = False
             self.budget_account_id = False
@@ -162,11 +167,17 @@ class PurchaseRequest(models.Model):
     def _link_to_procurement_plan(self):
         """A plan-driven PR (created from the plan, ADR-0006) enforces one active
         PR per plan, links the plan's already-reserved shared commitment, and
-        starts the plan. Reservation itself happened at appropriation post."""
+        starts the plan. Reservation itself happened at appropriation post.
+
+        The plan's budget context — budget account, fiscal year, procurement
+        method and the full analytic distribution (4 financial dimensions + the
+        plan's own procurement_plan dimension) — is written here **server-side**
+        so the พ.1 always carries it. analytic_distribution is the core
+        analytic.mixin field with a no-op compute, so the live-form onchange
+        prefill alone is not a guarantee; this write is (mirrors
+        kmitl_project_purchase_request._link_to_project)."""
         self.ensure_one()
         plan = self.procurement_plan_id
-        if not self.use_procurement_plan:
-            self.use_procurement_plan = True
         active_others = plan.purchase_request_ids.filtered(
             lambda r: r.id != self.id and r.state != "rejected"
         )
@@ -178,12 +189,26 @@ class PurchaseRequest(models.Model):
                 )
                 % plan.display_name
             )
+        vals = {
+            "use_procurement_plan": True,
+            "budget_account_id": plan.budget_account_id.id,
+            "account_fiscal_year_id": plan.account_fiscal_year_id.id,
+            "procurement_method_id": plan.procurement_method_id.id,
+            "analytic_distribution": plan.analytic_distribution or False,
+        }
         if not self.budget_commitment_id:
             commitment = plan.budget_commitment_ids.filtered(
                 lambda c: c.state in ("reserved", "partial")
             )[:1]
             if commitment:
-                self.budget_commitment_id = commitment.id
+                vals["budget_commitment_id"] = commitment.id
+        self.write(vals)
+        # write() does not fire the form's _onchange_analytic_distribution, so push
+        # the plan's distribution onto any existing lines explicitly.
+        if self.line_ids and plan.analytic_distribution:
+            self.line_ids.write(
+                {"analytic_distribution": plan.analytic_distribution}
+            )
         if plan.state == "ready":
             plan.action_in_progress()
 

--- a/purchase_request_budget_procurement/tests/__init__.py
+++ b/purchase_request_budget_procurement/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_link_to_plan

--- a/purchase_request_budget_procurement/tests/test_link_to_plan.py
+++ b/purchase_request_budget_procurement/tests/test_link_to_plan.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from datetime import date
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestLinkToPlan(TransactionCase):
+    """A plan-driven purchase request must receive the procurement plan's FULL
+    analytic_distribution (not a single analytic dimension) and budget context
+    server-side via _link_to_procurement_plan, so the value survives even though
+    purchase.request.analytic_distribution is a core field with a no-op compute
+    that the live-form onchange cannot prefill reliably."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        env = cls.env
+        env["ir.config_parameter"].sudo().set_param("budget.allow_negative", "True")
+
+        cls.activity_account = env["account.analytic.account"].create(
+            {
+                "name": "Test Activity",
+                "plan_id": env.ref(
+                    "account_analytic_kmitl.analytic_plan_activities"
+                ).id,
+            }
+        )
+        cls.source_account = env["account.analytic.account"].create(
+            {
+                "name": "Test Source",
+                "plan_id": env.ref(
+                    "account_analytic_kmitl.analytic_plan_sources"
+                ).id,
+            }
+        )
+
+        cls.fiscal_year = env["account.fiscal.year"].search([], limit=1)
+        if not cls.fiscal_year:
+            cls.fiscal_year = env["account.fiscal.year"].create(
+                {
+                    "name": "FY-TEST",
+                    "date_from": date(2025, 10, 1),
+                    "date_to": date(2026, 9, 30),
+                    "company_id": env.company.id,
+                }
+            )
+
+        cls.budget_account = env["budget.account"].create(
+            {
+                "code": "TESTPPLINK",
+                "name": "Test Procurement Plan Code",
+                "budget_type": "expense",
+                "budgetable": True,
+            }
+        )
+        cls.method = env["procurement.method"].create({"name": "Test Method"})
+
+    def _make_ready_plan(self):
+        plan = self.env["procurement.plan"].create(
+            {
+                "description": "Test Plan",
+                "amount": 1,
+                "unit": "ชุด",
+                "total_price": 1000.0,
+                "account_fiscal_year_id": self.fiscal_year.id,
+                "budget_account_id": self.budget_account.id,
+                "procurement_method_id": self.method.id,
+                "purchase_request_eta": "1",
+                "procurement_announcement_eta": "2",
+                "approval_signing_eta": "3",
+                "contract_order_signing_eta": "4",
+                "acceptance_eta": "5",
+                "analytic_distribution": {
+                    str(self.activity_account.id): 100,
+                    str(self.source_account.id): 100,
+                },
+            }
+        )
+        plan.action_new()
+        plan.action_ready()
+        return plan
+
+    def test_link_copies_full_distribution_server_side(self):
+        """The whole plan distribution (financial dims + the plan's own
+        procurement_plan dimension) is written onto the PR — not rebuilt from a
+        single analytic_id."""
+        plan = self._make_ready_plan()
+        # The plan carries its own procurement_plan dimension on top of the two
+        # financial dims, so the distribution has more than one entry to copy.
+        self.assertIn(
+            str(plan.analytic_account_id.id), plan.analytic_distribution
+        )
+
+        pr = self.env["purchase.request"].create(
+            {
+                "use_procurement_plan": True,
+                "procurement_plan_id": plan.id,
+            }
+        )
+
+        self.assertEqual(
+            pr.analytic_distribution,
+            plan.analytic_distribution,
+            "the PR must receive the plan's full analytic_distribution",
+        )
+        self.assertEqual(pr.budget_account_id, plan.budget_account_id)
+        self.assertEqual(pr.account_fiscal_year_id, plan.account_fiscal_year_id)
+        self.assertEqual(pr.procurement_method_id, plan.procurement_method_id)
+
+    def test_link_attaches_shared_commitment(self):
+        """The PR links the plan's already-reserved shared commitment."""
+        plan = self._make_ready_plan()
+        commitment = plan.budget_commitment_ids.filtered(
+            lambda c: c.state in ("reserved", "partial")
+        )[:1]
+        self.assertTrue(commitment)
+
+        pr = self.env["purchase.request"].create(
+            {
+                "use_procurement_plan": True,
+                "procurement_plan_id": plan.id,
+            }
+        )
+        self.assertEqual(pr.budget_commitment_id, commitment)


### PR DESCRIPTION
Makes the procurement plan's own `procurement_plan` analytic dimension reliably part of `analytic_distribution` end to end.

In `procurement_plan`, `_reserve_plan_commitment` now refolds that dimension before snapshotting the distribution onto the budget commitment, instead of relying solely on the `analytic_account_id` inverse having run at `action_new`, so the reserve line always carries the ownership tag.

In `purchase_request_budget_procurement`, a plan-driven purchase request now receives the plan's full `analytic_distribution` (plus budget account, fiscal year and procurement method) through a server-side write in `_link_to_procurement_plan` and onto its lines, mirroring `kmitl_project_purchase_request`. Its `_onchange_procurement_plan_id` no longer assigns `analytic_distribution`, whose core no-op compute would otherwise wipe it to False on the unsaved form.