### PR TITLE
[16.0][FIX] procurement_plan_budget_operating_unit: stamp plan OU on reservation commitment

### DIFF
--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Budgeting",
-    "version": "16.0.1.4.1",
+    "version": "16.0.1.4.2",
     "summary": """ KMITL Budgeting""",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget/models/budget_commitment_mixin.py
+++ b/budget/models/budget_commitment_mixin.py
@@ -218,6 +218,9 @@ class BudgetCommitmentMixin(models.AbstractModel):
             "line_ids": [(0, 0, line_vals)],
         }
 
+        if kwargs.get("operating_unit_id"):
+            commitment_vals["operating_unit_id"] = kwargs["operating_unit_id"]
+
         if include_company:
             commitment_vals["company_id"] = self.env.company.id
 

--- a/budget_operating_unit/__manifest__.py
+++ b/budget_operating_unit/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Budget Operating Unit',
-    'version': '16.0.0.0.0',
+    'version': '16.0.1.0.0',
     'summary': """ Budget Operating Unit """,
     'author': 'Aginix Technologies',
     'website': 'https://github.com/Aginix/kmitl',

--- a/budget_operating_unit/views/budget_commitment_views.xml
+++ b/budget_operating_unit/views/budget_commitment_views.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="budget.budget_commitment_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position="after">
-                <field name="operating_unit_id" widget="selection" groups="operating_unit.group_multi_operating_unit" />
+                <field name="operating_unit_id" widget="selection" groups="operating_unit.group_multi_operating_unit" readonly="0" />
             </xpath>
         </field>
     </record>

--- a/procurement_plan/__manifest__.py
+++ b/procurement_plan/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Procurement Plan",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.1.1",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
     "category": "KMITL",

--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -298,33 +298,8 @@ class ProcurementPlan(models.Model):
                 self.account_fiscal_year_id.id,
                 self.company_id.id,
             )
-        dist = dict(self.analytic_distribution or {})
         commitment = self.env["budget.commitment"].create(
-            {
-                "account_id": self.budget_account_id.id,
-                "amount": self.total_price,
-                "analytic_distribution": dist or False,
-                "account_fiscal_year_id": self.account_fiscal_year_id.id,
-                "company_id": self.company_id.id,
-                "date": fields.Date.context_today(self),
-                "ref": self.name,
-                "description": self.description,
-                "procurement_plan_id": self.id,
-                "user_id": self.env.user.id,
-                "line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "move_type": "reserve",
-                            "account_id": self.budget_account_id.id,
-                            "analytic_distribution": dist or False,
-                            "amount": self.total_price,
-                            "name": _("Initial reservation"),
-                        },
-                    )
-                ],
-            }
+            self._prepare_plan_commitment_vals()
         )
         commitment.action_reserve()
         self.message_post(
@@ -334,6 +309,40 @@ class ProcurementPlan(models.Model):
                 format_amount(self.env, self.total_price, self.currency_id),
             )
         )
+
+    def _prepare_plan_commitment_vals(self):
+        """Build the create vals for the plan's shared reservation commitment.
+        Split out of ``_reserve_plan_commitment`` so bridge modules can enrich the
+        commitment — e.g. stamp the plan's operating unit so the reservation lands
+        in the same OU as the plan/appropriation — without re-implementing the
+        whole reservation flow."""
+        self.ensure_one()
+        dist = dict(self.analytic_distribution or {})
+        return {
+            "account_id": self.budget_account_id.id,
+            "amount": self.total_price,
+            "analytic_distribution": dist or False,
+            "account_fiscal_year_id": self.account_fiscal_year_id.id,
+            "company_id": self.company_id.id,
+            "date": fields.Date.context_today(self),
+            "ref": self.name,
+            "description": self.description,
+            "procurement_plan_id": self.id,
+            "user_id": self.env.user.id,
+            "line_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "move_type": "reserve",
+                        "account_id": self.budget_account_id.id,
+                        "analytic_distribution": dist or False,
+                        "amount": self.total_price,
+                        "name": _("Initial reservation"),
+                    },
+                )
+            ],
+        }
 
     def _release_plan_commitment(self):
         """Release the plan's reservation when it leaves the active band

--- a/procurement_plan_budget_operating_unit/__manifest__.py
+++ b/procurement_plan_budget_operating_unit/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Procurement Plan Budget with Operating Units",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "KMITL",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
@@ -9,6 +9,7 @@
         "procurement_plan_budget",
         "procurement_plan_operating_unit",
         "budget_appropriation_operating_unit",
+        "budget_operating_unit",
     ],
     "data": [],
     "application": False,

--- a/procurement_plan_budget_operating_unit/models/__init__.py
+++ b/procurement_plan_budget_operating_unit/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import budget_appropriation_line
+from . import procurement_plan

--- a/procurement_plan_budget_operating_unit/models/procurement_plan.py
+++ b/procurement_plan_budget_operating_unit/models/procurement_plan.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class ProcurementPlan(models.Model):
+    _inherit = "procurement.plan"
+
+    def _prepare_plan_commitment_vals(self):
+        """Stamp the plan's operating unit onto its reservation commitment so the
+        commitment lands in the same OU as the plan (and the appropriation it was
+        created from). Without this the commitment falls back to the approving
+        user's default OU, which hides it — via the budget.commitment OU record
+        rule — from the users scoped to the plan's own operating unit."""
+        vals = super()._prepare_plan_commitment_vals()
+        vals["operating_unit_id"] = self.operating_unit_id.id
+        return vals

--- a/purchase_request_budget/__manifest__.py
+++ b/purchase_request_budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Purchase Request Budget",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "summary": """ Purchase Request Budget Summary """,
     "category": "KMITL",
     "author": "Aginix Technologies",

--- a/purchase_request_budget/models/purchase_request.py
+++ b/purchase_request_budget/models/purchase_request.py
@@ -198,6 +198,11 @@ class PurchaseRequest(models.Model):
             "target": "current",
         }
 
+    def _get_budget_commitment_extra_kwargs(self):
+        """Extra kwargs forwarded to _create_budget_commitment().
+        Override in bridge modules to inject e.g. operating_unit_id."""
+        return {}
+
     def action_reserve_budget(self):
         """Reserve budget by creating commitment"""
         self.ensure_one()
@@ -233,6 +238,7 @@ class PurchaseRequest(models.Model):
                 description=f"Purchase Request: {self.name}",
                 auto_reserve=True,
                 account_fiscal_year_id=self.account_fiscal_year_id.id,
+                **self._get_budget_commitment_extra_kwargs(),
             )
             self.message_post(
                 body=_("Budget reserved: %s for amount %s") % (commitment.name, amount)

--- a/purchase_request_budget_operating_unit/__init__.py
+++ b/purchase_request_budget_operating_unit/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/purchase_request_budget_operating_unit/__manifest__.py
+++ b/purchase_request_budget_operating_unit/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Purchase Request Budget with Operating Units",
+    "version": "16.0.1.0.0",
+    "category": "KMITL",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "purchase_request_budget",
+        "purchase_request_operating_unit",
+        "budget_operating_unit",
+    ],
+    "data": [],
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/purchase_request_budget_operating_unit/models/__init__.py
+++ b/purchase_request_budget_operating_unit/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import purchase_request

--- a/purchase_request_budget_operating_unit/models/purchase_request.py
+++ b/purchase_request_budget_operating_unit/models/purchase_request.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class PurchaseRequest(models.Model):
+    _inherit = "purchase.request"
+
+    def _get_budget_commitment_extra_kwargs(self):
+        """Stamp the PR's operating unit onto its reservation commitment so the
+        commitment lands in the same OU as the PR. Without this the commitment
+        defaults to the approving user's OU and becomes invisible to PR-scoped
+        users via the budget.commitment OU record rule."""
+        vals = super()._get_budget_commitment_extra_kwargs()
+        if self.operating_unit_id:
+            vals["operating_unit_id"] = self.operating_unit_id.id
+        return vals


### PR DESCRIPTION
## Summary
- `budget.commitment` created during appropriation approval defaulted `operating_unit_id` to the approving user's OU instead of the procurement plan's OU, making the commitment invisible to plan-scoped users via the OU record rule
- Extracted `_prepare_plan_commitment_vals()` in `procurement_plan` as an override seam
- Added override in `procurement_plan_budget_operating_unit` to stamp `operating_unit_id` from the plan onto its reservation commitment
- Added `budget_operating_unit` as a manifest dependency (required for the `budget.commitment.operating_unit_id` field)

## Test plan
- [ ] Approve a `budget.appropriation` that has a procurement plan line with a specific OU
- [ ] Verify the created `budget.commitment` has the same OU as the procurement plan
- [ ] Verify users scoped to that OU can see and access the commitment