### PR TITLE
[16.0][FIX] mail_activity_todo: add @api.model to get_my_todo_count

### DIFF
--- a/mail_activity_todo/models/res_users.py
+++ b/mail_activity_todo/models/res_users.py
@@ -1,4 +1,4 @@
-from odoo import fields, models, modules
+from odoo import api, fields, models, modules
 
 
 class ResUsers(models.Model):
@@ -11,6 +11,7 @@ class ResUsers(models.Model):
             ("todo_category", "!=", False),
         ]
 
+    @api.model
     def get_my_todo_count(self):
         """Systray payload: open Todos grouped by source model with per-model
         icon and overdue/today/planned counts.


### PR DESCRIPTION
## Problem

Server logs `IndexError: list index out of range` repeatedly and the Todo systray badge never loads (perceived as a hanging/loading UI):

```
File ".../odoo/api.py", line 465, in _call_kw_multi
    ids, args = args[0], args[1:]
IndexError: list index out of range
```

## Root cause

`res.users.get_my_todo_count` is a model-level method (it reads "my" todos via `self.env`/`self.env.user`, not per-record state) but was **missing the `@api.model` decorator**.

The systray component calls it over RPC with an **empty** positional args array:

```js
// mail_activity_todo/static/src/js/todo_systray.esm.js
this.orm.call("res.users", "get_my_todo_count", []);
```

Without `@api.model`, `call_kw` routes the call to `_call_kw_multi`, which immediately runs `ids, args = args[0], args[1:]` on the empty list → `IndexError`, before the method body even executes.

Because `TodoSystray` is registered globally (`sequence: 95`), this fired on **every backend page load**, on **dropdown open** (`beforeOpen.bind="fetchData"`), and on **every bus refresh** (`mail_activity_todo_updated`) — so it 500'd constantly, the badge never populated, and the log filled with tracebacks.

## Fix

Add `@api.model` to `get_my_todo_count` (and import `api`). This routes the call to `_call_kw_model`, which calls `method(recs)` without touching `args[0]`, matching the empty args array the JS already sends. The single existing caller is unaffected.

Swept JS↔Python call sites repo-wide; this was the only method called with empty args that lacked `@api.model`.

## Verification

- Before: open any backend page → `IndexError` in the log.
- After: restart/upgrade, open the Todo systray dropdown → no `IndexError`, badge/list render correctly; bus-triggered refetch works.