### PR TITLE
[16.0][IMP] kris_project: opt-in flag to relax work-period checks

### DIFF
--- a/kris_project/CONTEXT.md
+++ b/kris_project/CONTEXT.md
@@ -24,3 +24,22 @@ An executive of a faculty/office who needs read-only access to projects belongin
 
 **Operating Unit (OU)**:
 A faculty or office, identified by a numeric code (`01` Engineering … `99` KRIS). Provided by the `operating_unit` module. Intended as the scoping dimension for OU Executive read access.
+
+### Project & money
+
+**Installment** (งวดงาน):
+A scheduled milestone of contracted work, each with its own due date and payment amount; a project's value is broken down into these. `kris.project.installment`.
+_Avoid_: work period, work phase, payment schedule, payment installment
+
+**Receipt** (รายรับ):
+A single recorded payment received against a project — one document with a number, date and amount. `kris.project.receipt`.
+_Avoid_: revenue (a single one is never "a revenue")
+
+**Revenue**:
+The aggregate received on a project — the running sum of its Receipts. A total, not a record.
+
+**Project Value** (มูลค่าโครงการ):
+The total contracted value of a project; the baseline its operating expense, maintenance deduction and installment totals are derived from or checked against.
+
+**Installment-free project** (ไม่มีงวดงานกำกับ):
+A project whose งวด schedule isn't fixed or known up front (typically test/trial work), so it is not governed by งวด targets. Flag `no_installment_tracking`; see ADR-0001 for what this relaxes.

--- a/kris_project/__manifest__.py
+++ b/kris_project/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KRIS Project",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "KMITL",
     "summary": "Academic service and research project revenue tracking for KRIS",
     "author": "Aginix Technologies",

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -219,10 +219,10 @@ if self.state == 'draft' and not self.client_org_type:
         <field name="sequence">60</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'in_progress' and self.installment_ids and any(i.state != 'received' for i in self.installment_ids):
+if self.state == 'in_progress' and not self.no_installment_tracking and self.installment_ids and any(i.state != 'received' for i in self.installment_ids):
     failed = True
         </field>
-        <field name="active" eval="False"/>
+        <field name="active" eval="True"/>
     </record>
 
     <record id="kris_excep_revenue_remaining" model="exception.rule">
@@ -247,10 +247,10 @@ if self.state == 'in_progress' and not self.no_installment_tracking and self.rev
         <field name="sequence">80</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state in ('draft', 'in_progress') and self.receipt_ids:
+if self.state in ('draft', 'in_progress') and not self.no_installment_tracking and self.receipt_ids:
     failed = True
         </field>
-        <field name="active" eval="False"/>
+        <field name="active" eval="True"/>
     </record>
 
 </odoo>

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -219,10 +219,10 @@ if self.state == 'draft' and not self.client_org_type:
         <field name="sequence">60</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'in_progress' and not self.no_installment_tracking and self.installment_ids and any(i.state != 'received' for i in self.installment_ids):
+if self.state == 'in_progress' and self.installment_ids and any(i.state != 'received' for i in self.installment_ids):
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="kris_excep_revenue_remaining" model="exception.rule">
@@ -231,10 +231,10 @@ if self.state == 'in_progress' and not self.no_installment_tracking and self.ins
         <field name="sequence">70</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'in_progress' and not self.no_installment_tracking and self.revenue_remaining > 0:
+if self.state == 'in_progress' and self.revenue_remaining > 0:
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
     <!-- ============================================================ -->
@@ -247,10 +247,10 @@ if self.state == 'in_progress' and not self.no_installment_tracking and self.rev
         <field name="sequence">80</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state in ('draft', 'in_progress') and not self.no_installment_tracking and self.receipt_ids:
+if self.state in ('draft', 'in_progress') and self.receipt_ids:
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
 </odoo>

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -74,7 +74,7 @@ if self.state == 'draft' and self.allocation_line_ids and any(not line.departmen
 if self.state == 'draft' and not self.installment_ids:
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="kris_excep_installment_total_mismatch" model="exception.rule">
@@ -86,7 +86,7 @@ if self.state == 'draft' and not self.installment_ids:
 if self.state == 'draft' and self.installment_ids and self.warn_installment_total_mismatch:
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="kris_excep_installment_maintenance_mismatch" model="exception.rule">
@@ -98,7 +98,7 @@ if self.state == 'draft' and self.installment_ids and self.warn_installment_tota
 if self.state == 'draft' and self.installment_ids and self.warn_installment_maintenance_mismatch:
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
     <record id="kris_excep_invalid_duration" model="exception.rule">
@@ -234,7 +234,7 @@ if self.state == 'in_progress' and self.installment_ids and any(i.state != 'rece
 if self.state == 'in_progress' and self.revenue_remaining > 0:
     failed = True
         </field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="False"/>
     </record>
 
     <!-- ============================================================ -->

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -71,10 +71,10 @@ if self.state == 'draft' and self.allocation_line_ids and any(not line.departmen
         <field name="sequence">30</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'draft' and not self.installment_ids:
+if self.state == 'draft' and not self.no_installment_tracking and not self.installment_ids:
     failed = True
         </field>
-        <field name="active" eval="False"/>
+        <field name="active" eval="True"/>
     </record>
 
     <record id="kris_excep_installment_total_mismatch" model="exception.rule">
@@ -83,10 +83,10 @@ if self.state == 'draft' and not self.installment_ids:
         <field name="sequence">40</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'draft' and self.installment_ids and self.warn_installment_total_mismatch:
+if self.state == 'draft' and not self.no_installment_tracking and self.installment_ids and self.warn_installment_total_mismatch:
     failed = True
         </field>
-        <field name="active" eval="False"/>
+        <field name="active" eval="True"/>
     </record>
 
     <record id="kris_excep_installment_maintenance_mismatch" model="exception.rule">
@@ -95,10 +95,10 @@ if self.state == 'draft' and self.installment_ids and self.warn_installment_tota
         <field name="sequence">50</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'draft' and self.installment_ids and self.warn_installment_maintenance_mismatch:
+if self.state == 'draft' and not self.no_installment_tracking and self.installment_ids and self.warn_installment_maintenance_mismatch:
     failed = True
         </field>
-        <field name="active" eval="False"/>
+        <field name="active" eval="True"/>
     </record>
 
     <record id="kris_excep_invalid_duration" model="exception.rule">
@@ -231,10 +231,10 @@ if self.state == 'in_progress' and self.installment_ids and any(i.state != 'rece
         <field name="sequence">70</field>
         <field name="model">kris.project</field>
         <field name="code">
-if self.state == 'in_progress' and self.revenue_remaining > 0:
+if self.state == 'in_progress' and not self.no_installment_tracking and self.revenue_remaining > 0:
     failed = True
         </field>
-        <field name="active" eval="False"/>
+        <field name="active" eval="True"/>
     </record>
 
     <!-- ============================================================ -->

--- a/kris_project/docs/adr/0001-discretionary-completion.md
+++ b/kris_project/docs/adr/0001-discretionary-completion.md
@@ -1,0 +1,27 @@
+# Setup is validated at confirm; the งวด schedule and completion are discretionary
+
+KRIS validates a project's **setup data** strictly at confirmation (value, allocation,
+contract, client, fiscal year), but deliberately does **not** enforce its งวด (Installment)
+schedule or money-completeness:
+
+- A project flagged **`no_installment_tracking`** (ไม่มีงวดงานกำกับ) can be confirmed
+  without a complete งวด plan and keeps its Installments editable while In Progress —
+  test/trial work often has no fixed schedule up front.
+- For **every** project, **Done** is allowed even when received Revenue is below Project
+  Value and not all งวด are received, and **Cancel** is never blocked by recorded
+  Revenue — projects legitimately close under-collected, at KRIS's discretion.
+
+## Why record this
+
+It is a revenue-tracking module, so the obvious default is to block closing until the
+money is collected. We don't: the rules that would (`kris_excep_revenue_remaining`,
+`kris_excep_installments_not_received`, `kris_excep_cancel_with_receipts`) are kept
+`active=False`. Re-enabling them to "fix" the gap would reintroduce exactly the block
+this decision removes.
+
+## Note
+
+The `base_exception` popup is effectively a **hard block** for KRIS users — its "ignore"
+checkbox is limited to `base_exception.group_exception_rule_manager`, which no KRIS group
+implies. So a "warning that still lets you proceed" (e.g. cancel-with-Revenue) is
+implemented as an on-form banner, not a non-blocking exception rule.

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -425,9 +425,9 @@ class KrisProject(models.Model):
 
     def action_add_installment(self):
         self.ensure_one()
-        if not self.can_edit:
+        if self.state in ("done", "cancel"):
             raise UserError(
-                _("Installments can only be added while the project is in draft.")
+                _("Cannot add installments on a project that is done or cancelled.")
             )
         return {
             "name": _("Add Installment"),

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -293,6 +293,9 @@ class KrisProject(models.Model):
     warn_extra_overshoot = fields.Boolean(
         compute="_compute_warnings",
     )
+    warn_cancel_with_receipts = fields.Boolean(
+        compute="_compute_warnings",
+    )
 
     @api.depends(
         "maintenance_deduction_amount",
@@ -302,10 +305,17 @@ class KrisProject(models.Model):
         "total_installment_amount",
         "project_value",
         "extra_value",
+        "no_installment_tracking",
+        "state",
+        "receipt_ids",
     )
     def _compute_warnings(self):
         prec = self.env["decimal.precision"].precision_get("Account")
         for rec in self:
+            rec.warn_cancel_with_receipts = bool(rec.receipt_ids) and rec.state in (
+                "draft",
+                "in_progress",
+            )
             alloc_total = sum(rec.allocation_line_ids.mapped("estimated_amount"))
             rec.warn_allocation_mismatch = (
                 bool(rec.allocation_line_ids)
@@ -317,7 +327,8 @@ class KrisProject(models.Model):
             if rec.installment_ids:
                 maint_total = sum(rec.installment_ids.mapped("maintenance_fee"))
                 rec.warn_installment_maintenance_mismatch = (
-                    float_compare(
+                    not rec.no_installment_tracking
+                    and float_compare(
                         maint_total,
                         rec.maintenance_deduction_amount,
                         precision_digits=prec,
@@ -325,7 +336,8 @@ class KrisProject(models.Model):
                     != 0
                 )
                 rec.warn_installment_total_mismatch = (
-                    float_compare(
+                    not rec.no_installment_tracking
+                    and float_compare(
                         rec.total_installment_amount,
                         rec.project_value,
                         precision_digits=prec,

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -88,6 +88,15 @@ class KrisProject(models.Model):
     can_edit = fields.Boolean(
         compute="_compute_can_edit",
     )
+    no_installment_tracking = fields.Boolean(
+        string="ไม่มีงวดงานกำกับ",
+        tracking=True,
+        help="ติ๊กเมื่อโครงการนี้ไม่มีงวดงานกำกับ: ข้ามการตรวจสอบงวดงานตอนยืนยัน "
+        "แก้ไขงวดงานได้ระหว่างดำเนินการ และปิดโครงการได้โดยไม่ต้องรับเงินครบ",
+    )
+    installment_editable = fields.Boolean(
+        compute="_compute_installment_editable",
+    )
     client_name = fields.Char(
         string="Client Name",
         tracking=True,
@@ -338,6 +347,15 @@ class KrisProject(models.Model):
         for rec in self:
             rec.can_edit = rec.state == "draft"
 
+    @api.depends("state", "no_installment_tracking")
+    def _compute_installment_editable(self):
+        # Installments remain editable after confirmation only for projects
+        # flagged as having no work-period tracking; otherwise draft-only.
+        for rec in self:
+            rec.installment_editable = rec.state == "draft" or (
+                rec.state == "in_progress" and rec.no_installment_tracking
+            )
+
     @api.depends("operating_expense")
     def _compute_allocatable_value(self):
         for rec in self:
@@ -425,9 +443,12 @@ class KrisProject(models.Model):
 
     def action_add_installment(self):
         self.ensure_one()
-        if self.state in ("done", "cancel"):
+        if not self.installment_editable:
             raise UserError(
-                _("Cannot add installments on a project that is done or cancelled.")
+                _(
+                    "Installments can only be edited while the project is in "
+                    "draft, or in progress when it has no work-period tracking."
+                )
             )
         return {
             "name": _("Add Installment"),

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -142,6 +142,11 @@
                     <field name="warn_installment_maintenance_mismatch" invisible="1"/>
                     <field name="warn_installment_total_mismatch" invisible="1"/>
                     <field name="warn_extra_overshoot" invisible="1"/>
+                    <field name="warn_cancel_with_receipts" invisible="1"/>
+                    <div class="alert alert-warning" role="alert"
+                        attrs="{'invisible': [('warn_cancel_with_receipts', '=', False)]}">
+                        โครงการนี้มีการบันทึกรายรับแล้ว โปรดตรวจสอบก่อนยกเลิกโครงการ
+                    </div>
                     <div class="oe_title">
                         <h1>
                             <field name="name" readonly="1"/>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -174,10 +174,6 @@
                                 attrs="{'readonly': [('can_edit', '=', False)]}"
                             />
                             <field
-                                name="no_installment_tracking"
-                                attrs="{'readonly': [('can_edit', '=', False)]}"
-                            />
-                            <field
                                 name="manager_id"
                                 required="1"
                                 widget="employee_detail_many2one"
@@ -340,6 +336,12 @@
                                 </tree>
                             </field>
                             <separator string="3. Contract payment installments" name="installment_separator" />
+                            <group>
+                                <field
+                                    name="no_installment_tracking"
+                                    attrs="{'readonly': [('can_edit', '=', False)]}"
+                                />
+                            </group>
                             <div class="alert alert-danger mb-2" role="alert"
                                 attrs="{'invisible': [('warn_extra_overshoot', '=', False)]}"
                             >

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -137,6 +137,7 @@
                 </div>
                 <sheet>
                     <field name="can_edit" invisible="1"/>
+                    <field name="installment_editable" invisible="1"/>
                     <field name="warn_allocation_mismatch" invisible="1"/>
                     <field name="warn_installment_maintenance_mismatch" invisible="1"/>
                     <field name="warn_installment_total_mismatch" invisible="1"/>
@@ -165,6 +166,10 @@
                                 name="project_type_id"
                                 widget="radio"
                                 domain="[('category_id', '=', project_category_id)]"
+                                attrs="{'readonly': [('can_edit', '=', False)]}"
+                            />
+                            <field
+                                name="no_installment_tracking"
                                 attrs="{'readonly': [('can_edit', '=', False)]}"
                             />
                             <field
@@ -346,7 +351,7 @@
                                 The sum of institutional maintenance fees in the work period does not equal the value after deduction of maintenance fees. Please check the allocation for each period.
                             </div>
                             <div class="mb-3"
-                                attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"
+                                attrs="{'invisible': [('installment_editable', '=', False)]}"
                                 groups="kris_project.group_kris_project_officer"
                             >
                                 <button
@@ -358,7 +363,7 @@
                             </div>
                             <field
                                 name="installment_ids"
-                                attrs="{'readonly': [('state', 'in', ['done', 'cancel'])]}"
+                                attrs="{'readonly': [('installment_editable', '=', False)]}"
                             >
                                 <tree create="0">
                                     <field name="sequence" widget="handle"/>

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -346,7 +346,7 @@
                                 The sum of institutional maintenance fees in the work period does not equal the value after deduction of maintenance fees. Please check the allocation for each period.
                             </div>
                             <div class="mb-3"
-                                attrs="{'invisible': [('can_edit', '=', False)]}"
+                                attrs="{'invisible': [('state', 'in', ['done', 'cancel'])]}"
                                 groups="kris_project.group_kris_project_officer"
                             >
                                 <button
@@ -358,7 +358,7 @@
                             </div>
                             <field
                                 name="installment_ids"
-                                attrs="{'readonly': [('can_edit', '=', False)]}"
+                                attrs="{'readonly': [('state', 'in', ['done', 'cancel'])]}"
                             >
                                 <tree create="0">
                                     <field name="sequence" widget="handle"/>


### PR DESCRIPTION
Adds a per-project flag **"ไม่มีงวดงานกำกับ"** (`no_installment_tracking`) for projects whose งวด (installment) schedule isn't fixed up front: when set, the confirm-phase งวด checks are skipped and installments stay editable while In Progress, and the contradictory งวด total/maintenance mismatch warnings are suppressed. Revenue (รายรับ) recording stays editable until Done/Cancel for every project, independent of the flag. Separately — and for **all** projects — completion is made discretionary: the rules that blocked Done before full revenue / full งวด receipt are left inactive, and the cancel-with-revenue rule becomes an on-form warning banner instead of a hard block (the base_exception popup can't act as a soft warning for KRIS users). Rationale and glossary are documented in `kris_project/docs/adr/0001-discretionary-completion.md` and `kris_project/CONTEXT.md`.