### PR TITLE
[16.0][IMP] mail_activity_todo: color state badge by urgency

### DIFF
--- a/mail_activity_todo/views/mail_activity_views.xml
+++ b/mail_activity_todo/views/mail_activity_views.xml
@@ -15,7 +15,13 @@
                 decoration-danger="state == 'overdue' and todo_category in ['approval', 'execution']"
                 decoration-warning="state == 'today' and todo_category in ['approval', 'execution']"
             >
-                <field name="state" widget="badge" optional="show" />
+                <field
+                    name="state"
+                    widget="badge"
+                    optional="show"
+                    decoration-danger="state == 'overdue'"
+                    decoration-warning="state == 'today'"
+                />
                 <field name="todo_category" optional="show" />
                 <field name="summary" string="Subject" />
                 <field name="res_name" string="Source" />


### PR DESCRIPTION
The Todo inbox list now colors the **state** badge by deadline urgency: red (danger) when overdue and orange (warning) when due today, neutral otherwise. The badge follows its own value across all categories, while the existing row-level decoration stays gated to approval/execution todos. This is a view-only change to the tree view — no model or Python changes.