### PR TITLE
[16.0][IMP] kris_project: add fixed-amount maintenance deduction type

### DIFF
--- a/kris_project/CONTEXT.md
+++ b/kris_project/CONTEXT.md
@@ -25,6 +25,15 @@ An executive of a faculty/office who needs read-only access to projects belongin
 **Operating Unit (OU)**:
 A faculty or office, identified by a numeric code (`01` Engineering … `99` KRIS). Provided by the `operating_unit` module. Intended as the scoping dimension for OU Executive read access.
 
+**Maintenance Deduction** (ค่าบำรุง / ค่าบำรุงสถาบัน):
+The institutional fee KRIS deducts from a project's operating expense; the deducted total is the pool that is then allocated to departments. One of three **methods** determines the amount:
+
+- **Tiered** (ขั้นบันได): progressive rate brackets applied to the operating expense.
+- **Custom %** (กำหนดเปอร์เซ็นต์เอง): a manually entered percentage of the operating expense.
+- **Fixed Amount** (ระบุจำนวนเงิน): a manually entered baht figure used verbatim, independent of the operating expense.
+
+_Avoid_: "Custom" unqualified — ambiguous now that both Custom % and Fixed Amount are manually entered. Name the method (Custom % vs Fixed Amount).
+
 ### Project & money
 
 **Installment** (งวดงาน):

--- a/kris_project/__manifest__.py
+++ b/kris_project/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KRIS Project",
-    "version": "16.0.1.3.0",
+    "version": "16.0.1.4.0",
     "category": "KMITL",
     "summary": "Academic service and research project revenue tracking for KRIS",
     "author": "Aginix Technologies",

--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -41,6 +41,18 @@ if self.state == 'draft' and not self.department_analytic_id:
         <field name="active" eval="True"/>
     </record>
 
+    <record id="kris_excep_maintenance_exceeds_expense" model="exception.rule">
+        <field name="name">มูลค่าหักค่าบำรุงเกินค่าดำเนินการ</field>
+        <field name="description">มูลค่าหักค่าบำรุงต้องไม่เกินค่าดำเนินการ (Operating Expense)</field>
+        <field name="sequence">18</field>
+        <field name="model">kris.project</field>
+        <field name="code">
+if self.state == 'draft' and self.warn_maintenance_exceeds_expense:
+    failed = True
+        </field>
+        <field name="active" eval="True"/>
+    </record>
+
     <record id="kris_excep_allocation_mismatch" model="exception.rule">
         <field name="name">The allocated total does not match the maintenance fee.</field>
         <field name="description">The total allocated revenue does not equal the value minus maintenance fees.</field>

--- a/kris_project/i18n/th.po
+++ b/kris_project/i18n/th.po
@@ -638,8 +638,18 @@ msgstr "การเงิน"
 
 #. module: kris_project
 #: model:ir.model.fields.selection,name:kris_project.selection__kris_project__maintenance_deduction_type__custom
-msgid "Custom"
-msgstr "กำหนดเอง"
+msgid "Custom %"
+msgstr "กำหนดเปอร์เซ็นต์เอง"
+
+#. module: kris_project
+#: model:ir.model.fields.selection,name:kris_project.selection__kris_project__maintenance_deduction_type__fixed
+msgid "Fixed Amount"
+msgstr "ระบุจำนวนเงิน"
+
+#. module: kris_project
+#: model:ir.model.fields,field_description:kris_project.field_kris_project__maintenance_deduction_fixed_amount
+msgid "จำนวนเงินค่าบำรุง"
+msgstr ""
 
 #. module: kris_project
 #. odoo-javascript

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -451,6 +451,16 @@ class KrisProject(models.Model):
         ):
             self.project_type_id = False
 
+    @api.onchange("maintenance_deduction_type")
+    def _onchange_maintenance_deduction_type(self):
+        # Clear the inputs that do not apply to the selected method so stale
+        # values are neither stored nor exported (mirrors the Odoo core
+        # pattern in product.pricelist.item._onchange_compute_price).
+        if self.maintenance_deduction_type != "custom":
+            self.maintenance_deduction_pct = 0.0
+        if self.maintenance_deduction_type != "fixed":
+            self.maintenance_deduction_fixed_amount = 0.0
+
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -152,7 +152,8 @@ class KrisProject(models.Model):
     maintenance_deduction_type = fields.Selection(
         selection=[
             ("tiered", "Tiered"),
-            ("custom", "Custom"),
+            ("custom", "Custom %"),
+            ("fixed", "Fixed Amount"),
         ],
         string="Maintenance Deduction Type",
         default="tiered",
@@ -162,6 +163,10 @@ class KrisProject(models.Model):
     maintenance_deduction_pct = fields.Float(
         string="% หักค่าบำรุง",
         digits=(5, 2),
+        tracking=True,
+    )
+    maintenance_deduction_fixed_amount = fields.Monetary(
+        string="จำนวนเงินค่าบำรุง",
         tracking=True,
     )
     maintenance_deduction_amount = fields.Monetary(
@@ -296,9 +301,13 @@ class KrisProject(models.Model):
     warn_cancel_with_receipts = fields.Boolean(
         compute="_compute_warnings",
     )
+    warn_maintenance_exceeds_expense = fields.Boolean(
+        compute="_compute_warnings",
+    )
 
     @api.depends(
         "maintenance_deduction_amount",
+        "operating_expense",
         "allocation_line_ids.estimated_amount",
         "installment_ids.maintenance_fee",
         "installment_ids.extra_income",
@@ -315,6 +324,14 @@ class KrisProject(models.Model):
             rec.warn_cancel_with_receipts = bool(rec.receipt_ids) and rec.state in (
                 "draft",
                 "in_progress",
+            )
+            rec.warn_maintenance_exceeds_expense = (
+                float_compare(
+                    rec.maintenance_deduction_amount,
+                    rec.operating_expense,
+                    precision_digits=prec,
+                )
+                > 0
             )
             alloc_total = sum(rec.allocation_line_ids.mapped("estimated_amount"))
             rec.warn_allocation_mismatch = (
@@ -377,6 +394,7 @@ class KrisProject(models.Model):
         "operating_expense",
         "maintenance_deduction_type",
         "maintenance_deduction_pct",
+        "maintenance_deduction_fixed_amount",
     )
     def _compute_maintenance_deduction_amount(self):
         for rec in self:
@@ -384,9 +402,13 @@ class KrisProject(models.Model):
                 rec.maintenance_deduction_amount = _compute_tiered_deduction(
                     rec.operating_expense
                 )
-            else:
+            elif rec.maintenance_deduction_type == "custom":
                 rec.maintenance_deduction_amount = (
                     rec.operating_expense * rec.maintenance_deduction_pct / 100.0
+                )
+            else:  # "fixed"
+                rec.maintenance_deduction_amount = (
+                    rec.maintenance_deduction_fixed_amount
                 )
 
     @api.depends(

--- a/kris_project/tests/__init__.py
+++ b/kris_project/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_maintenance_deduction

--- a/kris_project/tests/test_maintenance_deduction.py
+++ b/kris_project/tests/test_maintenance_deduction.py
@@ -1,4 +1,4 @@
-from odoo.tests.common import TransactionCase, tagged
+from odoo.tests.common import Form, TransactionCase, tagged
 
 
 @tagged("post_install", "-at_install")
@@ -90,3 +90,22 @@ class TestMaintenanceDeduction(TransactionCase):
             maintenance_deduction_pct=150.0,
         )
         self.assertTrue(project.warn_maintenance_exceeds_expense)
+
+    def test_switching_type_clears_inactive_inputs(self):
+        # Switching the method clears the input that no longer applies, so no
+        # stale value lingers in storage or on export.
+        form = Form(self.Project)
+        form.project_name = "Switch Test"
+        form.project_category_id = self.category
+        form.project_type_id = self.project_type
+        form.project_value = 2_000_000.0
+
+        form.maintenance_deduction_type = "fixed"
+        form.maintenance_deduction_fixed_amount = 123_456.0
+
+        form.maintenance_deduction_type = "custom"
+        self.assertEqual(form.maintenance_deduction_fixed_amount, 0.0)
+
+        form.maintenance_deduction_pct = 5.0
+        form.maintenance_deduction_type = "fixed"
+        self.assertEqual(form.maintenance_deduction_pct, 0.0)

--- a/kris_project/tests/test_maintenance_deduction.py
+++ b/kris_project/tests/test_maintenance_deduction.py
@@ -1,0 +1,92 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestMaintenanceDeduction(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Project = cls.env["kris.project"]
+        cls.category = cls.env["kris.project.category"].create(
+            {"name": "Test Category"}
+        )
+        cls.project_type = cls.env["kris.project.type"].create(
+            {"name": "Test Type", "category_id": cls.category.id}
+        )
+
+    def _make_project(self, **vals):
+        base = {
+            "project_name": "Test Project",
+            "project_category_id": self.category.id,
+            "project_type_id": self.project_type.id,
+        }
+        base.update(vals)
+        return self.Project.create(base)
+
+    def test_tiered_deduction(self):
+        # operating_expense = 2,000,000 -> 1M * 10% + 1M * 9% = 190,000
+        project = self._make_project(
+            project_value=2_000_000.0,
+            maintenance_deduction_type="tiered",
+        )
+        self.assertAlmostEqual(
+            project.maintenance_deduction_amount, 190_000.0, places=2
+        )
+
+    def test_custom_percentage_deduction(self):
+        # operating_expense = 2,000,000 * 5% = 100,000
+        project = self._make_project(
+            project_value=2_000_000.0,
+            maintenance_deduction_type="custom",
+            maintenance_deduction_pct=5.0,
+        )
+        self.assertAlmostEqual(
+            project.maintenance_deduction_amount, 100_000.0, places=2
+        )
+
+    def test_fixed_amount_deduction(self):
+        # The entered figure is used verbatim, independent of operating_expense.
+        project = self._make_project(
+            project_value=2_000_000.0,
+            maintenance_deduction_type="fixed",
+            maintenance_deduction_fixed_amount=123_456.0,
+        )
+        self.assertAlmostEqual(
+            project.maintenance_deduction_amount, 123_456.0, places=2
+        )
+
+    def test_fixed_amount_recomputes_on_change(self):
+        project = self._make_project(
+            project_value=2_000_000.0,
+            maintenance_deduction_type="fixed",
+            maintenance_deduction_fixed_amount=50_000.0,
+        )
+        project.maintenance_deduction_fixed_amount = 75_000.0
+        self.assertAlmostEqual(
+            project.maintenance_deduction_amount, 75_000.0, places=2
+        )
+
+    def test_warn_fixed_exceeds_expense(self):
+        project = self._make_project(
+            project_value=100_000.0,
+            maintenance_deduction_type="fixed",
+            maintenance_deduction_fixed_amount=150_000.0,
+        )
+        self.assertTrue(project.warn_maintenance_exceeds_expense)
+
+    def test_no_warn_fixed_within_expense(self):
+        project = self._make_project(
+            project_value=100_000.0,
+            maintenance_deduction_type="fixed",
+            maintenance_deduction_fixed_amount=50_000.0,
+        )
+        self.assertFalse(project.warn_maintenance_exceeds_expense)
+
+    def test_warn_is_method_agnostic_custom_over_100(self):
+        # A custom percentage above 100% also trips the warning.
+        project = self._make_project(
+            project_value=100_000.0,
+            maintenance_deduction_type="custom",
+            maintenance_deduction_pct=150.0,
+        )
+        self.assertTrue(project.warn_maintenance_exceeds_expense)

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -143,6 +143,7 @@
                     <field name="warn_installment_total_mismatch" invisible="1"/>
                     <field name="warn_extra_overshoot" invisible="1"/>
                     <field name="warn_cancel_with_receipts" invisible="1"/>
+                    <field name="warn_maintenance_exceeds_expense" invisible="1"/>
                     <div class="alert alert-warning" role="alert"
                         attrs="{'invisible': [('warn_cancel_with_receipts', '=', False)]}">
                         โครงการนี้มีการบันทึกรายรับแล้ว โปรดตรวจสอบก่อนยกเลิกโครงการ
@@ -281,6 +282,13 @@
                                             'readonly': [('can_edit', '=', False)]
                                         }"
                                     />
+                                    <field
+                                        name="maintenance_deduction_fixed_amount"
+                                        attrs="{
+                                            'invisible': [('maintenance_deduction_type', '!=', 'fixed')],
+                                            'readonly': [('can_edit', '=', False)]
+                                        }"
+                                    />
                                     <field name="maintenance_deduction_amount" readonly="1"/>
                                 </group>
                             </group>
@@ -293,6 +301,11 @@
                                     />
                                 </group>
                             </group>
+                            <div class="alert alert-danger mb-2" role="alert"
+                                attrs="{'invisible': [('warn_maintenance_exceeds_expense', '=', False)]}"
+                            >
+                                มูลค่าหักค่าบำรุงเกินค่าดำเนินการ (Operating Expense) กรุณาตรวจสอบวิธีคิดค่าบำรุง
+                            </div>
                             <div class="mb-3"
                                 attrs="{'invisible': [('can_edit', '=', False)]}"
                                 groups="kris_project.group_kris_project_officer"


### PR DESCRIPTION
Adds a third `maintenance_deduction_type` — **Fixed Amount** (ระบุจำนวนเงิน) — where the KRIS Officer enters the deduction figure directly and it is used verbatim, independent of the operating expense; the existing `custom` option is relabelled **Custom %** to disambiguate the two manual methods. Switching method clears the input that no longer applies (mirroring `product.pricelist.item._onchange_compute_price`) so no stale value is stored or exported. A soft warning plus an ignorable confirm-time exception now fire when the maintenance deduction exceeds the operating expense, which also closes the pre-existing Custom % > 100% gap. Includes the new input field with form visibility, Thai translations, a `CONTEXT.md` glossary entry, a manifest version bump, and unit tests covering the three methods, the warning, and the clearing behaviour.