### PR TITLE
[16.0][FIX] kris_project: skip exception checks when cancelling

### DIFF
--- a/kris_project/__manifest__.py
+++ b/kris_project/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KRIS Project",
-    "version": "16.0.1.4.0",
+    "version": "16.0.1.4.1",
     "category": "KMITL",
     "summary": "Academic service and research project revenue tracking for KRIS",
     "author": "Aginix Technologies",

--- a/kris_project/models/kris_project_exception.py
+++ b/kris_project/models/kris_project_exception.py
@@ -58,10 +58,8 @@ class KrisProject(models.Model):
                 raise UserError(
                     _("This project is already cancelled.")
                 )
-        if self.detect_exceptions() and not self.ignore_exception:
-            return self.with_context(
-                kris_exception_action="action_cancel"
-            )._popup_exceptions()
+        # Cancelling abandons the project, so it must not be gated by the
+        # confirm/done validation rules; skip exception detection here.
         self.write({"state": "cancel", "ignore_exception": False})
 
     def action_draft(self):


### PR DESCRIPTION
`action_cancel` ran `detect_exceptions()` while the project was still in draft/in_progress, so the confirm-phase validation rules fired and forced the exception popup just to abandon a project. Cancel now transitions straight to the cancel state. The `warn_cancel_with_receipts` banner still informs the user when receipts exist, so cancelling a project with recorded revenue isn't done silently. Bumped the manifest version to 16.0.1.3.1.