### PR TITLE
[16.0][IMP] kris_project: allow multiple receipts per installment

### DIFF
--- a/kris_project/__manifest__.py
+++ b/kris_project/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "KRIS Project",
-    "version": "16.0.1.5.0",
+    "version": "16.0.1.6.0",
     "category": "KMITL",
     "summary": "Academic service and research project revenue tracking for KRIS",
     "author": "Aginix Technologies",

--- a/kris_project/docs/adr/0001-discretionary-completion.md
+++ b/kris_project/docs/adr/0001-discretionary-completion.md
@@ -10,6 +10,10 @@ schedule or money-completeness:
 - For **every** project, **Done** is allowed even when received Revenue is below Project
   Value and not all งวด are received, and **Cancel** is never blocked by recorded
   Revenue — projects legitimately close under-collected, at KRIS's discretion.
+- A single งวด may be recorded across **multiple Receipts** and may be **over-collected**
+  (its received total may exceed the งวด amount). The receipt wizard pre-fills only the
+  outstanding remainder, but does not cap the entry, so a fully-received งวด stays
+  selectable for a later correction or extra income.
 
 ## Why record this
 

--- a/kris_project/tests/__init__.py
+++ b/kris_project/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_copy, test_maintenance_deduction
+from . import test_copy, test_maintenance_deduction, test_receipt_wizard

--- a/kris_project/tests/test_receipt_wizard.py
+++ b/kris_project/tests/test_receipt_wizard.py
@@ -1,0 +1,135 @@
+from odoo.tests.common import Form, TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReceiptWizardRemaining(TransactionCase):
+    """A single installment (งวดงาน) may be recorded across several receipts.
+
+    The wizard must pre-fill only the amount still outstanding on the
+    installment so the 2nd/3rd receipt does not double-count and trip the
+    allocation / extra-income guards.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        category = cls.env["kris.project.category"].create({"name": "Cat"})
+        project_type = cls.env["kris.project.type"].create(
+            {"name": "Type", "category_id": category.id}
+        )
+        cls.item = cls.env["kris.project.allocation.item"].create({"name": "Dept A"})
+        # operating_expense = project_value (no equipment cost); fixed deduction
+        # of 200,000 is the allocation pool.
+        cls.project = cls.env["kris.project"].create(
+            {
+                "project_name": "Wizard Project",
+                "project_category_id": category.id,
+                "project_type_id": project_type.id,
+                "project_value": 1_000_000.0,
+                "extra_value": 50_000.0,
+                "maintenance_deduction_type": "fixed",
+                "maintenance_deduction_fixed_amount": 200_000.0,
+            }
+        )
+        cls.alloc_line = cls.env["kris.project.allocation.line"].create(
+            {
+                "project_id": cls.project.id,
+                "item_id": cls.item.id,
+                "estimated_amount": 200_000.0,
+            }
+        )
+        cls.installment = cls.env["kris.project.installment"].create(
+            {
+                "project_id": cls.project.id,
+                "name": "งวด 1",
+                "amount": 1_000_000.0,
+                "extra_income": 50_000.0,
+                "allocation_ids": [
+                    (0, 0, {"allocation_line_id": cls.alloc_line.id, "amount": 200_000.0})
+                ],
+            }
+        )
+
+    def _open_wizard(self):
+        return Form(
+            self.env["kris.project.receipt.wizard"].with_context(
+                default_project_id=self.project.id
+            )
+        )
+
+    def _alloc_amount(self, form):
+        with form.allocation_ids.edit(0) as line:
+            return line.amount
+
+    def test_first_receipt_prefills_full(self):
+        f = self._open_wizard()
+        f.installment_id = self.installment
+        self.assertAlmostEqual(f.amount, 1_000_000.0, places=2)
+        self.assertAlmostEqual(f.extra_income, 50_000.0, places=2)
+        self.assertAlmostEqual(self._alloc_amount(f), 200_000.0, places=2)
+
+    def test_second_receipt_prefills_remaining_and_saves(self):
+        # Receipt #1 records part of the installment.
+        receipt1 = self.env["kris.project.receipt"].create(
+            {
+                "project_id": self.project.id,
+                "installment_id": self.installment.id,
+                "name": "R1",
+                "date": "2026-01-01",
+                "amount": 600_000.0,
+                "extra_income": 30_000.0,
+            }
+        )
+        self.env["kris.project.receipt.allocation"].create(
+            {
+                "receipt_id": receipt1.id,
+                "allocation_line_id": self.alloc_line.id,
+                "amount": 120_000.0,
+            }
+        )
+        self.assertEqual(self.installment.state, "partial")
+
+        # Receipt #2 must pre-fill only what is left, not the full figures.
+        f = self._open_wizard()
+        f.installment_id = self.installment
+        self.assertAlmostEqual(f.amount, 400_000.0, places=2)
+        self.assertAlmostEqual(f.extra_income, 20_000.0, places=2)
+        self.assertAlmostEqual(self._alloc_amount(f), 80_000.0, places=2)
+
+        # Saving the remaining defaults must not trip the allocation /
+        # extra-income guards (this is what the full-figure pre-fill broke).
+        f.name = "R2"
+        wiz = f.save()
+        wiz.action_save()
+
+        self.assertEqual(self.installment.state, "received")
+        self.assertAlmostEqual(self.alloc_line.actual_amount, 200_000.0, places=2)
+
+    def test_fully_received_installment_prefills_zero(self):
+        # Fully receive the installment in one receipt.
+        receipt = self.env["kris.project.receipt"].create(
+            {
+                "project_id": self.project.id,
+                "installment_id": self.installment.id,
+                "name": "R1",
+                "date": "2026-01-01",
+                "amount": 1_000_000.0,
+                "extra_income": 50_000.0,
+            }
+        )
+        self.env["kris.project.receipt.allocation"].create(
+            {
+                "receipt_id": receipt.id,
+                "allocation_line_id": self.alloc_line.id,
+                "amount": 200_000.0,
+            }
+        )
+        self.assertEqual(self.installment.state, "received")
+
+        # The งวด stays selectable, but defaults to zero so any over-collection
+        # is entered deliberately.
+        f = self._open_wizard()
+        f.installment_id = self.installment
+        self.assertAlmostEqual(f.amount, 0.0, places=2)
+        self.assertAlmostEqual(f.extra_income, 0.0, places=2)
+        self.assertAlmostEqual(self._alloc_amount(f), 0.0, places=2)

--- a/kris_project/views/kris_project_receipt_wizard_views.xml
+++ b/kris_project/views/kris_project_receipt_wizard_views.xml
@@ -7,13 +7,12 @@
         <field name="arch" type="xml">
             <form string="Revenue Record">
                 <field name="currency_id" invisible="1"/>
-                <field name="available_installment_ids" invisible="1"/>
                 <group>
                     <field name="project_id" readonly="1"/>
                     <field name="name"/>
                     <field
                         name="installment_id"
-                        domain="[('id', 'in', available_installment_ids)]"
+                        domain="[('project_id', '=', project_id)]"
                         options="{'no_create': True, 'no_create_edit': True}"
                     />
                     <field name="date"/>

--- a/kris_project/wizard/kris_project_receipt_wizard.py
+++ b/kris_project/wizard/kris_project_receipt_wizard.py
@@ -11,15 +11,10 @@ class KrisProjectReceiptWizard(models.TransientModel):
         required=True,
         readonly=True,
     )
-    available_installment_ids = fields.Many2many(
-        comodel_name="kris.project.installment",
-        string="งวดที่ใช้ได้",
-        compute="_compute_available_installment_ids",
-    )
     installment_id = fields.Many2one(
         comodel_name="kris.project.installment",
         string="Installment Number",
-        domain="[('id', 'in', available_installment_ids)]",
+        domain="[('project_id', '=', project_id)]",
         ondelete="set null",
     )
     name = fields.Char(
@@ -72,16 +67,6 @@ class KrisProjectReceiptWizard(models.TransientModel):
             ]
         return res
 
-    @api.depends("project_id", "project_id.installment_ids.state")
-    def _compute_available_installment_ids(self):
-        for wiz in self:
-            # Allow splitting a single installment across multiple receipts:
-            # only fully received installments are removed from the choices.
-            available = wiz.project_id.installment_ids.filtered(
-                lambda i: i.state != "received"
-            )
-            wiz.available_installment_ids = available
-
     @api.depends("amount", "equipment_cost_in_installment")
     def _compute_net_amount(self):
         for wiz in self:
@@ -89,15 +74,32 @@ class KrisProjectReceiptWizard(models.TransientModel):
 
     @api.onchange("installment_id")
     def _onchange_installment_id(self):
-        if self.installment_id:
-            self.amount = self.installment_id.amount
-            self.extra_income = self.installment_id.extra_income
-            inst_alloc_by_line = {
-                ia.allocation_line_id.id: ia.amount
-                for ia in self.installment_id.allocation_ids
-            }
-            for line in self.allocation_ids:
-                line.amount = inst_alloc_by_line.get(line.allocation_line_id.id, 0.0)
+        inst = self.installment_id
+        if not inst:
+            return
+        # A single installment (งวดงาน) may be recorded across several receipts,
+        # so pre-fill only the amount still outstanding on it. Pre-filling the
+        # full figures would double-count and trip the allocation / extra-income
+        # guards; a fully-received installment therefore pre-fills zero, leaving
+        # any over-collection to be entered deliberately.
+        self.amount = max(0.0, inst.amount - inst.received_total)
+        received_extra = sum(inst.receipt_ids.mapped("extra_income"))
+        self.extra_income = max(0.0, inst.extra_income - received_extra)
+        inst_alloc_by_line = {
+            ia.allocation_line_id.id: ia.amount for ia in inst.allocation_ids
+        }
+        received_by_line = {}
+        for receipt in inst.receipt_ids:
+            for ra in receipt.allocation_ids:
+                received_by_line[ra.allocation_line_id.id] = (
+                    received_by_line.get(ra.allocation_line_id.id, 0.0) + ra.amount
+                )
+        for line in self.allocation_ids:
+            lid = line.allocation_line_id.id
+            line.amount = max(
+                0.0,
+                inst_alloc_by_line.get(lid, 0.0) - received_by_line.get(lid, 0.0),
+            )
 
     def action_save(self):
         self.ensure_one()


### PR DESCRIPTION
A งวดงาน (installment) can now be recorded across more than one ใบเสร็จรับเงิน (receipt): the receipt wizard's installment filter is lifted so a fully-received งวด stays selectable, and the wizard pre-fills only the outstanding remainder (amount, extra income, and per-line allocation) instead of the full figures — so a 2nd/3rd receipt no longer double-counts or trips the allocation / extra-income guards, and a fully-received งวด defaults to zero. The now-redundant `available_installment_ids` computed field is dropped in favour of a plain `[('project_id','=',project_id)]` domain. The multi-receipt / over-collection rule is documented in ADR-0001, and wizard tests cover the full / remaining / zero pre-fill cases.