### PR TITLE
[16.0][FIX] account_asset_kmitl: carry analytic into asset depreciation & removal entries

### DIFF
--- a/account_asset_kmitl/__init__.py
+++ b/account_asset_kmitl/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from . import controllers, models
+from . import controllers, models, wizard

--- a/account_asset_kmitl/models/__init__.py
+++ b/account_asset_kmitl/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import account_asset
+from . import account_asset_line

--- a/account_asset_kmitl/models/account_asset.py
+++ b/account_asset_kmitl/models/account_asset.py
@@ -102,6 +102,21 @@ class AccountAsset(models.Model):
         domain=[("root_plan_id.code", "=", "activities")],
     )
 
+    @api.depends("profile_id")
+    def _compute_analytic_distribution(self):
+        """Default the analytic distribution from the profile only when the
+        asset has none yet; never overwrite dimensions entered through the
+        convenience fields (source/department/fund/activity).
+
+        The base account_asset_management computes this purely from the profile,
+        which wipes out the values written by the convenience-field inverse.
+        """
+        for asset in self:
+            asset.analytic_distribution = (
+                asset.analytic_distribution
+                or asset.profile_id.analytic_distribution
+            )
+
     location = fields.Char(
         tracking=True,
         string="Location",

--- a/account_asset_kmitl/models/account_asset_line.py
+++ b/account_asset_kmitl/models/account_asset_line.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class AccountAssetLine(models.Model):
+    _inherit = "account.asset.line"
+
+    def _setup_move_data(self, depreciation_date):
+        move_data = super()._setup_move_data(depreciation_date)
+        # Stamp analytic on the journal-entry header (the "main document").
+        # The header field is provided by accounting_kmitl; guard in case it
+        # is not installed, since this module does not depend on it.
+        if "analytic_distribution" in self.env["account.move"]._fields:
+            move_data["analytic_distribution"] = self.asset_id.analytic_distribution
+        return move_data
+
+    def _setup_move_line_data(self, depreciation_date, account, ml_type, move):
+        move_line_data = super()._setup_move_line_data(
+            depreciation_date, account, ml_type, move
+        )
+        # super() stamps the depreciation line only when the
+        # asset_move_line_analytic company flag is set; always carry the asset
+        # analytic on every move line (depreciation and expense alike).
+        move_line_data["analytic_distribution"] = self.asset_id.analytic_distribution
+        return move_line_data

--- a/account_asset_kmitl/views/account_asset_views.xml
+++ b/account_asset_kmitl/views/account_asset_views.xml
@@ -64,10 +64,10 @@
                 />
             </xpath>
             <xpath expr="//group[@id='header_right_group']" position="inside">
-                <field name="activity_analytic_id" />
-                <field name="department_analytic_id" />
-                <field name="fund_analytic_id" />
-                <field name="source_analytic_id" />
+                <field name="activity_analytic_id" required="1" />
+                <field name="department_analytic_id" required="1" />
+                <field name="fund_analytic_id" required="1" />
+                <field name="source_analytic_id" required="1" />
             </xpath>
         </field>
     </record>

--- a/account_asset_kmitl/wizard/__init__.py
+++ b/account_asset_kmitl/wizard/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import account_asset_remove

--- a/account_asset_kmitl/wizard/account_asset_remove.py
+++ b/account_asset_kmitl/wizard/account_asset_remove.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class AccountAssetRemove(models.TransientModel):
+    _inherit = "account.asset.remove"
+
+    def remove(self):
+        res = super().remove()
+        # Stamp analytic on the removal journal-entry header (the "main
+        # document"). The header field is provided by accounting_kmitl; guard
+        # in case it is not installed, since this module does not depend on it.
+        if (
+            isinstance(res, dict)
+            and res.get("res_model") == "account.move"
+            and res.get("domain")
+            and "analytic_distribution" in self.env["account.move"]._fields
+        ):
+            for move in self.env["account.move"].search(res["domain"]):
+                assets = move.line_ids.mapped("asset_id")
+                if len(assets) == 1:
+                    move.analytic_distribution = assets.analytic_distribution
+        return res
+
+    def _get_removal_data(self, asset, residual_value):
+        move_lines = super()._get_removal_data(asset, residual_value)
+        # super() stamps analytic only on the P&L lines (and honours the
+        # asset_move_line_analytic flag for the rest); always carry the asset
+        # analytic on every removal move line.
+        for move_line in move_lines:
+            move_line[2]["analytic_distribution"] = asset.analytic_distribution
+        return move_lines


### PR DESCRIPTION
## Problem
Asset journal entries did not carry the asset analytic distribution, even when the asset had all four analytic dimensions (department / source / fund / activity) filled in:
- **Depreciation entries** — no analytic on the header or any line.
- **Removal (disposal) entries** — analytic only on the gain/loss lines (base); missing on the balance-sheet lines and the header.

## Root cause
On `account.asset`, `analytic_distribution` is a stored computed field. Core `analytic.mixin` ships a no-op compute, but `account_asset_management` overrides it to pull purely from the asset profile (`@api.depends("profile_id")`). That compute overwrites the value the KMITL convenience-field inverse (`_update_analytic_distribution`) writes, so the stored JSON ends up empty while the convenience fields still display their values. Both the depreciation and removal move creation then copy an empty `asset.analytic_distribution`.

The journal-entry header field (`account.move.analytic_distribution`, added by `accounting_kmitl`) was never set, and propagation to move lines was gated behind the `asset_move_line_analytic` company flag.

## Changes (account_asset_kmitl only)
- **`models/account_asset.py`** — override `_compute_analytic_distribution` to default from the profile **only when the asset has none yet**, never overwriting dimensions entered through the convenience fields.
- **`models/account_asset_line.py`** (new) — override depreciation move setup to always stamp the asset analytic on every move line **and** the header.
- **`wizard/account_asset_remove.py`** (new) — override the removal wizard to always stamp the asset analytic on every removal move line **and** the header. Low-value assets create no move, so they are unaffected.
- **`views/account_asset_views.xml`** — make the four analytic dimension fields required on the asset form so every asset carries a complete distribution.

Header writes are guarded with a `_fields` check since this module does not depend on `accounting_kmitl`. `l10n_th_gov_account_asset_management` is intentionally left untouched.

## How to verify
- [ ] Asset form requires all 4 analytic dimensions before saving
- [ ] Asset with all 4 dimensions → `analytic_distribution` JSON is populated
- [ ] Create depreciation entries → header + all move lines carry the analytic
- [ ] Remove / dispose an asset → header + all removal move lines carry the analytic
- [ ] Existing `l10n_th_gov_account_asset_management` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)