### PR TITLE
[16.0][IMP] accounting_kmitl: attach files on account.move form

### DIFF
--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -67,6 +67,14 @@
             </xpath>
             <xpath expr="//page[@id='other_tab_entry']/field[@name='narration']" position="replace"/>
 
+            <!-- Attachments (renders the base account.move attachment_ids field
+                 with the same many2many_binary widget disbursement.request uses) -->
+            <xpath expr="//page[@id='invoice_tab']/.." position="before">
+                <group name="attachment" string="Attachments">
+                    <field name="attachment_ids" widget="many2many_binary" nolabel="1" colspan="2" attrs="{'readonly': [('state', '=', 'posted')]}"/>
+                </group>
+            </xpath>
+
             <!-- Show reversed_entry_id only when it has a value -->
             <xpath expr="//page[@id='other_tab_entry']//field[@name='reversed_entry_id']" position="attributes">
                 <attribute name="attrs">{'invisible': ['|', ('move_type', '!=', 'entry'), ('reversed_entry_id', '=', False)]}</attribute>


### PR DESCRIPTION
## What

Render the existing base `account.move.attachment_ids` field on the invoice/bill/journal-entry form using the `many2many_binary` widget, mirroring how the `disbursement.request` form lets users attach files.

## Why

Users need to attach supporting documents (scans, evidence) directly on an `account.move` the same way they already can on a disbursement request.

## How

- **View-only change** in `accounting_kmitl/views/account_move_views.xml` — a new `<group name="attachment" string="Attachments">` placed above the notebook (same anchor as the existing budget/narration groups).
- No Python change: base Odoo 16 `account.move` already defines `attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')])` — it was simply never rendered.
- The box is locked (`readonly`) once the move is `posted`, mirroring how disbursement locks attachments after submit.
- No discriminator flag, no security change (ir.attachment inherits the parent document's ACLs), no manifest/dependency change.

## Notes

- Files posted in the chatter (also `res_model='account.move'`) appear in the Attachments box too — identical behaviour to `disbursement.request` and base `account.move`.

## Test plan

1. Open a Vendor Bill / Customer Invoice → confirm the **Attachments** box appears above the notebook.
2. Upload a file on a saved record → chip appears, downloads correctly; `ir.attachment` row has `res_model='account.move'`, `res_id=<move id>`.
3. Reload → attachment persists.
4. Post the move → attachments still visible but the box is readonly.
5. Regression: statusbar / Submit-Reset buttons / budget group unaffected.