### PR TITLE
[16.0][IMP] accounting_kmitl: add Account Entries menu

### DIFF
--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -131,6 +131,11 @@ msgid "Journal Entries"
 msgstr "รายการบันทึกบัญชี"
 
 #. module: accounting_kmitl
+#: model:ir.ui.menu,name:accounting_kmitl.menu_account_entries
+msgid "Account Entries"
+msgstr "รายการเดินบัญชี"
+
+#. module: accounting_kmitl
 #: model:ir.ui.menu,name:accounting_kmitl.menu_journal_items_all
 #: model:ir.actions.act_window,name:accounting_kmitl.action_account_move_lines_all
 msgid "Journal Items"

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -44,6 +44,15 @@
         sequence="20"
     />
 
+    <!-- All account.move entries (รายการเดินบัญชี) under Journal Entries -->
+    <menuitem
+        id="menu_account_entries"
+        name="Account Entries"
+        parent="menu_journal_entries"
+        action="account.action_move_journal_line"
+        sequence="5"
+    />
+
     <!-- All Journal Items (account.move.line) under Journal Entries -->
     <record id="action_account_move_lines_all" model="ir.actions.act_window">
         <field name="name">Journal Items</field>

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -58,6 +58,7 @@
         <field name="name">Journal Items</field>
         <field name="res_model">account.move.line</field>
         <field name="view_mode">tree,pivot,graph,kanban,form</field>
+        <field name="search_view_id" ref="account.view_account_move_line_filter"/>
         <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
         <field name="context">{'search_default_group_by_move': 1, 'create': 0}</field>
     </record>


### PR DESCRIPTION
## What

1. **Add an `Account Entries` menu** (Thai: รายการเดินบัญชี) under *Journal Entries* in the KMITL Accounting app, listing all `account.move` records — same view as Odoo's original Invoicing/Accounting app.
2. **Fix the `Journal Items` menu search view.** It was unintentionally using the bill-specific search view from `disbursement_accounting_kmitl`, so its filters/group-by were labelled "Bill" even though the menu shows journal items of every type.
3. **i18n**: add the Thai translation for the new `Account Entries` menu.

## Changes

### `Account Entries` menu (`accounting_kmitl/views/menuitem.xml`)
A single `<menuitem>` reusing the standard `account.action_move_journal_line` action (no new action/view/security/manifest changes):

```xml
<menuitem id="menu_account_entries" name="Account Entries"
          parent="menu_journal_entries"
          action="account.action_move_journal_line" sequence="5"/>
```
Child of `menu_journal_entries`, before *Journal Items*. Behaves exactly like Odoo (default `Posted` filter, clearable). Visibility inherited from the parent chain.

### Journal Items search view fix (`accounting_kmitl/views/menuitem.xml`)
`action_account_move_lines_all` had no `search_view_id`, so `account.move.line` fell back to its default search view. Because `ir.ui.view._order = "priority,name,id"` and `disbursement_accounting_kmitl`'s `account.move.line.disbursement.search` sorts before the standard `account.move.line.search` at equal priority, the bill-specific disbursement filters ("Draft Bills", "Posted Bills", group-by "Bill"/"Bill Status") leaked into this generic menu.

Fix — pin the action to the standard generic view:
```xml
<field name="search_view_id" ref="account.view_account_move_line_filter"/>
```
Now the menu shows generic *Journal Entry* terminology (group-by "Journal Entry", filters "Posted"/"Unposted", etc.) covering all move types. The disbursement module's own *Move Lines Review* menu — which is genuinely bill-scoped — keeps its "Bill" labels.

### i18n (`accounting_kmitl/i18n/th.po`)
`Account Entries` → `รายการเดินบัญชี`. The standard search view introduces no new module strings (handled by Odoo core translations).

## Notes
- The parent *Journal Entries* menu already opens the same action as the new `Account Entries` child — intentional, requested behaviour.

## Test
1. Upgrade the module (`-u accounting_kmitl`).
2. **Accounting** → expand **Journal Entries** → **Account Entries** appears before *Journal Items*; clicking it opens the full `account.move` list (Posted filter on by default).
3. Open **Journal Items** → filters/group-by now use generic *Journal Entry* terminology (no "Bill"); group-by Journal Entry still defaults on.