### PR TITLE
[16.0][ADD] accounting_kmitl_reports: add aged receivable/payable report

### DIFF
--- a/accounting_kmitl_reports/CONTEXT.md
+++ b/accounting_kmitl_reports/CONTEXT.md
@@ -1,6 +1,6 @@
 # Accounting Reports
 
-Financial-statement reports for KMITL — Trial Balance, Profit and Loss, Balance Sheet and Cash Flow Statement — computed over the standard `account.move.line` ledger and filterable by the KMITL accounting dimensions.
+Financial-statement reports for KMITL — Trial Balance, Profit and Loss, Balance Sheet, Cash Flow Statement and Aged Receivable/Payable — computed over the standard `account.move.line` ledger and filterable by the KMITL accounting dimensions.
 
 ## Language
 
@@ -19,3 +19,11 @@ _Avoid_: net, total
 **Accounting dimension (มิติทางบัญชี)**:
 A KMITL analytic plan used to filter the report, selected by `root_plan_id.code`. The Trial Balance filters the four core dimensions — Departments (ส่วนงาน), Sources (แหล่งเงิน), Funds (กองทุน) and Activities (ด้าน/แผนงาน/กิจกรรม) — read from each move line's `analytic_distribution`. Within one dimension the picks are OR-ed (a hierarchical pick also matches its descendants); across dimensions they are AND-ed.
 _Avoid_: analytic tag, segment
+
+**Aged Receivable / Aged Payable (รายงานอายุลูกหนี้/เจ้าหนี้)**:
+A partner-level listing, as of a chosen date, of each open (unreconciled) residual split into ageing buckets by how far past its due date it is — **Current** (not yet due), **1-30**, **31-60**, **61-90**, **91-120** and **120+** days. Aged Receivable covers `asset_receivable` accounts; Aged Payable covers `liability_payable`. Computed by the OCA `aged_partner_balance` engine. Opens straight from the menu as an OWL client action and shares its compute with the QWeb PDF and XLSX exports.
+_Avoid_: aging, overdue report
+
+**Accounting dimension on ageing (มิติทางบัญชีในรายงานอายุ)**:
+Because the receivable/payable control line carries no `analytic_distribution`, a dimension filter on the ageing reports works at the **move** level: it keeps only the residuals whose invoice contains a line matching the selected dimensions — not the control line itself.
+_Avoid_: line-level filter

--- a/accounting_kmitl_reports/__manifest__.py
+++ b/accounting_kmitl_reports/__manifest__.py
@@ -2,10 +2,10 @@
 
 {
     "name": "KMITL Accounting Reports",
-    "version": "16.0.2.0.0",
+    "version": "16.0.3.0.0",
     "category": "KMITL/Accounting",
     "summary": "KMITL accounting reports: Trial Balance, Profit and Loss, "
-    "Balance Sheet, Cash Flow Statement",
+    "Balance Sheet, Cash Flow Statement, Aged Receivable/Payable",
     "author": "KMITL",
     "website": "https://www.kmitl.ac.th",
     "license": "LGPL-3",
@@ -28,7 +28,9 @@
         "data/mis_report_instance_kmitl.xml",
         "data/paperformat_trial_balance_kmitl.xml",
         "data/report_action_trial_balance_kmitl.xml",
+        "data/report_action_aged_partner_balance_kmitl.xml",
         "report/trial_balance_kmitl_template.xml",
+        "report/aged_partner_balance_kmitl_template.xml",
         "views/menuitem.xml",
     ],
     "assets": {
@@ -37,6 +39,9 @@
             "accounting_kmitl_reports/static/src/trial_balance/trial_balance.js",
             "accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml",
             "accounting_kmitl_reports/static/src/trial_balance/trial_balance.scss",
+            "accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js",
+            "accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml",
+            "accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.scss",
         ],
     },
     "installable": True,

--- a/accounting_kmitl_reports/data/report_action_aged_partner_balance_kmitl.xml
+++ b/accounting_kmitl_reports/data/report_action_aged_partner_balance_kmitl.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="action_report_aged_partner_balance_kmitl" model="ir.actions.report">
+        <field name="name">Aged Partner Balance</field>
+        <field name="model">aged.partner.report.wizard.kmitl</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">accounting_kmitl_reports.aged_partner_balance_kmitl</field>
+        <field name="report_file">accounting_kmitl_reports.aged_partner_balance_kmitl</field>
+        <field name="paperformat_id" ref="paperformat_trial_balance_kmitl" />
+        <field name="binding_model_id" eval="False" />
+    </record>
+
+    <record id="action_report_aged_partner_balance_kmitl_xlsx" model="ir.actions.report">
+        <field name="name">Aged Partner Balance (XLSX)</field>
+        <field name="model">aged.partner.report.wizard.kmitl</field>
+        <field name="report_type">xlsx</field>
+        <field name="report_name">accounting_kmitl_reports.aged_partner_balance_xlsx</field>
+        <field name="report_file">accounting_kmitl_reports.aged_partner_balance_xlsx</field>
+        <field name="binding_model_id" eval="False" />
+    </record>
+</odoo>

--- a/accounting_kmitl_reports/models/__init__.py
+++ b/accounting_kmitl_reports/models/__init__.py
@@ -1,1 +1,3 @@
+from . import dimension_filter_mixin
 from . import trial_balance_kmitl
+from . import aged_partner_balance_kmitl

--- a/accounting_kmitl_reports/models/aged_partner_balance_kmitl.py
+++ b/accounting_kmitl_reports/models/aged_partner_balance_kmitl.py
@@ -1,0 +1,344 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+from odoo.tools import format_date
+
+# Aging buckets, in display order. ``residual`` is the row total.
+BUCKETS = ("current", "30_days", "60_days", "90_days", "120_days", "older")
+# Map the menu's account type to the chart-of-accounts ``account_type``.
+ACCOUNT_TYPE_MAP = {
+    "receivable": "asset_receivable",
+    "payable": "liability_payable",
+}
+
+
+class AgedPartnerBalanceKmitl(models.AbstractModel):
+    """Aged Partner Balance computed by the OCA engine, extended with KMITL
+    accounting-dimension filtering.
+
+    The same compute (:meth:`get_aged_partner_data`) feeds the on-screen OWL
+    client action (called over RPC), the QWeb PDF and the XLSX export, so all
+    three always agree. Uses the standard fixed buckets (current / 1-30 / 31-60
+    / 61-90 / 91-120 / 120+ days) — no configurable interval is exposed.
+    """
+
+    _name = "report.accounting_kmitl_reports.aged_partner_balance_kmitl"
+    _description = "KMITL Aged Partner Balance Report"
+    _inherit = [
+        "report.account_financial_report.aged_partner_balance",
+        "accounting_kmitl_reports.dimension.filter.mixin",
+    ]
+
+    # ------------------------------------------------------------------
+    # Dimension filtering
+    #
+    # The receivable/payable control line usually carries no
+    # ``analytic_distribution`` (the KMITL dimensions live on the invoice's
+    # income/expense lines). So we resolve the selected dimensions to the set
+    # of moves that carry them, and restrict the aged move lines to those
+    # moves via a ``move_id`` leaf passed through the context.
+    # ------------------------------------------------------------------
+    @api.model
+    def _get_move_lines_domain_not_reconciled(self, *args, **kwargs):
+        domain = super()._get_move_lines_domain_not_reconciled(*args, **kwargs)
+        return domain + self._kmitl_move_leaf()
+
+    @api.model
+    def _get_new_move_lines_domain(self, *args, **kwargs):
+        domain = super()._get_new_move_lines_domain(*args, **kwargs)
+        return domain + self._kmitl_move_leaf()
+
+    def _kmitl_move_leaf(self):
+        move_ids = self.env.context.get("kmitl_move_ids")
+        if move_ids is None:
+            return []
+        return [("move_id", "in", move_ids)]
+
+    @api.model
+    def _kmitl_accounts_for_type(self, account_type, company_id):
+        at = ACCOUNT_TYPE_MAP.get(account_type)
+        if not at:
+            return []
+        return (
+            self.env["account.account"]
+            .search([("company_id", "=", company_id), ("account_type", "=", at)])
+            .ids
+        )
+
+    # ------------------------------------------------------------------
+    # Shared compute
+    # ------------------------------------------------------------------
+    @api.model
+    def get_aged_partner_data(self, options):
+        """Compute the aged partner balance for ``options`` and return
+        JSON-friendly rows. Called over RPC by the OWL client action and
+        internally by the QWeb / XLSX reports.
+
+        ``options`` keys: ``company_id``, ``date_at`` (as-of date),
+        ``date_from`` (optional), ``only_posted`` (bool), ``account_type``
+        (``"receivable"``/``"payable"``), ``partner_ids``, ``account_ids``
+        (optional override), ``show_move_line_details`` (bool) and ``dims``
+        (``{code: [analytic_account_ids]}``).
+        """
+        options = options or {}
+        company_id = options.get("company_id") or self.env.company.id
+        company = self.env["res.company"].browse(company_id)
+        date_at = options.get("date_at")
+
+        empty = {
+            "accounts": [],
+            "totals": self._kmitl_empty_buckets(),
+            "currency_id": company.currency_id.id,
+        }
+        if not date_at:
+            return empty
+
+        account_type = options.get("account_type") or "receivable"
+        only_posted = bool(options.get("only_posted", True))
+        show_details = bool(options.get("show_move_line_details"))
+        partner_ids = options.get("partner_ids") or []
+        account_ids = list(options.get("account_ids") or [])
+        if not account_ids:
+            account_ids = self._kmitl_accounts_for_type(account_type, company_id)
+        if not account_ids:
+            return empty
+
+        # Resolve the selected dimensions to the moves that carry them.
+        move_ids = None
+        leaves = self._kmitl_build_dim_leaves(options.get("dims") or {})
+        if leaves:
+            move_ids = self.env["account.move.line"].search(leaves).move_id.ids
+
+        date_at_object = fields.Date.to_date(date_at)
+        report = self.with_context(
+            kmitl_move_ids=move_ids,
+            # No interval configuration: the OCA engine then only fills the
+            # fixed buckets, which is what we render.
+            age_partner_config=self.env["account.age.report.configuration"].browse(),
+        )
+        (
+            ag_pb_data,
+            accounts_data,
+            partners_data,
+            journals_data,
+        ) = report._get_move_lines_data(
+            company_id,
+            account_ids,
+            partner_ids,
+            date_at_object,
+            options.get("date_from") or False,
+            only_posted,
+            show_details,
+        )
+        aged = report._create_account_list(
+            ag_pb_data,
+            accounts_data,
+            partners_data,
+            journals_data,
+            show_details,
+            date_at_object,
+        )
+
+        accounts = []
+        totals = self._kmitl_empty_buckets()
+        for acc in aged:
+            partners = []
+            for prt in acc["partners"]:
+                prow = {"name": prt["name"] or _("Unknown")}
+                prow.update({k: prt[k] for k in ("residual",) + BUCKETS})
+                if show_details:
+                    prow["move_lines"] = [
+                        self._kmitl_format_move_line(ml) for ml in prt["move_lines"]
+                    ]
+                partners.append(prow)
+            arow = {
+                "id": acc["id"],
+                "code": acc["code"] or "",
+                "name": acc["name"] or "",
+                "partners": partners,
+            }
+            arow.update({k: acc[k] for k in ("residual",) + BUCKETS})
+            accounts.append(arow)
+            for key in totals:
+                totals[key] += acc[key]
+        return {
+            "accounts": accounts,
+            "totals": totals,
+            "currency_id": company.currency_id.id,
+        }
+
+    @api.model
+    def _kmitl_format_move_line(self, ml):
+        row = {
+            "date": fields.Date.to_string(ml["date"]) or "",
+            "due_date": fields.Date.to_string(ml["due_date"]) or "",
+            "entry": ml["entry"] or "",
+            "journal": ml["journal"] or "",
+            "ref_label": ml["ref_label"] or "",
+        }
+        row.update({k: ml[k] for k in ("residual",) + BUCKETS})
+        return row
+
+    @api.model
+    def _kmitl_empty_buckets(self):
+        return {key: 0.0 for key in ("residual",) + BUCKETS}
+
+    @api.model
+    def _kmitl_report_title(self, account_type):
+        if account_type == "payable":
+            return _("Aged Payable")
+        return _("Aged Receivable")
+
+    @api.model
+    def _kmitl_format_amount(self, value):
+        """Shared number formatting (kept identical to the OWL side so the PDF
+        mirrors the screen). Blank for ~zero to reduce clutter."""
+        if not value or abs(value) < 0.005:
+            return ""
+        return "{:,.2f}".format(value)
+
+    # ------------------------------------------------------------------
+    # PDF / XLSX export — return the report action so the OWL client action
+    # can ``doAction`` it. Filters travel in ``data`` so the output mirrors
+    # the on-screen report exactly (no persisted record needed).
+    # ------------------------------------------------------------------
+    def _kmitl_report_action(self, options, report_xmlid):
+        options = options or {}
+        carrier = self.env["aged.partner.report.wizard.kmitl"].create(
+            {
+                "company_id": options.get("company_id") or self.env.company.id,
+                "date_at": options.get("date_at"),
+            }
+        )
+        report = self.env.ref(report_xmlid)
+        return report.report_action(carrier, data={"options": options})
+
+    @api.model
+    def action_print_pdf(self, options):
+        return self._kmitl_report_action(
+            options,
+            "accounting_kmitl_reports.action_report_aged_partner_balance_kmitl",
+        )
+
+    @api.model
+    def action_export_xlsx(self, options):
+        return self._kmitl_report_action(
+            options,
+            "accounting_kmitl_reports.action_report_aged_partner_balance_kmitl_xlsx",
+        )
+
+    # ------------------------------------------------------------------
+    # QWeb PDF rendering — reuse the shared compute.
+    # ------------------------------------------------------------------
+    def _get_report_values(self, docids, data):
+        data = data or {}
+        options = data.get("options") or {}
+        result = self.get_aged_partner_data(options)
+        company = self.env["res.company"].browse(
+            options.get("company_id") or self.env.company.id
+        )
+        return {
+            "doc_ids": docids,
+            "doc_model": "aged.partner.report.wizard.kmitl",
+            "docs": self.env["aged.partner.report.wizard.kmitl"].browse(docids or []),
+            "res_company": company,
+            "accounts": result["accounts"],
+            "totals": result["totals"],
+            "report_title": self._kmitl_report_title(options.get("account_type")),
+            "format_amount": self._kmitl_format_amount,
+            "date_at_label": format_date(self.env, options.get("date_at")),
+        }
+
+
+class AgedPartnerBalanceXlsxKmitl(models.AbstractModel):
+    """XLSX export of the aged partner balance — shares the compute with the
+    screen and the PDF, so all three stay in sync."""
+
+    _name = "report.accounting_kmitl_reports.aged_partner_balance_xlsx"
+    _description = "KMITL Aged Partner Balance XLSX"
+    _inherit = "report.report_xlsx.abstract"
+
+    def generate_xlsx_report(self, workbook, data, objs):
+        data = data or {}
+        options = data.get("options") or {}
+        report = self.env[
+            "report.accounting_kmitl_reports.aged_partner_balance_kmitl"
+        ]
+        result = report.get_aged_partner_data(options)
+        accounts = result["accounts"]
+        totals = result["totals"]
+        company = self.env["res.company"].browse(
+            options.get("company_id") or self.env.company.id
+        )
+        title = report._kmitl_report_title(options.get("account_type"))
+
+        sheet = workbook.add_worksheet(title)
+        bold = workbook.add_format({"bold": True})
+        head = workbook.add_format(
+            {
+                "bold": True,
+                "bg_color": "#F0F0F0",
+                "border": 1,
+                "align": "center",
+                "valign": "vcenter",
+            }
+        )
+        cell = workbook.add_format({"border": 1})
+        cell_bold = workbook.add_format({"border": 1, "bold": True})
+        num = workbook.add_format({"border": 1, "num_format": "#,##0.00"})
+        num_bold = workbook.add_format(
+            {"border": 1, "bold": True, "num_format": "#,##0.00"}
+        )
+
+        last_col = 1 + len(BUCKETS) + 1  # name + total + buckets
+        sheet.merge_range(0, 0, 0, last_col, company.display_name, bold)
+        sheet.merge_range(1, 0, 1, last_col, title, bold)
+        sheet.merge_range(
+            2,
+            0,
+            2,
+            last_col,
+            "%s %s" % (_("As of"), options.get("date_at") or ""),
+        )
+
+        labels = [
+            _("Partner"),
+            _("Total"),
+            _("Current"),
+            _("1-30"),
+            _("31-60"),
+            _("61-90"),
+            _("91-120"),
+            _("120+"),
+        ]
+        row_top = 4
+        for col, label in enumerate(labels):
+            sheet.write(row_top, col, label, head)
+
+        keys = ("residual",) + BUCKETS
+
+        def write_amounts(row_idx, source, fmt):
+            for col, key in enumerate(keys, start=1):
+                value = source[key]
+                if not value or abs(value) < 0.005:
+                    sheet.write_blank(row_idx, col, None, fmt)
+                else:
+                    sheet.write_number(row_idx, col, value, fmt)
+
+        r = row_top + 1
+        for account in accounts:
+            sheet.write(
+                r, 0, "%s - %s" % (account["code"], account["name"]), cell_bold
+            )
+            write_amounts(r, account, num_bold)
+            r += 1
+            for partner in account["partners"]:
+                sheet.write(r, 0, "    %s" % partner["name"], cell)
+                write_amounts(r, partner, num)
+                r += 1
+
+        sheet.write(r, 0, _("Total"), num_bold)
+        write_amounts(r, totals, num_bold)
+
+        sheet.set_column(0, 0, 42)
+        sheet.set_column(1, last_col, 15)

--- a/accounting_kmitl_reports/models/dimension_filter_mixin.py
+++ b/accounting_kmitl_reports/models/dimension_filter_mixin.py
@@ -1,0 +1,42 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+# Dimension plan codes the KMITL reports can filter on. Order is the display
+# order. Read from each move line's ``analytic_distribution`` (a JSON of
+# {analytic_account_id: percentage}).
+DIMENSION_CODES = ("departments", "sources", "funds", "activities")
+# Hierarchical dimensions: a selected node also matches all of its descendants
+# (when analytic accounts carry a ``parent_id`` hierarchy). ``sources`` is flat.
+HIERARCHICAL_DIMS = ("departments", "funds", "activities")
+
+
+class DimensionFilterMixin(models.AbstractModel):
+    """Shared KMITL accounting-dimension filtering for the report models.
+
+    Turns the dimension values selected on screen into ``analytic_distribution``
+    domain leaves so reports can restrict the ledger to specific KMITL
+    dimensions. Used by the Trial Balance and the Aged Partner Balance reports.
+    """
+
+    _name = "accounting_kmitl_reports.dimension.filter.mixin"
+    _description = "KMITL Report Dimension Filter Mixin"
+
+    @api.model
+    def _kmitl_build_dim_leaves(self, dims):
+        """Turn the selected dimension values into ``analytic_distribution``
+        domain leaves. Within a dimension the ids (plus descendants for
+        hierarchical dimensions) are OR-ed; the resulting leaves are AND-ed
+        across dimensions by the domain builder.
+        """
+        analytic = self.env["account.analytic.account"]
+        use_child = "parent_id" in analytic._fields
+        leaves = []
+        for code in DIMENSION_CODES:
+            ids = (dims or {}).get(code) or []
+            if not ids:
+                continue
+            if code in HIERARCHICAL_DIMS and use_child:
+                ids = analytic.search([("id", "child_of", ids)]).ids
+            leaves.append(("analytic_distribution", "in", ids))
+        return leaves

--- a/accounting_kmitl_reports/models/trial_balance_kmitl.py
+++ b/accounting_kmitl_reports/models/trial_balance_kmitl.py
@@ -3,12 +3,6 @@
 from odoo import _, api, fields, models
 from odoo.tools import date_utils, format_date
 
-# Dimension plan codes this report can filter on. Order is the display order.
-DIMENSION_CODES = ("departments", "sources", "funds", "activities")
-# Hierarchical dimensions: a selected node also matches all of its descendants
-# (when analytic accounts carry a ``parent_id`` hierarchy). ``sources`` is flat.
-HIERARCHICAL_DIMS = ("departments", "funds", "activities")
-
 
 class TrialBalanceReportKmitl(models.AbstractModel):
     """Trial balance computed by the OCA engine, extended with KMITL
@@ -21,7 +15,10 @@ class TrialBalanceReportKmitl(models.AbstractModel):
 
     _name = "report.accounting_kmitl_reports.trial_balance_kmitl"
     _description = "KMITL Trial Balance Report"
-    _inherit = "report.account_financial_report.trial_balance"
+    _inherit = [
+        "report.account_financial_report.trial_balance",
+        "accounting_kmitl_reports.dimension.filter.mixin",
+    ]
 
     # ------------------------------------------------------------------
     # Dimension filtering
@@ -51,25 +48,6 @@ class TrialBalanceReportKmitl(models.AbstractModel):
     def _get_initial_balance_fy_pl_ml_domain(self, *args, **kwargs):
         domain = super()._get_initial_balance_fy_pl_ml_domain(*args, **kwargs)
         return domain + self._kmitl_dim_leaves()
-
-    @api.model
-    def _kmitl_build_dim_leaves(self, dims):
-        """Turn the selected dimension values into ``analytic_distribution``
-        domain leaves. Within a dimension the ids (plus descendants for
-        hierarchical dimensions) are OR-ed; the resulting leaves are AND-ed
-        across dimensions by the domain builder.
-        """
-        analytic = self.env["account.analytic.account"]
-        use_child = "parent_id" in analytic._fields
-        leaves = []
-        for code in DIMENSION_CODES:
-            ids = (dims or {}).get(code) or []
-            if not ids:
-                continue
-            if code in HIERARCHICAL_DIMS and use_child:
-                ids = analytic.search([("id", "child_of", ids)]).ids
-            leaves.append(("analytic_distribution", "in", ids))
-        return leaves
 
     # ------------------------------------------------------------------
     # Filter helpers

--- a/accounting_kmitl_reports/report/aged_partner_balance_kmitl_template.xml
+++ b/accounting_kmitl_reports/report/aged_partner_balance_kmitl_template.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="aged_partner_balance_kmitl">
+        <t t-call="web.html_container">
+            <t t-call="web.basic_layout">
+                <div class="header" style="border-bottom: 1px solid #000;">
+                    <table style="width: 100%; border: none;">
+                        <tr>
+                            <td style="width: 70px; border: none; vertical-align: top;">
+                                <img
+                                    t-if="res_company.logo"
+                                    t-att-src="image_data_uri(res_company.logo)"
+                                    style="max-height: 60px; max-width: 60px;"
+                                    alt="Logo"
+                                />
+                            </td>
+                            <td style="border: none; text-align: center; vertical-align: middle; line-height: 1.6;">
+                                <div style="font-size: 14pt; font-weight: bold; margin-bottom: 4px;">
+                                    <t t-out="res_company.display_name" />
+                                </div>
+                                <div style="font-size: 16pt; font-weight: bold; margin-bottom: 6px;">
+                                    <t t-out="report_title" />
+                                </div>
+                                <div style="font-size: 12pt;">
+                                    <span>As of</span>
+                                    <t t-out="date_at_label" />
+                                </div>
+                            </td>
+                            <td style="width: 70px; border: none;" />
+                        </tr>
+                    </table>
+                </div>
+
+                <div class="footer" style="text-align: right; font-size: 10pt;">
+                    <span class="page" />/<span class="topage" />
+                </div>
+
+                <div class="article">
+                    <style>
+                        table.kmitl-aged {
+                            width: 100%;
+                            border-collapse: collapse;
+                            font-size: 9pt;
+                        }
+                        table.kmitl-aged th,
+                        table.kmitl-aged td {
+                            border: 1px solid #000;
+                            padding: 3px 5px;
+                        }
+                        table.kmitl-aged thead th {
+                            background-color: #f0f0f0;
+                            text-align: center;
+                            font-weight: bold;
+                        }
+                        table.kmitl-aged td.text-right,
+                        table.kmitl-aged th.text-right {
+                            text-align: right;
+                        }
+                        table.kmitl-aged tr.account-row td {
+                            font-weight: bold;
+                            background-color: #f7f7f7;
+                        }
+                        table.kmitl-aged tr.partner-row td.partner-name {
+                            padding-left: 18px;
+                        }
+                        table.kmitl-aged tfoot td {
+                            font-weight: bold;
+                            background-color: #f0f0f0;
+                        }
+                    </style>
+                    <table class="kmitl-aged">
+                        <thead style="display: table-header-group;">
+                            <tr>
+                                <th style="width: 28%;">Partner</th>
+                                <th class="text-right">Total</th>
+                                <th class="text-right">Current</th>
+                                <th class="text-right">1-30</th>
+                                <th class="text-right">31-60</th>
+                                <th class="text-right">61-90</th>
+                                <th class="text-right">91-120</th>
+                                <th class="text-right">120+</th>
+                            </tr>
+                        </thead>
+                        <tfoot style="display: table-footer-group;">
+                            <tr>
+                                <td>Total</td>
+                                <td class="text-right" t-out="format_amount(totals['residual'])" />
+                                <td class="text-right" t-out="format_amount(totals['current'])" />
+                                <td class="text-right" t-out="format_amount(totals['30_days'])" />
+                                <td class="text-right" t-out="format_amount(totals['60_days'])" />
+                                <td class="text-right" t-out="format_amount(totals['90_days'])" />
+                                <td class="text-right" t-out="format_amount(totals['120_days'])" />
+                                <td class="text-right" t-out="format_amount(totals['older'])" />
+                            </tr>
+                        </tfoot>
+                        <tbody>
+                            <t t-foreach="accounts" t-as="account">
+                                <tr class="account-row">
+                                    <td>
+                                        <t t-out="account['code']" /> - <t t-out="account['name']" />
+                                    </td>
+                                    <td class="text-right" t-out="format_amount(account['residual'])" />
+                                    <td class="text-right" t-out="format_amount(account['current'])" />
+                                    <td class="text-right" t-out="format_amount(account['30_days'])" />
+                                    <td class="text-right" t-out="format_amount(account['60_days'])" />
+                                    <td class="text-right" t-out="format_amount(account['90_days'])" />
+                                    <td class="text-right" t-out="format_amount(account['120_days'])" />
+                                    <td class="text-right" t-out="format_amount(account['older'])" />
+                                </tr>
+                                <tr
+                                    class="partner-row"
+                                    t-foreach="account['partners']"
+                                    t-as="partner"
+                                >
+                                    <td class="partner-name" t-out="partner['name']" />
+                                    <td class="text-right" t-out="format_amount(partner['residual'])" />
+                                    <td class="text-right" t-out="format_amount(partner['current'])" />
+                                    <td class="text-right" t-out="format_amount(partner['30_days'])" />
+                                    <td class="text-right" t-out="format_amount(partner['60_days'])" />
+                                    <td class="text-right" t-out="format_amount(partner['90_days'])" />
+                                    <td class="text-right" t-out="format_amount(partner['120_days'])" />
+                                    <td class="text-right" t-out="format_amount(partner['older'])" />
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
+                </div>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/accounting_kmitl_reports/security/ir.model.access.csv
+++ b/accounting_kmitl_reports/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_trial_balance_report_wizard_kmitl,access_trial_balance_report_wizard_kmitl,model_trial_balance_report_wizard_kmitl,base.group_user,1,1,1,1
+access_aged_partner_report_wizard_kmitl,access_aged_partner_report_wizard_kmitl,model_aged_partner_report_wizard_kmitl,base.group_user,1,1,1,1

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
@@ -1,0 +1,152 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { MultiRecordSelect } from "../trial_balance/multi_record_select";
+
+const REPORT_MODEL = "report.accounting_kmitl_reports.aged_partner_balance_kmitl";
+
+// Selected-record state buckets that feed the report options.
+const SELECTION_KEYS = ["partners", "accounts", "departments", "sources", "funds", "activities"];
+
+export class AgedPartnerBalance extends Component {
+    setup() {
+        this.orm = useService("orm");
+        this.action = useService("action");
+        this.company = useService("company");
+        // The tag (set on the menu's client action) selects the account type.
+        this.accountType =
+            this.props.action.tag === "kmitl_aged_payable" ? "payable" : "receivable";
+        this.title = this.accountType === "payable" ? _t("Aged Payable") : _t("Aged Receivable");
+        this.fiscalYears = [];
+        this.state = useState({
+            dateAt: false,
+            onlyPosted: true,
+            showDetails: false,
+            showAdvanced: false,
+            // selections (each an Array<{id, name}>)
+            partners: [],
+            accounts: [],
+            departments: [],
+            sources: [],
+            funds: [],
+            activities: [],
+            accounts_data: [],
+            totals: {},
+            loading: false,
+        });
+        this.labels = {
+            partners: _t("Partners"),
+            accounts: _t("Accounts"),
+            departments: _t("Departments"),
+            sources: _t("Sources"),
+            funds: _t("Funds"),
+            activities: _t("Activities"),
+        };
+        onWillStart(this.onWillStart.bind(this));
+    }
+
+    async onWillStart() {
+        this.companyId = this.company.currentCompany.id;
+        this.state.dateAt = new Date().toISOString().slice(0, 10);
+        await this.load();
+    }
+
+    // ------------------------------------------------------------------
+    // Report options + data loading
+    // ------------------------------------------------------------------
+    get options() {
+        return {
+            company_id: this.companyId,
+            account_type: this.accountType,
+            date_at: this.state.dateAt,
+            only_posted: this.state.onlyPosted,
+            show_move_line_details: this.state.showDetails,
+            partner_ids: this.state.partners.map((r) => r.id),
+            account_ids: this.state.accounts.map((r) => r.id),
+            dims: {
+                departments: this.state.departments.map((r) => r.id),
+                sources: this.state.sources.map((r) => r.id),
+                funds: this.state.funds.map((r) => r.id),
+                activities: this.state.activities.map((r) => r.id),
+            },
+        };
+    }
+
+    async load() {
+        if (!this.state.dateAt) {
+            return;
+        }
+        this.state.loading = true;
+        try {
+            const data = await this.orm.call(REPORT_MODEL, "get_aged_partner_data", [
+                this.options,
+            ]);
+            this.state.accounts_data = data.accounts || [];
+            this.state.totals = data.totals || {};
+        } finally {
+            this.state.loading = false;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Filter events
+    // ------------------------------------------------------------------
+    onDateAtChange(ev) {
+        this.state.dateAt = ev.target.value || false;
+        this.load();
+    }
+
+    onTogglePosted(ev) {
+        this.state.onlyPosted = ev.target.checked;
+        this.load();
+    }
+
+    onToggleDetails(ev) {
+        this.state.showDetails = ev.target.checked;
+        this.load();
+    }
+
+    toggleAdvanced() {
+        this.state.showAdvanced = !this.state.showAdvanced;
+    }
+
+    // One change handler per selection bucket (bound in the template).
+    onSelectionChange(key, selected) {
+        if (SELECTION_KEYS.includes(key)) {
+            this.state[key] = selected;
+            this.load();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Rendering helpers
+    // ------------------------------------------------------------------
+    format(value) {
+        if (!value || Math.abs(value) < 0.005) {
+            return "";
+        }
+        return value.toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    }
+
+    async printPdf() {
+        const action = await this.orm.call(REPORT_MODEL, "action_print_pdf", [this.options]);
+        await this.action.doAction(action);
+    }
+
+    async exportXlsx() {
+        const action = await this.orm.call(REPORT_MODEL, "action_export_xlsx", [this.options]);
+        await this.action.doAction(action);
+    }
+}
+
+AgedPartnerBalance.template = "accounting_kmitl_reports.AgedPartnerBalance";
+AgedPartnerBalance.components = { MultiRecordSelect };
+
+registry.category("actions").add("kmitl_aged_receivable", AgedPartnerBalance);
+registry.category("actions").add("kmitl_aged_payable", AgedPartnerBalance);

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.scss
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.scss
@@ -1,0 +1,39 @@
+.o_kmitl_aged {
+    height: 100%;
+    overflow: auto;
+
+    .o_kmitl_aged_table_wrap {
+        overflow-x: auto;
+    }
+
+    .o_kmitl_aged_table {
+        th {
+            background-color: #f8f9fa;
+            vertical-align: middle;
+            white-space: nowrap;
+        }
+        td,
+        th {
+            font-size: 1rem;
+        }
+        .o_kmitl_aged_partner {
+            min-width: 18rem;
+        }
+        .o_kmitl_aged_account td {
+            background-color: #f1f3f5;
+        }
+        .o_kmitl_aged_indent {
+            padding-left: 1.5rem;
+        }
+        .o_kmitl_aged_indent2 {
+            padding-left: 3rem;
+            font-size: 0.9rem;
+        }
+        .o_kmitl_aged_ml td {
+            font-size: 0.9rem;
+        }
+        tfoot td {
+            background-color: #f8f9fa;
+        }
+    }
+}

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="accounting_kmitl_reports.AgedPartnerBalance" owl="1">
+        <div class="o_kmitl_aged o_action_manager p-3">
+            <div class="o_kmitl_aged_header d-flex align-items-center mb-3">
+                <h2 class="m-0 flex-grow-1"><t t-esc="title" /></h2>
+                <button class="btn btn-secondary me-2" t-on-click="exportXlsx">
+                    <i class="fa fa-file-excel-o me-1" />Export Excel
+                </button>
+                <button class="btn btn-primary" t-on-click="printPdf">
+                    <i class="fa fa-file-pdf-o me-1" />Print PDF
+                </button>
+            </div>
+
+            <!-- Filter bar -->
+            <div class="o_kmitl_aged_filters row g-2 mb-3">
+                <div class="col-md-2">
+                    <label class="o_form_label">As of</label>
+                    <input
+                        type="date"
+                        class="form-control"
+                        t-att-value="state.dateAt"
+                        t-on-change="onDateAtChange"
+                    />
+                </div>
+                <div class="col-md-6 d-flex align-items-end gap-3">
+                    <div class="form-check">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="kmitl_aged_posted"
+                            t-att-checked="state.onlyPosted"
+                            t-on-change="onTogglePosted"
+                        />
+                        <label class="form-check-label" for="kmitl_aged_posted">Posted entries only</label>
+                    </div>
+                    <div class="form-check">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="kmitl_aged_details"
+                            t-att-checked="state.showDetails"
+                            t-on-change="onToggleDetails"
+                        />
+                        <label class="form-check-label" for="kmitl_aged_details">Show move line details</label>
+                    </div>
+                </div>
+
+                <!-- KMITL accounting dimensions -->
+                <div class="col-md-3">
+                    <label class="o_form_label">Departments</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'departments']]"
+                        placeholder="labels.departments"
+                        selected="state.departments"
+                        onChange="(sel) => this.onSelectionChange('departments', sel)"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="o_form_label">Sources</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'sources']]"
+                        placeholder="labels.sources"
+                        selected="state.sources"
+                        onChange="(sel) => this.onSelectionChange('sources', sel)"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="o_form_label">Funds</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'funds']]"
+                        placeholder="labels.funds"
+                        selected="state.funds"
+                        onChange="(sel) => this.onSelectionChange('funds', sel)"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="o_form_label">Activities</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'activities']]"
+                        placeholder="labels.activities"
+                        selected="state.activities"
+                        onChange="(sel) => this.onSelectionChange('activities', sel)"
+                    />
+                </div>
+
+                <!-- Standard filters (collapsed by default) -->
+                <div class="col-12">
+                    <button
+                        class="btn btn-link p-0 o_kmitl_aged_more"
+                        t-on-click="toggleAdvanced"
+                    >
+                        <i
+                            t-att-class="state.showAdvanced ? 'fa fa-caret-down me-1' : 'fa fa-caret-right me-1'"
+                        />
+                        <t t-if="state.showAdvanced">Hide partner / account filters</t>
+                        <t t-else="">More filters</t>
+                    </button>
+                </div>
+                <t t-if="state.showAdvanced">
+                    <div class="col-md-3">
+                        <label class="o_form_label">Partners</label>
+                        <MultiRecordSelect
+                            resModel="'res.partner'"
+                            placeholder="labels.partners"
+                            selected="state.partners"
+                            onChange="(sel) => this.onSelectionChange('partners', sel)"
+                        />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="o_form_label">Accounts</label>
+                        <MultiRecordSelect
+                            resModel="'account.account'"
+                            domain="[['company_id', '=', companyId], ['reconcile', '=', true]]"
+                            placeholder="labels.accounts"
+                            selected="state.accounts"
+                            onChange="(sel) => this.onSelectionChange('accounts', sel)"
+                        />
+                    </div>
+                </t>
+            </div>
+
+            <!-- Report table -->
+            <div class="o_kmitl_aged_table_wrap">
+                <table class="table table-sm table-bordered o_kmitl_aged_table">
+                    <thead>
+                        <tr>
+                            <th class="o_kmitl_aged_partner">Partner</th>
+                            <th class="text-end">Total</th>
+                            <th class="text-end">Current</th>
+                            <th class="text-end">1-30</th>
+                            <th class="text-end">31-60</th>
+                            <th class="text-end">61-90</th>
+                            <th class="text-end">91-120</th>
+                            <th class="text-end">120+</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-if="state.loading">
+                            <td colspan="8" class="text-center text-muted">Loading...</td>
+                        </tr>
+                        <tr t-elif="!state.accounts_data.length">
+                            <td colspan="8" class="text-center text-muted">No data</td>
+                        </tr>
+                        <t t-foreach="state.accounts_data" t-as="account" t-key="account.id">
+                            <tr class="o_kmitl_aged_account fw-bold">
+                                <td><t t-esc="account.code" /> - <t t-esc="account.name" /></td>
+                                <td class="text-end" t-esc="format(account.residual)" />
+                                <td class="text-end" t-esc="format(account.current)" />
+                                <td class="text-end" t-esc="format(account['30_days'])" />
+                                <td class="text-end" t-esc="format(account['60_days'])" />
+                                <td class="text-end" t-esc="format(account['90_days'])" />
+                                <td class="text-end" t-esc="format(account['120_days'])" />
+                                <td class="text-end" t-esc="format(account.older)" />
+                            </tr>
+                            <t t-foreach="account.partners" t-as="partner" t-key="partner_index">
+                                <tr class="o_kmitl_aged_partner_row">
+                                    <td class="o_kmitl_aged_indent" t-esc="partner.name" />
+                                    <td class="text-end" t-esc="format(partner.residual)" />
+                                    <td class="text-end" t-esc="format(partner.current)" />
+                                    <td class="text-end" t-esc="format(partner['30_days'])" />
+                                    <td class="text-end" t-esc="format(partner['60_days'])" />
+                                    <td class="text-end" t-esc="format(partner['90_days'])" />
+                                    <td class="text-end" t-esc="format(partner['120_days'])" />
+                                    <td class="text-end" t-esc="format(partner.older)" />
+                                </tr>
+                                <t t-if="state.showDetails and partner.move_lines">
+                                    <tr
+                                        class="o_kmitl_aged_ml text-muted"
+                                        t-foreach="partner.move_lines"
+                                        t-as="ml"
+                                        t-key="ml_index"
+                                    >
+                                        <td class="o_kmitl_aged_indent2">
+                                            <t t-esc="ml.date" /> · <t t-esc="ml.entry" />
+                                            <t t-if="ml.ref_label"> · <t t-esc="ml.ref_label" /></t>
+                                        </td>
+                                        <td class="text-end" t-esc="format(ml.residual)" />
+                                        <td class="text-end" t-esc="format(ml.current)" />
+                                        <td class="text-end" t-esc="format(ml['30_days'])" />
+                                        <td class="text-end" t-esc="format(ml['60_days'])" />
+                                        <td class="text-end" t-esc="format(ml['90_days'])" />
+                                        <td class="text-end" t-esc="format(ml['120_days'])" />
+                                        <td class="text-end" t-esc="format(ml.older)" />
+                                    </tr>
+                                </t>
+                            </t>
+                        </t>
+                    </tbody>
+                    <tfoot t-if="state.accounts_data.length">
+                        <tr class="fw-bold">
+                            <td>Total</td>
+                            <td class="text-end" t-esc="format(state.totals.residual)" />
+                            <td class="text-end" t-esc="format(state.totals.current)" />
+                            <td class="text-end" t-esc="format(state.totals['30_days'])" />
+                            <td class="text-end" t-esc="format(state.totals['60_days'])" />
+                            <td class="text-end" t-esc="format(state.totals['90_days'])" />
+                            <td class="text-end" t-esc="format(state.totals['120_days'])" />
+                            <td class="text-end" t-esc="format(state.totals.older)" />
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/accounting_kmitl_reports/views/menuitem.xml
+++ b/accounting_kmitl_reports/views/menuitem.xml
@@ -8,6 +8,17 @@
         <field name="tag">kmitl_trial_balance</field>
     </record>
 
+    <!-- Aged Receivable / Aged Payable: OWL client actions sharing one
+         component; the tag selects the account type filtered. -->
+    <record id="action_aged_receivable_kmitl" model="ir.actions.client">
+        <field name="name">Aged Receivable</field>
+        <field name="tag">kmitl_aged_receivable</field>
+    </record>
+    <record id="action_aged_payable_kmitl" model="ir.actions.client">
+        <field name="name">Aged Payable</field>
+        <field name="tag">kmitl_aged_payable</field>
+    </record>
+
     <!-- Actions: open the pre-configured instance directly on its result
          view (the same view mis_builder.preview() uses, so the report
          renders inline without a "Preview" click). -->
@@ -67,6 +78,20 @@
         parent="accounting_kmitl.menu_accounting_reports"
         action="action_report_cf_kmitl"
         sequence="30"
+    />
+    <menuitem
+        id="menu_report_aged_receivable_kmitl"
+        name="Aged Receivable"
+        parent="accounting_kmitl.menu_accounting_reports"
+        action="action_aged_receivable_kmitl"
+        sequence="40"
+    />
+    <menuitem
+        id="menu_report_aged_payable_kmitl"
+        name="Aged Payable"
+        parent="accounting_kmitl.menu_accounting_reports"
+        action="action_aged_payable_kmitl"
+        sequence="50"
     />
 
 </odoo>

--- a/accounting_kmitl_reports/wizard/__init__.py
+++ b/accounting_kmitl_reports/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import trial_balance_wizard_kmitl
+from . import aged_partner_balance_wizard_kmitl

--- a/accounting_kmitl_reports/wizard/aged_partner_balance_wizard_kmitl.py
+++ b/accounting_kmitl_reports/wizard/aged_partner_balance_wizard_kmitl.py
@@ -1,0 +1,21 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class AgedPartnerReportWizardKmitl(models.TransientModel):
+    """Non-user-facing carrier model.
+
+    The aged partner balance is reached through an OWL client action, not a
+    wizard form. This model exists only so the ``ir.actions.report`` has a
+    valid ``model`` to render against; all filters travel through the report
+    ``data`` dict.
+    """
+
+    _name = "aged.partner.report.wizard.kmitl"
+    _description = "KMITL Aged Partner Balance Report (PDF carrier)"
+
+    company_id = fields.Many2one(
+        "res.company", default=lambda self: self.env.company
+    )
+    date_at = fields.Date()


### PR DESCRIPTION
## What

เพิ่มรายงาน **Aged Receivable (ลูกหนี้)** และ **Aged Payable (เจ้าหนี้)** ใน `accounting_kmitl_reports` เป็น OWL client action แบบเดียวกับ Trial Balance — filter บนหน้าจอแบบ realtime พร้อมปุ่ม **Print PDF** และ **Export Excel**

แต่ละเมนูแยกกัน และ pre-filter ชนิดบัญชีอัตโนมัติ (`asset_receivable` / `liability_payable`) แสดง residual ที่ยังไม่กระทบยอด แบ่งตามช่วงอายุครบกำหนดมาตรฐาน: **Current / 1‑30 / 31‑60 / 61‑90 / 91‑120 / 120+** วัน

## How

- **Wrap OCA engine** `report.account_financial_report.aged_partner_balance` (จาก `account_financial_report` ที่ module นี้ depend อยู่แล้ว) — compute ตัวเดียว `get_aged_partner_data(options)` ป้อนทั้งหน้าจอ (RPC), PDF (QWeb) และ XLSX จึงตรงกันเสมอ ใช้ fixed buckets (ส่ง `account.age.report.configuration` ว่างเป็น context)
- **Dimension filter ทำที่ระดับ move**: บรรทัดบัญชีลูกหนี้/เจ้าหนี้มักไม่ถือ `analytic_distribution` (มิติอยู่บนบรรทัดรายได้/ค่าใช้จ่ายของ invoice เดียวกัน) จึงหา move ที่มีบรรทัดถือมิติที่เลือกก่อน แล้วจำกัด residual เฉพาะ move เหล่านั้น ผ่าน context `kmitl_move_ids` ใน `_get_move_lines_domain_not_reconciled` / `_get_new_move_lines_domain`
- **Shared mixin** `accounting_kmitl_reports.dimension.filter.mixin` ดึง helper แปลงมิติ → analytic leaves ออกมาใช้ร่วมกับ Trial Balance (refactor minimal พฤติกรรมเดิมไม่เปลี่ยน)
- โครงสร้าง mirror Trial Balance 1:1 (report model + XLSX model + carrier `aged.partner.report.wizard.kmitl` + QWeb template + OWL component 2 tags + menu/security/manifest)

## Files

- `models/dimension_filter_mixin.py` (ใหม่), `models/aged_partner_balance_kmitl.py` (ใหม่), `wizard/aged_partner_balance_wizard_kmitl.py` (ใหม่)
- `data/report_action_aged_partner_balance_kmitl.xml`, `report/aged_partner_balance_kmitl_template.xml`, `static/src/aged_partner_balance/*` (ใหม่)
- แก้: `models/trial_balance_kmitl.py` (ใช้ mixin), `__manifest__.py` (16.0.3.0.0, +data/+assets), `views/menuitem.xml`, `security/ir.model.access.csv`, `CONTEXT.md`, `__init__.py`

## หมายเหตุ

- String ในโค้ดเป็นอังกฤษทั้งหมด — แปลไทยด้วย i18n ภายหลัง
- ผ่าน adversarial code review บน diff (3 lens: Python/ORM, OWL frontend, XML wiring) ไม่มี defect ที่ยืนยันได้
- ยังไม่ได้รัน/ติดตั้งทดสอบบน instance จริง — ขั้นตอนทดสอบ end‑to‑end: เปิด Accounting → KMITL Reports → Aged Receivable/Payable, ปรับ as‑of date / partner / dimension แล้วเทียบยอด, ทดสอบ Print PDF + Export Excel