### PR TITLE
[16.0][ADD] mail_notification_inbox_email: add email+inbox notification type

### DIFF
--- a/mail_notification_inbox_email/__init__.py
+++ b/mail_notification_inbox_email/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/mail_notification_inbox_email/__manifest__.py
+++ b/mail_notification_inbox_email/__manifest__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "User Notifications in Odoo and by Email",
+    "version": "16.0.1.0.0",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "category": "Discuss",
+    "summary": "User Notifications in Odoo and by Email",
+    "depends": ["mail"],
+    "description": "Handle user notifications in Odoo and by email",
+    "author": "Aginix Technologies",
+    "license": "LGPL-3",
+}

--- a/mail_notification_inbox_email/models/__init__.py
+++ b/mail_notification_inbox_email/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import mail_thread
+from . import res_users

--- a/mail_notification_inbox_email/models/mail_thread.py
+++ b/mail_notification_inbox_email/models/mail_thread.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import logging
+from odoo import models
+_logger = logging.getLogger(__name__)
+
+
+class MailThread(models.AbstractModel):
+    _inherit = 'mail.thread'
+
+    def _notify_thread(self, message, msg_vals=False, **kwargs):
+        rdata = super()._notify_thread(message, msg_vals=msg_vals, **kwargs)
+        self = self._fallback_lang()
+        inbox_rdata = []
+        email_rdata = []
+        for partner_data in rdata:
+            if partner_data['notif'] == 'email_inbox':
+                inbox_partner = partner_data.copy()
+                email_partner = partner_data.copy()
+                inbox_partner['notif'] = 'inbox'
+                email_partner['notif'] = 'email'
+                inbox_rdata.append(inbox_partner)
+                email_rdata.append(email_partner)
+        if inbox_rdata:
+            self._notify_thread_by_inbox(message, inbox_rdata, msg_vals=msg_vals, **kwargs)
+        if email_rdata:
+            email_message = message.copy()
+            self._notify_thread_by_email(email_message, email_rdata, msg_vals=msg_vals, **kwargs)
+        return rdata

--- a/mail_notification_inbox_email/models/res_users.py
+++ b/mail_notification_inbox_email/models/res_users.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    notification_type = fields.Selection(
+        selection_add=[('email_inbox', "Handle by Emails and Odoo")],
+        ondelete={'email_inbox': 'set inbox'}
+    )

--- a/mail_notification_inbox_email/static/description/index.html
+++ b/mail_notification_inbox_email/static/description/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>User Notifications by Email and Odoo</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a new `email_inbox` notification type to `res.users` that delivers messages both to the Odoo inbox and by email simultaneously.
- Extends `mail.thread._notify_thread` to split `email_inbox` recipients into two separate notification dispatches (inbox + email).
- Users can select "Handle by Emails and Odoo" as their notification preference; reverting removes the selection gracefully (`set inbox`).