### PR TITLE
[16.0][FIX] disbursement: make fields read-only in bills_posted state

### DIFF
--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -30,6 +30,7 @@ class DisbursementRequest(models.Model):
         "signed": [("readonly", True)],
         "verified": [("readonly", True)],
         "approved": [("readonly", True)],
+        "bills_posted": [("readonly", True)],
         "cancel": [("readonly", True)],
     }
 


### PR DESCRIPTION
## ปัญหา (Problem)

ใน **Disbursement Request** บาง field ยังแก้ไขได้ทั้งที่ไม่ได้อยู่ในสถานะ `draft`

**Root cause:** โมเดล `disbursement.request` ล็อก field ด้วย `states=READONLY_STATES` ซึ่งระบุไว้แค่ `submitted, signed, verified, approved, cancel` แต่โมดูลบริดจ์ `disbursement_accounting_kmitl` เพิ่ม state ใหม่ `"bills_posted"` เข้าไปใน `state` field (และ `action_post_bills()` เซ็ต state นี้จริง) โดย **ไม่ได้เพิ่ม `"bills_posted"` ลงใน `READONLY_STATES`**

Odoo แปลง `states=READONLY_STATES` เป็น modifier `readonly = [('state', 'in', ['submitted','signed','verified','approved','cancel'])]` ดังนั้นเมื่อ `state == 'bills_posted'` (ไม่อยู่ในลิสต์) → modifier เป็น `False` → field กลับมาแก้ไขได้

**field ที่ได้รับผลกระทบ** (พึ่งพา `states=READONLY_STATES` อย่างเดียว ไม่มี `attrs` ระดับ view):
`partner_id`, `partner_bank_id`, `company_id`, `date`, `ref`, `budget_commitment_id`, `user_id`, `attachment_ids` และ `line_ids` (ทำให้ทุก field ในตารางรายการแก้ไขได้ด้วย)

> field ที่มี `attrs="{'readonly': [..., ('state','!=','draft')]}"` ระดับ view อยู่แล้ว (`partner_type`, `reference`, analytic dimensions, `budget_account_id`) ไม่ได้รับผลกระทบ

## การแก้ไข (Fix)

เพิ่ม `"bills_posted"` ลงใน `READONLY_STATES` ที่ base module — field ทุกตัวอ้างอิง dict เดียวกันตอนประกาศ จึงป้องกันครบทุกตัวพร้อมกันโดยไม่ต้องแตะ view

```python
READONLY_STATES = {
    "submitted": [("readonly", True)],
    "signed": [("readonly", True)],
    "verified": [("readonly", True)],
    "approved": [("readonly", True)],
    "bills_posted": [("readonly", True)],   # <-- added
    "cancel": [("readonly", True)],
}
```

แก้ที่ base module ปลอดภัยแม้ไม่ได้ติดตั้งบริดจ์ — `states` แค่สร้าง domain ถ้าค่า state นั้นไม่มีจริง modifier ก็ไม่เคย match

## วิธีทดสอบ (How to test)

1. สร้าง Disbursement Request → Submit → Sign → Validate → Approve → **Create Bill** → **ตั้งหนี้** (state กลายเป็น `bills_posted`)
2. ตรวจว่า `partner_id`, `date`, `ref`, `user_id`, attachment และตารางรายการเป็น **readonly ทั้งหมด**
3. ตรวจสถานะอื่น (submitted/signed/verified/approved/cancel) ว่ายัง readonly เหมือนเดิม และ `draft` ยังแก้ไขได้ปกติ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
