### PR TITLE
[16.0][IMP] mail_activity_todo: make Todo category user-selectable

### DIFF
--- a/mail_activity_todo/models/mail_activity.py
+++ b/mail_activity_todo/models/mail_activity.py
@@ -30,11 +30,22 @@ class MailActivity(models.Model):
     _inherit = "mail.activity"
 
     todo_category = fields.Selection(
-        related="activity_type_id.todo_category",
+        TODO_CATEGORIES,
+        string="Todo Category",
+        compute="_compute_todo_category",
         store=True,
         index=True,
-        readonly=True,
+        readonly=False,
+        help="Defaults from the activity type. Set it on a manually scheduled "
+        "activity to turn it into a Todo that lands in your inbox.",
     )
+
+    @api.depends("activity_type_id")
+    def _compute_todo_category(self):
+        """Default the category from the type, but leave it user-overridable so a
+        manually scheduled activity can be categorised into the Todo inbox."""
+        for activity in self:
+            activity.todo_category = activity.activity_type_id.todo_category
 
     read_ids = fields.One2many("todo.read", "activity_id", string="Read receipts")
     is_my_todo = fields.Boolean(

--- a/mail_activity_todo/views/mail_activity_views.xml
+++ b/mail_activity_todo/views/mail_activity_views.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
+    <!-- Let users categorise a manually-scheduled activity from the native
+         "Schedule Activity" dialog, so it lands in their Todo inbox (the inbox
+         shows only categorised activities). -->
+    <record id="mail_activity_view_form_popup_todo" model="ir.ui.view">
+        <field name="name">mail.activity.view.form.popup.todo</field>
+        <field name="model">mail.activity</field>
+        <field name="inherit_id" ref="mail.mail_activity_view_form_popup" />
+        <field name="arch" type="xml">
+            <field name="activity_type_id" position="after">
+                <field name="todo_category" />
+            </field>
+        </field>
+    </record>
+
     <!-- ================= Inbox list (L1) ================= -->
     <record id="view_my_todo_tree" model="ir.ui.view">
         <field name="name">mail.activity.todo.tree</field>


### PR DESCRIPTION
A Todo is a `mail.activity` with a `todo_category`, but that field was `related`/`readonly` and only set by activity types defined in bridge modules — so an activity a user schedules manually with a standard type (To Do, Email, …) carried no category, was excluded from the Todo inbox, and offered no way to set one. This makes `todo_category` a computed, stored, user-overridable field that still defaults from the activity type, and surfaces it on the native Schedule Activity dialog. Users can now categorise their own activities so they appear in their Todo inbox. Programmatic Todos from bridge modules are unaffected — the category still derives from the type.