### PR TITLE
[16.0][IMP] kris_project: อนุญาตให้แก้ไข Receipt ได้โดยตรง

### DIFF
--- a/kris_project/CONTEXT.md
+++ b/kris_project/CONTEXT.md
@@ -41,7 +41,7 @@ A scheduled milestone of contracted work, each with its own due date and payment
 _Avoid_: work period, work phase, payment schedule, payment installment
 
 **Receipt** (รายรับ):
-A single recorded payment received against a project — one document with a number, date and amount. `kris.project.receipt`.
+A single recorded payment received against a project — one document with a number, date and amount. `kris.project.receipt`. Amendable while the project is `draft`/`in_progress`; frozen once the project is `done`/`cancel`. `project_id` is immutable — a receipt belongs to one project for life. See ADR-0003.
 _Avoid_: revenue (a single one is never "a revenue")
 
 **Revenue**:

--- a/kris_project/docs/adr/0003-receipts-are-amendable.md
+++ b/kris_project/docs/adr/0003-receipts-are-amendable.md
@@ -1,0 +1,28 @@
+# Receipts are amendable, not immutable
+
+A **Receipt** (`kris.project.receipt`) records a single payment received against a project. It is **amendable** — any business field can be edited after creation — while its project is `draft` or `in_progress`, and **frozen** once the project reaches `done` or `cancel`. `project_id` is the only field locked for the receipt's whole lifetime: a receipt belongs to one project for life.
+
+Editability follows exactly the existing rule for *adding* and *deleting* receipts (the "Add Revenue" button and trash icon are already hidden on `done`/`cancel`). Net effect: while the project is open, KRIS Officers can correct any receipt freely; once the project closes, every money figure on it is locked.
+
+## Why record this
+
+A Receipt looks like an accounting document, and accounting documents are conventionally immutable — the historical default in this module agreed (every field on the form was `readonly="1"`, and the only "edit" path was delete + recreate). We have reversed that default.
+
+The original immutability assumed receipts would be entered once and never need correction. In practice KRIS Officers hit this regularly: typo in the receipt number, wrong date, amount off by a digit, allocation split to the wrong line. Forcing delete + recreate for these cases means re-keying the whole allocation breakdown, which is itself error-prone — the cure was worse than the disease.
+
+We keep the freeze on `done`/`cancel` so the rule "**when a project closes, its money figures stop moving**" still holds. This is the same invariant ADR-0001 relies on when it permits under-collected closure: closure is a discretionary point in time, and Revenue at that point is whatever the open-state edits added up to.
+
+## Considered Options
+
+- **Keep immutable; require delete + recreate** — the prior design. Rejected: the dominant edit case is data correction, where delete + recreate destroys the allocation breakdown the user is *trying to preserve*. Audit clarity from "a receipt never changes" is real but cheap to recover via `mail.thread` field tracking.
+- **Edit Wizard mirroring the create wizard** — rejected: the create wizard's value is its *pre-fill* of outstanding amount per installment, which only makes sense at creation. At edit time the receipt already has its values; a wizard would just re-render the form view inside a modal with no added logic.
+- **Editable in every state, including `done`/`cancel`** — rejected: it would let a closed project's Revenue total drift after closure. KRIS Admin already has the `cancel → draft` reset path (`action_draft`) for the rare case a closed project legitimately needs correction; that route reopens the project explicitly rather than silently mutating closed data.
+- **One2many audit on `allocation_ids`** — deferred. Tracking allocation row changes requires overriding write/create/unlink on the child model and posting messages by hand. The existing `_check_actual_not_exceed_estimated` constraint already prevents the only allocation mistake that has real money consequences; field-level tracking on the parent Receipt covers the typical dispute case.
+
+## Consequences
+
+- `kris.project.receipt` exposes `tracking=True` on the fields that move money or change meaning (`name`, `date`, `equipment_cost_in_installment`, `amount`, `extra_income`, `installment_id`, `note`); audit trail is via chatter, not via row-level history.
+- The constraints `_check_extra_income_total` (receipt) and `_check_actual_not_exceed_estimated` (allocation) now fire on edit as well as on create — they were already correct for both paths, no extra logic needed.
+- Computed `actual_amount` on `kris.project.allocation.line` recomputes automatically on receipt-allocation writes via its existing `@api.depends`; the explicit `_compute_actual_amount()` call in `KrisProjectReceipt.unlink` is now strictly a safety net, not load-bearing.
+- Moving a Receipt between `installment_id` values is allowed and shifts the computed `state` (`pending` / `partial` / `received`) on both the old and new installment. This is the intended behaviour — correcting an installment assignment is one of the cases that drove this decision.
+- `project_id` stays hard-readonly in the view. Moving a Receipt across projects would invalidate every `allocation_ids` row (each points at an `allocation_line_id` belonging to the original project) and is not a meaningful edit; the right answer there remains delete + recreate under the correct project.

--- a/kris_project/models/kris_project_receipt.py
+++ b/kris_project/models/kris_project_receipt.py
@@ -24,6 +24,7 @@ class KrisProjectReceipt(models.Model):
         string="Installment Number",
         domain="[('project_id', '=', project_id)]",
         ondelete="set null",
+        tracking=True,
     )
     name = fields.Char(
         string="Receipt Number",
@@ -61,6 +62,7 @@ class KrisProjectReceipt(models.Model):
     )
     note = fields.Text(
         string="Note",
+        tracking=True,
     )
     currency_id = fields.Many2one(
         comodel_name="res.currency",

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -2,7 +2,9 @@
 <odoo>
 
     <!-- ============================================================ -->
-    <!-- RECEIPT FORM VIEW (readonly)                                 -->
+    <!-- RECEIPT FORM VIEW                                            -->
+    <!-- Editable while project is draft/in_progress; frozen on       -->
+    <!-- done/cancel. See ADR-0003.                                   -->
     <!-- ============================================================ -->
 
     <record id="view_kris_project_receipt_form" model="ir.ui.view">
@@ -11,24 +13,25 @@
         <field name="arch" type="xml">
             <form string="Revenue Record">
                 <field name="currency_id" invisible="1"/>
+                <field name="project_state" invisible="1"/>
                 <group>
                     <field name="project_id" readonly="1"/>
-                    <field name="name" readonly="1"/>
-                    <field name="installment_id" readonly="1"/>
-                    <field name="date" readonly="1"/>
-                    <field name="equipment_cost_in_installment" readonly="1"/>
-                    <field name="amount" readonly="1"/>
-                    <field name="extra_income" readonly="1"/>
+                    <field name="name" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
+                    <field name="installment_id" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
+                    <field name="date" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
+                    <field name="equipment_cost_in_installment" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
+                    <field name="amount" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
+                    <field name="extra_income" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
                     <field name="net_amount" readonly="1"/>
-                    <field name="note" readonly="1"/>
+                    <field name="note" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}"/>
                 </group>
                 <separator string="Allocation based on revenue."/>
-                <field name="allocation_ids" readonly="1">
-                    <tree create="0" delete="0">
-                        <field name="allocation_line_id" invisible="1" readonly="1"/>
+                <field name="allocation_ids" attrs="{'readonly': [('project_state', 'in', ['done', 'cancel'])]}">
+                    <tree editable="bottom">
+                        <field name="allocation_line_id"/>
                         <field name="name" readonly="1" string="Allocator"/>
                         <field name="remaining_amount" readonly="1"/>
-                        <field name="amount" readonly="1"/>
+                        <field name="amount"/>
                         <field name="currency_id" invisible="1"/>
                     </tree>
                 </field>


### PR DESCRIPTION
## สรุปการเปลี่ยนแปลง

ก่อนหน้านี้ เมื่อบันทึกรายรับ (Receipt) ใน module `kris_project` แล้ว ผู้ใช้ไม่สามารถแก้ไขข้อมูลได้เลย ต้องลบแล้วสร้างใหม่ทุกครั้ง ซึ่งเป็นปัญหาในทางปฏิบัติ เมื่อต้องแก้ไขข้อมูล เช่น เลขที่ใบเสร็จ, วันที่, จำนวนเงิน, การจัดสรร (allocation)

PR นี้เปลี่ยน Receipt จาก **immutable** → **amendable** โดยยังคงรักษา invariant ของระบบว่า "เมื่อ project ปิดแล้ว ตัวเลขเงินทั้งหมดต้อง lock"

## รายละเอียดการเปลี่ยนแปลง

- **`kris_project/views/kris_project_views.xml`** — เปลี่ยน form view ของ Receipt จาก `readonly="1"` ทุก field เป็น `attrs` ที่ gate บน `project_state`: แก้ไขได้เมื่อ project อยู่ใน `draft`/`in_progress` และ freeze อัตโนมัติเมื่อ project เป็น `done`/`cancel`
- **`kris_project/models/kris_project_receipt.py`** — เพิ่ม `tracking=True` บน `installment_id` และ `note` เพื่อให้ chatter บันทึก audit trail ทุกครั้งที่มีการแก้ไข
- **`kris_project/CONTEXT.md`** — อัปเดต glossary entry ของ Receipt ให้สะท้อน amendable semantics และ link ไปยัง ADR-0003
- **`kris_project/docs/adr/0003-receipts-are-amendable.md`** — เพิ่ม ADR ใหม่บันทึก design decision พร้อม context, alternatives ที่ถูก reject, และ consequences

## กฎที่ยังคงเดิม

- `project_id` ของ Receipt ล็อกตลอด ไม่สามารถย้าย Receipt ข้ามไป project อื่นได้
- Receipt ไม่สามารถเพิ่ม/แก้ไข/ลบได้เมื่อ project เป็น `done`/`cancel` (เดียวกับปุ่ม "Add Revenue" และ trash icon ที่มีอยู่เดิม)
- Constraint ทุกอย่างยังทำงานเหมือนเดิม: allocation ห้ามเกิน estimated, extra income รวมห้ามเกิน project extra_value
- `actual_amount` บน `kris.project.allocation.line` recompute อัตโนมัติผ่าน `@api.depends` ที่มีอยู่แล้ว ไม่ต้องเพิ่ม logic ใหม่

## แนวทางการทดสอบ

- [ ] สร้าง project ใหม่ → Confirm เข้า in_progress → เพิ่ม Receipt ผ่าน wizard
- [ ] คลิกเปิด Receipt form → ตรวจว่า field ส่วนใหญ่ editable, `project_id` + `net_amount` ยัง readonly
- [ ] แก้ `amount` → save → ตรวจว่า `net_amount` recompute และ `actual_amount` ของ allocation line เปลี่ยนตาม
- [ ] แก้ `installment_id` หรือ `note` → ตรวจ chatter ว่ามี log การเปลี่ยนแปลง
- [ ] กด Done บน project → กลับเข้า Receipt form → ทุก field ต้อง readonly
- [ ] ทดสอบ ValidationError: แก้ allocation amount ให้เกิน estimated → ต้องโดน error ภาษาไทย