### PR TITLE
[16.0][IMP] accounting_kmitl: require and default Bill Date on vendor bills

### DIFF
--- a/accounting_kmitl/models/account_move.py
+++ b/accounting_kmitl/models/account_move.py
@@ -14,6 +14,20 @@ class AccountMove(models.Model):
         ondelete={"submitted": "set default"},
     )
 
+    # --- Defaults ---
+    @api.model
+    def default_get(self, fields_list):
+        """Default Bill Date to today for vendor bills."""
+        res = super().default_get(fields_list)
+        move_type = self._context.get("default_move_type") or res.get("move_type")
+        if (
+            "invoice_date" in fields_list
+            and not res.get("invoice_date")
+            and move_type == "in_invoice"
+        ):
+            res["invoice_date"] = fields.Date.context_today(self)
+        return res
+
     # --- Compute ---
     @api.depends("date", "auto_post", "state")
     def _compute_hide_post_button(self):

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -44,6 +44,11 @@
                 }</attribute>
             </xpath>
 
+            <!-- Bill Date is required for vendor bills -->
+            <xpath expr="//field[@name='invoice_date']" position="attributes">
+                <attribute name="attrs">{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))], 'required': [('move_type', '=', 'in_invoice')]}</attribute>
+            </xpath>
+
             <!-- Budget fields on main form (before invoice_tab notebook) -->
             <xpath expr="//page[@id='invoice_tab']/.." position="before">
                 <group name="budget_root" string="Accounting Dimensions">


### PR DESCRIPTION
Make `invoice_date` (Bill Date) required in the form and auto-default it to today when creating a vendor bill (`move_type = in_invoice`).

The view adds a conditional `required` modifier on `invoice_date` for bills (keeping core's existing `invisible` logic), and a `default_get` override sets today's date only for new vendor bills without overwriting values from other flows. Other move types (customer invoices, journal entries) are unaffected.