### PR TITLE
[16.0][IMP] mail_activity_todo_discuss: enrich Todo cards & fix systray filter

### DIFF
--- a/mail_activity_todo/static/src/xml/todo_systray.xml
+++ b/mail_activity_todo/static/src/xml/todo_systray.xml
@@ -29,7 +29,7 @@
                                 <div class="d-flex align-items-center">
                                     <img t-if="group.icon" t-att-src="group.icon" class="o_mail_activity_todo_group_icon me-2" alt=""/>
                                     <span class="flex-grow-1 text-truncate fw-semibold" t-esc="group.name"/>
-                                    <span class="badge rounded-pill bg-primary ms-2" t-esc="group.total_count"/>
+                                    <span class="badge rounded-pill text-bg-primary ms-2" t-esc="group.total_count"/>
                                 </div>
                                 <div class="small mt-1">
                                     <span t-if="group.overdue_count" class="text-danger me-2">

--- a/mail_activity_todo/views/mail_activity_views.xml
+++ b/mail_activity_todo/views/mail_activity_views.xml
@@ -118,7 +118,9 @@
                             <field name="is_read_by_me" invisible="1" />
                         </group>
                     </group>
-                    <field name="note" readonly="1" />
+                    <group string="Note">
+                        <field name="note" nolabel="1" colspan="2"/>
+                    </group>
                 </sheet>
             </form>
         </field>

--- a/mail_activity_todo_discuss/__manifest__.py
+++ b/mail_activity_todo_discuss/__manifest__.py
@@ -14,9 +14,10 @@ A collapsible "Todos" section in the Discuss sidebar (next to
 Inbox/Starred/History) lists pending Todos grouped by source app with live
 counts. Clicking the header opens the full Todo page in the main content pane;
 clicking an app group opens it filtered to that app. The page lists each Todo
-with its detail (app, source record, activity type, category, assignee, note
-and a colour-coded deadline), each clickable straight to its source document,
-plus a link to the full Todo app. The activity systray routes here too.
+with its detail (app, source record, activity type, assignee, note, who created
+it and when — as a relative time — and a colour-coded deadline countdown), each
+clickable straight to its source document, plus a link to the full Todo app. The
+activity systray routes here too, opening the page filtered to the clicked app.
 """,
     "depends": [
         "mail_activity_todo",

--- a/mail_activity_todo_discuss/i18n/th.po
+++ b/mail_activity_todo_discuss/i18n/th.po
@@ -96,6 +96,20 @@ msgstr "ผู้ใช้"
 #. odoo-javascript
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
 #, python-format
+msgid "by"
+msgstr "โดย"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
+#, python-format
+msgid "created"
+msgstr "สร้างเมื่อ"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
+#, python-format
 msgid "of"
 msgstr "ของ"
 

--- a/mail_activity_todo_discuss/models/res_users.py
+++ b/mail_activity_todo_discuss/models/res_users.py
@@ -67,6 +67,14 @@ class ResUsers(models.Model):
                     else False
                 ),
                 "state": act.state,
+                # Serialized UTC datetime; the client renders it as a locale-aware
+                # relative time ("3 hours ago") and formats the tooltip.
+                "create_date": (
+                    fields.Datetime.to_string(act.create_date)
+                    if act.create_date
+                    else False
+                ),
+                "create_uid": act.create_uid.display_name or "",
             }
             for act in activities
         ]

--- a/mail_activity_todo_discuss/static/src/js/discuss_todo_view.esm.js
+++ b/mail_activity_todo_discuss/static/src/js/discuss_todo_view.esm.js
@@ -3,15 +3,15 @@
 import { registerMessagingComponent } from "@mail/utils/messaging_component";
 import { LegacyComponent } from "@web/legacy/legacy_component";
 import { useService, useBus } from "@web/core/utils/hooks";
+import {
+    deserializeDate,
+    deserializeDateTime,
+    formatDate,
+    formatDateTime,
+} from "@web/core/l10n/dates";
 
 const { useState, useEffect } = owl;
-
-const CATEGORY_LABELS = {
-    approval: "Approval",
-    execution: "Execution",
-    acknowledgement: "Acknowledgement",
-    fyi: "FYI",
-};
+const { DateTime } = luxon;
 
 /**
  * The Todo inbox rendered in the Discuss MAIN content pane (when
@@ -60,8 +60,61 @@ export class DiscussTodoView extends LegacyComponent {
             : this.discuss.todoResModel;
     }
 
-    categoryLabel(code) {
-        return CATEGORY_LABELS[code] || "";
+    /**
+     * Locale-aware "created X ago" for the meta line, e.g. "3 hours ago".
+     * create_date is a UTC datetime string; deserializeDateTime lands it in the
+     * user's timezone. Returns "" when absent/unparseable so the line hides.
+     */
+    createdAgo(todo) {
+        if (!todo.create_date) {
+            return "";
+        }
+        return deserializeDateTime(todo.create_date).toRelative() || "";
+    }
+
+    /** Exact created datetime for the meta-line tooltip. */
+    createdTooltip(todo) {
+        if (!todo.create_date) {
+            return "";
+        }
+        return formatDateTime(deserializeDateTime(todo.create_date));
+    }
+
+    /**
+     * Deadline as a human countdown plus its urgency styling. Uses
+     * toRelativeCalendar ("today"/"tomorrow"/"in 3 days"/"yesterday") — the
+     * calendar form is correct for date-only deadlines, unlike toRelative which
+     * would measure from midnight. Colour/icon follow the server-computed state
+     * (overdue/today/planned), with planned deadlines within two days flagged
+     * as imminent. Returns null when there is no deadline.
+     */
+    deadlineInfo(todo) {
+        if (!todo.date_deadline) {
+            return null;
+        }
+        const dt = deserializeDate(todo.date_deadline);
+        const info = {
+            label: dt.toRelativeCalendar() || "",
+            exact: formatDate(dt),
+            className: "text-muted",
+            icon: "fa-clock-o",
+        };
+        if (todo.state === "overdue") {
+            info.className = "text-danger fw-bold";
+            info.icon = "fa-exclamation-circle";
+        } else if (todo.state === "today") {
+            info.className = "text-warning fw-bold";
+            info.icon = "fa-hourglass-half";
+        } else {
+            const days = dt
+                .startOf("day")
+                .diff(DateTime.now().startOf("day"), "days").days;
+            if (days <= 2) {
+                info.className = "text-warning";
+                info.icon = "fa-hourglass-start";
+            }
+        }
+        return info;
     }
 
     async fetchData() {

--- a/mail_activity_todo_discuss/static/src/js/todo_systray_patch.esm.js
+++ b/mail_activity_todo_discuss/static/src/js/todo_systray_patch.esm.js
@@ -10,22 +10,21 @@ import { TodoSystray } from "@mail_activity_todo/js/todo_systray.esm";
  * Todo app (correct fallback).
  */
 patch(TodoSystray.prototype, "mail_activity_todo_discuss.TodoSystray", {
-    _openTodosInDiscuss() {
+    _openTodosInDiscuss(resModel = "") {
         // get() awaits messaging create + init, so discuss is safe to use.
         // Fire-and-forget; swallow a rare init/doAction rejection so it does
         // not surface as an unhandled promise rejection.
         this.env.services.messaging
             .get()
-            .then((messaging) => messaging.discuss.openTodos())
+            .then((messaging) => messaging.discuss.openTodos(resModel))
             .catch((error) =>
                 console.error("Failed to open Todos in Discuss:", error)
             );
     },
-    // Route every systray click to the single Todos page in Discuss. The base
-    // per-source-app drill-down (the `group` arg) is intentionally collapsed
-    // into the unified pane; the signature is kept for clarity.
+    // Clicking a source-app group opens the Todos page filtered to that app,
+    // mirroring the sidebar drill-down (openTodos highlights the group too).
     onGroupClick(group) {
-        this._openTodosInDiscuss();
+        this._openTodosInDiscuss(group.model);
     },
     onViewAllClick() {
         this._openTodosInDiscuss();

--- a/mail_activity_todo_discuss/static/src/scss/discuss_todo.scss
+++ b/mail_activity_todo_discuss/static/src/scss/discuss_todo.scss
@@ -9,6 +9,20 @@
     // Let the text column truncate inside the flex row.
     .o_DiscussTodoView_text {
         min-width: 0;
+
+        // Bootstrap ships no standalone .text-sm font-size utility (only the
+        // responsive .text-sm-* alignment ones), so scope a compact size here
+        // for the note preview.
+        .text-sm {
+            font-size: 0.8125rem;
+        }
+    }
+
+    // Secondary metadata (assignee, created-ago) — smaller and quieter than the
+    // rest of the card; column-gap keeps it tidy when it wraps.
+    .o_DiscussTodoView_meta {
+        font-size: 0.75rem;
+        column-gap: 0.25rem;
     }
 
     .o_DiscussTodoView_item:hover {

--- a/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
+++ b/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
@@ -29,36 +29,40 @@
             <t t-else="">
                 <div class="o_DiscussTodoView_list flex-grow-1 overflow-auto">
                     <t t-foreach="state.todos" t-as="todo" t-key="todo.id">
+                        <t t-set="deadline" t-value="deadlineInfo(todo)"/>
                         <button class="o_DiscussTodoView_item btn d-flex align-items-start w-100 text-start px-4 py-2 border-0 border-bottom rounded-0"
                             t-on-click="() => this.onTodoClick(todo)"
                             t-att-title="todo.summary"
                         >
-                            <img t-if="todo.icon" t-att-src="todo.icon" class="o_DiscussTodoView_icon me-3" alt=""/>
+                            <img t-if="todo.icon" t-att-src="todo.icon" class="o_DiscussTodoView_icon me-3 mt-1" alt=""/>
                             <i t-else="" class="fa fa-fw fa-check-square-o me-3 mt-1"/>
                             <div class="o_DiscussTodoView_text flex-grow-1">
-                                <small class="text-muted d-flex align-items-center">
-                                    <t t-if="todo.activity_type" t-esc="todo.activity_type" />
-                                    <span t-if="todo.todo_category" class="badge bg-light text-dark border ms-2" t-esc="categoryLabel(todo.todo_category)"/>
-                                </small>
                                 <div class="d-flex align-items-center">
-                                    <span class="fw-medium text-truncate" t-esc="todo.summary"/>
+                                    <small class="text-muted text-truncate flex-grow-1" t-if="todo.activity_type" t-esc="todo.activity_type"/>
+                                    <small t-if="deadline"
+                                        class="o_DiscussTodoView_deadline ms-2 text-nowrap"
+                                        t-att-class="deadline.className"
+                                        t-att-title="deadline.exact"
+                                    >
+                                        <i class="fa fa-fw me-1" t-att-class="deadline.icon"/><t t-esc="deadline.label"/>
+                                    </small>
                                 </div>
+                                <div class="fw-medium text-truncate" t-esc="todo.summary"/>
                                 <small class="text-muted text-truncate d-block">
                                     <span t-if="todo.app" t-esc="todo.app"/>
                                     <t t-if="todo.res_name"> · <t t-esc="todo.res_name"/></t>
-                                    <t t-if="todo.assigned"> · <i class="fa fa-user-o me-1"/><t t-esc="todo.assigned"/></t>
                                 </small>
                                 <span class="text-sm text-muted fst-italic text-truncate d-block" t-if="todo.note" t-out="todo.note"/>
+                                <small class="o_DiscussTodoView_meta text-muted d-flex align-items-center flex-wrap mt-1">
+                                    <span t-if="todo.assigned" class="me-2 text-truncate">
+                                        <i class="fa fa-user-o me-1"/><t t-esc="todo.assigned"/>
+                                    </span>
+                                    <span t-if="todo.create_date" class="text-truncate" t-att-title="createdTooltip(todo)">
+                                        <i class="fa fa-clock-o me-1"/>created <t t-esc="createdAgo(todo)"/>
+                                        <t t-if="todo.create_uid"> by <t t-esc="todo.create_uid"/></t>
+                                    </span>
+                                </small>
                             </div>
-                            <small t-if="todo.date_deadline"
-                                class="ms-3 text-nowrap"
-                                t-att-class="{
-                                    'text-danger': todo.state === 'overdue',
-                                    'text-warning': todo.state === 'today',
-                                    'text-muted': todo.state === 'planned',
-                                }"
-                                t-esc="todo.date_deadline"
-                            />
                         </button>
                     </t>
                 </div>

--- a/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
+++ b/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
@@ -42,14 +42,13 @@
                                 </small>
                                 <div class="d-flex align-items-center">
                                     <span class="fw-medium text-truncate" t-esc="todo.summary"/>
-                                    <span t-if="todo.todo_category" class="badge bg-light text-dark border ms-2" t-esc="categoryLabel(todo.todo_category)"/>
                                 </div>
                                 <small class="text-muted text-truncate d-block">
                                     <span t-if="todo.app" t-esc="todo.app"/>
                                     <t t-if="todo.res_name"> · <t t-esc="todo.res_name"/></t>
                                     <t t-if="todo.assigned"> · <i class="fa fa-user-o me-1"/><t t-esc="todo.assigned"/></t>
                                 </small>
-                                <small class="text-muted fst-italic text-truncate d-block" t-if="todo.note" t-esc="todo.note"/>
+                                <span class="text-sm text-muted fst-italic text-truncate d-block" t-if="todo.note" t-out="todo.note"/>
                             </div>
                             <small t-if="todo.date_deadline"
                                 class="ms-3 text-nowrap"


### PR DESCRIPTION
## Summary

Improves the UI/UX of the Discuss Todo panel, fixes a systray routing bug, tidies the Todo form note, and fixes an unreadable systray badge.

- **Creator & timing**: each Todo card now shows who created it and when, as a locale-aware relative time ("created 3 hours ago by …"), with the exact datetime on hover.
- **Deadline countdown**: the deadline renders as a human countdown ("today" / "tomorrow" / "in 3 days" / "yesterday") with urgency-based colour and icon (overdue → danger, today → warning, imminent ≤2 days → warning).
- **Systray filter fix**: clicking a source-app group in the systray now opens the Todos page filtered to that app in Discuss — previously the model filter was dropped, so every systray click showed all apps.
- **Systray badge legibility**: the per-group count badge in the systray dropdown used `bg-primary` with no foreground colour (invisible number on the teal background) — switched to `text-bg-primary` like the other badges.
- **Card polish**: activity type and deadline share the top row, the source line follows, and a quiet meta footer carries the assignee + creation info; finished removing the leftover category badge; note preview now renders as HTML (`t-out`) at a real compact size.
- **Todo form (base module)**: wrap the note field in a `<group string="Note">` so it reads as its own titled section on the `view_my_todo_form` form.

Relative dates use luxon's `toRelative`/`toRelativeCalendar` (wired to the Odoo UI language, so Thai localizes); new strings are translated in `i18n/th.po`.

## Test plan

- [ ] Discuss → Todo panel: each card shows "created … ago by …" and a deadline countdown, coloured by urgency; hover shows exact dates.
- [ ] Click a source-app group in the activity systray → Discuss opens filtered to that app and the matching sidebar group is highlighted.
- [ ] Open the systray dropdown: each group's count badge shows a legible (contrasting) number.
- [ ] Open a Todo form (Todos → Inbox → a record): the note appears under a "Note" section heading, full width.
- [ ] Switch UI language to Thai and confirm relative times and the "created/by" labels localize.