### PR TITLE
[16.0][IMP] disbursement_accounting_kmitl: DR smart button on account.move

### DIFF
--- a/disbursement_accounting_kmitl/__manifest__.py
+++ b/disbursement_accounting_kmitl/__manifest__.py
@@ -17,6 +17,7 @@
     "data": [
         "security/ir.model.access.csv",
         "views/disbursement_request_views.xml",
+        "views/account_move_views.xml",
         "views/account_move_line_views.xml",
     ],
     "installable": True,

--- a/disbursement_accounting_kmitl/i18n/th.po
+++ b/disbursement_accounting_kmitl/i18n/th.po
@@ -32,6 +32,16 @@ msgid "Disbursement Request"
 msgstr "ใบขอเบิก"
 
 #. module: disbursement_accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:disbursement_accounting_kmitl.view_account_move_form_inherit_disbursement
+msgid "Disbursement Request"
+msgstr "ใบขอเบิก"
+
+#. module: disbursement_accounting_kmitl
+#: model:ir.model.fields,field_description:disbursement_accounting_kmitl.field_account_move__disbursement_request_name
+msgid "Disbursement Request Number"
+msgstr "เลขที่ใบขอเบิก"
+
+#. module: disbursement_accounting_kmitl
 #: model:ir.model.fields,field_description:disbursement_accounting_kmitl.field_disbursement_request__bill_ids
 msgid "Vendor Bills"
 msgstr "ใบตั้งหนี้ผู้ขาย"

--- a/disbursement_accounting_kmitl/models/account_move.py
+++ b/disbursement_accounting_kmitl/models/account_move.py
@@ -13,6 +13,21 @@ class AccountMove(models.Model):
         index=True,
         copy=False,
     )
+    disbursement_request_name = fields.Char(
+        related="disbursement_request_id.name",
+        string="Disbursement Request Number",
+    )
+
+    def action_view_disbursement_request(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Disbursement Request"),
+            "res_model": "disbursement.request",
+            "res_id": self.disbursement_request_id.id,
+            "view_mode": "form",
+            "target": "current",
+        }
 
     def _post(self, soft=True):
         """Advance the linked disbursement request to ``bills_posted`` once all

--- a/disbursement_accounting_kmitl/views/account_move_views.xml
+++ b/disbursement_accounting_kmitl/views/account_move_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Form view: add DR smart button (navigate to the linked Disbursement Request) -->
+    <record id="view_account_move_form_inherit_disbursement" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.disbursement_accounting_kmitl</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_disbursement_request"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-file-text-o"
+                        groups="accounting_kmitl.group_accounting_kmitl_user"
+                        attrs="{'invisible': [('disbursement_request_name', '=', False)]}">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Disbursement Request</span>
+                        <span class="o_stat_text"><field name="disbursement_request_name" nolabel="1"/></span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Adds a smart button on the vendor bill (`account.move`) form that displays and navigates to its linked Disbursement Request (DR), completing two-way navigation between DR and bills. The button shows the DR number and is hidden when no DR is linked. It is restricted to `accounting_kmitl.group_accounting_kmitl_user` because general accounting users cannot read `disbursement.request` (preventing AccessError). No new field is added — the existing `disbursement_request_id` Many2one is embedded in the button for both display and visibility, and the English label reuses the existing Thai translation.