### PR TITLE
[16.0][IMP] accounting_kmitl_workflow: notify approver of their own submitted entry

### DIFF
--- a/accounting_kmitl_workflow/models/account_move.py
+++ b/accounting_kmitl_workflow/models/account_move.py
@@ -152,11 +152,12 @@ class AccountMove(models.Model):
 
     def _schedule_approval_todo(self):
         """Push an approval Todo to every approver (manager) for these entries
-        so it surfaces in their Todo inbox. Cleared when the entry leaves the
-        ``to_approve`` workflow (approve / reject / recall)."""
+        so it surfaces in their Todo inbox — including an approver who submitted
+        the entry themselves. Cleared when the entry leaves the ``to_approve``
+        workflow (approve / reject / recall)."""
         approvers = self.env.ref(APPROVER_GROUP).users
         for move in self:
-            for approver in approvers - move.submitted_by:
+            for approver in approvers:
                 move.activity_schedule(
                     TO_APPROVE_ACTIVITY,
                     user_id=approver.id,

--- a/accounting_kmitl_workflow/tests/test_workflow.py
+++ b/accounting_kmitl_workflow/tests/test_workflow.py
@@ -148,6 +148,60 @@ class TestAccountMoveWorkflow(TransactionCase):
             )
         )
 
+    def test_submitter_who_is_approver_gets_own_todo(self):
+        """An approver who submits their own entry still receives the
+        'to approve' Todo so it surfaces in their Todo inbox."""
+        to_approve_type = self.env.ref(
+            "accounting_kmitl_workflow.mail_activity_move_to_approve"
+        )
+        maker_approver = self.env["res.users"].create(
+            {
+                "name": "Maker Approver",
+                "login": "kmitl_maker_approver",
+                "groups_id": [
+                    Command.set(
+                        [
+                            self.env.ref(
+                                "accounting_kmitl.group_accounting_kmitl_user"
+                            ).id,
+                            self.env.ref(
+                                "accounting_kmitl.group_accounting_kmitl_manager"
+                            ).id,
+                            self.env.ref("account.group_account_manager").id,
+                        ]
+                    )
+                ],
+            }
+        )
+        move = self.env["account.move"].with_user(maker_approver).create(
+            {
+                "move_type": "entry",
+                "journal_id": self.journal.id,
+                "date": fields.Date.today(),
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": self.account_a.id,
+                            "debit": 100.0,
+                            "credit": 0.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.account_b.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.with_user(maker_approver).action_submit()
+        activities = move.activity_ids.filtered(
+            lambda a: a.activity_type_id == to_approve_type
+        )
+        self.assertIn(maker_approver, activities.mapped("user_id"))
+
     def test_recall_returns_to_draft(self):
         move = self._new_entry()
         move.with_user(self.maker).action_submit()


### PR DESCRIPTION
## สรุป

ให้ผู้อนุมัติ (กลุ่ม `accounting_kmitl.group_accounting_kmitl_manager`) สามารถอนุมัติรายการ `account.move` ที่ตัวเองเป็นผู้จัดทำ/ส่งได้แบบครบวงจรผ่านกล่อง Todo

## ปัญหา

การอนุมัติรายการของตัวเอง **ทำได้อยู่แล้ว** ทุกช่องทาง:
- `action_approve()` ไม่มีการกั้น self-approval (ยืนยันด้วย `test_maker_can_approve_own_entry`)
- ปุ่ม Approve บนฟอร์มแสดงตามกลุ่ม manager + `workflow_state == 'to_approve'` ไม่กรองผู้จัดทำ
- หน้า Approval List (client action) ใช้ domain แค่ `workflow_state = to_approve`

ติดแค่จุดเดียว: `_schedule_approval_todo()` ใช้ `approvers - move.submitted_by` ตัดผู้จัดทำออกจากการรับ Todo ขณะที่กล่อง Todo inbox ของ `mail_activity_todo` กรองงานด้วย `('user_id', '=', uid)` แบบเข้มงวด → ผู้อนุมัติที่ส่งรายการเอง **หางานของตัวเองในกล่อง Todo ไม่เจอ** จึงรู้สึกว่าอนุมัติเองไม่ได้

## การแก้ไข

- `models/account_move.py`: เปลี่ยน `for approver in approvers - move.submitted_by:` → `for approver in approvers:` เพื่อให้ Todo "Entry to approve" ถูกส่งถึงผู้อนุมัติทุกคนรวมถึงผู้จัดทำ
- `tests/test_workflow.py`: เพิ่ม `test_submitter_who_is_approver_gets_own_todo` ยืนยันพฤติกรรมใหม่

ไม่มี string ใหม่ที่ผู้ใช้เห็น จึงไม่ต้องแก้ i18n

## การทดสอบ

- รัน test ของโมดูล `accounting_kmitl_workflow` (test เดิม `test_submit_notifies_approvers_and_clears_on_approve` ยังผ่าน เพราะ `maker` ไม่ได้อยู่ในกลุ่ม manager)
- ทดสอบมือ: ล็อกอินด้วยผู้ใช้กลุ่ม manager → สร้าง move → Submit → เปิดกล่อง Todo → เห็นงานของตัวเอง → กด Approve → รายการ post และ Todo ถูกเคลียร์
