### PR TITLE
[16.0][IMP] accounting_kmitl: translate bill form notebook labels to Thai

### DIFF
--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -165,3 +165,18 @@ msgstr "สมุดรายวัน"
 #: model:ir.ui.menu,name:accounting_kmitl.menu_config_taxes
 msgid "Taxes"
 msgstr "ภาษี"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
+msgid "Invoice Lines"
+msgstr "รายการตั้งหนี้"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
+msgid "Add a line"
+msgstr "เพิ่มบรรทัด"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
+msgid "Account Items"
+msgstr "รายการบัญชี"

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -44,6 +44,11 @@
                 }</attribute>
             </xpath>
 
+            <!-- Rename the Journal Items notebook tab (unique source for translation) -->
+            <xpath expr="//page[@id='aml_tab']" position="attributes">
+                <attribute name="string">Account Items</attribute>
+            </xpath>
+
             <!-- Bill Date is required for vendor bills -->
             <xpath expr="//field[@name='invoice_date']" position="attributes">
                 <attribute name="attrs">{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))], 'required': [('move_type', '=', 'in_invoice')]}</attribute>


### PR DESCRIPTION
แปลภาษาไทยของ label บนหน้า form ใบตั้งหนี้ (`account.move`) ในส่วน notebook ของ module `accounting_kmitl`

**th.po** เพิ่มคำแปล 3 รายการ: `Invoice Lines` → รายการตั้งหนี้, `Add a line` → เพิ่มบรรทัด (override term ของ base view `account.view_move_form` เฉพาะภาษาไทย คง English เดิม), และ `Account Items` → รายการบัญชี

**account_move_views.xml** เพิ่ม xpath relabel แท็บ `aml_tab` (เดิม "Journal Items") เป็น source ใหม่ `Account Items` เพื่อให้มี source string ไม่ซ้ำกับ msgid เมนู "Journal Items" ที่มีอยู่แล้ว (เลี่ยง duplicate msgid ใน po)

ตรวจสอบแล้ว: `msgfmt -c` ผ่านไม่มี duplicate และ XML well-formed