### PR TITLE
[16.0][IMP] accounting_kmitl: translate Add a line on journal entries

### DIFF
--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -173,6 +173,7 @@ msgstr "รายการตั้งหนี้"
 
 #. module: accounting_kmitl
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
 msgid "Add a line"
 msgstr "เพิ่มบรรทัด"
 

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -49,6 +49,16 @@
                 <attribute name="string">Account Items</attribute>
             </xpath>
 
+            <!-- Explicit "Add a line" control on the journal entry lines so its
+                 label is translatable through this view. The base aml_tab tree
+                 has no <control>, so the web client renders a default control
+                 whose label comes from JS and bypasses view translations. -->
+            <xpath expr="//page[@id='aml_tab']//field[@name='line_ids']/tree" position="inside">
+                <control>
+                    <create name="add_line_control" string="Add a line"/>
+                </control>
+            </xpath>
+
             <!-- Bill Date is required for vendor bills -->
             <xpath expr="//field[@name='invoice_date']" position="attributes">
                 <attribute name="attrs">{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))], 'required': [('move_type', '=', 'in_invoice')]}</attribute>


### PR DESCRIPTION
ต่อยอดจาก #918 — ปุ่ม "Add a line" บนแท็บ journal items (`aml_tab`) ตอนสร้าง journal entry ยังไม่ถูกแปลเป็นไทย เพราะ tree ของ `line_ids` ใน base view ไม่มี `<control>` web client จึง render ปุ่ม default ที่ label มาจากฝั่ง JavaScript และไม่ผ่านการแปลของ view

แก้โดยเพิ่ม `<control><create string="Add a line"/>` ให้ tree ของ `line_ids` ในแท็บ `aml_tab` (ผ่าน view inheritance) ทำให้ label มาจาก view arch และแปลผ่าน `th.po` ได้ (กลไกเดียวกับแท็บ invoice ที่ทำงานอยู่แล้ว) → แสดงเป็น "เพิ่มบรรทัด"

`th.po` เพิ่ม reference ของ kmitl view เข้า entry "Add a line" เดิม (msgstr เดิม ไม่มี msgid ซ้ำ) ตรวจสอบแล้ว `msgfmt -c` ผ่าน และ XML well-formed