### PR TITLE
[16.0][IMP] accounting_kmitl_reports: per-dimension hierarchy filter toggle + expand-all

### DIFF
--- a/accounting_kmitl_reports/i18n/th.po
+++ b/accounting_kmitl_reports/i18n/th.po
@@ -496,3 +496,14 @@ msgstr "มิติทางบัญชี"
 #: code:addons/accounting_kmitl_reports/static/src/general_journal/general_journal.js:0
 msgid "Date-Time"
 msgstr "วันเวลา"
+
+#. module: accounting_kmitl_reports
+#: code:addons/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml:0
+#: code:addons/accounting_kmitl_reports/static/src/general_journal/general_journal.xml:0
+msgid "Expand all"
+msgstr "ขยายทุกแถว"
+
+#. module: accounting_kmitl_reports
+#: code:addons/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml:0
+msgid "Only the specified entry"
+msgstr "เฉพาะรายการที่เลือก (ไม่รวมระดับย่อย)"

--- a/accounting_kmitl_reports/models/aged_partner_balance_kmitl.py
+++ b/accounting_kmitl_reports/models/aged_partner_balance_kmitl.py
@@ -105,7 +105,9 @@ class AgedPartnerBalanceKmitl(models.AbstractModel):
 
         # Resolve the selected dimensions to the moves that carry them.
         move_ids = None
-        leaves = self._kmitl_build_dim_leaves(options.get("dims") or {})
+        leaves = self._kmitl_build_dim_leaves(
+            options.get("dims") or {}, options.get("dim_only_self")
+        )
         if leaves:
             move_ids = self.env["account.move.line"].search(leaves).move_id.ids
 

--- a/accounting_kmitl_reports/models/cash_flow_statement_kmitl.py
+++ b/accounting_kmitl_reports/models/cash_flow_statement_kmitl.py
@@ -88,7 +88,9 @@ class CashFlowReportKmitl(models.AbstractModel):
 
         only_posted = bool(options.get("only_posted", True))
         hide_at_0 = bool(options.get("hide_account_at_0", True))
-        leaves = self._kmitl_build_dim_leaves(options.get("dims") or {})
+        leaves = self._kmitl_build_dim_leaves(
+            options.get("dims") or {}, options.get("dim_only_self")
+        )
         # Posted only, or every non-cancelled entry (posted + draft).
         state_leaf = (
             [("parent_state", "=", "posted")]

--- a/accounting_kmitl_reports/models/dimension_filter_mixin.py
+++ b/accounting_kmitl_reports/models/dimension_filter_mixin.py
@@ -7,9 +7,6 @@ from odoo.tools import date_utils
 # order. Read from each move line's ``analytic_distribution`` (a JSON of
 # {analytic_account_id: percentage}).
 DIMENSION_CODES = ("departments", "sources", "funds", "activities")
-# Hierarchical dimensions: a selected node also matches all of its descendants
-# (when analytic accounts carry a ``parent_id`` hierarchy). ``sources`` is flat.
-HIERARCHICAL_DIMS = ("departments", "funds", "activities")
 # Display order of the dimension chips shown in the shared expand-detail panel.
 DETAIL_DIM_PLANS = ("funds", "departments", "activities", "sources")
 # Lines never shown in the detail panel.
@@ -28,20 +25,28 @@ class DimensionFilterMixin(models.AbstractModel):
     _description = "KMITL Report Dimension Filter Mixin"
 
     @api.model
-    def _kmitl_build_dim_leaves(self, dims):
+    def _kmitl_build_dim_leaves(self, dims, dim_only_self=None):
         """Turn the selected dimension values into ``analytic_distribution``
-        domain leaves. Within a dimension the ids (plus descendants for
-        hierarchical dimensions) are OR-ed; the resulting leaves are AND-ed
-        across dimensions by the domain builder.
+        domain leaves. Within a dimension the ids (plus descendants by
+        default) are OR-ed; the resulting leaves are AND-ed across dimensions
+        by the domain builder.
+
+        ``dim_only_self``: optional ``{code: bool}``. When truthy for a
+        dimension only the exact selected analytic accounts match; otherwise
+        (the default) the selection is expanded to include all of its
+        descendants, since the KMITL dimensions are hierarchical. Flat
+        dimensions (e.g. ``sources``) have no descendants, so the toggle has
+        no effect on them.
         """
         analytic = self.env["account.analytic.account"]
         use_child = "parent_id" in analytic._fields
+        dim_only_self = dim_only_self or {}
         leaves = []
         for code in DIMENSION_CODES:
             ids = (dims or {}).get(code) or []
             if not ids:
                 continue
-            if code in HIERARCHICAL_DIMS and use_child:
+            if use_child and not dim_only_self.get(code):
                 ids = analytic.search([("id", "child_of", ids)]).ids
             leaves.append(("analytic_distribution", "in", ids))
         return leaves
@@ -134,6 +139,13 @@ class DimensionFilterMixin(models.AbstractModel):
         """RPC for the on-screen expand: one entry's posting lines (account,
         label, partner, debit, credit and the KMITL accounting dimensions)."""
         return self._kmitl_move_lines_detail([move_id]).get(move_id, [])
+
+    @api.model
+    def get_move_lines_details(self, move_ids):
+        """RPC for the "Expand all" toggle: posting lines for several entries
+        at once, keyed by move id (so the current page can expand in a single
+        round-trip)."""
+        return self._kmitl_move_lines_detail(move_ids)
 
     # ------------------------------------------------------------------
     # Shared filter helpers used by the date-ranged reports (Trial Balance,

--- a/accounting_kmitl_reports/models/general_journal_kmitl.py
+++ b/accounting_kmitl_reports/models/general_journal_kmitl.py
@@ -65,7 +65,7 @@ class GeneralJournalReportKmitl(models.AbstractModel):
         if partner_ids:
             domain.append(("line_ids.partner_id", "in", partner_ids))
         for field_name, op, value in self._kmitl_build_dim_leaves(
-            options.get("dims") or {}
+            options.get("dims") or {}, options.get("dim_only_self")
         ):
             domain.append(("line_ids." + field_name, op, value))
 

--- a/accounting_kmitl_reports/models/general_ledger_kmitl.py
+++ b/accounting_kmitl_reports/models/general_ledger_kmitl.py
@@ -72,7 +72,11 @@ class GeneralLedgerReportKmitl(models.AbstractModel):
 
         # KMITL dimensions (and the optional journal filter) ride along on the
         # engine's extra_domain, which is AND-ed into every move-line query.
-        extra_domain = list(self._kmitl_build_dim_leaves(options.get("dims") or {}))
+        extra_domain = list(
+            self._kmitl_build_dim_leaves(
+                options.get("dims") or {}, options.get("dim_only_self")
+            )
+        )
         if journal_ids:
             extra_domain += [("journal_id", "in", journal_ids)]
 

--- a/accounting_kmitl_reports/models/trial_balance_kmitl.py
+++ b/accounting_kmitl_reports/models/trial_balance_kmitl.py
@@ -88,7 +88,9 @@ class TrialBalanceReportKmitl(models.AbstractModel):
         account_ids = self._kmitl_apply_account_range(options, company_id, account_ids)
 
         fy_start_date = self._kmitl_fy_start_date(date_from, company)
-        leaves = self._kmitl_build_dim_leaves(options.get("dims") or {})
+        leaves = self._kmitl_build_dim_leaves(
+            options.get("dims") or {}, options.get("dim_only_self")
+        )
 
         report = self.with_context(kmitl_dim_leaves=leaves)
         total_amount, accounts_data, _partners = report._get_data(

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
@@ -33,6 +33,14 @@ export class AgedPartnerBalance extends Component {
             sources: [],
             funds: [],
             activities: [],
+            // Per-dimension "only the specified entry" toggles. When false
+            // (default) a selected node also matches its descendants.
+            dimOnlySelf: {
+                departments: false,
+                sources: false,
+                funds: false,
+                activities: false,
+            },
             accounts_data: [],
             totals: {},
             loading: false,
@@ -72,6 +80,7 @@ export class AgedPartnerBalance extends Component {
                 funds: this.state.funds.map((r) => r.id),
                 activities: this.state.activities.map((r) => r.id),
             },
+            dim_only_self: { ...this.state.dimOnlySelf },
         };
     }
 
@@ -119,6 +128,12 @@ export class AgedPartnerBalance extends Component {
             this.state[key] = selected;
             this.load();
         }
+    }
+
+    // Toggle a dimension's "only the specified entry" flag (no descendants).
+    onToggleDimOnlySelf(code, value) {
+        this.state.dimOnlySelf[code] = value;
+        this.load();
     }
 
     // ------------------------------------------------------------------

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
@@ -57,6 +57,9 @@
                         placeholder="labels.departments"
                         selected="state.departments"
                         onChange="(sel) => this.onSelectionChange('departments', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.departments"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('departments', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -67,6 +70,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -77,6 +83,9 @@
                         placeholder="labels.funds"
                         selected="state.funds"
                         onChange="(sel) => this.onSelectionChange('funds', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.funds"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('funds', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -87,6 +96,9 @@
                         placeholder="labels.activities"
                         selected="state.activities"
                         onChange="(sel) => this.onSelectionChange('activities', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.activities"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('activities', val)"
                     />
                 </div>
 

--- a/accounting_kmitl_reports/static/src/cash_flow/cash_flow.js
+++ b/accounting_kmitl_reports/static/src/cash_flow/cash_flow.js
@@ -29,6 +29,14 @@ export class CashFlow extends Component {
             sources: [],
             funds: [],
             activities: [],
+            // Per-dimension "only the specified entry" toggles. When false
+            // (default) a selected node also matches its descendants.
+            dimOnlySelf: {
+                departments: false,
+                sources: false,
+                funds: false,
+                activities: false,
+            },
             rows: [],
             summary: {},
             loading: false,
@@ -84,6 +92,7 @@ export class CashFlow extends Component {
                 funds: this.state.funds.map((r) => r.id),
                 activities: this.state.activities.map((r) => r.id),
             },
+            dim_only_self: { ...this.state.dimOnlySelf },
         };
     }
 
@@ -143,6 +152,12 @@ export class CashFlow extends Component {
             this.state[key] = selected;
             this.load();
         }
+    }
+
+    // Toggle a dimension's "only the specified entry" flag (no descendants).
+    onToggleDimOnlySelf(code, value) {
+        this.state.dimOnlySelf[code] = value;
+        this.load();
     }
 
     // ------------------------------------------------------------------

--- a/accounting_kmitl_reports/static/src/cash_flow/cash_flow.xml
+++ b/accounting_kmitl_reports/static/src/cash_flow/cash_flow.xml
@@ -81,6 +81,9 @@
                         placeholder="labels.departments"
                         selected="state.departments"
                         onChange="(sel) => this.onSelectionChange('departments', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.departments"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('departments', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -91,6 +94,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -101,6 +107,9 @@
                         placeholder="labels.funds"
                         selected="state.funds"
                         onChange="(sel) => this.onSelectionChange('funds', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.funds"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('funds', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -111,6 +120,9 @@
                         placeholder="labels.activities"
                         selected="state.activities"
                         onChange="(sel) => this.onSelectionChange('activities', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.activities"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('activities', val)"
                     />
                 </div>
                 </div>

--- a/accounting_kmitl_reports/static/src/general_journal/general_journal.js
+++ b/accounting_kmitl_reports/static/src/general_journal/general_journal.js
@@ -33,6 +33,8 @@ export class GeneralJournal extends Component {
             expanded: {},
             // Lazily-fetched detail lines of each entry, by move id.
             linesByMove: {},
+            // "Expand all" toggle: expand every entry on the current page.
+            expandAll: false,
             // Row-based pagination (rows = entries).
             page: 0,
             pageSize: 50,
@@ -49,6 +51,14 @@ export class GeneralJournal extends Component {
             sources: [],
             funds: [],
             activities: [],
+            // Per-dimension "only the specified entry" toggles. When false
+            // (default) a selected node also matches its descendants.
+            dimOnlySelf: {
+                departments: false,
+                sources: false,
+                funds: false,
+                activities: false,
+            },
         });
         this.labels = {
             title: _t("General Journal"),
@@ -123,6 +133,7 @@ export class GeneralJournal extends Component {
                 funds: this.state.funds.map((r) => r.id),
                 activities: this.state.activities.map((r) => r.id),
             },
+            dim_only_self: { ...this.state.dimOnlySelf },
         };
     }
 
@@ -142,6 +153,9 @@ export class GeneralJournal extends Component {
             this.state.entries = data.entries || [];
         } finally {
             this.state.loading = false;
+        }
+        if (this.state.expandAll) {
+            await this.expandCurrentPage();
         }
     }
 
@@ -172,18 +186,27 @@ export class GeneralJournal extends Component {
     prevPage() {
         if (!this.isFirstPage) {
             this.state.page -= 1;
+            if (this.state.expandAll) {
+                this.expandCurrentPage();
+            }
         }
     }
 
     nextPage() {
         if (!this.isLastPage) {
             this.state.page += 1;
+            if (this.state.expandAll) {
+                this.expandCurrentPage();
+            }
         }
     }
 
     setPageSize(ev) {
         this.state.pageSize = parseInt(ev.target.value) || 50;
         this.state.page = 0;
+        if (this.state.expandAll) {
+            this.expandCurrentPage();
+        }
     }
 
     // ------------------------------------------------------------------
@@ -227,6 +250,12 @@ export class GeneralJournal extends Component {
         }
     }
 
+    // Toggle a dimension's "only the specified entry" flag (no descendants).
+    onToggleDimOnlySelf(code, value) {
+        this.state.dimOnlySelf[code] = value;
+        this.load();
+    }
+
     // ------------------------------------------------------------------
     // Row interactions
     // ------------------------------------------------------------------
@@ -244,6 +273,35 @@ export class GeneralJournal extends Component {
                 "get_move_lines_detail",
                 [entry.id]
             );
+        }
+    }
+
+    // Expand every entry on the current page, batch-fetching the detail lines
+    // that are not cached yet (one round-trip per page).
+    async expandCurrentPage() {
+        const moveIds = new Set();
+        for (const entry of this.pagedEntries) {
+            this.state.expanded[entry.id] = true;
+            if (!this.state.linesByMove[entry.id]) {
+                moveIds.add(entry.id);
+            }
+        }
+        if (moveIds.size) {
+            const data = await this.orm.call(
+                REPORT_MODEL,
+                "get_move_lines_details",
+                [[...moveIds]]
+            );
+            Object.assign(this.state.linesByMove, data);
+        }
+    }
+
+    async onToggleExpandAll(ev) {
+        this.state.expandAll = ev.target.checked;
+        if (this.state.expandAll) {
+            await this.expandCurrentPage();
+        } else {
+            this.state.expanded = {};
         }
     }
 

--- a/accounting_kmitl_reports/static/src/general_journal/general_journal.xml
+++ b/accounting_kmitl_reports/static/src/general_journal/general_journal.xml
@@ -49,7 +49,7 @@
                             t-on-change="onDateToChange"
                         />
                     </div>
-                    <div class="col-md-5 d-flex align-items-end">
+                    <div class="col-md-5 d-flex align-items-end gap-3">
                         <div class="form-check">
                             <input
                                 type="checkbox"
@@ -59,6 +59,16 @@
                                 t-on-change="onTogglePosted"
                             />
                             <label class="form-check-label" for="kmitl_gj_posted">Posted entries only</label>
+                        </div>
+                        <div class="form-check">
+                            <input
+                                type="checkbox"
+                                class="form-check-input"
+                                id="kmitl_gj_expand_all"
+                                t-att-checked="state.expandAll"
+                                t-on-change="onToggleExpandAll"
+                            />
+                            <label class="form-check-label" for="kmitl_gj_expand_all">Expand all</label>
                         </div>
                     </div>
 
@@ -80,6 +90,9 @@
                             placeholder="labels.departments"
                             selected="state.departments"
                             onChange="(sel) => this.onSelectionChange('departments', sel)"
+                            withOnlySelf="true"
+                            onlySelf="state.dimOnlySelf.departments"
+                            onOnlySelfChange="(val) => this.onToggleDimOnlySelf('departments', val)"
                         />
                     </div>
                     <div class="col-md-3">
@@ -90,6 +103,9 @@
                             placeholder="labels.sources"
                             selected="state.sources"
                             onChange="(sel) => this.onSelectionChange('sources', sel)"
+                            withOnlySelf="true"
+                            onlySelf="state.dimOnlySelf.sources"
+                            onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                         />
                     </div>
                     <div class="col-md-3">
@@ -100,6 +116,9 @@
                             placeholder="labels.funds"
                             selected="state.funds"
                             onChange="(sel) => this.onSelectionChange('funds', sel)"
+                            withOnlySelf="true"
+                            onlySelf="state.dimOnlySelf.funds"
+                            onOnlySelfChange="(val) => this.onToggleDimOnlySelf('funds', val)"
                         />
                     </div>
                     <div class="col-md-3">
@@ -110,6 +129,9 @@
                             placeholder="labels.activities"
                             selected="state.activities"
                             onChange="(sel) => this.onSelectionChange('activities', sel)"
+                            withOnlySelf="true"
+                            onlySelf="state.dimOnlySelf.activities"
+                            onOnlySelfChange="(val) => this.onToggleDimOnlySelf('activities', val)"
                         />
                     </div>
 

--- a/accounting_kmitl_reports/static/src/general_ledger/general_ledger.js
+++ b/accounting_kmitl_reports/static/src/general_ledger/general_ledger.js
@@ -41,6 +41,8 @@ export class GeneralLedger extends Component {
             expanded: {},
             // Lazily-fetched Dr/Cr breakdown of each journal entry, by move id.
             linesByMove: {},
+            // "Expand all" toggle: expand every row on the current page.
+            expandAll: false,
             // Filters (mirror the Trial Balance).
             fiscalYearId: false,
             dateFrom: false,
@@ -59,6 +61,14 @@ export class GeneralLedger extends Component {
             sources: [],
             funds: [],
             activities: [],
+            // Per-dimension "only the specified entry" toggles. When false
+            // (default) a selected node also matches its descendants.
+            dimOnlySelf: {
+                departments: false,
+                sources: false,
+                funds: false,
+                activities: false,
+            },
         });
         this.labels = {
             title: _t("General Ledger"),
@@ -168,6 +178,7 @@ export class GeneralLedger extends Component {
                 funds: this.state.funds.map((r) => r.id),
                 activities: this.state.activities.map((r) => r.id),
             },
+            dim_only_self: { ...this.state.dimOnlySelf },
         };
     }
 
@@ -187,6 +198,9 @@ export class GeneralLedger extends Component {
             this.state.sections = data.accounts || [];
         } finally {
             this.state.loading = false;
+        }
+        if (this.state.expandAll) {
+            await this.expandCurrentPage();
         }
     }
 
@@ -261,18 +275,27 @@ export class GeneralLedger extends Component {
     prevPage() {
         if (!this.isFirstPage) {
             this.state.page -= 1;
+            if (this.state.expandAll) {
+                this.expandCurrentPage();
+            }
         }
     }
 
     nextPage() {
         if (!this.isLastPage) {
             this.state.page += 1;
+            if (this.state.expandAll) {
+                this.expandCurrentPage();
+            }
         }
     }
 
     setPageSize(ev) {
         this.state.pageSize = parseInt(ev.target.value) || 100;
         this.state.page = 0;
+        if (this.state.expandAll) {
+            this.expandCurrentPage();
+        }
     }
 
     // ------------------------------------------------------------------
@@ -321,6 +344,12 @@ export class GeneralLedger extends Component {
         }
     }
 
+    // Toggle a dimension's "only the specified entry" flag (no descendants).
+    onToggleDimOnlySelf(code, value) {
+        this.state.dimOnlySelf[code] = value;
+        this.load();
+    }
+
     // ------------------------------------------------------------------
     // Row interactions
     // ------------------------------------------------------------------
@@ -339,6 +368,37 @@ export class GeneralLedger extends Component {
                 "get_move_lines_detail",
                 [moveId]
             );
+        }
+    }
+
+    // Expand every row on the current page, batch-fetching the entry details
+    // that are not cached yet (one round-trip per page).
+    async expandCurrentPage() {
+        const moveIds = new Set();
+        for (const acc of this.pagedSections) {
+            for (const line of acc.lines) {
+                this.state.expanded[line.id] = true;
+                if (line.entry_id && !this.state.linesByMove[line.entry_id]) {
+                    moveIds.add(line.entry_id);
+                }
+            }
+        }
+        if (moveIds.size) {
+            const data = await this.orm.call(
+                REPORT_MODEL,
+                "get_move_lines_details",
+                [[...moveIds]]
+            );
+            Object.assign(this.state.linesByMove, data);
+        }
+    }
+
+    async onToggleExpandAll(ev) {
+        this.state.expandAll = ev.target.checked;
+        if (this.state.expandAll) {
+            await this.expandCurrentPage();
+        } else {
+            this.state.expanded = {};
         }
     }
 

--- a/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml
+++ b/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml
@@ -73,6 +73,16 @@
                         />
                         <label class="form-check-label" for="kmitl_gl_hide0">Hide accounts at 0</label>
                     </div>
+                    <div class="form-check">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="kmitl_gl_expand_all"
+                            t-att-checked="state.expandAll"
+                            t-on-change="onToggleExpandAll"
+                        />
+                        <label class="form-check-label" for="kmitl_gl_expand_all">Expand all</label>
+                    </div>
                 </div>
 
                 <!-- KMITL accounting dimensions -->
@@ -84,6 +94,9 @@
                         placeholder="labels.departments"
                         selected="state.departments"
                         onChange="(sel) => this.onSelectionChange('departments', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.departments"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('departments', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -94,6 +107,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -104,6 +120,9 @@
                         placeholder="labels.funds"
                         selected="state.funds"
                         onChange="(sel) => this.onSelectionChange('funds', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.funds"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('funds', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -114,6 +133,9 @@
                         placeholder="labels.activities"
                         selected="state.activities"
                         onChange="(sel) => this.onSelectionChange('activities', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.activities"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('activities', val)"
                     />
                 </div>
 

--- a/accounting_kmitl_reports/static/src/trial_balance/multi_record_select.js
+++ b/accounting_kmitl_reports/static/src/trial_balance/multi_record_select.js
@@ -16,6 +16,10 @@ import { useService } from "@web/core/utils/hooks";
  *  - single: keep at most one selection (used for the account code range)
  *  - selected: Array<{id, name}> currently selected (controlled by parent)
  *  - onChange: called with the new Array<{id, name}>
+ *  - withOnlySelf: render an "only the specified entry" checkbox below the box
+ *    (used by the hierarchical KMITL dimension filters)
+ *  - onlySelf: current state of that checkbox (controlled by parent)
+ *  - onOnlySelfChange: called with the new boolean when the checkbox toggles
  */
 export class MultiRecordSelect extends Component {
     setup() {
@@ -83,10 +87,15 @@ MultiRecordSelect.props = {
     single: { type: Boolean, optional: true },
     selected: { type: Array, optional: true },
     onChange: Function,
+    withOnlySelf: { type: Boolean, optional: true },
+    onlySelf: { type: Boolean, optional: true },
+    onOnlySelfChange: { type: Function, optional: true },
 };
 MultiRecordSelect.defaultProps = {
     domain: [],
     placeholder: "",
     single: false,
     selected: [],
+    withOnlySelf: false,
+    onlySelf: false,
 };

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.js
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.js
@@ -45,6 +45,14 @@ export class TrialBalance extends Component {
             sources: [],
             funds: [],
             activities: [],
+            // Per-dimension "only the specified entry" toggles. When false
+            // (default) a selected node also matches its descendants.
+            dimOnlySelf: {
+                departments: false,
+                sources: false,
+                funds: false,
+                activities: false,
+            },
             rows: [],
             totals: {},
             loading: false,
@@ -110,6 +118,7 @@ export class TrialBalance extends Component {
                 funds: this.state.funds.map((r) => r.id),
                 activities: this.state.activities.map((r) => r.id),
             },
+            dim_only_self: { ...this.state.dimOnlySelf },
         };
     }
 
@@ -173,6 +182,12 @@ export class TrialBalance extends Component {
             this.state[key] = selected;
             this.load();
         }
+    }
+
+    // Toggle a dimension's "only the specified entry" flag (no descendants).
+    onToggleDimOnlySelf(code, value) {
+        this.state.dimOnlySelf[code] = value;
+        this.load();
     }
 
     // ------------------------------------------------------------------

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.scss
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.scss
@@ -108,4 +108,9 @@
             background-color: #f1f3f5;
         }
     }
+
+    .o_kmitl_ms_onlyself {
+        margin-top: 0.25rem;
+        font-size: 0.85em;
+    }
 }

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml
@@ -40,6 +40,15 @@
                     <t t-esc="opt.name" />
                 </div>
             </div>
+            <div class="form-check o_kmitl_ms_onlyself" t-if="props.withOnlySelf">
+                <input
+                    type="checkbox"
+                    class="form-check-input"
+                    t-att-checked="props.onlySelf"
+                    t-on-change="(ev) => props.onOnlySelfChange(ev.target.checked)"
+                />
+                <label class="form-check-label">Only the specified entry</label>
+            </div>
         </div>
     </t>
 
@@ -126,6 +135,9 @@
                         placeholder="labels.departments"
                         selected="state.departments"
                         onChange="(sel) => this.onSelectionChange('departments', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.departments"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('departments', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -136,6 +148,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -146,6 +161,9 @@
                         placeholder="labels.funds"
                         selected="state.funds"
                         onChange="(sel) => this.onSelectionChange('funds', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.funds"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('funds', val)"
                     />
                 </div>
                 <div class="col-md-3">
@@ -156,6 +174,9 @@
                         placeholder="labels.activities"
                         selected="state.activities"
                         onChange="(sel) => this.onSelectionChange('activities', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.activities"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('activities', val)"
                     />
                 </div>
 


### PR DESCRIPTION
## Context
ปรับปรุงรายงานที่ custom ด้วย OWL ในโมดูล `accounting_kmitl_reports` ตาม 2 ความต้องการของ user (PR เดียว, code อังกฤษ + แปลไทยผ่าน i18n).

## Task 1 — Checkbox "Expand all" (ขยายเฉพาะหน้าปัจจุบัน)
ลงที่ **General Ledger** และ **General Journal** (รายงานที่ expand รายแถวได้จริง — กดขยายดู Dr/Cr รายเอกสาร)
- เพิ่ม RPC `get_move_lines_details(move_ids)` ใน `dimension_filter_mixin.py` ดึง detail หลายเอกสารในครั้งเดียว (batch)
- เพิ่ม `state.expandAll` + checkbox "Expand all" ในแถบ filter
- `expandCurrentPage()` ขยายเฉพาะแถวในหน้าปัจจุบัน (pagination) และ re-expand อัตโนมัติเมื่อเลื่อนหน้า / เปลี่ยน page size / โหลดใหม่ ตราบใดที่ยังติ๊กค้างไว้

## Task 2 — Checkbox "only the specified entry" ต่อมิติบัญชี
ลงทั้ง **5 รายงาน** ที่มี filter มิติบัญชี: Trial Balance, General Ledger, General Journal, Aged Receivable/Payable, Cash Flow
- `_kmitl_build_dim_leaves(dims, dim_only_self)`: ทำให้ **"รวมตัวลูก" เป็น default ทุกมิติ** และข้าม `child_of` เฉพาะมิติที่ถูกติ๊ก (ลบ `HIERARCHICAL_DIMS` — มิติ flat เช่น sources คืนค่าตัวเองอยู่แล้ว ผลไม่เปลี่ยน)
- ส่ง `dim_only_self` ผ่าน `options` ครบทั้ง 5 model (PDF/XLSX export รับค่าอัตโนมัติ)
- ทำแบบ DRY: เพิ่ม optional checkbox เข้าไปใน component กลาง `MultiRecordSelect` (props `withOnlySelf`/`onlySelf`/`onOnlySelfChange`) — แต่ละรายงานแค่ wire `state.dimOnlySelf` + handler เดียว ใส่ครบทั้ง 4 มิติ
- **Backward compatible**: ไม่ติ๊ก = พฤติกรรมเดิม (รวมตัวลูก)

## i18n
เพิ่มใน `th.po`: `"Expand all"` → "ขยายทุกแถว", `"Only the specified entry"` → "เฉพาะรายการที่เลือก (ไม่รวมระดับย่อย)"

## ไฟล์ที่แก้ (19)
Python 6 · JS 6 · XML 5 · SCSS 1 · i18n 1

## Verification
- ✅ Python compile ผ่านทั้ง 6 model
- ✅ XML well-formed ทั้ง 5 template (`xmllint`)
- ✅ ไม่มี reference `HIERARCHICAL_DIMS` หลงเหลือ, callers อัปเดตครบ 5 จุด, RPC wire ครบ GL/GJ
- ⏳ ยังไม่ได้รัน `oca_run_tests` / `pre-commit` / ทดสอบบนเบราว์เซอร์ (รอ reviewer หรือสั่งเพิ่ม)