### PR TITLE
[16.0][ADD] budget_revenue_comparison: budget vs actual revenue report

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -8,6 +8,7 @@ This map is seeded lazily — modules are listed here as they get a `CONTEXT.md`
 
 - [KRIS Project](./kris_project/CONTEXT.md) — revenue tracking for projects run under the KRIS unit (operating unit `99`); external academic-service and research work channelled through KRIS.
 - [Budget](./budget/CONTEXT.md) — appropriation, reservation and disbursement tracking; appropriated pool (`budget.move`) consumed through a reserve→obligate→consume commitment pipeline (`budget.commitment`).
+- [Budget Revenue Comparison](./budget_revenue_comparison/CONTEXT.md) — configurable report setting **budgeted revenue** (`budget.move`, revenue codes) beside **actual revenue** (`account.move.line`, income types) row by row; each row carries two independent selectors because the budget chart and the CoA have no stored link.
 - [Procurement Plan](./procurement_plan/CONTEXT.md) — annual procurement planning; each plan is created from an appropriation, reserves its budget at that moment, and is realised through one purchase request + installment disbursements.
 - [KMITL Project](./kmitl_project/CONTEXT.md) — institutional project/activity planning (โครงการ/กิจกรรม); a project draws from a *floating* project-type budget pool, reserves its full budget when confirmed, then spends like a procurement plan.
 - [Accounting Reports](./accounting_kmitl_reports/CONTEXT.md) — financial-statement reports (Trial Balance, P&L, Balance Sheet, Cash Flow) over the GL (`account.move.line`), filterable by the KMITL accounting dimensions.

--- a/budget_revenue_comparison/CONTEXT.md
+++ b/budget_revenue_comparison/CONTEXT.md
@@ -14,7 +14,15 @@ _Avoid_: cash received, collections, receipts (those imply cash basis, which is 
 
 **Percentage (%)**:
 Actual ÷ Budget × 100 — the share of the annual revenue target realized. Rendered to 2 decimals; shown as a dash (`–`) when Budget is zero (a percentage of nothing is meaningless). Header rows carry no percentage; total rows take it from their own Budget/Actual figures.
-_Avoid_: variance, achievement ratio (keep the single label "Percentage")
+_Avoid_: achievement ratio (keep the single label "Percentage")
+
+**Variance (ส่วนต่าง)**:
+Actual − Budget — the absolute gap between realized and budgeted revenue. Positive (revenue met or exceeded the target) renders green, negative (a shortfall) renders red. Unlike Percentage it is defined even when Budget is zero. Header/department rows carry none.
+_Avoid_: difference, gap (keep the single label "Variance / ส่วนต่าง"); do not conflate with Percentage
+
+**Report dimensions (มิติที่ใช้กรอง/จำแนก)**:
+Only **Department (ส่วนงาน)** and **Source (แหล่งเงิน)** apply — estimated revenue budget is not allocated by Fund or Activity, so those two dimensions are deliberately excluded from both the filters and the group-by axis. Department additionally serves as the optional group-by section axis; both are read from `analytic_distribution`.
+_Avoid_: funds, activities (not used here), the four-dimension set (that is the accounting-reports module)
 
 **Indicator (ตัวชี้วัด)**:
 A configured row of the report (`budget.revenue.report.line`), carrying a label, a `sequence`, a `row_type` (`header` / `line` / `total`), and — for `line`/`total` rows — two free-text formulas: a **budget formula** (`B[...]` over revenue budget codes) and an **actual formula** (`A[...]` over GL income accounts). The report is the flat, sequence-ordered list of these rows; there is no parent-child nesting and no auto-summing (a total row sums via its own formula, e.g. `B['4%']`).

--- a/budget_revenue_comparison/CONTEXT.md
+++ b/budget_revenue_comparison/CONTEXT.md
@@ -1,0 +1,21 @@
+# Budget Revenue Comparison
+
+A configurable report that compares **budgeted revenue** (from the budget chart) against **actual revenue** (from the General Ledger), row by row, for a fiscal period. The budget chart and the Chart of Accounts are parallel charts with no stored link between them, so each report row carries two independent selectors — one over budget codes, one over GL accounts — and the report sets the two figures side by side.
+
+## Language
+
+**Budget Revenue (งบประมาณรายรับ)**:
+The *Budget* column. The current revenue budget for the **whole fiscal year** = the net of posted `budget.move` lines on revenue-typed budget accounts (`budget.account.budget_type = "revenue"`) whose `move_type` is `appropriation` or `entry` (**excluding** `consume`) — initial appropriation plus supplementary plus transfers, i.e. the revenue-side analogue of the budget glossary's *Current Budget (a)*. Scoped by the fiscal-year FK (`account_fiscal_year_id`), never by a partial date range. "Posted" is the default of a screen toggle (`only_posted`); turning it off widens both columns to every non-cancelled move. A planned/target figure, not money received.
+_Avoid_: revenue target, actual revenue (that is the other column), งบคงเหลือ
+
+**Actual Revenue (รายรับจริง)**:
+The *Actual* column. Revenue actually recognized in the General Ledger = posted `account.move.line` on income-type accounts (`account.account.account_type ∈ {income, income_other}`), dated within the report's date range — which defaults to the fiscal year but whose end (`date_to`) is an editable **as-of** date. It is recognized/earned revenue, **not** cash received (the GL carries no cash-basis tagging). The deliberate **full-year Budget vs to-date Actual** asymmetry is what makes the Percentage read as "% of the annual revenue target realized so far."
+_Avoid_: cash received, collections, receipts (those imply cash basis, which is not tracked)
+
+**Percentage (%)**:
+Actual ÷ Budget × 100 — the share of the annual revenue target realized. Rendered to 2 decimals; shown as a dash (`–`) when Budget is zero (a percentage of nothing is meaningless). Header rows carry no percentage; total rows take it from their own Budget/Actual figures.
+_Avoid_: variance, achievement ratio (keep the single label "Percentage")
+
+**Indicator (ตัวชี้วัด)**:
+A configured row of the report (`budget.revenue.report.line`), carrying a label, a `sequence`, a `row_type` (`header` / `line` / `total`), and — for `line`/`total` rows — two free-text formulas: a **budget formula** (`B[...]` over revenue budget codes) and an **actual formula** (`A[...]` over GL income accounts). The report is the flat, sequence-ordered list of these rows; there is no parent-child nesting and no auto-summing (a total row sums via its own formula, e.g. `B['4%']`).
+_Avoid_: KPI (reserve for MIS Builder's `mis.report.kpi`, a different engine), line item

--- a/budget_revenue_comparison/README.rst
+++ b/budget_revenue_comparison/README.rst
@@ -20,6 +20,8 @@ Columns
 * **รายรับจริง (Actual)** — recognized revenue from the General Ledger
   (posted ``account.move.line`` on income-type accounts) up to the chosen
   as-of date
+* **ส่วนต่าง (Variance)** — Actual − Budget; green when revenue met/exceeded
+  the target, red when short
 * **%** — Actual ÷ Budget × 100 (dash when Budget is zero)
 
 The full-year Budget vs to-date Actual asymmetry makes the percentage read as
@@ -47,8 +49,10 @@ Output
 ======
 
 * Interactive OWL screen (budget *รายงาน* menu), filterable by fiscal year, an
-  as-of date, posted-only, and the four KMITL accounting dimensions
-  (department / source / fund / activity)
+  as-of date, posted-only, and the **Department** and **Source** dimensions
+  (Fund / Activity are excluded — estimated revenue budget is not allocated by
+  them). A *จำแนกตามส่วนงาน* toggle breaks the report into one section per
+  department.
 * XLSX export sharing the same compute
 
 This module deliberately does **not** use OCA MIS Builder; see

--- a/budget_revenue_comparison/README.rst
+++ b/budget_revenue_comparison/README.rst
@@ -1,0 +1,56 @@
+==================================
+KMITL Budget Revenue Comparison
+==================================
+
+Configurable report that sets **budgeted revenue** (งบประมาณรายรับ) beside
+**actual revenue** (รายรับจริง), row by row, for a fiscal period.
+
+Because KMITL's budget chart (``budget.account``) and the accounting Chart of
+Accounts (``account.account``) are parallel charts with **no stored link**,
+each report row carries two independent free-text formulas — one over budget
+codes, one over GL accounts.
+
+Columns
+=======
+
+* **ตัวชี้วัด (Indicator)** — the row label
+* **งบประมาณรายรับ (Budget)** — the *current* revenue budget for the whole
+  fiscal year (posted ``budget.move`` lines on revenue codes, appropriation +
+  entry, excluding consume)
+* **รายรับจริง (Actual)** — recognized revenue from the General Ledger
+  (posted ``account.move.line`` on income-type accounts) up to the chosen
+  as-of date
+* **%** — Actual ÷ Budget × 100 (dash when Budget is zero)
+
+The full-year Budget vs to-date Actual asymmetry makes the percentage read as
+"% of the annual revenue target realized so far".
+
+Configuring rows
+================
+
+Configuration ▸ *ตัวชี้วัดเปรียบเทียบรายรับ* (Budget Manager only). Each row has:
+
+* **ประเภทแถว (Row type)** — ``หัวข้อ`` (header, no figures) / ``รายการ`` (line) /
+  ``รวม`` (total; emphasised, computed from its own formula)
+* **ลำดับ (Sequence)** — drag to order
+* **สูตรงบประมาณรายรับ (Budget formula)** — ``B['<code-pattern>']``, e.g.
+  ``B['41%']`` (all revenue codes starting 41). Arithmetic ``+ - * / ()`` allowed.
+* **สูตรรายรับจริง (Actual formula)** — ``A['<selector>']``, where an
+  alphabetic selector matches ``account_type`` (``A['income']``) and a numeric
+  selector matches the CoA code (``A['41%']``). Revenue is credit-positive, so
+  no leading ``-`` is needed.
+
+Formulas are validated on save and evaluated with Odoo ``safe_eval`` (no
+builtins exposed).
+
+Output
+======
+
+* Interactive OWL screen (budget *รายงาน* menu), filterable by fiscal year, an
+  as-of date, posted-only, and the four KMITL accounting dimensions
+  (department / source / fund / activity)
+* XLSX export sharing the same compute
+
+This module deliberately does **not** use OCA MIS Builder; see
+``docs/adr/0001-bespoke-report-not-mis-builder.md`` and
+``docs/adr/0002-two-namespace-formula-language.md``.

--- a/budget_revenue_comparison/__init__.py
+++ b/budget_revenue_comparison/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/budget_revenue_comparison/__manifest__.py
+++ b/budget_revenue_comparison/__manifest__.py
@@ -1,0 +1,32 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "KMITL Budget Revenue Comparison Report",
+    "version": "16.0.1.0.0",
+    "category": "KMITL/Budget",
+    "summary": "Configurable report comparing budgeted revenue with actual "
+    "revenue (งบประมาณรายรับ vs รายรับจริง)",
+    "author": "KMITL",
+    "website": "https://www.kmitl.ac.th",
+    "license": "LGPL-3",
+    "depends": [
+        "budget",
+        "account",
+        "report_xlsx",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/report_action_xlsx.xml",
+        "views/budget_revenue_report_line_views.xml",
+        "views/menuitem.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "budget_revenue_comparison/static/src/budget_revenue_comparison/multi_record_select.js",
+            "budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js",
+            "budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml",
+            "budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss",
+        ],
+    },
+    "installable": True,
+    "auto_install": False,
+}

--- a/budget_revenue_comparison/__manifest__.py
+++ b/budget_revenue_comparison/__manifest__.py
@@ -16,6 +16,7 @@
     "data": [
         "security/ir.model.access.csv",
         "data/report_action_xlsx.xml",
+        "data/budget_revenue_report_line.xml",
         "views/budget_revenue_report_line_views.xml",
         "views/menuitem.xml",
     ],

--- a/budget_revenue_comparison/data/budget_revenue_report_line.xml
+++ b/budget_revenue_comparison/data/budget_revenue_report_line.xml
@@ -11,14 +11,28 @@
         <field name="sequence">2</field>
         <field name="row_type">line</field>
         <field name="name">รายได้จากค่าธรรมเนียมการศึกษา</field>
-        <field name="budget_formula">B['43100%'] + B['412101%'] + B['412400%']</field>
-        <field name="actual_formula">A['412103%']</field>
+        <field name="budget_formula">B['43100'] + B['412101%'] + B['412400%']</field>
+        <field name="actual_formula">A['412101%'] + A['412102%']</field>
     </record>
     <record id="line_revenue_academic_service" model="budget.revenue.report.line">
         <field name="sequence">3</field>
         <field name="row_type">line</field>
         <field name="name">รายได้จากงานบริการวิชาการ</field>
-        <field name="budget_formula">B['43300%'] + B['412103%']</field>
+        <field name="budget_formula">B['43300'] + B['412103%']</field>
         <field name="actual_formula">A['412103%']</field>
+    </record>
+    <record id="line_revenue_benefit" model="budget.revenue.report.line">
+        <field name="sequence">4</field>
+        <field name="row_type">line</field>
+        <field name="name">รายได้จากเงินผลประโยชน์</field>
+        <field name="budget_formula">B['43400'] + B['412104%']</field>
+        <field name="actual_formula">A['412104%']</field>
+    </record>
+    <record id="line_revenue_donation" model="budget.revenue.report.line">
+        <field name="sequence">5</field>
+        <field name="row_type">line</field>
+        <field name="name">รายได้จากการรับบริจาค หรือ เงินอุดหนุน</field>
+        <field name="budget_formula">B['43500'] + B['412200%'] + B['43600'] + B['221%'] + B['223%']</field>
+        <field name="actual_formula">A['412200%'] + A['412105%']</field>
     </record>
 </odoo>

--- a/budget_revenue_comparison/data/budget_revenue_report_line.xml
+++ b/budget_revenue_comparison/data/budget_revenue_report_line.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <!-- Default revenue indicators. noupdate="1": created on install, then left
+         for users to edit freely (a module upgrade will not overwrite them). -->
+    <record id="line_revenue_header" model="budget.revenue.report.line">
+        <field name="sequence">1</field>
+        <field name="row_type">header</field>
+        <field name="name">รายรับ</field>
+    </record>
+    <record id="line_revenue_tuition" model="budget.revenue.report.line">
+        <field name="sequence">2</field>
+        <field name="row_type">line</field>
+        <field name="name">รายได้จากค่าธรรมเนียมการศึกษา</field>
+        <field name="budget_formula">B['43100%'] + B['412101%'] + B['412400%']</field>
+        <field name="actual_formula">A['412103%']</field>
+    </record>
+    <record id="line_revenue_academic_service" model="budget.revenue.report.line">
+        <field name="sequence">3</field>
+        <field name="row_type">line</field>
+        <field name="name">รายได้จากงานบริการวิชาการ</field>
+        <field name="budget_formula">B['43300%'] + B['412103%']</field>
+        <field name="actual_formula">A['412103%']</field>
+    </record>
+</odoo>

--- a/budget_revenue_comparison/data/report_action_xlsx.xml
+++ b/budget_revenue_comparison/data/report_action_xlsx.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- XLSX export. Rendered against the throwaway carrier wizard; the real
+         filters travel in the report ``data`` dict (see the OWL client action's
+         action_export_xlsx), so the spreadsheet mirrors the screen. -->
+    <record id="action_report_budget_revenue_comparison_xlsx" model="ir.actions.report">
+        <field name="name">Budget vs Actual Revenue (XLSX)</field>
+        <field name="model">budget.revenue.comparison.wizard</field>
+        <field name="report_type">xlsx</field>
+        <field name="report_name">budget_revenue_comparison.report_xlsx</field>
+        <field name="report_file">budget_revenue_comparison.report_xlsx</field>
+        <field name="binding_model_id" eval="False" />
+    </record>
+</odoo>

--- a/budget_revenue_comparison/docs/adr/0001-bespoke-report-not-mis-builder.md
+++ b/budget_revenue_comparison/docs/adr/0001-bespoke-report-not-mis-builder.md
@@ -1,0 +1,15 @@
+# Budget-vs-actual-revenue report is a bespoke config model + OWL, not MIS Builder
+
+The report sets **budgeted revenue** (`budget.move`, revenue codes) beside **actual revenue** (`account.move.line`, income types) on each configured row. We build it as our own `budget.revenue.report.line` config model with a custom compute and an OWL screen, **not** on OCA MIS Builder — even though MIS Builder is already in the deployment and natively offers comparison and percentage columns.
+
+The blocker is structural: the budget chart (`budget.account.code`) and the Chart of Accounts (`account.account.code`) are parallel charts with no stored link, so each row needs **two different formulas over two different account-code namespaces**. A MIS Builder KPI exposes exactly **one** expression, evaluated identically for every column regardless of that column's `source` — it physically cannot run a budget-code formula in one column and a CoA formula in the next. Making MIS Builder do it would require either re-keying all budget data into the CoA namespace or writing a custom `ExpressionEvaluator` plus a new period `source` — significant, fragile machinery for a single report.
+
+## Considered options
+
+- **MIS Builder with `mis_budget` / `mis_budget_by_account` sources** — its budget columns map onto the *same* KPI expression as the actuals column, so they only work when budget data lives in the account.account namespace. Ours doesn't, and we are not going to mirror the budget chart into the CoA.
+- **MIS Builder with a custom `ExpressionEvaluator` + new `source`** — the only way to keep two genuinely different formulas on one KPI, but it means subclassing core MIS internals and shipping a new column source. Too much surface area, and it couples a budget report to the MIS framework's release cycle.
+
+## Consequences
+
+- We own a small formula engine (see ADR-0002) and the OWL/XLSX surfaces, mirroring the bespoke pattern already used by Trial Balance / Cash Flow in `accounting_kmitl_reports` — but **without** depending on that module (dependencies are `budget` + `account` + `report_xlsx`, copying the ~80-line dimension-filter mixin).
+- If a future report needs budget-vs-actual on the *expense* side too, this engine generalizes; if MIS Builder ever gains per-source expressions, revisit this.

--- a/budget_revenue_comparison/docs/adr/0002-two-namespace-formula-language.md
+++ b/budget_revenue_comparison/docs/adr/0002-two-namespace-formula-language.md
@@ -1,0 +1,19 @@
+# Each row carries two free-text formulas with `B[...]` / `A[...]` accessors
+
+A report row's Budget figure and Actual figure come from two separate free-text formula fields evaluated by `safe_eval`: `budget_formula` references revenue budget codes via `B['<code-pattern>']`, and `actual_formula` references GL income accounts via `A['<account_type-or-code-pattern>']`. Each accessor resolves to the period sum for the matching accounts; full arithmetic (`+ - * / ()` and constants) is allowed. We chose typed formulas over the simpler "pick a set of accounts" because revenue rows genuinely need within-row arithmetic (e.g. gross income minus a refund sub-account).
+
+Two deliberate semantics:
+- **Disambiguation is automatic** on the actual side — an alphabetic selector (`A['income']`) means `account_type`, a numeric/`%` selector (`A['41%']`) means a CoA code pattern. No collision is possible because CoA codes are digits.
+- **`A[...]` returns credit-positive** (`credit − debit`), so revenue reads as a positive number and a debit refund naturally reduces the figure — authors write natural positive formulas instead of the MIS-style leading `-`. `B[...]` returns `balance` as-is (a revenue appropriation is already a positive balance).
+
+## Considered options
+
+- **Many2many account selection (no expression)** — simplest and eval-free, but cannot express "revenue A minus refund B" inside one row, and newly-created accounts must be added by hand.
+- **Code-pattern / `account_type` selector only (declarative domain, no arithmetic)** — auto-includes matching accounts and fits the numeric charts, but still no within-row arithmetic.
+- **Free-text arithmetic expression (chosen)** — the only option that supports within-row `+`/`−`; the price is a `safe_eval` surface that must be locked down and validated.
+
+## Consequences
+
+- Formulas are compiled/validated on save (`@api.constrains`): only `B`/`A` resolvers and arithmetic are exposed to `safe_eval` (no builtins), and bad syntax or disallowed names raise `ValidationError`.
+- For performance each side is pre-aggregated by account once per period, then each bracket resolves against that cache (the MIS-AEP "one query" approach) — formulas never trigger per-row queries.
+- Cross-row subtotals are **not** auto-summed: a `total` row computes via its own formula (e.g. `B['4%']`), keeping the row list flat and sequence-ordered.

--- a/budget_revenue_comparison/models/__init__.py
+++ b/budget_revenue_comparison/models/__init__.py
@@ -1,0 +1,2 @@
+from . import budget_revenue_report_line
+from . import budget_revenue_comparison_report

--- a/budget_revenue_comparison/models/budget_revenue_comparison_report.py
+++ b/budget_revenue_comparison/models/budget_revenue_comparison_report.py
@@ -15,6 +15,10 @@ _logger = logging.getLogger(__name__)
 DIMENSION_CODES = ("departments", "sources")
 HIERARCHICAL_DIMS = ("departments",)
 
+# The dimension that doubles as the optional group-by section axis (group by
+# ส่วนงาน): excluded from the per-section filters and used as the section key.
+GROUP_BY_DIM = "departments"
+
 # A budget appropriation/transfer move; ``consume`` is excluded so the Budget
 # column is the *Current Budget (a)* (initial + supplementary + transfers).
 BUDGET_MOVE_TYPES = ("appropriation", "entry")
@@ -199,7 +203,7 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
     # ------------------------------------------------------------------
     @api.model
     def _grouped_rows(self, options, lines, dims):
-        dims_wo_dept = {k: v for k, v in dims.items() if k != "departments"}
+        dims_wo_dept = {k: v for k, v in dims.items() if k != GROUP_BY_DIM}
         base_leaves = self._build_dim_leaves(dims_wo_dept)
         rows = []
         for name, dept_leaf in self._department_groups(options, dims, base_leaves):
@@ -219,7 +223,7 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
         departments roll up their descendants (``child_of``); auto-discovered
         departments use their exact id so the sections stay disjoint."""
         Analytic = self.env["account.analytic.account"]
-        selected = dims.get("departments") or []
+        selected = dims.get(GROUP_BY_DIM) or []
         if selected:
             for dept in Analytic.browse(selected).exists():
                 ids = Analytic.search([("id", "child_of", dept.id)]).ids
@@ -389,7 +393,6 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
             "line": workbook.add_format({"indent": 1}),
             "total": workbook.add_format({"bold": True, "top": 1, "indent": 1}),
         }
-        is_bold = {"department", "header", "total"}
 
         sheet.merge_range(0, 0, 0, 4, company.display_name, bold)
         sheet.merge_range(1, 0, 1, 4, _("Budget vs Actual Revenue"), bold)
@@ -419,7 +422,9 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
 
         r = 5
         for row in rows:
-            bold_row = row["row_type"] in is_bold
+            # Every row type except a plain "line" is emphasised (headers,
+            # department sections and totals).
+            bold_row = row["row_type"] != "line"
             sheet.write(r, 0, row["name"] or "", label_fmt.get(row["row_type"]))
             if row["budget"] is not None:
                 sheet.write_number(r, 1, row["budget"], num_bold if bold_row else num)
@@ -435,7 +440,7 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
                 sheet.write_number(
                     r, 4, row["percentage"], pct_bold if bold_row else pct
                 )
-            elif row["row_type"] not in ("header", "department"):
+            elif row["row_type"] in ("line", "total"):
                 sheet.write(r, 4, "–", center)
             r += 1
 

--- a/budget_revenue_comparison/models/budget_revenue_comparison_report.py
+++ b/budget_revenue_comparison/models/budget_revenue_comparison_report.py
@@ -17,6 +17,11 @@ HIERARCHICAL_DIMS = ("departments", "funds", "activities")
 # column is the *Current Budget (a)* (initial + supplementary + transfers).
 BUDGET_MOVE_TYPES = ("appropriation", "entry")
 
+# GL income account types -- used only to bound the auto-discovery of which
+# departments appear in the revenue data (the row formulas still decide what
+# actually counts in each figure).
+INCOME_TYPES = ("income", "income_other")
+
 
 class BudgetRevenueComparisonReport(models.AbstractModel):
     """Budget-vs-Actual revenue report.
@@ -60,53 +65,56 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
         )
 
     # ------------------------------------------------------------------
-    # Per-side aggregation -- one read_group each, regardless of how many rows
-    # or brackets the formulas use.
+    # Domain builders + per-side aggregation. ``leaves`` are extra domain
+    # leaves (dimension filters and/or a per-department group scope), so the
+    # same aggregators serve the flat report, each department section and the
+    # grand total -- one read_group per call regardless of formula count.
     # ------------------------------------------------------------------
     @api.model
-    def _aggregate_budget(self, options):
-        """``{budget_code: balance}`` of the current revenue budget for the
-        whole fiscal year (appropriation + entry, excluding consume)."""
-        fy_id = options.get("fiscal_year_id")
-        if not fy_id:
-            return {}
-        domain = [
+    def _budget_domain(self, options, leaves):
+        return [
             ("company_id", "=", options["company_id"]),
-            ("account_fiscal_year_id", "=", fy_id),
+            ("account_fiscal_year_id", "=", options["fiscal_year_id"]),
             ("budget_type", "=", "revenue"),
             ("move_type", "in", list(BUDGET_MOVE_TYPES)),
-        ] + self._state_leaf(options["only_posted"]) + self._build_dim_leaves(
-            options.get("dims") or {}
-        )
+        ] + self._state_leaf(options["only_posted"]) + list(leaves)
+
+    @api.model
+    def _actual_domain(self, options, leaves):
+        return [
+            ("company_id", "=", options["company_id"]),
+            ("date", ">=", options["date_from"]),
+            ("date", "<=", options["date_to"]),
+        ] + self._state_leaf(options["only_posted"]) + list(leaves)
+
+    @api.model
+    def _aggregate_budget(self, options, leaves):
+        """``{budget_code: balance}`` of the current revenue budget for the
+        whole fiscal year (appropriation + entry, excluding consume)."""
+        if not options.get("fiscal_year_id"):
+            return {}
         groups = self.env["budget.move.line"].read_group(
-            domain, ["balance:sum"], ["code"]
+            self._budget_domain(options, leaves), ["balance:sum"], ["code"]
         )
         return {
             g["code"]: (g.get("balance") or 0.0) for g in groups if g.get("code")
         }
 
     @api.model
-    def _aggregate_actual(self, options):
+    def _aggregate_actual(self, options, leaves):
         """List of ``{'code', 'type', 'value'}`` for GL accounts with activity
         in the date range, where ``value`` is credit-positive (``credit -
-        debit``) so revenue reads as a positive number."""
-        date_from = options.get("date_from")
-        date_to = options.get("date_to")
-        if not date_from or not date_to:
+        debit``) so revenue reads as a positive number. No account_type
+        restriction on purpose: the row's actual formula scopes the accounts
+        (``A['income']`` by type, ``A['41%']`` by code), so pre-aggregating
+        every account keeps code-based selectors working for non-income
+        accounts too."""
+        if not options.get("date_from") or not options.get("date_to"):
             return []
-        # No account_type restriction here on purpose: the row's actual formula
-        # is what scopes the accounts (``A['income']`` by type, ``A['41%']`` by
-        # code), so pre-aggregating every account keeps code-based selectors
-        # working for accounts that are not income-typed.
-        domain = [
-            ("company_id", "=", options["company_id"]),
-            ("date", ">=", date_from),
-            ("date", "<=", date_to),
-        ] + self._state_leaf(options["only_posted"]) + self._build_dim_leaves(
-            options.get("dims") or {}
-        )
         groups = self.env["account.move.line"].read_group(
-            domain, ["debit:sum", "credit:sum"], ["account_id"]
+            self._actual_domain(options, leaves),
+            ["debit:sum", "credit:sum"],
+            ["account_id"],
         )
         acc_ids = [g["account_id"][0] for g in groups if g.get("account_id")]
         info = {
@@ -137,10 +145,11 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
 
         ``options`` keys: ``company_id``, ``fiscal_year_id`` (drives the
         full-year Budget column), ``date_from`` / ``date_to`` (drive the
-        to-date Actual column), ``only_posted`` (bool) and ``dims``
-        (``{code: [analytic_account_ids]}``). Each row is
-        ``{id, row_type, name, budget, actual, percentage}`` -- header rows
-        carry ``None`` for the three figures.
+        to-date Actual column), ``only_posted`` (bool), ``dims``
+        (``{code: [analytic_account_ids]}``) and ``group_by_department``
+        (bool). Each row is ``{id, row_type, name, budget, actual,
+        percentage}``; ``header`` and ``department`` rows carry ``None`` for
+        the three figures.
         """
         options = options or {}
         company_id = options.get("company_id") or self.env.company.id
@@ -151,14 +160,25 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
             company_id=company_id,
             only_posted=bool(options.get("only_posted", True)),
         )
+        dims = options.get("dims") or {}
 
         lines = self.env["budget.revenue.report.line"].search(
             [("company_id", "=", company_id)], order="sequence, id"
         )
 
-        budget = BudgetResolver(self._aggregate_budget(options))
-        actual = ActualResolver(self._aggregate_actual(options))
+        if options.get("group_by_department"):
+            rows = self._grouped_rows(options, lines, dims)
+        else:
+            rows = self._section_rows(options, lines, self._build_dim_leaves(dims))
 
+        return {"rows": rows, "currency_id": company.currency_id.id}
+
+    @api.model
+    def _section_rows(self, options, lines, leaves):
+        """The indicator rows (report body) computed against ``leaves`` --
+        reused for the flat report, each department section and the total."""
+        budget = BudgetResolver(self._aggregate_budget(options, leaves))
+        actual = ActualResolver(self._aggregate_actual(options, leaves))
         rows = []
         for line in lines:
             if line.row_type == "header":
@@ -167,8 +187,103 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
             budget_amount = self._eval(line, line.budget_formula, budget, actual)
             actual_amount = self._eval(line, line.actual_formula, budget, actual)
             rows.append(self._row(line, budget_amount, actual_amount))
+        return rows
 
-        return {"rows": rows, "currency_id": company.currency_id.id}
+    # ------------------------------------------------------------------
+    # Group by department -- the department dimension becomes a section axis;
+    # the other three dimensions still filter within each section. The grouping
+    # is derived from ``analytic_distribution`` only (no reliance on the stored
+    # department_analytic_id mirror).
+    # ------------------------------------------------------------------
+    @api.model
+    def _grouped_rows(self, options, lines, dims):
+        dims_wo_dept = {k: v for k, v in dims.items() if k != "departments"}
+        base_leaves = self._build_dim_leaves(dims_wo_dept)
+        rows = []
+        for name, dept_leaf in self._department_groups(options, dims, base_leaves):
+            section = self._section_rows(options, lines, base_leaves + [dept_leaf])
+            if not self._section_has_data(section):
+                continue
+            rows.append(self._section_header_row(name))
+            rows.extend(section)
+        # Grand total: respects an explicit department selection, else all data.
+        rows.append(self._section_header_row(_("รวมทุกส่วนงาน")))
+        rows.extend(self._section_rows(options, lines, self._build_dim_leaves(dims)))
+        return rows
+
+    @api.model
+    def _department_groups(self, options, dims, base_leaves):
+        """Yield ``(name, leaf)`` per department section. Explicitly selected
+        departments roll up their descendants (``child_of``); auto-discovered
+        departments use their exact id so the sections stay disjoint."""
+        Analytic = self.env["account.analytic.account"]
+        selected = dims.get("departments") or []
+        if selected:
+            for dept in Analytic.browse(selected).exists():
+                ids = Analytic.search([("id", "child_of", dept.id)]).ids
+                yield dept.display_name, ("analytic_distribution", "in", ids)
+        else:
+            for dept in Analytic.browse(self._discover_department_ids(options, base_leaves)):
+                yield dept.display_name, ("analytic_distribution", "in", [dept.id])
+
+    @api.model
+    def _discover_department_ids(self, options, base_leaves):
+        """Department analytic accounts that actually appear in the period's
+        data, extracted from the ``analytic_distribution`` JSON of both the
+        revenue budget lines and the income GL lines (ordered by the analytic
+        plan for a stable display)."""
+        dept_ids = set(
+            self.env["account.analytic.account"]
+            .search([("root_plan_id.code", "=", "departments")])
+            .ids
+        )
+        if not dept_ids:
+            return []
+        sources = []
+        if options.get("fiscal_year_id"):
+            sources.append(
+                ("budget.move.line", self._budget_domain(options, base_leaves))
+            )
+        if options.get("date_from") and options.get("date_to"):
+            sources.append(
+                (
+                    "account.move.line",
+                    self._actual_domain(options, base_leaves)
+                    + [("account_id.account_type", "in", list(INCOME_TYPES))],
+                )
+            )
+        present = set()
+        for model, domain in sources:
+            for rec in self.env[model].search_read(domain, ["analytic_distribution"]):
+                for key in rec.get("analytic_distribution") or {}:
+                    try:
+                        aid = int(key)
+                    except (TypeError, ValueError):
+                        continue
+                    if aid in dept_ids:
+                        present.add(aid)
+        return (
+            self.env["account.analytic.account"]
+            .search([("id", "in", list(present))])
+            .ids
+        )
+
+    @api.model
+    def _section_header_row(self, name):
+        return {
+            "id": 0,
+            "row_type": "department",
+            "name": name,
+            "budget": None,
+            "actual": None,
+            "percentage": None,
+        }
+
+    @api.model
+    def _section_has_data(self, section):
+        """A section is worth showing if any indicator row carries a non-zero
+        budget or actual figure."""
+        return any(row["budget"] or row["actual"] for row in section)
 
     @api.model
     def _row(self, line, budget_amount, actual_amount):
@@ -248,11 +363,14 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
         center = workbook.add_format({"align": "center"})
 
         label_fmt = {
+            "department": workbook.add_format(
+                {"bold": True, "bg_color": "#e9ecef", "top": 1}
+            ),
             "header": workbook.add_format({"bold": True}),
             "line": workbook.add_format({"indent": 1}),
             "total": workbook.add_format({"bold": True, "top": 1, "indent": 1}),
         }
-        is_bold = {"header", "total"}
+        is_bold = {"department", "header", "total"}
 
         sheet.merge_range(0, 0, 0, 3, company.display_name, bold)
         sheet.merge_range(1, 0, 1, 3, _("Budget vs Actual Revenue"), bold)
@@ -286,7 +404,7 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
                 sheet.write_number(
                     r, 3, row["percentage"], pct_bold if bold_row else pct
                 )
-            elif row["row_type"] != "header":
+            elif row["row_type"] not in ("header", "department"):
                 sheet.write(r, 3, "–", center)
             r += 1
 

--- a/budget_revenue_comparison/models/budget_revenue_comparison_report.py
+++ b/budget_revenue_comparison/models/budget_revenue_comparison_report.py
@@ -1,0 +1,295 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+import logging
+
+from odoo import _, api, models
+
+from .formula import ActualResolver, BudgetResolver, eval_formula
+
+_logger = logging.getLogger(__name__)
+
+# KMITL accounting-dimension plan codes the report can filter on, in display
+# order. Read from each line's ``analytic_distribution`` JSON. ``sources`` is
+# flat; the rest are hierarchical (a pick also matches descendants).
+DIMENSION_CODES = ("departments", "sources", "funds", "activities")
+HIERARCHICAL_DIMS = ("departments", "funds", "activities")
+
+# A budget appropriation/transfer move; ``consume`` is excluded so the Budget
+# column is the *Current Budget (a)* (initial + supplementary + transfers).
+BUDGET_MOVE_TYPES = ("appropriation", "entry")
+
+
+class BudgetRevenueComparisonReport(models.AbstractModel):
+    """Budget-vs-Actual revenue report.
+
+    One shared compute (:meth:`get_comparison_data`) feeds the OWL client
+    action (over RPC) and the XLSX export, so screen and spreadsheet always
+    agree. Each configured row's Budget figure comes from ``budget.move``
+    (revenue codes, full fiscal year) and its Actual figure from
+    ``account.move.line`` (income postings, to the as-of date) -- two
+    independent formulas because the budget chart and the CoA have no link.
+    """
+
+    _name = "budget.revenue.comparison.report"
+    _description = "Budget Revenue Comparison Report"
+
+    # ------------------------------------------------------------------
+    # Dimension filtering (inlined; this module does not depend on
+    # accounting_kmitl_reports). Same ``analytic_distribution`` leaves the
+    # other KMITL reports build, applied to both the budget and the GL side.
+    # ------------------------------------------------------------------
+    @api.model
+    def _build_dim_leaves(self, dims):
+        analytic = self.env["account.analytic.account"]
+        use_child = "parent_id" in analytic._fields
+        leaves = []
+        for code in DIMENSION_CODES:
+            ids = (dims or {}).get(code) or []
+            if not ids:
+                continue
+            if code in HIERARCHICAL_DIMS and use_child:
+                ids = analytic.search([("id", "child_of", ids)]).ids
+            leaves.append(("analytic_distribution", "in", ids))
+        return leaves
+
+    @api.model
+    def _state_leaf(self, only_posted):
+        return (
+            [("parent_state", "=", "posted")]
+            if only_posted
+            else [("parent_state", "!=", "cancel")]
+        )
+
+    # ------------------------------------------------------------------
+    # Per-side aggregation -- one read_group each, regardless of how many rows
+    # or brackets the formulas use.
+    # ------------------------------------------------------------------
+    @api.model
+    def _aggregate_budget(self, options):
+        """``{budget_code: balance}`` of the current revenue budget for the
+        whole fiscal year (appropriation + entry, excluding consume)."""
+        fy_id = options.get("fiscal_year_id")
+        if not fy_id:
+            return {}
+        domain = [
+            ("company_id", "=", options["company_id"]),
+            ("account_fiscal_year_id", "=", fy_id),
+            ("budget_type", "=", "revenue"),
+            ("move_type", "in", list(BUDGET_MOVE_TYPES)),
+        ] + self._state_leaf(options["only_posted"]) + self._build_dim_leaves(
+            options.get("dims") or {}
+        )
+        groups = self.env["budget.move.line"].read_group(
+            domain, ["balance:sum"], ["code"]
+        )
+        return {
+            g["code"]: (g.get("balance") or 0.0) for g in groups if g.get("code")
+        }
+
+    @api.model
+    def _aggregate_actual(self, options):
+        """List of ``{'code', 'type', 'value'}`` for GL accounts with activity
+        in the date range, where ``value`` is credit-positive (``credit -
+        debit``) so revenue reads as a positive number."""
+        date_from = options.get("date_from")
+        date_to = options.get("date_to")
+        if not date_from or not date_to:
+            return []
+        # No account_type restriction here on purpose: the row's actual formula
+        # is what scopes the accounts (``A['income']`` by type, ``A['41%']`` by
+        # code), so pre-aggregating every account keeps code-based selectors
+        # working for accounts that are not income-typed.
+        domain = [
+            ("company_id", "=", options["company_id"]),
+            ("date", ">=", date_from),
+            ("date", "<=", date_to),
+        ] + self._state_leaf(options["only_posted"]) + self._build_dim_leaves(
+            options.get("dims") or {}
+        )
+        groups = self.env["account.move.line"].read_group(
+            domain, ["debit:sum", "credit:sum"], ["account_id"]
+        )
+        acc_ids = [g["account_id"][0] for g in groups if g.get("account_id")]
+        info = {
+            a.id: (a.code or "", a.account_type or "")
+            for a in self.env["account.account"].browse(acc_ids)
+        }
+        accounts = []
+        for g in groups:
+            acc = g.get("account_id")
+            if not acc:
+                continue
+            code, atype = info.get(acc[0], ("", ""))
+            accounts.append(
+                {
+                    "code": code,
+                    "type": atype,
+                    "value": (g.get("credit") or 0.0) - (g.get("debit") or 0.0),
+                }
+            )
+        return accounts
+
+    # ------------------------------------------------------------------
+    # Shared compute
+    # ------------------------------------------------------------------
+    @api.model
+    def get_comparison_data(self, options):
+        """Compute the report for ``options`` and return JSON-friendly rows.
+
+        ``options`` keys: ``company_id``, ``fiscal_year_id`` (drives the
+        full-year Budget column), ``date_from`` / ``date_to`` (drive the
+        to-date Actual column), ``only_posted`` (bool) and ``dims``
+        (``{code: [analytic_account_ids]}``). Each row is
+        ``{id, row_type, name, budget, actual, percentage}`` -- header rows
+        carry ``None`` for the three figures.
+        """
+        options = options or {}
+        company_id = options.get("company_id") or self.env.company.id
+        company = self.env["res.company"].browse(company_id)
+        # Normalise once so the aggregators read a complete options dict.
+        options = dict(
+            options,
+            company_id=company_id,
+            only_posted=bool(options.get("only_posted", True)),
+        )
+
+        lines = self.env["budget.revenue.report.line"].search(
+            [("company_id", "=", company_id)], order="sequence, id"
+        )
+
+        budget = BudgetResolver(self._aggregate_budget(options))
+        actual = ActualResolver(self._aggregate_actual(options))
+
+        rows = []
+        for line in lines:
+            if line.row_type == "header":
+                rows.append(self._row(line, None, None))
+                continue
+            budget_amount = self._eval(line, line.budget_formula, budget, actual)
+            actual_amount = self._eval(line, line.actual_formula, budget, actual)
+            rows.append(self._row(line, budget_amount, actual_amount))
+
+        return {"rows": rows, "currency_id": company.currency_id.id}
+
+    @api.model
+    def _row(self, line, budget_amount, actual_amount):
+        # Percentage is meaningful only against a non-zero budget; the OWL/XLSX
+        # layers render ``None`` as a dash.
+        percentage = (
+            (actual_amount / budget_amount * 100.0) if budget_amount else None
+        )
+        return {
+            "id": line.id,
+            "row_type": line.row_type,
+            "name": line.name,
+            "budget": budget_amount,
+            "actual": actual_amount,
+            "percentage": percentage,
+        }
+
+    @api.model
+    def _eval(self, line, formula, budget, actual):
+        """Evaluate one formula, never letting a bad row crash the whole
+        report (formulas are validated on save, so this is belt-and-braces)."""
+        try:
+            return eval_formula(formula, budget, actual)
+        except Exception:  # noqa: BLE001
+            _logger.warning(
+                "budget_revenue_comparison: bad formula on row %s (%s): %s",
+                line.id,
+                line.name,
+                formula,
+            )
+            return 0.0
+
+    # ------------------------------------------------------------------
+    # XLSX export -- return the report action so the OWL client action can
+    # ``doAction`` it. Filters travel in ``data`` (no persisted state), so the
+    # spreadsheet mirrors the screen exactly.
+    # ------------------------------------------------------------------
+    @api.model
+    def action_export_xlsx(self, options):
+        options = options or {}
+        carrier = self.env["budget.revenue.comparison.wizard"].create(
+            {
+                "company_id": options.get("company_id") or self.env.company.id,
+                "fiscal_year_id": options.get("fiscal_year_id"),
+                "date_from": options.get("date_from"),
+                "date_to": options.get("date_to"),
+            }
+        )
+        report = self.env.ref(
+            "budget_revenue_comparison.action_report_budget_revenue_comparison_xlsx"
+        )
+        return report.report_action(carrier, data={"options": options})
+
+
+class BudgetRevenueComparisonXlsx(models.AbstractModel):
+    """XLSX export -- shares the compute with the screen so the two agree."""
+
+    _name = "report.budget_revenue_comparison.report_xlsx"
+    _description = "Budget Revenue Comparison XLSX"
+    _inherit = "report.report_xlsx.abstract"
+
+    def generate_xlsx_report(self, workbook, data, objs):
+        options = (data or {}).get("options") or {}
+        report = self.env["budget.revenue.comparison.report"]
+        result = report.get_comparison_data(options)
+        rows = result["rows"]
+        company = self.env["res.company"].browse(
+            options.get("company_id") or self.env.company.id
+        )
+
+        sheet = workbook.add_worksheet(_("Budget vs Actual Revenue"))
+        bold = workbook.add_format({"bold": True})
+        num = workbook.add_format({"num_format": "#,##0.00"})
+        num_bold = workbook.add_format({"bold": True, "num_format": "#,##0.00"})
+        pct = workbook.add_format({"num_format": '#,##0.00"%"'})
+        pct_bold = workbook.add_format({"bold": True, "num_format": '#,##0.00"%"'})
+        center = workbook.add_format({"align": "center"})
+
+        label_fmt = {
+            "header": workbook.add_format({"bold": True}),
+            "line": workbook.add_format({"indent": 1}),
+            "total": workbook.add_format({"bold": True, "top": 1, "indent": 1}),
+        }
+        is_bold = {"header", "total"}
+
+        sheet.merge_range(0, 0, 0, 3, company.display_name, bold)
+        sheet.merge_range(1, 0, 1, 3, _("Budget vs Actual Revenue"), bold)
+        sheet.merge_range(
+            2,
+            0,
+            2,
+            3,
+            "%s %s %s %s"
+            % (
+                _("From"),
+                options.get("date_from") or "",
+                _("to"),
+                options.get("date_to") or "",
+            ),
+        )
+
+        headers = [_("Indicator"), _("Budget"), _("Actual"), _("%")]
+        for col, title in enumerate(headers):
+            sheet.write(4, col, title, bold if col == 0 else center)
+
+        r = 5
+        for row in rows:
+            bold_row = row["row_type"] in is_bold
+            sheet.write(r, 0, row["name"] or "", label_fmt.get(row["row_type"]))
+            if row["budget"] is not None:
+                sheet.write_number(r, 1, row["budget"], num_bold if bold_row else num)
+            if row["actual"] is not None:
+                sheet.write_number(r, 2, row["actual"], num_bold if bold_row else num)
+            if row["percentage"] is not None:
+                sheet.write_number(
+                    r, 3, row["percentage"], pct_bold if bold_row else pct
+                )
+            elif row["row_type"] != "header":
+                sheet.write(r, 3, "–", center)
+            r += 1
+
+        sheet.set_column(0, 0, 48)
+        sheet.set_column(1, 2, 18)
+        sheet.set_column(3, 3, 12)

--- a/budget_revenue_comparison/models/budget_revenue_comparison_report.py
+++ b/budget_revenue_comparison/models/budget_revenue_comparison_report.py
@@ -8,10 +8,12 @@ from .formula import ActualResolver, BudgetResolver, eval_formula
 _logger = logging.getLogger(__name__)
 
 # KMITL accounting-dimension plan codes the report can filter on, in display
-# order. Read from each line's ``analytic_distribution`` JSON. ``sources`` is
-# flat; the rest are hierarchical (a pick also matches descendants).
-DIMENSION_CODES = ("departments", "sources", "funds", "activities")
-HIERARCHICAL_DIMS = ("departments", "funds", "activities")
+# order. Read from each line's ``analytic_distribution`` JSON. Only Department
+# and Source apply here -- estimated revenue budget is not allocated by Fund or
+# Activity, so those dimensions are intentionally excluded. ``sources`` is
+# flat; ``departments`` is hierarchical (a pick also matches descendants).
+DIMENSION_CODES = ("departments", "sources")
+HIERARCHICAL_DIMS = ("departments",)
 
 # A budget appropriation/transfer move; ``consume`` is excluded so the Budget
 # column is the *Current Budget (a)* (initial + supplementary + transfers).
@@ -276,6 +278,7 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
             "name": name,
             "budget": None,
             "actual": None,
+            "variance": None,
             "percentage": None,
         }
 
@@ -288,9 +291,15 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
     @api.model
     def _row(self, line, budget_amount, actual_amount):
         # Percentage is meaningful only against a non-zero budget; the OWL/XLSX
-        # layers render ``None`` as a dash.
+        # layers render ``None`` as a dash. Variance = Actual - Budget (positive
+        # means revenue exceeded the target).
         percentage = (
             (actual_amount / budget_amount * 100.0) if budget_amount else None
+        )
+        variance = (
+            actual_amount - budget_amount
+            if actual_amount is not None and budget_amount is not None
+            else None
         )
         return {
             "id": line.id,
@@ -298,6 +307,7 @@ class BudgetRevenueComparisonReport(models.AbstractModel):
             "name": line.name,
             "budget": budget_amount,
             "actual": actual_amount,
+            "variance": variance,
             "percentage": percentage,
         }
 
@@ -361,6 +371,15 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
         pct = workbook.add_format({"num_format": '#,##0.00"%"'})
         pct_bold = workbook.add_format({"bold": True, "num_format": '#,##0.00"%"'})
         center = workbook.add_format({"align": "center"})
+        # Variance: green when revenue >= budget, red when short.
+        var_pos = workbook.add_format({"num_format": "#,##0.00", "font_color": "#1c7c3a"})
+        var_neg = workbook.add_format({"num_format": "#,##0.00", "font_color": "#c0392b"})
+        var_pos_bold = workbook.add_format(
+            {"bold": True, "num_format": "#,##0.00", "font_color": "#1c7c3a"}
+        )
+        var_neg_bold = workbook.add_format(
+            {"bold": True, "num_format": "#,##0.00", "font_color": "#c0392b"}
+        )
 
         label_fmt = {
             "department": workbook.add_format(
@@ -372,13 +391,13 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
         }
         is_bold = {"department", "header", "total"}
 
-        sheet.merge_range(0, 0, 0, 3, company.display_name, bold)
-        sheet.merge_range(1, 0, 1, 3, _("Budget vs Actual Revenue"), bold)
+        sheet.merge_range(0, 0, 0, 4, company.display_name, bold)
+        sheet.merge_range(1, 0, 1, 4, _("Budget vs Actual Revenue"), bold)
         sheet.merge_range(
             2,
             0,
             2,
-            3,
+            4,
             "%s %s %s %s"
             % (
                 _("From"),
@@ -388,7 +407,13 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
             ),
         )
 
-        headers = [_("Indicator"), _("Budget"), _("Actual"), _("%")]
+        headers = [
+            _("Indicator"),
+            _("Budget"),
+            _("Actual"),
+            _("Variance"),
+            _("%"),
+        ]
         for col, title in enumerate(headers):
             sheet.write(4, col, title, bold if col == 0 else center)
 
@@ -400,14 +425,20 @@ class BudgetRevenueComparisonXlsx(models.AbstractModel):
                 sheet.write_number(r, 1, row["budget"], num_bold if bold_row else num)
             if row["actual"] is not None:
                 sheet.write_number(r, 2, row["actual"], num_bold if bold_row else num)
+            if row["variance"] is not None:
+                if row["variance"] < 0:
+                    var_fmt = var_neg_bold if bold_row else var_neg
+                else:
+                    var_fmt = var_pos_bold if bold_row else var_pos
+                sheet.write_number(r, 3, row["variance"], var_fmt)
             if row["percentage"] is not None:
                 sheet.write_number(
-                    r, 3, row["percentage"], pct_bold if bold_row else pct
+                    r, 4, row["percentage"], pct_bold if bold_row else pct
                 )
             elif row["row_type"] not in ("header", "department"):
-                sheet.write(r, 3, "–", center)
+                sheet.write(r, 4, "–", center)
             r += 1
 
         sheet.set_column(0, 0, 48)
-        sheet.set_column(1, 2, 18)
-        sheet.set_column(3, 3, 12)
+        sheet.set_column(1, 3, 18)
+        sheet.set_column(4, 4, 12)

--- a/budget_revenue_comparison/models/budget_revenue_report_line.py
+++ b/budget_revenue_comparison/models/budget_revenue_report_line.py
@@ -1,0 +1,95 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+from .formula import validate_formula
+
+
+class BudgetRevenueReportLine(models.Model):
+    """A configured row (indicator) of the Budget-vs-Actual-Revenue report.
+
+    The report is the flat, ``sequence``-ordered list of these rows. Each
+    ``line``/``total`` row carries two free-text formulas -- a budget formula
+    (``B[...]`` over revenue budget codes) and an actual formula (``A[...]``
+    over GL income accounts) -- which the report compute evaluates per period.
+    ``header`` rows are titles only and carry no formulas or figures. There is
+    no parent-child nesting: a total row sums via its own formula (e.g.
+    ``B['4%']``), not by aggregating other rows.
+    """
+
+    _name = "budget.revenue.report.line"
+    _description = "Budget Revenue Comparison Report Line"
+    _order = "sequence, id"
+
+    sequence = fields.Integer(default=10)
+    name = fields.Char(string="ตัวชี้วัด", required=True, translate=True)
+    row_type = fields.Selection(
+        selection=[
+            ("header", "หัวข้อ"),
+            ("line", "รายการ"),
+            ("total", "รวม"),
+        ],
+        string="ประเภทแถว",
+        required=True,
+        default="line",
+        help=(
+            "หัวข้อ = แถวชื่อกลุ่ม ไม่มีค่า; "
+            "รายการ = แถวตัวชี้วัดปกติ มีสูตร; "
+            "รวม = แถวผลรวม (เน้นตัวหนา) คำนวณจากสูตรของตัวเอง"
+        ),
+    )
+    budget_formula = fields.Char(
+        string="สูตรงบประมาณรายรับ",
+        help=(
+            "สูตรฝั่งงบประมาณ อ้างอิงรหัสงบประมาณรายรับด้วย B['<รหัส>'] เช่น "
+            "B['41%'] (ทุกรหัสที่ขึ้นต้น 41) รองรับ + - * / และวงเล็บ"
+        ),
+    )
+    actual_formula = fields.Char(
+        string="สูตรรายรับจริง (CoA)",
+        help=(
+            "สูตรฝั่งบัญชี อ้างอิงผังบัญชีรายได้ด้วย A['<ตัวเลือก>'] เช่น "
+            "A['income'] (ตาม account_type) หรือ A['41%'] (ตามรหัสบัญชี) "
+            "รองรับ + - * / และวงเล็บ; ค่ารายรับเป็นบวกอัตโนมัติ"
+        ),
+    )
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        required=True,
+        default=lambda self: self.env.company,
+    )
+    active = fields.Boolean(default=True)
+
+    @api.onchange("row_type")
+    def _onchange_row_type_clear_formulas(self):
+        """A header row carries no figures, so clear its formulas when the row
+        is switched to ``header`` (mirrors the Odoo convention of clearing the
+        inactive companion inputs of a mode selector)."""
+        if self.row_type == "header":
+            self.budget_formula = False
+            self.actual_formula = False
+
+    @api.constrains("row_type", "budget_formula", "actual_formula")
+    def _check_formulas(self):
+        """Reject formulas that do not compile / dry-run, so a typo surfaces at
+        configuration time rather than blanking a figure on the report."""
+        for line in self:
+            if line.row_type == "header":
+                continue
+            for label, formula in (
+                (_("budget formula"), line.budget_formula),
+                (_("actual formula"), line.actual_formula),
+            ):
+                error = validate_formula(formula)
+                if error:
+                    raise ValidationError(
+                        _(
+                            "Invalid %(label)s on row '%(name)s':\n"
+                            "    %(formula)s\n%(error)s",
+                            label=label,
+                            name=line.name or "",
+                            formula=formula,
+                            error=error,
+                        )
+                    )

--- a/budget_revenue_comparison/models/formula.py
+++ b/budget_revenue_comparison/models/formula.py
@@ -1,0 +1,125 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+"""Two-namespace formula engine for the budget-vs-actual-revenue report.
+
+Each report row carries two free-text formulas evaluated with Odoo's
+``safe_eval``:
+
+* ``budget_formula`` references **revenue budget codes** through ``B['<pat>']``
+* ``actual_formula`` references **GL income accounts** through ``A['<sel>']``
+
+``B`` / ``A`` are resolver objects exposing ``__getitem__`` so a bracket like
+``B['41%']`` becomes ``B.__getitem__('41%')`` -> the period sum for every
+matching account. Full arithmetic (``+ - * / ()`` and numeric constants) is
+allowed; nothing else is, because ``safe_eval`` exposes only ``B`` and ``A``
+(no builtins).
+
+The selectors are SQL-``LIKE``-flavoured (``%`` = any run, ``_`` = one char).
+On the actual side an *alphabetic* selector (``A['income']``) matches
+``account_type`` while a *numeric* selector (``A['41%']``) matches the CoA
+``code`` -- unambiguous because CoA codes are digits.
+"""
+import re
+
+from odoo.tools.safe_eval import safe_eval
+
+# safe_eval globals are rebuilt fresh for every evaluation, so passing
+# ``nocopy=True`` only avoids a redundant shallow copy of the 2-key mapping.
+_EVAL_KW = {"mode": "eval", "nocopy": True}
+
+
+def _like_to_regex(pattern):
+    """Compile an SQL-``LIKE``-style pattern (``%`` any run, ``_`` one char)
+    into an anchored, case-insensitive regex. Every other character is matched
+    literally."""
+    parts = []
+    for ch in pattern or "":
+        if ch == "%":
+            parts.append(".*")
+        elif ch == "_":
+            parts.append(".")
+        else:
+            parts.append(re.escape(ch))
+    return re.compile("^" + "".join(parts) + "$", re.IGNORECASE)
+
+
+class BudgetResolver:
+    """``B['<code-pattern>']`` -> Σ budgeted-revenue balance of matching budget
+    codes. Fed a ``{code: balance}`` mapping pre-aggregated for the period."""
+
+    __slots__ = ("_by_code",)
+
+    def __init__(self, balance_by_code):
+        self._by_code = balance_by_code
+
+    def __getitem__(self, pattern):
+        if not (pattern or "").strip():
+            raise ValueError("empty budget code selector B['']")
+        rx = _like_to_regex(pattern)
+        return sum(
+            bal for code, bal in self._by_code.items() if code and rx.match(code)
+        )
+
+
+class ActualResolver:
+    """``A['<selector>']`` -> Σ credit-positive actual revenue of matching GL
+    accounts. ``selector`` is read as a CoA ``code`` pattern when it is numeric
+    (``A['41%']``), otherwise as an ``account_type`` pattern (``A['income']``,
+    ``A['income%']``). Fed a list of ``{'code', 'type', 'value'}`` dicts where
+    ``value`` is already ``credit - debit`` (so revenue is positive)."""
+
+    __slots__ = ("_accounts",)
+
+    def __init__(self, accounts):
+        self._accounts = accounts
+
+    def __getitem__(self, selector):
+        sel = (selector or "").strip()
+        if not sel:
+            raise ValueError("empty account selector A['']")
+        rx = _like_to_regex(sel)
+        if sel.replace("%", "").replace("_", "").isdigit():
+            # Numeric selector -> match the CoA account code.
+            return sum(
+                a["value"] for a in self._accounts if a["code"] and rx.match(a["code"])
+            )
+        # Alphabetic selector -> match the account_type.
+        return sum(
+            a["value"] for a in self._accounts if a["type"] and rx.match(a["type"])
+        )
+
+
+class _ZeroResolver:
+    """Resolver used for validation: any bracket resolves to ``0.0`` so a
+    formula can be compiled/evaluated to surface syntax or disallowed-name
+    errors without touching the database."""
+
+    def __getitem__(self, key):
+        if not (key or "").strip():
+            raise ValueError("empty account selector")
+        return 0.0
+
+
+def eval_formula(formula, budget_resolver, actual_resolver):
+    """Evaluate one formula against the two resolvers, returning a float.
+    Returns ``0.0`` for an empty formula. Raises whatever ``safe_eval`` raises
+    (callers that must not crash should pre-validate or wrap)."""
+    if not formula:
+        return 0.0
+    result = safe_eval(
+        formula, {"B": budget_resolver, "A": actual_resolver}, **_EVAL_KW
+    )
+    return float(result or 0.0)
+
+
+def validate_formula(formula):
+    """Compile + dry-run a formula with zero-valued resolvers. Returns ``None``
+    on success or a short error string on failure (syntax error, unknown name,
+    disallowed construct). Empty formula is valid."""
+    if not formula:
+        return None
+    try:
+        zero = _ZeroResolver()
+        safe_eval(formula, {"B": zero, "A": zero}, **_EVAL_KW)
+    except Exception as exc:  # noqa: BLE001 - surfaced to the user verbatim
+        return str(exc) or exc.__class__.__name__
+    return None

--- a/budget_revenue_comparison/models/formula.py
+++ b/budget_revenue_comparison/models/formula.py
@@ -19,18 +19,18 @@ On the actual side an *alphabetic* selector (``A['income']``) matches
 ``code`` -- unambiguous because CoA codes are digits.
 """
 import re
+from functools import lru_cache
 
 from odoo.tools.safe_eval import safe_eval
 
-# safe_eval globals are rebuilt fresh for every evaluation, so passing
-# ``nocopy=True`` only avoids a redundant shallow copy of the 2-key mapping.
-_EVAL_KW = {"mode": "eval", "nocopy": True}
 
-
+@lru_cache(maxsize=512)
 def _like_to_regex(pattern):
     """Compile an SQL-``LIKE``-style pattern (``%`` any run, ``_`` one char)
     into an anchored, case-insensitive regex. Every other character is matched
-    literally."""
+    literally. Cached: patterns come from a small fixed set of configured
+    formulas, so the same regex is reused across rows, sections and
+    departments."""
     parts = []
     for ch in pattern or "":
         if ch == "%":
@@ -106,7 +106,7 @@ def eval_formula(formula, budget_resolver, actual_resolver):
     if not formula:
         return 0.0
     result = safe_eval(
-        formula, {"B": budget_resolver, "A": actual_resolver}, **_EVAL_KW
+        formula, {"B": budget_resolver, "A": actual_resolver}, mode="eval"
     )
     return float(result or 0.0)
 
@@ -119,7 +119,7 @@ def validate_formula(formula):
         return None
     try:
         zero = _ZeroResolver()
-        safe_eval(formula, {"B": zero, "A": zero}, **_EVAL_KW)
+        safe_eval(formula, {"B": zero, "A": zero}, mode="eval")
     except Exception as exc:  # noqa: BLE001 - surfaced to the user verbatim
         return str(exc) or exc.__class__.__name__
     return None

--- a/budget_revenue_comparison/security/ir.model.access.csv
+++ b/budget_revenue_comparison/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_budget_revenue_report_line_viewer,budget.revenue.report.line viewer,model_budget_revenue_report_line,budget.group_budget_viewer,1,0,0,0
+access_budget_revenue_report_line_manager,budget.revenue.report.line manager,model_budget_revenue_report_line,budget.group_budget_manager,1,1,1,1
+access_budget_revenue_comparison_wizard_viewer,budget.revenue.comparison.wizard viewer,model_budget_revenue_comparison_wizard,budget.group_budget_viewer,1,0,1,0

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
@@ -1,0 +1,176 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { MultiRecordSelect } from "./multi_record_select";
+
+const REPORT_MODEL = "budget.revenue.comparison.report";
+
+// Selected-record state buckets that feed the report options (the four KMITL
+// accounting dimensions).
+const SELECTION_KEYS = ["departments", "sources", "funds", "activities"];
+
+export class BudgetRevenueComparison extends Component {
+    setup() {
+        this.orm = useService("orm");
+        this.action = useService("action");
+        this.company = useService("company");
+        this.fiscalYears = [];
+        this.state = useState({
+            fiscalYearId: false,
+            dateFrom: false,
+            dateTo: false,
+            onlyPosted: true,
+            departments: [],
+            sources: [],
+            funds: [],
+            activities: [],
+            rows: [],
+            loading: false,
+        });
+        this.labels = {
+            departments: _t("Departments"),
+            sources: _t("Sources"),
+            funds: _t("Funds"),
+            activities: _t("Activities"),
+        };
+        onWillStart(this.onWillStart.bind(this));
+    }
+
+    async onWillStart() {
+        this.companyId = this.company.currentCompany.id;
+        this.fiscalYears = await this.orm.searchRead(
+            "account.fiscal.year",
+            [],
+            ["id", "name", "date_from", "date_to"],
+            { order: "date_from desc" }
+        );
+        const today = new Date().toISOString().slice(0, 10);
+        const covering = this.fiscalYears.find(
+            (fy) => fy.date_from <= today && fy.date_to >= today
+        );
+        const fy = covering || this.fiscalYears[0];
+        if (fy) {
+            this.state.fiscalYearId = fy.id;
+            this.state.dateFrom = fy.date_from;
+            this.state.dateTo = fy.date_to;
+        } else {
+            const year = new Date().getFullYear();
+            this.state.dateFrom = `${year}-01-01`;
+            this.state.dateTo = `${year}-12-31`;
+        }
+        await this.load();
+    }
+
+    // ------------------------------------------------------------------
+    // Report options + data loading
+    // ------------------------------------------------------------------
+    get options() {
+        return {
+            company_id: this.companyId,
+            fiscal_year_id: this.state.fiscalYearId,
+            date_from: this.state.dateFrom,
+            date_to: this.state.dateTo,
+            only_posted: this.state.onlyPosted,
+            dims: {
+                departments: this.state.departments.map((r) => r.id),
+                sources: this.state.sources.map((r) => r.id),
+                funds: this.state.funds.map((r) => r.id),
+                activities: this.state.activities.map((r) => r.id),
+            },
+        };
+    }
+
+    async load() {
+        if (!this.state.fiscalYearId) {
+            this.state.rows = [];
+            return;
+        }
+        this.state.loading = true;
+        try {
+            const data = await this.orm.call(
+                REPORT_MODEL,
+                "get_comparison_data",
+                [this.options]
+            );
+            this.state.rows = data.rows || [];
+        } finally {
+            this.state.loading = false;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Filter events
+    // ------------------------------------------------------------------
+    onFiscalYearChange(ev) {
+        const id = parseInt(ev.target.value) || false;
+        this.state.fiscalYearId = id;
+        const fy = this.fiscalYears.find((f) => f.id === id);
+        if (fy) {
+            this.state.dateFrom = fy.date_from;
+            this.state.dateTo = fy.date_to;
+        }
+        this.load();
+    }
+
+    onDateFromChange(ev) {
+        this.state.dateFrom = ev.target.value || false;
+        this.load();
+    }
+
+    onDateToChange(ev) {
+        this.state.dateTo = ev.target.value || false;
+        this.load();
+    }
+
+    onTogglePosted(ev) {
+        this.state.onlyPosted = ev.target.checked;
+        this.load();
+    }
+
+    onSelectionChange(key, selected) {
+        if (SELECTION_KEYS.includes(key)) {
+            this.state[key] = selected;
+            this.load();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Rendering helpers
+    // ------------------------------------------------------------------
+    formatAmount(value) {
+        if (value === null || value === undefined) {
+            return "";
+        }
+        return value.toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    }
+
+    formatPercentage(value) {
+        if (value === null || value === undefined) {
+            return "–";
+        }
+        return (
+            value.toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+            }) + "%"
+        );
+    }
+
+    async exportXlsx() {
+        const action = await this.orm.call(REPORT_MODEL, "action_export_xlsx", [
+            this.options,
+        ]);
+        await this.action.doAction(action);
+    }
+}
+
+BudgetRevenueComparison.template = "budget_revenue_comparison.BudgetRevenueComparison";
+BudgetRevenueComparison.components = { MultiRecordSelect };
+
+registry.category("actions").add("budget_revenue_comparison", BudgetRevenueComparison);

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
@@ -23,6 +23,7 @@ export class BudgetRevenueComparison extends Component {
             dateFrom: false,
             dateTo: false,
             onlyPosted: true,
+            groupByDepartment: false,
             departments: [],
             sources: [],
             funds: [],
@@ -74,6 +75,7 @@ export class BudgetRevenueComparison extends Component {
             date_from: this.state.dateFrom,
             date_to: this.state.dateTo,
             only_posted: this.state.onlyPosted,
+            group_by_department: this.state.groupByDepartment,
             dims: {
                 departments: this.state.departments.map((r) => r.id),
                 sources: this.state.sources.map((r) => r.id),
@@ -127,6 +129,11 @@ export class BudgetRevenueComparison extends Component {
 
     onTogglePosted(ev) {
         this.state.onlyPosted = ev.target.checked;
+        this.load();
+    }
+
+    onToggleGroupByDept(ev) {
+        this.state.groupByDepartment = ev.target.checked;
         this.load();
     }
 

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
@@ -8,9 +8,10 @@ import { MultiRecordSelect } from "./multi_record_select";
 
 const REPORT_MODEL = "budget.revenue.comparison.report";
 
-// Selected-record state buckets that feed the report options (the four KMITL
-// accounting dimensions).
-const SELECTION_KEYS = ["departments", "sources", "funds", "activities"];
+// Selected-record state buckets that feed the report options. Only Department
+// and Source apply -- estimated revenue budget is not allocated by Fund or
+// Activity.
+const SELECTION_KEYS = ["departments", "sources"];
 
 export class BudgetRevenueComparison extends Component {
     setup() {
@@ -26,16 +27,12 @@ export class BudgetRevenueComparison extends Component {
             groupByDepartment: false,
             departments: [],
             sources: [],
-            funds: [],
-            activities: [],
             rows: [],
             loading: false,
         });
         this.labels = {
             departments: _t("Departments"),
             sources: _t("Sources"),
-            funds: _t("Funds"),
-            activities: _t("Activities"),
         };
         onWillStart(this.onWillStart.bind(this));
     }
@@ -79,8 +76,6 @@ export class BudgetRevenueComparison extends Component {
             dims: {
                 departments: this.state.departments.map((r) => r.id),
                 sources: this.state.sources.map((r) => r.id),
-                funds: this.state.funds.map((r) => r.id),
-                activities: this.state.activities.map((r) => r.id),
             },
         };
     }
@@ -167,6 +162,14 @@ export class BudgetRevenueComparison extends Component {
                 maximumFractionDigits: 2,
             }) + "%"
         );
+    }
+
+    // Green when actual met/exceeded budget, red when short.
+    varianceClass(value) {
+        if (value === null || value === undefined) {
+            return "";
+        }
+        return value < 0 ? "text-danger" : "text-success";
     }
 
     async exportXlsx() {

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.js
@@ -3,7 +3,9 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
-import { Component, onWillStart, useState } from "@odoo/owl";
+import { Layout } from "@web/search/layout";
+import { getDefaultConfig } from "@web/views/view";
+import { Component, onWillStart, useState, useSubEnv } from "@odoo/owl";
 import { MultiRecordSelect } from "./multi_record_select";
 
 const REPORT_MODEL = "budget.revenue.comparison.report";
@@ -15,6 +17,9 @@ const SELECTION_KEYS = ["departments", "sources"];
 
 export class BudgetRevenueComparison extends Component {
     setup() {
+        // Provide the config the Layout/ControlPanel chrome expects (the
+        // client action's own config is merged on top for the breadcrumb).
+        useSubEnv({ config: { ...getDefaultConfig(), ...this.env.config } });
         this.orm = useService("orm");
         this.action = useService("action");
         this.company = useService("company");
@@ -181,6 +186,6 @@ export class BudgetRevenueComparison extends Component {
 }
 
 BudgetRevenueComparison.template = "budget_revenue_comparison.BudgetRevenueComparison";
-BudgetRevenueComparison.components = { MultiRecordSelect };
+BudgetRevenueComparison.components = { Layout, MultiRecordSelect };
 
 registry.category("actions").add("budget_revenue_comparison", BudgetRevenueComparison);

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
@@ -28,6 +28,12 @@
         }
 
         // Row types
+        .o_brc_department td {
+            font-weight: bold;
+            background-color: #e9ecef;
+            border-top: 2px solid #adb5bd;
+            padding-top: 0.5rem;
+        }
         .o_brc_header td {
             font-weight: bold;
             padding-top: 0.6rem;

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
@@ -1,0 +1,102 @@
+.o_brc {
+    height: 100%;
+    overflow: auto;
+
+    .o_brc_table_wrap {
+        overflow-x: auto;
+        max-width: 70rem;
+    }
+
+    .o_brc_table {
+        th {
+            background-color: #f8f9fa;
+            vertical-align: middle;
+            white-space: nowrap;
+        }
+        td,
+        th {
+            font-size: 1rem;
+        }
+        .o_brc_item {
+            min-width: 28rem;
+        }
+        .o_brc_amount {
+            min-width: 12rem;
+        }
+        .o_brc_pct {
+            min-width: 7rem;
+        }
+
+        // Row types
+        .o_brc_header td {
+            font-weight: bold;
+            padding-top: 0.6rem;
+        }
+        .o_brc_line td:first-child {
+            padding-left: 1.5rem;
+        }
+        .o_brc_total td {
+            font-weight: bold;
+            border-top: 1px solid #adb5bd;
+        }
+    }
+
+    // Dimension multi-select (copied styling)
+    .o_brc_ms {
+        position: relative;
+
+        .o_brc_ms_box {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.25rem;
+            min-height: 2.25rem;
+            height: auto;
+            padding: 0.2rem 0.4rem;
+        }
+
+        .o_brc_ms_tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
+
+        .o_brc_ms_x {
+            cursor: pointer;
+            font-weight: bold;
+            line-height: 1;
+        }
+
+        .o_brc_ms_input {
+            flex: 1 1 4rem;
+            min-width: 4rem;
+            border: 0;
+            outline: 0;
+            background: transparent;
+            padding: 0.1rem;
+        }
+
+        .o_brc_ms_dropdown {
+            position: absolute;
+            z-index: 1000;
+            left: 0;
+            right: 0;
+            top: 100%;
+            max-height: 14rem;
+            overflow-y: auto;
+            background: #fff;
+            border: 1px solid #ced4da;
+            border-radius: 0 0 0.25rem 0.25rem;
+            box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+        }
+
+        .o_brc_ms_option {
+            padding: 0.3rem 0.5rem;
+            cursor: pointer;
+
+            &:hover {
+                background-color: #f1f3f5;
+            }
+        }
+    }
+}

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
@@ -14,10 +14,12 @@
 
 // Centered report body
 .o_brc_body {
-    .o_brc_table_wrap {
+    // Paper/card framing the table, centered on screen.
+    .o_brc_card {
         max-width: 72rem;
         margin: 0 auto;
-        overflow-x: auto;
+        // Clip the table's square corners to the card's rounded border.
+        overflow: hidden;
     }
 
     .o_brc_table {

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
@@ -15,29 +15,38 @@
 // Centered report body
 .o_brc_body {
     .o_brc_table_wrap {
-        max-width: 70rem;
+        max-width: 72rem;
         margin: 0 auto;
         overflow-x: auto;
     }
 
     .o_brc_table {
+        // Fixed layout so the columns keep stable, proportional widths and
+        // fill the centered frame exactly (no overflow, no dead space).
+        table-layout: fixed;
+        width: 100%;
+
         th {
             background-color: #f8f9fa;
             vertical-align: middle;
-            white-space: nowrap;
         }
         td,
         th {
             font-size: 1rem;
         }
+        // The indicator label may wrap; the numeric columns stay on one line.
+        .o_brc_amount,
+        .o_brc_pct {
+            white-space: nowrap;
+        }
         .o_brc_item {
-            min-width: 28rem;
+            width: 37%;
         }
         .o_brc_amount {
-            min-width: 12rem;
+            width: 17%;
         }
         .o_brc_pct {
-            min-width: 7rem;
+            width: 12%;
         }
 
         // Row types

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.scss
@@ -1,10 +1,23 @@
-.o_brc {
-    height: 100%;
-    overflow: auto;
+// Filters hosted in the control panel
+.o_brc_filters {
+    label.o_form_label {
+        display: block;
+    }
+    .form-select-sm,
+    .form-control-sm {
+        min-width: 9rem;
+    }
+    .o_brc_dim {
+        min-width: 13rem;
+    }
+}
 
+// Centered report body
+.o_brc_body {
     .o_brc_table_wrap {
-        overflow-x: auto;
         max-width: 70rem;
+        margin: 0 auto;
+        overflow-x: auto;
     }
 
     .o_brc_table {
@@ -46,63 +59,63 @@
             border-top: 1px solid #adb5bd;
         }
     }
+}
 
-    // Dimension multi-select (copied styling)
-    .o_brc_ms {
-        position: relative;
+// Dimension multi-select (now hosted in the control panel)
+.o_brc_ms {
+    position: relative;
 
-        .o_brc_ms_box {
-            display: flex;
-            flex-wrap: wrap;
-            align-items: center;
-            gap: 0.25rem;
-            min-height: 2.25rem;
-            height: auto;
-            padding: 0.2rem 0.4rem;
-        }
+    .o_brc_ms_box {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem;
+        min-height: 2.25rem;
+        height: auto;
+        padding: 0.2rem 0.4rem;
+    }
 
-        .o_brc_ms_tag {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.25rem;
-        }
+    .o_brc_ms_tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+    }
 
-        .o_brc_ms_x {
-            cursor: pointer;
-            font-weight: bold;
-            line-height: 1;
-        }
+    .o_brc_ms_x {
+        cursor: pointer;
+        font-weight: bold;
+        line-height: 1;
+    }
 
-        .o_brc_ms_input {
-            flex: 1 1 4rem;
-            min-width: 4rem;
-            border: 0;
-            outline: 0;
-            background: transparent;
-            padding: 0.1rem;
-        }
+    .o_brc_ms_input {
+        flex: 1 1 4rem;
+        min-width: 4rem;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        padding: 0.1rem;
+    }
 
-        .o_brc_ms_dropdown {
-            position: absolute;
-            z-index: 1000;
-            left: 0;
-            right: 0;
-            top: 100%;
-            max-height: 14rem;
-            overflow-y: auto;
-            background: #fff;
-            border: 1px solid #ced4da;
-            border-radius: 0 0 0.25rem 0.25rem;
-            box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
-        }
+    .o_brc_ms_dropdown {
+        position: absolute;
+        z-index: 1000;
+        left: 0;
+        right: 0;
+        top: 100%;
+        max-height: 14rem;
+        overflow-y: auto;
+        background: #fff;
+        border: 1px solid #ced4da;
+        border-radius: 0 0 0.25rem 0.25rem;
+        box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+    }
 
-        .o_brc_ms_option {
-            padding: 0.3rem 0.5rem;
-            cursor: pointer;
+    .o_brc_ms_option {
+        padding: 0.3rem 0.5rem;
+        cursor: pointer;
 
-            &:hover {
-                background-color: #f1f3f5;
-            }
+        &:hover {
+            background-color: #f1f3f5;
         }
     }
 }

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
@@ -122,8 +122,8 @@
 
             <!-- Centered report body -->
             <div class="o_brc_body p-3">
-                <div class="o_brc_table_wrap">
-                    <table class="table table-sm o_brc_table">
+                <div class="o_brc_card card shadow-sm">
+                    <table class="table table-sm o_brc_table mb-0">
                         <thead>
                             <tr>
                                 <th class="o_brc_item">ตัวชี้วัด</th>

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
@@ -80,7 +80,7 @@
                         t-on-change="onDateToChange"
                     />
                 </div>
-                <div class="col-md-5 d-flex align-items-end">
+                <div class="col-md-5 d-flex align-items-end gap-3">
                     <div class="form-check">
                         <input
                             type="checkbox"
@@ -90,6 +90,16 @@
                             t-on-change="onTogglePosted"
                         />
                         <label class="form-check-label" for="brc_posted">Posted entries only</label>
+                    </div>
+                    <div class="form-check">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="brc_group_dept"
+                            t-att-checked="state.groupByDepartment"
+                            t-on-change="onToggleGroupByDept"
+                        />
+                        <label class="form-check-label" for="brc_group_dept">จำแนกตามส่วนงาน</label>
                     </div>
                 </div>
 
@@ -157,14 +167,14 @@
                         <tr
                             t-foreach="state.rows"
                             t-as="row"
-                            t-key="row.id"
+                            t-key="row_index"
                             t-att-class="'o_brc_' + row.row_type"
                         >
                             <td t-esc="row.name" />
                             <td class="text-end" t-esc="formatAmount(row.budget)" />
                             <td class="text-end" t-esc="formatAmount(row.actual)" />
                             <td class="text-end">
-                                <t t-if="row.row_type !== 'header'" t-esc="formatPercentage(row.percentage)" />
+                                <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatPercentage(row.percentage)" />
                             </td>
                         </tr>
                     </tbody>

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
@@ -124,26 +124,6 @@
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
                     />
                 </div>
-                <div class="col-md-3">
-                    <label class="o_form_label">Funds</label>
-                    <MultiRecordSelect
-                        resModel="'account.analytic.account'"
-                        domain="[['root_plan_id.code', '=', 'funds']]"
-                        placeholder="labels.funds"
-                        selected="state.funds"
-                        onChange="(sel) => this.onSelectionChange('funds', sel)"
-                    />
-                </div>
-                <div class="col-md-3">
-                    <label class="o_form_label">Activities</label>
-                    <MultiRecordSelect
-                        resModel="'account.analytic.account'"
-                        domain="[['root_plan_id.code', '=', 'activities']]"
-                        placeholder="labels.activities"
-                        selected="state.activities"
-                        onChange="(sel) => this.onSelectionChange('activities', sel)"
-                    />
-                </div>
             </div>
 
             <!-- Report table -->
@@ -154,15 +134,16 @@
                             <th class="o_brc_item">ตัวชี้วัด</th>
                             <th class="text-end o_brc_amount">งบประมาณรายรับ</th>
                             <th class="text-end o_brc_amount">รายรับจริง</th>
+                            <th class="text-end o_brc_amount">ส่วนต่าง</th>
                             <th class="text-end o_brc_pct">%</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr t-if="state.loading">
-                            <td colspan="4" class="text-center text-muted">Loading...</td>
+                            <td colspan="5" class="text-center text-muted">Loading...</td>
                         </tr>
                         <tr t-elif="!state.rows.length">
-                            <td colspan="4" class="text-center text-muted">No data</td>
+                            <td colspan="5" class="text-center text-muted">No data</td>
                         </tr>
                         <tr
                             t-foreach="state.rows"
@@ -173,6 +154,9 @@
                             <td t-esc="row.name" />
                             <td class="text-end" t-esc="formatAmount(row.budget)" />
                             <td class="text-end" t-esc="formatAmount(row.actual)" />
+                            <td t-att-class="'text-end ' + varianceClass(row.variance)">
+                                <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatAmount(row.variance)" />
+                            </td>
                             <td class="text-end">
                                 <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatPercentage(row.percentage)" />
                             </td>

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="budget_revenue_comparison.MultiRecordSelect" owl="1">
+        <div class="o_brc_ms" t-ref="root">
+            <div class="o_brc_ms_box form-control">
+                <span
+                    t-foreach="selected"
+                    t-as="rec"
+                    t-key="rec.id"
+                    class="badge text-bg-primary o_brc_ms_tag"
+                >
+                    <t t-esc="rec.name" />
+                    <span class="o_brc_ms_x" t-on-click="() => this.remove(rec.id)">×</span>
+                </span>
+                <input
+                    type="text"
+                    class="o_brc_ms_input"
+                    t-att-placeholder="props.placeholder"
+                    t-att-value="state.query"
+                    t-on-focus="onFocus"
+                    t-on-input="onInput"
+                />
+            </div>
+            <div class="o_brc_ms_dropdown" t-if="state.open and state.options.length">
+                <div
+                    t-foreach="state.options"
+                    t-as="opt"
+                    t-key="opt.id"
+                    class="o_brc_ms_option"
+                    t-on-click="() => this.add(opt)"
+                >
+                    <t t-esc="opt.name" />
+                </div>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="budget_revenue_comparison.BudgetRevenueComparison" owl="1">
+        <div class="o_brc o_action_manager p-3">
+            <div class="o_brc_header d-flex align-items-center mb-3">
+                <h2 class="m-0 flex-grow-1">เปรียบเทียบงบประมาณรายรับ - รายรับจริง</h2>
+                <button class="btn btn-secondary" t-on-click="exportXlsx">
+                    <i class="fa fa-file-excel-o me-1" />Export Excel
+                </button>
+            </div>
+
+            <!-- Filter bar -->
+            <div class="o_brc_filters row g-2 mb-3">
+                <div class="col-md-3">
+                    <label class="o_form_label">Fiscal Year</label>
+                    <select class="form-select" t-on-change="onFiscalYearChange">
+                        <option value="">/</option>
+                        <option
+                            t-foreach="fiscalYears"
+                            t-as="fy"
+                            t-key="fy.id"
+                            t-att-value="fy.id"
+                            t-att-selected="fy.id === state.fiscalYearId"
+                        >
+                            <t t-esc="fy.name" />
+                        </option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="o_form_label">Date From</label>
+                    <input
+                        type="date"
+                        class="form-control"
+                        t-att-value="state.dateFrom"
+                        t-on-change="onDateFromChange"
+                    />
+                </div>
+                <div class="col-md-2">
+                    <label class="o_form_label">Date To ( as of)</label>
+                    <input
+                        type="date"
+                        class="form-control"
+                        t-att-value="state.dateTo"
+                        t-on-change="onDateToChange"
+                    />
+                </div>
+                <div class="col-md-5 d-flex align-items-end">
+                    <div class="form-check">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="brc_posted"
+                            t-att-checked="state.onlyPosted"
+                            t-on-change="onTogglePosted"
+                        />
+                        <label class="form-check-label" for="brc_posted">Posted entries only</label>
+                    </div>
+                </div>
+
+                <!-- KMITL accounting dimensions -->
+                <div class="col-md-3">
+                    <label class="o_form_label">Departments</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'departments']]"
+                        placeholder="labels.departments"
+                        selected="state.departments"
+                        onChange="(sel) => this.onSelectionChange('departments', sel)"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="o_form_label">Sources</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'sources']]"
+                        placeholder="labels.sources"
+                        selected="state.sources"
+                        onChange="(sel) => this.onSelectionChange('sources', sel)"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="o_form_label">Funds</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'funds']]"
+                        placeholder="labels.funds"
+                        selected="state.funds"
+                        onChange="(sel) => this.onSelectionChange('funds', sel)"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="o_form_label">Activities</label>
+                    <MultiRecordSelect
+                        resModel="'account.analytic.account'"
+                        domain="[['root_plan_id.code', '=', 'activities']]"
+                        placeholder="labels.activities"
+                        selected="state.activities"
+                        onChange="(sel) => this.onSelectionChange('activities', sel)"
+                    />
+                </div>
+            </div>
+
+            <!-- Report table -->
+            <div class="o_brc_table_wrap">
+                <table class="table table-sm o_brc_table">
+                    <thead>
+                        <tr>
+                            <th class="o_brc_item">ตัวชี้วัด</th>
+                            <th class="text-end o_brc_amount">งบประมาณรายรับ</th>
+                            <th class="text-end o_brc_amount">รายรับจริง</th>
+                            <th class="text-end o_brc_pct">%</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-if="state.loading">
+                            <td colspan="4" class="text-center text-muted">Loading...</td>
+                        </tr>
+                        <tr t-elif="!state.rows.length">
+                            <td colspan="4" class="text-center text-muted">No data</td>
+                        </tr>
+                        <tr
+                            t-foreach="state.rows"
+                            t-as="row"
+                            t-key="row.id"
+                            t-att-class="'o_brc_' + row.row_type"
+                        >
+                            <td t-esc="row.name" />
+                            <td class="text-end" t-esc="formatAmount(row.budget)" />
+                            <td class="text-end" t-esc="formatAmount(row.actual)" />
+                            <td class="text-end">
+                                <t t-if="row.row_type !== 'header'" t-esc="formatPercentage(row.percentage)" />
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/budget_revenue_comparison.xml
@@ -37,51 +37,64 @@
     </t>
 
     <t t-name="budget_revenue_comparison.BudgetRevenueComparison" owl="1">
-        <div class="o_brc o_action_manager p-3">
-            <div class="o_brc_header d-flex align-items-center mb-3">
-                <h2 class="m-0 flex-grow-1">เปรียบเทียบงบประมาณรายรับ - รายรับจริง</h2>
-                <button class="btn btn-secondary" t-on-click="exportXlsx">
-                    <i class="fa fa-file-excel-o me-1" />Export Excel
-                </button>
-            </div>
-
-            <!-- Filter bar -->
-            <div class="o_brc_filters row g-2 mb-3">
-                <div class="col-md-3">
-                    <label class="o_form_label">Fiscal Year</label>
-                    <select class="form-select" t-on-change="onFiscalYearChange">
-                        <option value="">/</option>
-                        <option
-                            t-foreach="fiscalYears"
-                            t-as="fy"
-                            t-key="fy.id"
-                            t-att-value="fy.id"
-                            t-att-selected="fy.id === state.fiscalYearId"
-                        >
-                            <t t-esc="fy.name" />
-                        </option>
-                    </select>
-                </div>
-                <div class="col-md-2">
-                    <label class="o_form_label">Date From</label>
-                    <input
-                        type="date"
-                        class="form-control"
-                        t-att-value="state.dateFrom"
-                        t-on-change="onDateFromChange"
-                    />
-                </div>
-                <div class="col-md-2">
-                    <label class="o_form_label">Date To ( as of)</label>
-                    <input
-                        type="date"
-                        class="form-control"
-                        t-att-value="state.dateTo"
-                        t-on-change="onDateToChange"
-                    />
-                </div>
-                <div class="col-md-5 d-flex align-items-end gap-3">
-                    <div class="form-check">
+        <Layout display="{ controlPanel: { 'top-right': false, 'bottom-right': false } }">
+            <!-- Filters + actions live in the control panel -->
+            <t t-set-slot="control-panel-bottom-left">
+                <div class="o_brc_filters d-flex flex-wrap align-items-end gap-2">
+                    <div>
+                        <label class="o_form_label small mb-0">Fiscal Year</label>
+                        <select class="form-select form-select-sm" t-on-change="onFiscalYearChange">
+                            <option value="">/</option>
+                            <option
+                                t-foreach="fiscalYears"
+                                t-as="fy"
+                                t-key="fy.id"
+                                t-att-value="fy.id"
+                                t-att-selected="fy.id === state.fiscalYearId"
+                            >
+                                <t t-esc="fy.name" />
+                            </option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="o_form_label small mb-0">Date From</label>
+                        <input
+                            type="date"
+                            class="form-control form-control-sm"
+                            t-att-value="state.dateFrom"
+                            t-on-change="onDateFromChange"
+                        />
+                    </div>
+                    <div>
+                        <label class="o_form_label small mb-0">Date To (as of)</label>
+                        <input
+                            type="date"
+                            class="form-control form-control-sm"
+                            t-att-value="state.dateTo"
+                            t-on-change="onDateToChange"
+                        />
+                    </div>
+                    <div class="o_brc_dim">
+                        <label class="o_form_label small mb-0">Departments</label>
+                        <MultiRecordSelect
+                            resModel="'account.analytic.account'"
+                            domain="[['root_plan_id.code', '=', 'departments']]"
+                            placeholder="labels.departments"
+                            selected="state.departments"
+                            onChange="(sel) => this.onSelectionChange('departments', sel)"
+                        />
+                    </div>
+                    <div class="o_brc_dim">
+                        <label class="o_form_label small mb-0">Sources</label>
+                        <MultiRecordSelect
+                            resModel="'account.analytic.account'"
+                            domain="[['root_plan_id.code', '=', 'sources']]"
+                            placeholder="labels.sources"
+                            selected="state.sources"
+                            onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        />
+                    </div>
+                    <div class="form-check ms-1">
                         <input
                             type="checkbox"
                             class="form-check-input"
@@ -101,70 +114,53 @@
                         />
                         <label class="form-check-label" for="brc_group_dept">จำแนกตามส่วนงาน</label>
                     </div>
+                    <button class="btn btn-secondary btn-sm" t-on-click="exportXlsx">
+                        <i class="fa fa-file-excel-o me-1" />Export Excel
+                    </button>
                 </div>
+            </t>
 
-                <!-- KMITL accounting dimensions -->
-                <div class="col-md-3">
-                    <label class="o_form_label">Departments</label>
-                    <MultiRecordSelect
-                        resModel="'account.analytic.account'"
-                        domain="[['root_plan_id.code', '=', 'departments']]"
-                        placeholder="labels.departments"
-                        selected="state.departments"
-                        onChange="(sel) => this.onSelectionChange('departments', sel)"
-                    />
-                </div>
-                <div class="col-md-3">
-                    <label class="o_form_label">Sources</label>
-                    <MultiRecordSelect
-                        resModel="'account.analytic.account'"
-                        domain="[['root_plan_id.code', '=', 'sources']]"
-                        placeholder="labels.sources"
-                        selected="state.sources"
-                        onChange="(sel) => this.onSelectionChange('sources', sel)"
-                    />
+            <!-- Centered report body -->
+            <div class="o_brc_body p-3">
+                <div class="o_brc_table_wrap">
+                    <table class="table table-sm o_brc_table">
+                        <thead>
+                            <tr>
+                                <th class="o_brc_item">ตัวชี้วัด</th>
+                                <th class="text-end o_brc_amount">งบประมาณรายรับ</th>
+                                <th class="text-end o_brc_amount">รายรับจริง</th>
+                                <th class="text-end o_brc_amount">ส่วนต่าง</th>
+                                <th class="text-end o_brc_pct">%</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr t-if="state.loading">
+                                <td colspan="5" class="text-center text-muted">Loading...</td>
+                            </tr>
+                            <tr t-elif="!state.rows.length">
+                                <td colspan="5" class="text-center text-muted">No data</td>
+                            </tr>
+                            <tr
+                                t-foreach="state.rows"
+                                t-as="row"
+                                t-key="row_index"
+                                t-att-class="'o_brc_' + row.row_type"
+                            >
+                                <td t-esc="row.name" />
+                                <td class="text-end" t-esc="formatAmount(row.budget)" />
+                                <td class="text-end" t-esc="formatAmount(row.actual)" />
+                                <td t-att-class="'text-end ' + varianceClass(row.variance)">
+                                    <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatAmount(row.variance)" />
+                                </td>
+                                <td class="text-end">
+                                    <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatPercentage(row.percentage)" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
-
-            <!-- Report table -->
-            <div class="o_brc_table_wrap">
-                <table class="table table-sm o_brc_table">
-                    <thead>
-                        <tr>
-                            <th class="o_brc_item">ตัวชี้วัด</th>
-                            <th class="text-end o_brc_amount">งบประมาณรายรับ</th>
-                            <th class="text-end o_brc_amount">รายรับจริง</th>
-                            <th class="text-end o_brc_amount">ส่วนต่าง</th>
-                            <th class="text-end o_brc_pct">%</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr t-if="state.loading">
-                            <td colspan="5" class="text-center text-muted">Loading...</td>
-                        </tr>
-                        <tr t-elif="!state.rows.length">
-                            <td colspan="5" class="text-center text-muted">No data</td>
-                        </tr>
-                        <tr
-                            t-foreach="state.rows"
-                            t-as="row"
-                            t-key="row_index"
-                            t-att-class="'o_brc_' + row.row_type"
-                        >
-                            <td t-esc="row.name" />
-                            <td class="text-end" t-esc="formatAmount(row.budget)" />
-                            <td class="text-end" t-esc="formatAmount(row.actual)" />
-                            <td t-att-class="'text-end ' + varianceClass(row.variance)">
-                                <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatAmount(row.variance)" />
-                            </td>
-                            <td class="text-end">
-                                <t t-if="row.row_type === 'line' or row.row_type === 'total'" t-esc="formatPercentage(row.percentage)" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        </Layout>
     </t>
 
 </templates>

--- a/budget_revenue_comparison/static/src/budget_revenue_comparison/multi_record_select.js
+++ b/budget_revenue_comparison/static/src/budget_revenue_comparison/multi_record_select.js
@@ -1,0 +1,84 @@
+/** @odoo-module **/
+
+import { Component, useState, useRef, useExternalListener } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * Small reusable multi-select that searches records with the native
+ * ``name_search`` RPC and renders the picks as removable badges. Copied from
+ * the accounting_kmitl_reports report screens so this module stays decoupled
+ * from that module.
+ *
+ * Props:
+ *  - resModel: model to search
+ *  - domain: base domain applied to the search
+ *  - placeholder: input placeholder
+ *  - selected: Array<{id, name}> currently selected (controlled by parent)
+ *  - onChange: called with the new Array<{id, name}>
+ */
+export class MultiRecordSelect extends Component {
+    setup() {
+        this.orm = useService("orm");
+        this.state = useState({ query: "", open: false, options: [] });
+        this.root = useRef("root");
+        useExternalListener(window, "mousedown", (ev) => this.onClickAway(ev));
+    }
+
+    get selected() {
+        return this.props.selected || [];
+    }
+
+    onClickAway(ev) {
+        if (this.root.el && !this.root.el.contains(ev.target)) {
+            this.state.open = false;
+        }
+    }
+
+    async _search(query) {
+        const selectedIds = this.selected.map((r) => r.id);
+        const domain = [...(this.props.domain || []), ["id", "not in", selectedIds]];
+        const results = await this.orm.call(this.props.resModel, "name_search", [], {
+            name: query || "",
+            args: domain,
+            operator: "ilike",
+            limit: 12,
+        });
+        this.state.options = results.map(([id, name]) => ({ id, name }));
+    }
+
+    async onFocus() {
+        this.state.open = true;
+        await this._search(this.state.query);
+    }
+
+    async onInput(ev) {
+        this.state.query = ev.target.value;
+        this.state.open = true;
+        await this._search(this.state.query);
+    }
+
+    add(option) {
+        this.state.query = "";
+        this.state.options = [];
+        this.state.open = false;
+        this.props.onChange([...this.selected, option]);
+    }
+
+    remove(id) {
+        this.props.onChange(this.selected.filter((r) => r.id !== id));
+    }
+}
+
+MultiRecordSelect.template = "budget_revenue_comparison.MultiRecordSelect";
+MultiRecordSelect.props = {
+    resModel: String,
+    domain: { type: Array, optional: true },
+    placeholder: { type: String, optional: true },
+    selected: { type: Array, optional: true },
+    onChange: Function,
+};
+MultiRecordSelect.defaultProps = {
+    domain: [],
+    placeholder: "",
+    selected: [],
+};

--- a/budget_revenue_comparison/tests/__init__.py
+++ b/budget_revenue_comparison/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_budget_revenue_comparison

--- a/budget_revenue_comparison/tests/test_budget_revenue_comparison.py
+++ b/budget_revenue_comparison/tests/test_budget_revenue_comparison.py
@@ -162,18 +162,24 @@ class TestComparisonCompute(TransactionCase):
         # Header carries no figures.
         self.assertIsNone(header["budget"])
         self.assertIsNone(header["actual"])
+        self.assertIsNone(header["variance"])
         self.assertIsNone(header["percentage"])
-        # Line aggregates to zero (no FY/date), so percentage is a dash (None).
+        # Line aggregates to zero (no FY/date), so percentage is a dash (None)
+        # while variance is a concrete 0.0 (actual - budget).
         self.assertEqual(line["budget"], 0.0)
         self.assertEqual(line["actual"], 0.0)
+        self.assertEqual(line["variance"], 0.0)
         self.assertIsNone(line["percentage"])
 
-    def test_percentage_against_nonzero_budget(self):
-        # _row computes Actual / Budget * 100 when budget is non-zero.
+    def test_percentage_and_variance_against_nonzero_budget(self):
+        # _row computes Actual / Budget * 100 and Variance = Actual - Budget.
         row = self.Report._row(self.line, 1000000.0, 1500000.0)
         self.assertAlmostEqual(row["percentage"], 150.0)
-        # ...and None when budget is zero.
-        self.assertIsNone(self.Report._row(self.line, 0.0, 500000.0)["percentage"])
+        self.assertAlmostEqual(row["variance"], 500000.0)
+        # Percentage is None against a zero budget; variance still computes.
+        zero_budget = self.Report._row(self.line, 0.0, 500000.0)
+        self.assertIsNone(zero_budget["percentage"])
+        self.assertAlmostEqual(zero_budget["variance"], 500000.0)
 
     def test_group_by_department_appends_total_section(self):
         # With no fiscal year/date there is no data to discover departments

--- a/budget_revenue_comparison/tests/test_budget_revenue_comparison.py
+++ b/budget_revenue_comparison/tests/test_budget_revenue_comparison.py
@@ -1,0 +1,176 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.budget_revenue_comparison.models.formula import (
+    ActualResolver,
+    BudgetResolver,
+    eval_formula,
+    validate_formula,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestFormulaEngine(TransactionCase):
+    """The two-namespace formula engine: LIKE-matching, credit-positive
+    actuals, within-row arithmetic and validation -- exercised through the real
+    ``safe_eval`` (not a stand-in)."""
+
+    def setUp(self):
+        super().setUp()
+        self.budget = BudgetResolver(
+            {
+                "4101000000": 1000000.0,
+                "4102000000": 500000.0,
+                "4201000000": 250000.0,
+            }
+        )
+        self.actual = ActualResolver(
+            [
+                {"code": "4101000001", "type": "income", "value": 1500000.0},
+                {"code": "4102000001", "type": "income", "value": 400000.0},
+                {"code": "4900000001", "type": "income_other", "value": 50000.0},
+                # A debit (refund) booked to income -> credit-positive value < 0
+                {"code": "4199000001", "type": "income", "value": -20000.0},
+            ]
+        )
+
+    def _eval(self, formula):
+        return eval_formula(formula, self.budget, self.actual)
+
+    def test_budget_code_pattern(self):
+        self.assertAlmostEqual(self._eval("B['41%']"), 1500000.0)
+        self.assertAlmostEqual(self._eval("B['4%']"), 1750000.0)
+        self.assertAlmostEqual(self._eval("B['4101000000']"), 1000000.0)
+
+    def test_actual_by_type_and_code(self):
+        # Alphabetic selector -> account_type; '%' widens to income_other.
+        self.assertAlmostEqual(self._eval("A['income']"), 1880000.0)
+        self.assertAlmostEqual(self._eval("A['income%']"), 1930000.0)
+        # Numeric selector -> CoA code.
+        self.assertAlmostEqual(self._eval("A['41%']"), 1880000.0)
+
+    def test_within_row_arithmetic(self):
+        self.assertAlmostEqual(
+            self._eval("A['income'] - A['4199%']"), 1900000.0
+        )
+        self.assertAlmostEqual(self._eval("B['41%'] + B['42%']"), 1750000.0)
+
+    def test_empty_formula_is_zero(self):
+        self.assertEqual(self._eval(""), 0.0)
+        self.assertEqual(self._eval(False), 0.0)
+
+    def test_validation_accepts_good_formulas(self):
+        self.assertIsNone(validate_formula("B['41%'] - A['4199%']"))
+        self.assertIsNone(validate_formula("(B['4%'] + B['5%']) * 1.0"))
+        self.assertIsNone(validate_formula(""))
+
+    def test_validation_rejects_bad_formulas(self):
+        # Syntax error, unknown name, builtin access, empty selector.
+        self.assertIsNotNone(validate_formula("B['41%'] +"))
+        self.assertIsNotNone(validate_formula("foo['x']"))
+        self.assertIsNotNone(validate_formula("__import__('os')"))
+        self.assertIsNotNone(validate_formula("A['']"))
+        self.assertIsNotNone(validate_formula("B['']"))
+
+
+@tagged("post_install", "-at_install")
+class TestReportLine(TransactionCase):
+    """The configurable indicator rows: save-time validation and the
+    header-clears-formulas onchange."""
+
+    def setUp(self):
+        super().setUp()
+        self.Line = self.env["budget.revenue.report.line"]
+
+    def test_bad_formula_raises_on_save(self):
+        with self.assertRaises(ValidationError):
+            self.Line.create(
+                {
+                    "name": "broken",
+                    "row_type": "line",
+                    "budget_formula": "B['41%'] +",
+                }
+            )
+
+    def test_good_formula_saves(self):
+        line = self.Line.create(
+            {
+                "name": "tuition",
+                "row_type": "line",
+                "budget_formula": "B['41%']",
+                "actual_formula": "A['income']",
+            }
+        )
+        self.assertTrue(line.id)
+
+    def test_header_row_skips_formula_validation(self):
+        # A header keeps whatever is in the formula fields but is never
+        # validated or evaluated; creating one with junk must not raise.
+        line = self.Line.create(
+            {"name": "section", "row_type": "header", "budget_formula": "junk +"}
+        )
+        self.assertTrue(line.id)
+
+    def test_onchange_header_clears_formulas(self):
+        line = self.Line.new(
+            {
+                "name": "x",
+                "row_type": "line",
+                "budget_formula": "B['41%']",
+                "actual_formula": "A['income']",
+            }
+        )
+        line.row_type = "header"
+        line._onchange_row_type_clear_formulas()
+        self.assertFalse(line.budget_formula)
+        self.assertFalse(line.actual_formula)
+
+
+@tagged("post_install", "-at_install")
+class TestComparisonCompute(TransactionCase):
+    """The shared compute's row shaping: header rows carry no figures, the
+    percentage is a dash (None) against a zero budget, and rows come out in
+    sequence order. With no fiscal year/date both sides aggregate to nothing,
+    so every formula resolves to 0.0 -- enough to exercise the shaping without
+    seeding ledger data."""
+
+    def setUp(self):
+        super().setUp()
+        self.Report = self.env["budget.revenue.comparison.report"]
+        Line = self.env["budget.revenue.report.line"]
+        self.header = Line.create(
+            {"name": "รายได้จากการดำเนินงาน", "row_type": "header", "sequence": 1}
+        )
+        self.line = Line.create(
+            {
+                "name": "ค่าธรรมเนียมการศึกษา",
+                "row_type": "line",
+                "sequence": 2,
+                "budget_formula": "B['41%']",
+                "actual_formula": "A['income']",
+            }
+        )
+
+    def test_row_to_id(self):
+        rows = {
+            r["id"]: r
+            for r in self.Report.get_comparison_data({})["rows"]
+        }
+        header = rows[self.header.id]
+        line = rows[self.line.id]
+        # Header carries no figures.
+        self.assertIsNone(header["budget"])
+        self.assertIsNone(header["actual"])
+        self.assertIsNone(header["percentage"])
+        # Line aggregates to zero (no FY/date), so percentage is a dash (None).
+        self.assertEqual(line["budget"], 0.0)
+        self.assertEqual(line["actual"], 0.0)
+        self.assertIsNone(line["percentage"])
+
+    def test_percentage_against_nonzero_budget(self):
+        # _row computes Actual / Budget * 100 when budget is non-zero.
+        row = self.Report._row(self.line, 1000000.0, 1500000.0)
+        self.assertAlmostEqual(row["percentage"], 150.0)
+        # ...and None when budget is zero.
+        self.assertIsNone(self.Report._row(self.line, 0.0, 500000.0)["percentage"])

--- a/budget_revenue_comparison/tests/test_budget_revenue_comparison.py
+++ b/budget_revenue_comparison/tests/test_budget_revenue_comparison.py
@@ -174,3 +174,14 @@ class TestComparisonCompute(TransactionCase):
         self.assertAlmostEqual(row["percentage"], 150.0)
         # ...and None when budget is zero.
         self.assertIsNone(self.Report._row(self.line, 0.0, 500000.0)["percentage"])
+
+    def test_group_by_department_appends_total_section(self):
+        # With no fiscal year/date there is no data to discover departments
+        # from, so no per-department section appears -- but the grand-total
+        # section ("รวมทุกส่วนงาน") is always present, with the configured
+        # indicator rows under it.
+        rows = self.Report.get_comparison_data({"group_by_department": True})["rows"]
+        dept_headers = [r for r in rows if r["row_type"] == "department"]
+        self.assertTrue(dept_headers)
+        self.assertIsNone(dept_headers[0]["budget"])
+        self.assertIn(self.line.name, [r["name"] for r in rows])

--- a/budget_revenue_comparison/views/budget_revenue_report_line_views.xml
+++ b/budget_revenue_comparison/views/budget_revenue_report_line_views.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_budget_revenue_report_line_tree" model="ir.ui.view">
+        <field name="name">budget.revenue.report.line.tree</field>
+        <field name="model">budget.revenue.report.line</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom" decoration-bf="row_type == 'total'" decoration-info="row_type == 'header'">
+                <field name="sequence" widget="handle" />
+                <field name="row_type" />
+                <field name="name" />
+                <field name="budget_formula" attrs="{'readonly': [('row_type', '=', 'header')]}" />
+                <field name="actual_formula" attrs="{'readonly': [('row_type', '=', 'header')]}" />
+                <field name="active" invisible="1" />
+                <field name="company_id" groups="base.group_multi_company" optional="hide" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_budget_revenue_report_line_form" model="ir.ui.view">
+        <field name="name">budget.revenue.report.line.form</field>
+        <field name="model">budget.revenue.report.line</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                    <group>
+                        <group>
+                            <field name="name" />
+                            <field name="row_type" />
+                            <field name="sequence" />
+                        </group>
+                        <group>
+                            <field name="company_id" groups="base.group_multi_company" />
+                            <field name="active" invisible="1" />
+                        </group>
+                    </group>
+                    <group
+                        string="สูตรการคำนวณ"
+                        attrs="{'invisible': [('row_type', '=', 'header')]}"
+                    >
+                        <field name="budget_formula" placeholder="เช่น  B['41%'] + B['42%']" />
+                        <field name="actual_formula" placeholder="เช่น  A['income'] - A['4199%']" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_budget_revenue_report_line" model="ir.actions.act_window">
+        <field name="name">ตัวชี้วัดรายงานเปรียบเทียบรายรับ</field>
+        <field name="res_model">budget.revenue.report.line</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'active_test': False}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">เพิ่มตัวชี้วัดของรายงานเปรียบเทียบรายรับ</p>
+            <p>
+                แต่ละแถวกำหนดชื่อตัวชี้วัด ลำดับ และสูตรคำนวณ 2 ฝั่ง —
+                ฝั่งงบประมาณด้วย <code>B['รหัส']</code> และฝั่งบัญชีด้วย <code>A['ตัวเลือก']</code>
+            </p>
+        </field>
+    </record>
+
+    <menuitem
+        id="menu_budget_revenue_report_line"
+        name="ตัวชี้วัดเปรียบเทียบรายรับ"
+        parent="budget.budget_config_menu"
+        action="action_budget_revenue_report_line"
+        sequence="60"
+    />
+
+</odoo>

--- a/budget_revenue_comparison/views/menuitem.xml
+++ b/budget_revenue_comparison/views/menuitem.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- Budget vs Actual Revenue: OWL client action, opened straight from the
+         budget reporting menu (defaults to the current fiscal year, filterable
+         by the KMITL accounting dimensions). -->
+    <record id="action_budget_revenue_comparison" model="ir.actions.client">
+        <field name="name">เปรียบเทียบงบประมาณรายรับ - รายรับจริง</field>
+        <field name="tag">budget_revenue_comparison</field>
+    </record>
+
+    <menuitem
+        id="menu_budget_revenue_comparison"
+        name="เปรียบเทียบรายรับ (งบประมาณ vs จริง)"
+        parent="budget.budget_reporting_menu"
+        action="action_budget_revenue_comparison"
+        sequence="10"
+    />
+
+</odoo>

--- a/budget_revenue_comparison/wizard/__init__.py
+++ b/budget_revenue_comparison/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import budget_revenue_comparison_wizard

--- a/budget_revenue_comparison/wizard/budget_revenue_comparison_wizard.py
+++ b/budget_revenue_comparison/wizard/budget_revenue_comparison_wizard.py
@@ -1,0 +1,22 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from odoo import fields, models
+
+
+class BudgetRevenueComparisonWizard(models.TransientModel):
+    """Throwaway carrier so ``ir.actions.report`` (XLSX) has a record to render
+    against. Not user-facing: the OWL client action builds it on export and the
+    real filters travel in the report ``data`` dict, not on this record."""
+
+    _name = "budget.revenue.comparison.wizard"
+    _description = "Budget Revenue Comparison Report Carrier"
+
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        default=lambda self: self.env.company,
+    )
+    fiscal_year_id = fields.Many2one(
+        comodel_name="account.fiscal.year", string="Fiscal Year"
+    )
+    date_from = fields.Date(string="Date From")
+    date_to = fields.Date(string="Date To")


### PR DESCRIPTION
New module **`budget_revenue_comparison`**: a configurable report setting **budgeted revenue** (`budget.move`, revenue codes — full fiscal year) beside **actual revenue** (`account.move.line`, income types — to an editable as-of date), row by row, with a Percentage column. Because the budget chart and the CoA have no stored link, each indicator row (`budget.revenue.report.line`) carries two independent free-text formulas — `B[...]` over budget codes and `A[...]` over GL accounts (credit-positive) — evaluated with `safe_eval` and validated on save. Output is an OWL client action plus XLSX export, filterable by the four KMITL accounting dimensions; rows are flat, sequence-ordered, and typed `header`/`line`/`total`. It deliberately does **not** use MIS Builder (a KPI has a single expression per column and cannot span two account-code namespaces) — recorded in two ADRs, alongside `CONTEXT.md`, a README, and a unit-test suite. Depends on `budget` + `account` + `report_xlsx`; report menu under Budgeting ▸ รายงาน and indicator config under Budget Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)