### PR TITLE
[16.0][FIX] kris_project: แก้ไขการตรวจสอบยอดจัดสรรและยอดคงเหลืองวดงาน

### DIFF
--- a/kris_project/docs/adr/0001-discretionary-completion.md
+++ b/kris_project/docs/adr/0001-discretionary-completion.md
@@ -13,7 +13,11 @@ schedule or money-completeness:
 - A single งวด may be recorded across **multiple Receipts** and may be **over-collected**
   (its received total may exceed the งวด amount). The receipt wizard pre-fills only the
   outstanding remainder, but does not cap the entry, so a fully-received งวด stays
-  selectable for a later correction or extra income.
+  selectable for a later correction or extra income. The same allowance applies
+  **per allocator**: a Receipt's per-allocation-line amount is not capped against the
+  allocation line's `estimated_amount`, and the Installment breakdown's "remaining"
+  cell clamps at 0 once the plan is met (never negative) so over-allocation reads as
+  exhausted rather than an error.
 
 ## Why record this
 

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -2,7 +2,6 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -98,22 +97,5 @@ class KrisProjectAllocationLine(models.Model):
                         "ผลรวมประมาณการจัดสรรต้องไม่เกินมูลค่าหักค่าบำรุง (%.2f บาท)"
                     )
                     % base
-                )
-
-    @api.constrains("estimated_amount", "actual_amount")
-    def _check_actual_not_exceed_estimated(self):
-        prec = self.env["decimal.precision"].precision_get("Account")
-        for line in self:
-            if (
-                float_compare(
-                    line.actual_amount, line.estimated_amount, precision_digits=prec
-                )
-                > 0
-            ):
-                raise ValidationError(
-                    _(
-                        "ยอดจัดสรรจริงของ %s (%.2f บาท) เกินประมาณการ (%.2f บาท)"
-                    )
-                    % (line.name or "", line.actual_amount, line.estimated_amount)
                 )
 

--- a/kris_project/models/kris_project_installment_allocation.py
+++ b/kris_project/models/kris_project_installment_allocation.py
@@ -72,4 +72,4 @@ class KrisProjectInstallmentAllocation(models.Model):
                 continue
             allocated = allocated_by_id.get(line.allocation_line_id.id, 0.0)
             line.allocated_amount = allocated
-            line.remaining_amount = line.estimated_amount - allocated
+            line.remaining_amount = max(0.0, line.estimated_amount - allocated)

--- a/kris_project/models/kris_project_receipt_allocation.py
+++ b/kris_project/models/kris_project_receipt_allocation.py
@@ -1,6 +1,4 @@
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
-from odoo.tools import float_compare
+from odoo import fields, models
 
 
 class KrisProjectReceiptAllocation(models.Model):
@@ -35,21 +33,3 @@ class KrisProjectReceiptAllocation(models.Model):
         related="receipt_id.currency_id",
         readonly=True,
     )
-
-    @api.constrains("amount", "allocation_line_id")
-    def _check_actual_not_exceed_estimated(self):
-        prec = self.env["decimal.precision"].precision_get("Account")
-        for alloc_line in self.mapped("allocation_line_id"):
-            actual = sum(alloc_line.receipt_allocation_ids.mapped("amount"))
-            if (
-                float_compare(
-                    actual, alloc_line.estimated_amount, precision_digits=prec
-                )
-                > 0
-            ):
-                raise ValidationError(
-                    _(
-                        "ยอดจัดสรรจริงของ %s (%.2f บาท) เกินประมาณการ (%.2f บาท)"
-                    )
-                    % (alloc_line.name or "", actual, alloc_line.estimated_amount)
-                )

--- a/kris_project/tests/test_kris_project_lines.py
+++ b/kris_project/tests/test_kris_project_lines.py
@@ -235,6 +235,45 @@ class TestKrisProjectLines(KrisProjectCommon):
         self.assertAlmostEqual(ia.allocated_amount, 0.0, 2)
         self.assertAlmostEqual(ia.remaining_amount, 100_000.0, 2)
 
+    def test_installment_allocation_remaining_clamps_at_zero(self):
+        # When prior installments have already met or exceeded the line's plan,
+        # the breakdown's "remaining" cell shows 0, never a negative figure.
+        p = self._make_project(project_value=1_200_000.0, equipment_cost=200_000.0)
+        line = self.AllocationLine.create(
+            {
+                "project_id": p.id,
+                "item_id": self.item_a.id,
+                "estimated_amount": 100_000.0,
+            }
+        )
+        inst1 = self.Installment.create(
+            {"project_id": p.id, "name": "งวด 1", "amount": 100_000.0}
+        )
+        inst2 = self.Installment.create(
+            {"project_id": p.id, "name": "งวด 2", "amount": 100_000.0}
+        )
+        # Installment 1 takes more than the plan on this line.
+        self.InstallmentAlloc.create(
+            {
+                "installment_id": inst1.id,
+                "allocation_line_id": line.id,
+                "amount": 150_000.0,
+            }
+        )
+        ia2 = self.InstallmentAlloc.create(
+            {
+                "installment_id": inst2.id,
+                "allocation_line_id": line.id,
+                "amount": 0.0,
+            }
+        )
+        self.env.invalidate_all()
+        ia2 = self.InstallmentAlloc.browse(ia2.id)
+        # Allocated still reflects the real over-allocation,
+        # but remaining is clamped at 0 (never negative).
+        self.assertAlmostEqual(ia2.allocated_amount, 150_000.0, 2)
+        self.assertAlmostEqual(ia2.remaining_amount, 0.0, 2)
+
     # ------------------------------------------------------------------
     # Guard constraints (calculation integrity)
     # ------------------------------------------------------------------
@@ -250,35 +289,9 @@ class TestKrisProjectLines(KrisProjectCommon):
                 }
             )
 
-    def test_constraint_receipt_alloc_exceeds_estimated(self):
-        p = self._make_project(project_value=1_200_000.0, equipment_cost=200_000.0)
-        line = self.AllocationLine.create(
-            {
-                "project_id": p.id,
-                "item_id": self.item_a.id,
-                "estimated_amount": 50_000.0,
-            }
-        )
-        receipt = self.Receipt.create(
-            {
-                "project_id": p.id,
-                "name": "R",
-                "date": date(2025, 1, 1),
-                "amount": 100_000.0,
-            }
-        )
-        with self.assertRaises(ValidationError):
-            self.ReceiptAlloc.create(
-                {
-                    "receipt_id": receipt.id,
-                    "allocation_line_id": line.id,
-                    "amount": 60_000.0,
-                }
-            )
-
-    def test_constraint_alloc_line_actual_exceeds_estimated(self):
-        # The line-level guard (distinct from the receipt.allocation one):
-        # lowering estimated below an already-booked actual must raise.
+    def test_receipt_alloc_may_exceed_estimated(self):
+        # ADR-0001: a งวด may be over-collected, including at the per-allocator
+        # level — Receipts are not capped against the allocation line's plan.
         p = self._make_project(project_value=1_200_000.0, equipment_cost=200_000.0)
         line = self.AllocationLine.create(
             {
@@ -299,12 +312,13 @@ class TestKrisProjectLines(KrisProjectCommon):
             {
                 "receipt_id": receipt.id,
                 "allocation_line_id": line.id,
-                "amount": 40_000.0,
+                "amount": 60_000.0,
             }
         )
-        self.assertAlmostEqual(line.actual_amount, 40_000.0, 2)
-        with self.assertRaises(ValidationError):
-            line.estimated_amount = 30_000.0
+        self.assertAlmostEqual(line.actual_amount, 60_000.0, 2)
+        # And lowering the plan below the now-booked actual must also succeed.
+        line.estimated_amount = 30_000.0
+        self.assertAlmostEqual(line.estimated_amount, 30_000.0, 2)
 
     def test_constraint_installment_extra_exceeds_project(self):
         p = self._make_project(project_value=1_000_000.0, extra_value=10_000.0)


### PR DESCRIPTION
ด้านล่างนี้คือรายละเอียด PR ที่สามารถนำไปใช้ได้เลย:

---

### สรุปสิ่งที่แก้ไข

#### 1. บันทึกรับ — สามารถระบุยอดจัดสรรสูงกว่าประมาณการได้แล้ว

**ปัญหาเดิม:** เมื่อสร้างบันทึกรับ (รายรับ) แล้วกรอกยอดจัดสรรในแต่ละบรรทัด (per-allocator) เกินกว่าที่ตั้ง `estimated_amount` ไว้ ระบบจะแสดง error:

> "ยอดจัดสรรจริงของ X (… บาท) เกินประมาณการ (… บาท)"

และไม่ยอมบันทึก

**สาเหตุ:** มี `@api.constrains` อยู่สองจุดที่บังคับกฎเดียวกัน คือ ยอดจริง ≤ ยอดประมาณการ ทั้งบนโมเดล `kris.project.receipt.allocation` และ `kris.project.allocation.line`

**การแก้ไข:** ลบทั้งสอง constraint ออก เนื่องจากนโยบาย (ADR-0001) ระบุไว้ชัดเจนว่า KRIS อนุญาตให้งวดงานรับเงินเกินกว่าที่วางแผนได้ (over-collection is discretionary) ซึ่งใช้หลักการเดียวกันทั้งยอดรวมงวดงานและยอดย่อยรายบรรทัดจัดสรร

---

#### 2. ยอดคงเหลือที่จัดสรรได้ในงวดงาน — ไม่แสดงค่าติดลบอีกต่อไป

**ปัญหาเดิม:** เมื่อโครงการติ๊ก "ไม่มีงวดงานกำกับ" แล้วสร้างงวดงานได้หลายงวด หากงวดที่ 1 ใส่ยอดจัดสรรบรรทัดใดบรรทัดหนึ่งจนเต็มหรือเกินประมาณการ ช่อง **ยอดคงเหลือ (Remaining Amount)** ของงวดงานถัดไปในบรรทัดเดียวกันจะแสดงค่าติดลบ

**การแก้ไข:** เพิ่ม `max(0.0, ...)` รอบการคำนวณ `remaining_amount` ใน `_compute_allocated_amount` ของโมเดล `kris.project.installment.allocation` ทำให้ช่องนี้แสดงค่าต่ำสุดที่ `0.00` เสมอ โดย `allocated_amount` ยังคงแสดงยอดจริงตามที่จัดสรรไว้ทุกงวด (ไม่ถูก clamp) เพื่อให้ยังสามารถตรวจสอบการ over-allocate ได้

---

### ไฟล์ที่เปลี่ยนแปลง

| ไฟล์ | การเปลี่ยนแปลง |
|------|----------------|
| `models/kris_project_receipt_allocation.py` | ลบ constraint `_check_actual_not_exceed_estimated` และ import ที่ไม่ใช้แล้ว |
| `models/kris_project_allocation.py` | ลบ constraint `_check_actual_not_exceed_estimated` และ import `float_compare` |
| `models/kris_project_installment_allocation.py` | clamp `remaining_amount` ที่ 0 ด้วย `max(0.0, ...)` |
| `tests/test_kris_project_lines.py` | ลบ 2 test เดิม (ที่ assert ว่าต้องเกิด error), เพิ่ม 2 test ใหม่ |
| `docs/adr/0001-discretionary-completion.md` | เพิ่มข้อความชี้แจงว่านโยบาย over-collection ใช้กับยอดรายบรรทัดด้วย |

---

### แนวทางทดสอบ

1. สร้างโครงการใหม่ → กำหนด Allocation Line พร้อม `estimated_amount`
2. เพิ่มบันทึกรับ → กรอกยอดจัดสรรบรรทัดนั้นให้เกินกว่าประมาณการ → บันทึก: **ต้องผ่าน ไม่มี error**
3. สร้างโครงการที่ติ๊ก "ไม่มีงวดงานกำกับ" → เพิ่มงวดงานที่ 1 กรอกยอดจัดสรรเต็ม → บันทึก → เพิ่มงวดที่ 2: ช่อง "ยอดคงเหลือ" ของงวดที่ 2 ต้องแสดง `0.00` ไม่ใช่ค่าติดลบ