### PR TITLE
[16.0][FIX] agx_approval: budget commitment number stuck as "/" on reserve

### DIFF
--- a/agx_approval/models/approval_category.py
+++ b/agx_approval/models/approval_category.py
@@ -98,7 +98,6 @@ class ApprovalCategory(models.Model):
             "views": [[False, "form"]],
             "context": {
                 'form_view_initial_mode': 'edit',
-                'default_name': "/",
                 'default_category_id': self.id,
             },
         }


### PR DESCRIPTION
## Problem
บางครั้งเมื่อกด "จองงบประมาณ" ใน `approval.request` ชื่อของ budget commitment (BC) จะกลายเป็น `"/"` แทนที่จะเป็นเลขที่ `"BCxxxxx"` (เห็นใน alert "Budget Reserved: / — …").

## Root cause
`approval.category.create_request()` ฉีด `default_name="/"` เข้า context ของฟอร์มสร้าง `approval.request`. Context นี้ค้างอยู่ใน session และถูกส่งต่อเมื่อกดปุ่มจองงบ ไปจนถึง `budget.commitment.create()` ซึ่งไม่ได้ส่ง `name` มาเอง → Odoo เอา `default_name="/"` มาทับ field default `_("New")`.

ใน `budget.commitment.action_reserve()` เงื่อนไข `if record.name == _("New")` จึงเป็น `False` (เพราะ name เป็น `"/"`) → ข้ามการ assign sequence → ชื่อค้างเป็น `"/"` ถาวร.

**ทำไม "บางครั้ง":** เกิดเฉพาะตอนสร้างคำขอผ่านปุ่ม "สร้างคำขอ" แล้วกดจองงบในฟอร์มเดิมทันที (context ยังสกปรก). ถ้าเปิดคำขอที่ save แล้วใหม่ค่อยกดจอง จะได้ `BCxxxxx` ตามปกติ.

## Fix
ลบ key `default_name: "/"` ที่ซ้ำซ้อนออกจาก context ของ `create_request()`. Field `approval.request.name` มี `default="/"` อยู่แล้ว ฟอร์มจึงยังแสดง `"/"` เหมือนเดิม และ `approval.request.create()` ก็แทนด้วย sequence ให้อยู่แล้ว — เปลี่ยนแค่ไม่ให้ `default_name` รั่วไปทับ name ของ commitment.

## Note
- Commitment เก่าที่ name ค้างเป็น `"/"` จะไม่ถูกแก้อัตโนมัติ หากต้องการล้างข้อมูลเก่าต้องทำ data migration แยก.

🤖 Generated with [Claude Code](https://claude.com/claude-code)