### PR TITLE
[16.0][ADD] accounting_kmitl: warn on self-canceling same-account Dr/Cr pair

### DIFF
--- a/accounting_kmitl/__init__.py
+++ b/accounting_kmitl/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -8,12 +8,15 @@
     "license": "AGPL-3",
     "depends": [
         "account_operating_unit",
+        "base_exception",
         "base_tier_validation",
         "budget",
         "l10n_th_account_tax",
     ],
     "data": [
         "security/security.xml",
+        "data/account_move_exception_data.xml",
+        "wizard/account_move_exception_confirm_view.xml",
         "views/account_move_views.xml",
         "views/account_payment_method_views.xml",
         "views/menuitem.xml",

--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     "data": [
         "security/security.xml",
+        "security/ir.model.access.csv",
         "data/account_move_exception_data.xml",
         "wizard/account_move_exception_confirm_view.xml",
         "views/account_move_views.xml",

--- a/accounting_kmitl/data/account_move_exception_data.xml
+++ b/accounting_kmitl/data/account_move_exception_data.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="excep_self_canceling_pair" model="exception.rule">
+        <field name="name">คู่บัญชีหักล้างตัวเอง (Dr./Cr. รหัสบัญชีเดียวกัน)</field>
+        <field name="description">สมุดรายวันมีเพียง 1 คู่ ที่ใช้รหัสบัญชีเดียวกันทั้ง Dr. และ Cr. ด้วยยอดเท่ากัน ทำให้รายการหักล้างตัวเองไม่มีผลทางบัญชี กรุณาตรวจสอบว่าเป็นการบันทึกโดยตั้งใจ</field>
+        <field name="sequence">50</field>
+        <field name="model">account.move</field>
+        <field name="exception_type">by_py_code</field>
+        <field name="code">
+lines = obj.line_ids.filtered(
+    lambda l: l.account_id and l.display_type not in ('line_section', 'line_note')
+)
+if len(lines) == 2 and lines[0].account_id == lines[1].account_id:
+    debit_lines = lines.filtered(lambda l: l.debit &gt; 0)
+    credit_lines = lines.filtered(lambda l: l.credit &gt; 0)
+    if len(debit_lines) == 1 and len(credit_lines) == 1 \
+            and debit_lines.debit == credit_lines.credit:
+        failed = True
+        </field>
+        <field name="active" eval="True" />
+        <field name="is_blocking" eval="False" />
+    </record>
+</odoo>

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -205,3 +205,18 @@ msgstr "ตัวช่วยยืนยันข้อยกเว้นสม
 #: model:ir.model.fields,field_description:accounting_kmitl.field_account_move_exception_confirm__related_model_id
 msgid "Journal Entry"
 msgstr "รายการบันทึกบัญชี"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
+msgid "There are exceptions blocking this Journal Entry:"
+msgstr "มีข้อยกเว้นที่ต้องจัดการก่อนยืนยันรายการบันทึกบัญชีนี้:"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
+msgid "Ignore Exceptions"
+msgstr "ยืนยันโดยข้ามข้อยกเว้น"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
+msgid "Click here to be able to submit this Journal Entry regardless of the exceptions."
+msgstr "คลิกที่นี่เพื่อยืนยันรายการบันทึกบัญชีนี้โดยไม่สนใจข้อยกเว้น"

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -180,3 +180,28 @@ msgstr "เพิ่มบรรทัด"
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
 msgid "Account Items"
 msgstr "รายการบัญชี"
+
+#. module: accounting_kmitl
+#: model:exception.rule,name:accounting_kmitl.excep_self_canceling_pair
+msgid "คู่บัญชีหักล้างตัวเอง (Dr./Cr. รหัสบัญชีเดียวกัน)"
+msgstr "คู่บัญชีหักล้างตัวเอง (Dr./Cr. รหัสบัญชีเดียวกัน)"
+
+#. module: accounting_kmitl
+#: model:exception.rule,description:accounting_kmitl.excep_self_canceling_pair
+msgid "สมุดรายวันมีเพียง 1 คู่ ที่ใช้รหัสบัญชีเดียวกันทั้ง Dr. และ Cr. ด้วยยอดเท่ากัน ทำให้รายการหักล้างตัวเองไม่มีผลทางบัญชี กรุณาตรวจสอบว่าเป็นการบันทึกโดยตั้งใจ"
+msgstr "สมุดรายวันมีเพียง 1 คู่ ที่ใช้รหัสบัญชีเดียวกันทั้ง Dr. และ Cr. ด้วยยอดเท่ากัน ทำให้รายการหักล้างตัวเองไม่มีผลทางบัญชี กรุณาตรวจสอบว่าเป็นการบันทึกโดยตั้งใจ"
+
+#. module: accounting_kmitl
+#: model:ir.actions.act_window,name:accounting_kmitl.action_account_move_exception_confirm
+msgid "Outstanding exceptions to manage"
+msgstr "รายการข้อยกเว้นที่ต้องจัดการ"
+
+#. module: accounting_kmitl
+#: model:ir.model,name:accounting_kmitl.model_account_move_exception_confirm
+msgid "KMITL Account Move exception wizard"
+msgstr "ตัวช่วยยืนยันข้อยกเว้นสมุดรายวัน KMITL"
+
+#. module: accounting_kmitl
+#: model:ir.model.fields,field_description:accounting_kmitl.field_account_move_exception_confirm__related_model_id
+msgid "Journal Entry"
+msgstr "รายการบันทึกบัญชี"

--- a/accounting_kmitl/models/__init__.py
+++ b/accounting_kmitl/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move
+from . import exception_rule

--- a/accounting_kmitl/models/account_move.py
+++ b/accounting_kmitl/models/account_move.py
@@ -6,7 +6,7 @@ from odoo.exceptions import UserError, ValidationError
 
 class AccountMove(models.Model):
     _name = "account.move"
-    _inherit = ["account.move", "analytic.distribution.mixin"]
+    _inherit = ["account.move", "analytic.distribution.mixin", "base.exception"]
 
     # --- State ---
     state = fields.Selection(
@@ -44,10 +44,17 @@ class AccountMove(models.Model):
 
     # --- Actions ---
     def action_submit(self):
-        """Submit (lock) the journal entry; assign sequence number."""
+        """Submit (lock) the journal entry; assign sequence number.
+
+        Runs base_exception checks before locking so accidental entries
+        (e.g. same-account Dr/Cr self-canceling pair) are surfaced.
+        """
         for move in self:
             if move.state != "draft":
                 raise UserError(_("Only draft entries can be submitted."))
+        to_check = self.filtered(lambda m: not m.ignore_exception)
+        if to_check and to_check.detect_exceptions():
+            return to_check._popup_exceptions()
         self.write({"state": "submitted"})
         # Assign sequence number on submit
         for move in self.sorted(lambda m: (m.date, m.ref or "", m.id)):
@@ -63,7 +70,16 @@ class AccountMove(models.Model):
                     _("Only submitted entries can be reset to draft.")
                 )
             move.state = "draft"
+            move.exception_ids = False
+            move.main_exception_id = False
+            move.ignore_exception = False
         return True
+
+    @api.model
+    def _get_popup_action(self):
+        return self.env.ref(
+            "accounting_kmitl.action_account_move_exception_confirm"
+        )
 
     # --- Budget validation ---
     def _check_analytic_distribution_complete(self):

--- a/accounting_kmitl/models/account_move.py
+++ b/accounting_kmitl/models/account_move.py
@@ -81,6 +81,10 @@ class AccountMove(models.Model):
             "accounting_kmitl.action_account_move_exception_confirm"
         )
 
+    @api.model
+    def _reverse_field(self):
+        return "account_move_ids"
+
     # --- Budget validation ---
     def _check_analytic_distribution_complete(self):
         """Validate that all required analytic dimensions are present."""

--- a/accounting_kmitl/models/exception_rule.py
+++ b/accounting_kmitl/models/exception_rule.py
@@ -1,0 +1,18 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ExceptionRule(models.Model):
+    _inherit = "exception.rule"
+
+    account_move_ids = fields.Many2many(
+        comodel_name="account.move",
+        string="Journal Entries",
+    )
+    model = fields.Selection(
+        selection_add=[
+            ("account.move", "Journal Entry"),
+        ],
+        ondelete={"account.move": "cascade"},
+    )

--- a/accounting_kmitl/security/ir.model.access.csv
+++ b/accounting_kmitl/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_account_move_exception_confirm,account_move_exception_confirm,model_account_move_exception_confirm,base.group_user,1,1,1,1

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -12,6 +12,17 @@
                 <attribute name="statusbar_visible">draft,submitted,posted</attribute>
             </xpath>
 
+            <!-- base_exception banner: warn about detected exceptions before submit -->
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('exceptions_summary','=',False)]}">
+                    <p>
+                        <strong>There are exceptions blocking this Journal Entry:</strong>
+                    </p>
+                    <field name="exceptions_summary"/>
+                    <button name="action_ignore_exceptions" type="object" class="btn-danger" string="Ignore Exceptions" help="Click here to be able to submit this Journal Entry regardless of the exceptions." groups="base_exception.group_exception_rule_manager"/>
+                </div>
+            </xpath>
+
             <!-- Submit and Reset to Draft buttons.
                  Anchor on the second action_post button (the "Confirm" variant
                  for non-entry move types) via the unique attrs discriminator. -->

--- a/accounting_kmitl/wizard/__init__.py
+++ b/accounting_kmitl/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_exception_confirm

--- a/accounting_kmitl/wizard/account_move_exception_confirm.py
+++ b/accounting_kmitl/wizard/account_move_exception_confirm.py
@@ -1,0 +1,21 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountMoveExceptionConfirm(models.TransientModel):
+    _name = "account.move.exception.confirm"
+    _description = "KMITL Account Move exception wizard"
+    _inherit = ["exception.rule.confirm"]
+
+    related_model_id = fields.Many2one("account.move", "Journal Entry")
+
+    def action_confirm(self):
+        self.ensure_one()
+        exceptions_blocking = self.exception_ids.filtered("is_blocking")
+        if self.ignore and not exceptions_blocking:
+            self.related_model_id.ignore_exception = True
+            self.related_model_id.action_submit()
+        else:
+            self.related_model_id.ignore_exception = False
+        return super().action_confirm()

--- a/accounting_kmitl/wizard/account_move_exception_confirm_view.xml
+++ b/accounting_kmitl/wizard/account_move_exception_confirm_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="action_account_move_exception_confirm" model="ir.actions.act_window">
+        <field name="name">Outstanding exceptions to manage</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">account.move.exception.confirm</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="base_exception.view_exception_rule_confirm" />
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- เพิ่ม `base_exception` rule ใน `accounting_kmitl` เพื่อดักสมุดรายวันที่มี 2 บรรทัด ใช้รหัสบัญชีเดียวกัน และ Dr = Cr (หักล้างตัวเอง) ป้องกันข้อมูลขยะจากการบันทึกโดยไม่ตั้งใจ
- ผูก `account.move` เข้ากับ `base.exception`; `action_submit` จะเรียก `detect_exceptions` และเปิด wizard `account.move.exception.confirm` ให้ผู้ใช้แก้ไขหรือ ignore พร้อม audit trail ก่อน lock state
- Rule เป็น data-driven (`by_py_code`, `is_blocking=False`) สามารถ toggle active/blocking ได้จากหน้า Exception Rules; `action_draft` เคลียร์ exception state; เพิ่มคำแปลไทยครบใน `i18n/th.po`

## Test plan
- [ ] `-u accounting_kmitl` ติดตั้ง `base_exception` และ load rule ใหม่สำเร็จ
- [ ] Submit JE 2 บรรทัดบัญชีเดียวกัน Dr=Cr → เห็น wizard "รายการข้อยกเว้นที่ต้องจัดการ"
- [ ] Submit JE บัญชีต่างกัน หรือ ≥ 3 บรรทัด → ผ่านปกติ
- [ ] กด Ignore Exceptions ใน wizard → entry เข้าสถานะ submitted, `ignore_exception=True`
- [ ] Reset to draft → เคลียร์ `exception_ids`, `main_exception_id`, `ignore_exception`