### PR TITLE
[16.0][IMP] agx_approval: show budget section before expense table in PDF

### DIFF
--- a/agx_approval/__manifest__.py
+++ b/agx_approval/__manifest__.py
@@ -12,6 +12,7 @@
         "budget",
         "base_exception",
         "account_fiscal_year_enhance",
+        "l10n_th_amount_to_text",
     ],
     "data": [
         "security/security.xml",

--- a/agx_approval/reports/report_approval_request.xml
+++ b/agx_approval/reports/report_approval_request.xml
@@ -90,6 +90,11 @@
                             </div>
                         </div>
 
+                        <!-- Budget Details -->
+                        <div class="my-4" />
+                        <p>รายละเอียดงบประมาณ</p>
+                        <t t-call="agx_approval.report_approval_request_budget" />
+
                         <!-- Expense Lines Table -->
                         <div class="my-4" />
                         <div class="row my-2">
@@ -180,11 +185,6 @@
                                 </tbody>
                             </table>
                         </t>
-
-                        <!-- Budget Details -->
-                        <div class="my-4" />
-                        <p>รายละเอียดงบประมาณ</p>
-                        <t t-call="agx_approval.report_approval_request_budget" />
                     </div>
                 </t>
             </t>

--- a/agx_approval/reports/report_approval_request.xml
+++ b/agx_approval/reports/report_approval_request.xml
@@ -128,6 +128,9 @@
                                     <tr>
                                         <td colspan="3" class="text-center fw-bolder">
                                             รวมทั้งสิ้น
+                                            <div class="fw-normal">
+                                                (<t t-esc="o.currency_id.with_context({'lang': 'th_TH'}).amount_to_text(grand_total)" />)
+                                            </div>
                                         </td>
                                         <td class="text-end fw-bolder" t-out="'{0:,.2f}'.format(grand_total)" />
                                     </tr>
@@ -179,6 +182,9 @@
                                     <tr>
                                         <td colspan="3" class="text-center fw-bolder">
                                             รวมทั้งสิ้น
+                                            <div class="fw-normal">
+                                                (<t t-esc="o.currency_id.with_context({'lang': 'th_TH'}).amount_to_text(grand_total)" />)
+                                            </div>
                                         </td>
                                         <td class="text-end fw-bolder" t-out="'{0:,.2f}'.format(grand_total)" />
                                     </tr>
@@ -198,6 +204,12 @@
                     <td>เลขที่ใบจองงบประมาณ</td>
                     <td>
                         <span t-field="o.budget_commitment_id" />
+                    </td>
+                </tr>
+                <tr class="o_field_budget_commitment_amount">
+                    <td>มูลค่างบประมาณ</td>
+                    <td>
+                        <span t-field="o.budget_commitment_amount" />
                     </td>
                 </tr>
                 <tr class="o_field_budget_account_id">

--- a/agx_approval/reports/report_approval_request.xml
+++ b/agx_approval/reports/report_approval_request.xml
@@ -206,12 +206,6 @@
                         <span t-field="o.budget_commitment_id" />
                     </td>
                 </tr>
-                <tr class="o_field_budget_commitment_amount">
-                    <td>มูลค่างบประมาณ</td>
-                    <td>
-                        <span t-field="o.budget_commitment_amount" />
-                    </td>
-                </tr>
                 <tr class="o_field_budget_account_id">
                     <td>รหัสงบประมาณค่าใช้จ่าย</td>
                     <td>
@@ -240,6 +234,12 @@
                     <td>กองทุน</td>
                     <td>
                         <span t-field="o.fund_analytic_id" />
+                    </td>
+                </tr>
+                <tr class="o_field_budget_commitment_amount">
+                    <td>มูลค่างบประมาณ</td>
+                    <td>
+                        <span t-field="o.budget_commitment_amount" />
                     </td>
                 </tr>
             </tbody>

--- a/agx_approval_sarabun/reports/report_approval_request.xml
+++ b/agx_approval_sarabun/reports/report_approval_request.xml
@@ -218,12 +218,6 @@
                         <span t-field="o.budget_commitment_id" />
                     </td>
                 </tr>
-                <tr class="o_field_budget_commitment_amount">
-                    <td>มูลค่างบประมาณ</td>
-                    <td>
-                        <span t-field="o.budget_commitment_amount" />
-                    </td>
-                </tr>
                 <tr class="o_field_budget_account_id">
                     <td>รหัสงบประมาณค่าใช้จ่าย</td>
                     <td>
@@ -252,6 +246,12 @@
                     <td>กองทุน</td>
                     <td>
                         <span t-field="o.fund_analytic_id" />
+                    </td>
+                </tr>
+                <tr class="o_field_budget_commitment_amount">
+                    <td>มูลค่างบประมาณ</td>
+                    <td>
+                        <span t-field="o.budget_commitment_amount" />
                     </td>
                 </tr>
             </tbody>

--- a/agx_approval_sarabun/reports/report_approval_request.xml
+++ b/agx_approval_sarabun/reports/report_approval_request.xml
@@ -142,6 +142,13 @@
                             </div>
                         </div>
 
+                        <!-- Budget Details -->
+                        <div class="my-4" />
+                        <p>รายละเอียดงบประมาณ</p>
+                        <t
+                            t-call="agx_approval_sarabun.report_approval_request_budget"
+                        />
+
                         <!-- Expense Lines Table -->
                         <div class="my-4" />
                         <div class="row my-2">
@@ -187,13 +194,6 @@
                                 </tr>
                             </tbody>
                         </table>
-
-                        <!-- Budget Details -->
-                        <div class="my-4" />
-                        <p>รายละเอียดงบประมาณ</p>
-                        <t
-                            t-call="agx_approval_sarabun.report_approval_request_budget"
-                        />
 
                         <!-- Signature Section -->
                         <div class="my-5" style="height: 10px" />

--- a/agx_approval_sarabun/reports/report_approval_request.xml
+++ b/agx_approval_sarabun/reports/report_approval_request.xml
@@ -186,6 +186,11 @@
                                 <tr>
                                     <td colspan="3" class="text-center fw-bolder">
                                         รวมทั้งสิ้น
+                                        <div class="fw-normal">
+                                            (<t
+                                                t-esc="o.currency_id.with_context({'lang': 'th_TH'}).amount_to_text(total)"
+                                            />)
+                                        </div>
                                     </td>
                                     <td
                                         class="text-end fw-bolder"
@@ -211,6 +216,12 @@
                     <td>เลขที่ใบจองงบประมาณ</td>
                     <td>
                         <span t-field="o.budget_commitment_id" />
+                    </td>
+                </tr>
+                <tr class="o_field_budget_commitment_amount">
+                    <td>มูลค่างบประมาณ</td>
+                    <td>
+                        <span t-field="o.budget_commitment_amount" />
                     </td>
                 </tr>
                 <tr class="o_field_budget_account_id">


### PR DESCRIPTION
## สรุป
ย้ายส่วน "รายละเอียดงบประมาณ" ให้ขึ้นมาแสดงก่อนตาราง "รายการค่าใช้จ่าย" ใน PDF report ของ `approval.request` ทั้งสองรูปแบบ คือ `agx_approval` (ใบขออนุมัติ) และ `agx_approval_sarabun` (บันทึกข้อความ)

เป็นการสลับลำดับบล็อกใน QWeb template เท่านั้น ไม่ได้แก้ sub-template งบประมาณหรือ logic ตารางค่าใช้จ่าย (รวมทั้งกรณี single/multi-payee)

## การทดสอบ
- ตรวจว่า XML ทั้งสองไฟล์ well-formed
- พิมพ์ PDF ของ approval.request ทั้งสองรูปแบบ ยืนยันว่างบประมาณแสดงก่อนตารางค่าใช้จ่าย และส่วนลายเซ็นของ sarabun ยังอยู่ท้ายสุด