### PR TITLE
[16.0][ADD] finance_kmitl: cheque control register (ทะเบียนคุมเช็ค)

### DIFF
--- a/finance_kmitl/__manifest__.py
+++ b/finance_kmitl/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "KMITL Finance",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "KMITL/Finance",
     "summary": "งานการเงิน KMITL: จ่ายเงิน, bank export, WHT, ทะเบียนคุมเช็ค, รายรับ/ใบเสร็จ",
     "license": "LGPL-3",
@@ -30,10 +30,14 @@
         "views/account_payment_views.xml",
         "views/bank_payment_export_views.xml",
         "views/cheque_register_views.xml",
+        "views/cheque_layout_views.xml",
+        "views/account_journal_views.xml",
         "views/menuitem.xml",
         "report/paperformat.xml",
         "report/report_bank_payment_export_action.xml",
         "report/report_bank_payment_export.xml",
+        "report/report_cheque_print.xml",
+        "report/report_cheque_print_action.xml",
     ],
     "installable": True,
     "application": True,

--- a/finance_kmitl/__manifest__.py
+++ b/finance_kmitl/__manifest__.py
@@ -2,9 +2,9 @@
 
 {
     "name": "KMITL Finance",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "category": "KMITL/Finance",
-    "summary": "งานการเงิน KMITL: จ่ายเงิน, bank export, WHT, รายรับ/ใบเสร็จ",
+    "summary": "งานการเงิน KMITL: จ่ายเงิน, bank export, WHT, ทะเบียนคุมเช็ค, รายรับ/ใบเสร็จ",
     "license": "LGPL-3",
     "author": "KMITL",
     "website": "https://www.kmitl.ac.th",
@@ -25,9 +25,11 @@
         "security/security.xml",
         "security/ir.model.access.csv",
         "data/kmitl_payment_type_data.xml",
+        "data/cheque_register_sequence.xml",
         "views/kmitl_payment_type_views.xml",
         "views/account_payment_views.xml",
         "views/bank_payment_export_views.xml",
+        "views/cheque_register_views.xml",
         "views/menuitem.xml",
         "report/paperformat.xml",
         "report/report_bank_payment_export_action.xml",

--- a/finance_kmitl/data/cheque_register_sequence.xml
+++ b/finance_kmitl/data/cheque_register_sequence.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <!-- Issued cheque register numbering -->
+        <record id="seq_cheque_register_outbound" model="ir.sequence">
+            <field name="name">Cheque Register (Issued)</field>
+            <field name="code">cheque.register.outbound</field>
+            <field name="prefix">CHQ-OUT/%(year)s/</field>
+            <field name="padding">4</field>
+            <field name="company_id" eval="False" />
+        </record>
+        <!-- Received cheque register numbering -->
+        <record id="seq_cheque_register_inbound" model="ir.sequence">
+            <field name="name">Cheque Register (Received)</field>
+            <field name="code">cheque.register.inbound</field>
+            <field name="prefix">CHQ-IN/%(year)s/</field>
+            <field name="padding">4</field>
+            <field name="company_id" eval="False" />
+        </record>
+    </data>
+</odoo>

--- a/finance_kmitl/i18n/th.po
+++ b/finance_kmitl/i18n/th.po
@@ -144,6 +144,7 @@ msgstr "ผู้ชำระเงิน"
 
 #. module: finance_kmitl
 #: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_payment_form_inherit
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
 msgid "Payee"
 msgstr "ผู้รับเงิน"
 
@@ -543,3 +544,145 @@ msgstr "เช็คเด้งได้เฉพาะเช็คที่ค
 #, python-format
 msgid "Cleared cheques cannot be cancelled."
 msgstr "เช็คที่ขึ้นเงินแล้วยกเลิกไม่ได้"
+
+#. module: finance_kmitl
+#: model:ir.model,name:finance_kmitl.model_cheque_layout
+msgid "Cheque Print Layout"
+msgstr "รูปแบบการพิมพ์เช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__name
+msgid "Name"
+msgstr "ชื่อ"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__journal_ids
+msgid "Cheque Books"
+msgstr "สมุดเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__font_size
+msgid "Font Size (pt)"
+msgstr "ขนาดตัวอักษร (pt)"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__date_buddhist_year
+msgid "Buddhist Era Date"
+msgstr "ใช้ปี พ.ศ."
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__date_spacing
+msgid "Date Digit Spacing (mm)"
+msgstr "ระยะห่างตัวเลขวันที่ (มม.)"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__date_top
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__payee_top
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__amount_figure_top
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__amount_text_top
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__crossing_top
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__bearer_top
+msgid "Top"
+msgstr "บน"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__date_left
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__payee_left
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__amount_figure_left
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__amount_text_left
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__crossing_left
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_layout__bearer_left
+msgid "Left"
+msgstr "ซ้าย"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__crossed
+msgid "A/C Payee Only"
+msgstr "ขีดคร่อม A/C Payee Only"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__strike_bearer
+msgid "Strike 'or Bearer'"
+msgstr "ขีดฆ่า 'หรือผู้ถือ'"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_account_journal__cheque_layout_id
+msgid "Cheque Layout"
+msgstr "รูปแบบการพิมพ์เช็ค"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "Layout Settings"
+msgstr "ตั้งค่ารูปแบบ"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "Cheque Books (assign on the journal)"
+msgstr "สมุดเช็ค (กำหนดที่สมุดรายวัน)"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "Field Positions (mm from top-left of the cheque)"
+msgstr "ตำแหน่งฟิลด์ (มม. จากมุมซ้ายบนของเช็ค)"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "Date (DDMMYYYY boxes)"
+msgstr "วันที่ (ช่อง DDMMYYYY)"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "Amount (figures)"
+msgstr "จำนวนเงิน (ตัวเลข)"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "Amount (words)"
+msgstr "จำนวนเงิน (ตัวอักษร)"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "A/C Payee Only crossing"
+msgstr "ขีดคร่อม A/C Payee Only"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_layout_form
+msgid "'or bearer' strike"
+msgstr "ขีดฆ่า 'หรือผู้ถือ'"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_journal_form_cheque
+msgid "Cheque"
+msgstr "เช็ค"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#: model:ir.actions.report,name:finance_kmitl.action_report_cheque_print
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+#, python-format
+msgid "Print Cheque"
+msgstr "พิมพ์เช็ค"
+
+#. module: finance_kmitl
+#: model:ir.actions.act_window,name:finance_kmitl.action_cheque_layout
+#: model:ir.ui.menu,name:finance_kmitl.menu_settings_cheque_layout
+msgid "Cheque Layouts"
+msgstr "รูปแบบการพิมพ์เช็ค"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Enter the cheque number before printing."
+msgstr "กรุณาระบุเลขที่เช็คก่อนพิมพ์"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Select the bank/cheque book (journal) before printing."
+msgstr "กรุณาเลือกสมุดเช็ค (สมุดรายวัน) ก่อนพิมพ์"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Configure a Cheque Layout on journal '%s' before printing."
+msgstr "กรุณาตั้งค่ารูปแบบการพิมพ์เช็คให้สมุดรายวัน '%s' ก่อนพิมพ์"

--- a/finance_kmitl/i18n/th.po
+++ b/finance_kmitl/i18n/th.po
@@ -64,6 +64,8 @@ msgstr "สมุดรายวันเริ่มต้นสำหรับ
 
 #. module: finance_kmitl
 #: model:ir.model.fields,field_description:finance_kmitl.field_kmitl_payment_type__direction
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__direction
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
 msgid "Direction"
 msgstr "ทิศทาง"
 
@@ -126,6 +128,7 @@ msgstr "แทนที่บัญชีปลายทาง เว้นว�
 #. module: finance_kmitl
 #: model:ir.model,name:finance_kmitl.model_account_payment
 #: model:ir.ui.menu,name:finance_kmitl.menu_payment_root
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__payment_id
 msgid "Payment"
 msgstr "การเบิกจ่ายเงิน"
 
@@ -292,3 +295,251 @@ msgstr "รูปแบบส่งออกข้อมูลธนาคาร
 #: model:ir.ui.menu,name:finance_kmitl.menu_settings_payment_types
 msgid "Payment Types (KMITL)"
 msgstr "ประเภทการจ่ายเงิน (KMITL)"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_kmitl_payment_type__is_cheque
+msgid "Paid/Received by Cheque"
+msgstr "จ่าย/รับด้วยเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model,name:finance_kmitl.model_cheque_register
+msgid "Cheque Control Register"
+msgstr "ทะเบียนคุมเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__name
+msgid "Reference"
+msgstr "เลขที่อ้างอิง"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__cheque_number
+msgid "Cheque No."
+msgstr "เลขที่เช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__cheque_date
+msgid "Cheque Date"
+msgstr "วันที่หน้าเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__journal_id
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Bank/Cheque Book"
+msgstr "ธนาคาร/สมุดเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__bank_id
+msgid "Bank"
+msgstr "ธนาคาร"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__partner_id
+msgid "Payee/Drawer"
+msgstr "ผู้รับเงิน/ผู้สั่งจ่าย"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__amount
+msgid "Amount"
+msgstr "จำนวนเงิน"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__currency_id
+msgid "Currency"
+msgstr "สกุลเงิน"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__ref
+msgid "Source Document"
+msgstr "เลขที่ฎีกา/เอกสารอ้างอิง"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__handover_date
+msgid "Handover/Receipt Date"
+msgstr "วันที่จ่าย/รับเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__deposit_date
+msgid "Deposit Date"
+msgstr "วันที่ฝากเช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__clearing_date
+msgid "Clearing Date"
+msgstr "วันที่ขึ้นเงิน"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__note
+msgid "Notes"
+msgstr "หมายเหตุ"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_cheque_register__state
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Status"
+msgstr "สถานะ"
+
+#. module: finance_kmitl
+#: model:ir.model.fields,field_description:finance_kmitl.field_account_payment__cheque_register_ids
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_account_payment_form_inherit
+msgid "Cheques"
+msgstr "เช็ค"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__direction__outbound
+msgid "Issued Cheque"
+msgstr "เช็คจ่าย"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__direction__inbound
+msgid "Received Cheque"
+msgstr "เช็ครับ"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__state__draft
+msgid "Draft"
+msgstr "ร่าง"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__state__active
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Outstanding"
+msgstr "คงค้าง (รอขึ้นเงิน)"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__state__cleared
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Cleared"
+msgstr "ขึ้นเงินแล้ว"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__state__bounced
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Bounced"
+msgstr "เช็คเด้ง"
+
+#. module: finance_kmitl
+#: model:ir.model.fields.selection,name:finance_kmitl.selection__cheque_register__state__cancelled
+msgid "Cancelled"
+msgstr "ยกเลิก"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Issue / Receive"
+msgstr "ออก/รับเช็ค"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Clear (Cashed)"
+msgstr "ขึ้นเงิน"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Cancel"
+msgstr "ยกเลิก"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Reset to Draft"
+msgstr "กลับเป็นร่าง"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Cheque Information"
+msgstr "ข้อมูลเช็ค"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Payment Information"
+msgstr "ข้อมูลการจ่าย/รับเงิน"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+msgid "Dates & Status"
+msgstr "วันที่และสถานะ"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/account_payment.py:0
+#: model:ir.ui.menu,name:finance_kmitl.menu_cheque_register_root
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_form
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_tree
+#, python-format
+msgid "Cheque Register"
+msgstr "ทะเบียนคุมเช็ค"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Issued"
+msgstr "เช็คจ่าย"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Received"
+msgstr "เช็ครับ"
+
+#. module: finance_kmitl
+#: model_terms:ir.ui.view,arch_db:finance_kmitl.view_cheque_register_search
+msgid "Group By"
+msgstr "จัดกลุ่มตาม"
+
+#. module: finance_kmitl
+#: model:ir.actions.act_window,name:finance_kmitl.action_cheque_register_outbound
+msgid "Issued Cheque Register"
+msgstr "ทะเบียนคุมเช็คจ่าย"
+
+#. module: finance_kmitl
+#: model:ir.actions.act_window,name:finance_kmitl.action_cheque_register_inbound
+msgid "Received Cheque Register"
+msgstr "ทะเบียนคุมเช็ครับ"
+
+#. module: finance_kmitl
+#: model:ir.ui.menu,name:finance_kmitl.menu_cheque_register_outbound
+msgid "Issued Cheques"
+msgstr "เช็คจ่าย"
+
+#. module: finance_kmitl
+#: model:ir.ui.menu,name:finance_kmitl.menu_cheque_register_inbound
+msgid "Received Cheques"
+msgstr "เช็ครับ"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "New"
+msgstr "ใหม่"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Cheque number %(num)s already exists in this cheque book."
+msgstr "เลขที่เช็ค %(num)s มีอยู่แล้วในสมุดเช็คนี้"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "A cheque number is required before the cheque can be issued."
+msgstr "ต้องระบุเลขที่เช็คก่อนออกเช็ค"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Only draft cheques can be issued/received."
+msgstr "ออก/รับเช็คได้เฉพาะรายการที่เป็นร่าง"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Only outstanding cheques can be cleared."
+msgstr "ขึ้นเงินได้เฉพาะเช็คที่คงค้าง"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Only outstanding cheques can bounce."
+msgstr "เช็คเด้งได้เฉพาะเช็คที่คงค้าง"
+
+#. module: finance_kmitl
+#: code:addons/finance_kmitl/models/cheque_register.py:0
+#, python-format
+msgid "Cleared cheques cannot be cancelled."
+msgstr "เช็คที่ขึ้นเงินแล้วยกเลิกไม่ได้"

--- a/finance_kmitl/models/__init__.py
+++ b/finance_kmitl/models/__init__.py
@@ -5,4 +5,6 @@ from . import account_move
 from . import bank_payment_export
 from . import bank_payment_export_line
 from . import kmitl_payment_type
+from . import cheque_layout
 from . import cheque_register
+from . import account_journal

--- a/finance_kmitl/models/__init__.py
+++ b/finance_kmitl/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_move
 from . import bank_payment_export
 from . import bank_payment_export_line
 from . import kmitl_payment_type
+from . import cheque_register

--- a/finance_kmitl/models/account_journal.py
+++ b/finance_kmitl/models/account_journal.py
@@ -1,0 +1,14 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    cheque_layout_id = fields.Many2one(
+        comodel_name="cheque.layout",
+        string="Cheque Layout",
+        help="Print calibration used when printing cheques drawn on this "
+        "journal (cheque book).",
+    )

--- a/finance_kmitl/models/account_move.py
+++ b/finance_kmitl/models/account_move.py
@@ -20,6 +20,7 @@ class AccountMove(models.Model):
             if (
                 payment
                 and payment.payment_type == "outbound"
+                and not payment.kmitl_payment_type_id.is_cheque
                 and payment.export_status == "draft"
             ):
                 raise UserError(

--- a/finance_kmitl/models/account_payment.py
+++ b/finance_kmitl/models/account_payment.py
@@ -36,6 +36,15 @@ class AccountPayment(models.Model):
         "withholding tax).",
     )
 
+    cheque_register_ids = fields.One2many(
+        comodel_name="cheque.register",
+        inverse_name="payment_id",
+        string="Cheques",
+    )
+    cheque_register_count = fields.Integer(
+        compute="_compute_cheque_register_count",
+    )
+
     @api.depends("move_id.line_ids.wht_tax_id", "move_id.line_ids.balance", "amount")
     def _compute_amount_wht(self):
         for payment in self:
@@ -43,11 +52,17 @@ class AccountPayment(models.Model):
             payment.amount_wht = sum(abs(line.balance) for line in wht_lines)
             payment.amount_before_wht = payment.amount + payment.amount_wht
 
+    @api.depends("cheque_register_ids")
+    def _compute_cheque_register_count(self):
+        for payment in self:
+            payment.cheque_register_count = len(payment.cheque_register_ids)
+
     def action_post(self):
         """Validate bank export for outbound, then reconcile after posting."""
         for payment in self:
             if (
                 payment.payment_type == "outbound"
+                and not payment.kmitl_payment_type_id.is_cheque
                 and payment.export_status == "draft"
             ):
                 raise UserError(
@@ -55,7 +70,49 @@ class AccountPayment(models.Model):
                 )
         res = super().action_post()
         self._reconcile_source_invoice_lines()
+        self._create_cheque_register_entries()
         return res
+
+    def _create_cheque_register_entries(self):
+        """Add a cheque to the control register when a cheque-type payment posts.
+
+        The row is created in ``draft`` because the physical cheque number is
+        entered by the finance officer, who then issues it from the register.
+        """
+        for payment in self.filtered(
+            lambda p: p.kmitl_payment_type_id.is_cheque and not p.cheque_register_ids
+        ):
+            self.env["cheque.register"].create(
+                payment._prepare_cheque_register_vals()
+            )
+
+    def _prepare_cheque_register_vals(self):
+        self.ensure_one()
+        return {
+            "direction": self.payment_type,
+            "partner_id": self.partner_id.id,
+            "amount": self.amount,
+            "currency_id": self.currency_id.id,
+            "journal_id": self.journal_id.id,
+            "cheque_date": self.date,
+            "ref": self.ref or self.name,
+            "payment_id": self.id,
+            "company_id": self.company_id.id,
+        }
+
+    def action_view_cheque_register(self):
+        self.ensure_one()
+        return {
+            "name": _("Cheque Register"),
+            "type": "ir.actions.act_window",
+            "res_model": "cheque.register",
+            "view_mode": "tree,form",
+            "domain": [("payment_id", "=", self.id)],
+            "context": {
+                "default_payment_id": self.id,
+                "default_direction": self.payment_type,
+            },
+        }
 
     def _reconcile_source_invoice_lines(self):
         """Reconcile payment lines with stored source invoice lines."""

--- a/finance_kmitl/models/cheque_layout.py
+++ b/finance_kmitl/models/cheque_layout.py
@@ -1,0 +1,58 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ChequeLayout(models.Model):
+    """Print calibration for a physical cheque form.
+
+    Cheque layouts differ per bank, so field positions are stored as top/left
+    offsets (in millimetres from the top-left of the cheque) and reused across
+    the cheque books (journals) that share the same printed form.
+    """
+
+    _name = "cheque.layout"
+    _description = "Cheque Print Layout"
+    _order = "name"
+
+    name = fields.Char(required=True, translate=True)
+    active = fields.Boolean(default=True)
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        default=lambda self: self.env.company,
+    )
+    journal_ids = fields.One2many(
+        comodel_name="account.journal",
+        inverse_name="cheque_layout_id",
+        string="Cheque Books",
+        help="Bank/cash journals whose cheques use this printed form.",
+    )
+
+    # Rendering
+    font_size = fields.Float(string="Font Size (pt)", default=14.0)
+    date_buddhist_year = fields.Boolean(
+        string="Buddhist Era Date",
+        help="Print the year in the Buddhist Era (พ.ศ.) instead of the "
+        "Gregorian year.",
+    )
+    date_spacing = fields.Float(
+        string="Date Digit Spacing (mm)",
+        default=2.5,
+        help="Letter spacing between the 8 date digits so they line up with "
+        "the pre-printed boxes.",
+    )
+
+    # Field positions (mm from top-left of the cheque). Grouped in the form
+    # view, so each pair is labelled simply "Top"/"Left".
+    date_top = fields.Float(string="Top", default=8.0)
+    date_left = fields.Float(string="Left", default=135.0)
+    payee_top = fields.Float(string="Top", default=22.0)
+    payee_left = fields.Float(string="Left", default=22.0)
+    amount_figure_top = fields.Float(string="Top", default=22.0)
+    amount_figure_left = fields.Float(string="Left", default=138.0)
+    amount_text_top = fields.Float(string="Top", default=33.0)
+    amount_text_left = fields.Float(string="Left", default=22.0)
+    crossing_top = fields.Float(string="Top", default=5.0)
+    crossing_left = fields.Float(string="Left", default=12.0)
+    bearer_top = fields.Float(string="Top", default=40.0)
+    bearer_left = fields.Float(string="Left", default=118.0)

--- a/finance_kmitl/models/cheque_register.py
+++ b/finance_kmitl/models/cheque_register.py
@@ -213,17 +213,6 @@ class ChequeRegister(models.Model):
         self.ensure_one()
         if not self.cheque_number:
             raise UserError(_("Enter the cheque number before printing."))
-        if not self.journal_id:
-            raise UserError(
-                _("Select the bank/cheque book (journal) before printing.")
-            )
-        if not self.journal_id.cheque_layout_id:
-            raise UserError(
-                _(
-                    "Configure a Cheque Layout on journal '%s' before printing.",
-                )
-                % self.journal_id.display_name
-            )
         return self.env.ref(
             "finance_kmitl.action_report_cheque_print"
         ).report_action(self)

--- a/finance_kmitl/models/cheque_register.py
+++ b/finance_kmitl/models/cheque_register.py
@@ -1,0 +1,180 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+
+class ChequeRegister(models.Model):
+    _name = "cheque.register"
+    _description = "Cheque Control Register"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "cheque_date desc, id desc"
+
+    name = fields.Char(
+        string="Reference",
+        required=True,
+        copy=False,
+        readonly=True,
+        default=lambda self: _("New"),
+    )
+    direction = fields.Selection(
+        selection=[
+            ("outbound", "Issued Cheque"),
+            ("inbound", "Received Cheque"),
+        ],
+        string="Direction",
+        required=True,
+        default=lambda self: self.env.context.get("default_direction", "outbound"),
+        tracking=True,
+    )
+    cheque_number = fields.Char(string="Cheque No.", tracking=True)
+    cheque_date = fields.Date(
+        string="Cheque Date",
+        required=True,
+        default=fields.Date.context_today,
+        tracking=True,
+    )
+    journal_id = fields.Many2one(
+        comodel_name="account.journal",
+        string="Bank/Cheque Book",
+        domain="[('type', 'in', ('bank', 'cash'))]",
+        tracking=True,
+    )
+    bank_id = fields.Many2one(
+        comodel_name="res.bank",
+        related="journal_id.bank_id",
+        string="Bank",
+        readonly=True,
+    )
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Payee/Drawer",
+        tracking=True,
+    )
+    amount = fields.Monetary(
+        string="Amount", currency_field="currency_id", tracking=True
+    )
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        default=lambda self: self.env.company.currency_id,
+        required=True,
+    )
+    ref = fields.Char(string="Source Document")
+    payment_id = fields.Many2one(
+        comodel_name="account.payment",
+        string="Payment",
+        ondelete="set null",
+        index=True,
+        copy=False,
+        readonly=True,
+    )
+    handover_date = fields.Date(string="Handover/Receipt Date", tracking=True)
+    deposit_date = fields.Date(string="Deposit Date", tracking=True)
+    clearing_date = fields.Date(string="Clearing Date", tracking=True)
+    note = fields.Text(string="Notes")
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        default=lambda self: self.env.company,
+        required=True,
+    )
+    state = fields.Selection(
+        selection=[
+            ("draft", "Draft"),
+            ("active", "Outstanding"),
+            ("cleared", "Cleared"),
+            ("bounced", "Bounced"),
+            ("cancelled", "Cancelled"),
+        ],
+        string="Status",
+        default="draft",
+        required=True,
+        copy=False,
+        tracking=True,
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("name", _("New")) == _("New"):
+                direction = vals.get("direction") or self.env.context.get(
+                    "default_direction", "outbound"
+                )
+                vals["name"] = self.env["ir.sequence"].next_by_code(
+                    "cheque.register.%s" % direction
+                ) or _("New")
+        return super().create(vals_list)
+
+    @api.constrains("cheque_number", "journal_id", "direction", "company_id")
+    def _check_unique_outbound_number(self):
+        """Issued cheques must keep consecutive, non-repeating numbers per cheque
+        book. A cancelled cheque still occupies its number (never reused). Received
+        cheques carry numbers from external banks, so no uniqueness is enforced."""
+        for cheque in self:
+            if cheque.direction != "outbound" or not cheque.cheque_number:
+                continue
+            duplicate = self.search_count(
+                [
+                    ("id", "!=", cheque.id),
+                    ("direction", "=", "outbound"),
+                    ("cheque_number", "=", cheque.cheque_number),
+                    ("journal_id", "=", cheque.journal_id.id),
+                    ("company_id", "=", cheque.company_id.id),
+                ]
+            )
+            if duplicate:
+                raise ValidationError(
+                    _(
+                        "Cheque number %(num)s already exists in this cheque book.",
+                        num=cheque.cheque_number,
+                    )
+                )
+
+    @api.constrains("state", "cheque_number")
+    def _check_cheque_number_required(self):
+        """A draft row may pre-exist (e.g. auto-created from a payment) before the
+        physical cheque number is known; the number becomes mandatory once the
+        cheque is issued/received."""
+        for cheque in self:
+            if cheque.state != "draft" and not cheque.cheque_number:
+                raise ValidationError(
+                    _("A cheque number is required before the cheque can be issued.")
+                )
+
+    def action_activate(self):
+        for cheque in self:
+            if cheque.state != "draft":
+                raise UserError(_("Only draft cheques can be issued/received."))
+            cheque.write(
+                {
+                    "state": "active",
+                    "handover_date": cheque.handover_date
+                    or fields.Date.context_today(cheque),
+                }
+            )
+
+    def action_clear(self):
+        for cheque in self:
+            if cheque.state != "active":
+                raise UserError(_("Only outstanding cheques can be cleared."))
+            cheque.write(
+                {
+                    "state": "cleared",
+                    "clearing_date": cheque.clearing_date
+                    or fields.Date.context_today(cheque),
+                }
+            )
+
+    def action_bounce(self):
+        for cheque in self:
+            if cheque.state != "active":
+                raise UserError(_("Only outstanding cheques can bounce."))
+            cheque.state = "bounced"
+
+    def action_cancel(self):
+        for cheque in self:
+            if cheque.state == "cleared":
+                raise UserError(_("Cleared cheques cannot be cancelled."))
+            cheque.state = "cancelled"
+
+    def action_reset_draft(self):
+        self.write({"state": "draft"})

--- a/finance_kmitl/models/cheque_register.py
+++ b/finance_kmitl/models/cheque_register.py
@@ -7,7 +7,7 @@ from odoo.exceptions import UserError, ValidationError
 class ChequeRegister(models.Model):
     _name = "cheque.register"
     _description = "Cheque Control Register"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _inherit = ["mail.thread", "mail.activity.mixin", "thai.date.mixin"]
     _order = "cheque_date desc, id desc"
 
     name = fields.Char(
@@ -72,6 +72,17 @@ class ChequeRegister(models.Model):
     deposit_date = fields.Date(string="Deposit Date", tracking=True)
     clearing_date = fields.Date(string="Clearing Date", tracking=True)
     note = fields.Text(string="Notes")
+    crossed = fields.Boolean(
+        string="A/C Payee Only",
+        default=True,
+        help="Print the 'A/C PAYEE ONLY' crossing when printing the cheque.",
+    )
+    strike_bearer = fields.Boolean(
+        string="Strike 'or Bearer'",
+        default=True,
+        help="Strike out the pre-printed 'หรือผู้ถือ' (or bearer) wording when "
+        "printing the cheque.",
+    )
     company_id = fields.Many2one(
         comodel_name="res.company",
         default=lambda self: self.env.company,
@@ -178,3 +189,41 @@ class ChequeRegister(models.Model):
 
     def action_reset_draft(self):
         self.write({"state": "draft"})
+
+    # ------------------------------------------------------------------
+    # Cheque printing
+    # ------------------------------------------------------------------
+    def amount_in_words(self):
+        """Amount spelled out in Thai baht text (for the cheque)."""
+        self.ensure_one()
+        return self.currency_id.with_context(lang="th_TH").amount_to_text(
+            self.amount
+        )
+
+    def date_digits(self, buddhist_year=False):
+        """Return the cheque date as ``DDMMYYYY`` digits for the date boxes."""
+        self.ensure_one()
+        if not self.cheque_date:
+            return ""
+        d = self.cheque_date
+        year = d.year + 543 if buddhist_year else d.year
+        return "%02d%02d%04d" % (d.day, d.month, year)
+
+    def action_print_cheque(self):
+        self.ensure_one()
+        if not self.cheque_number:
+            raise UserError(_("Enter the cheque number before printing."))
+        if not self.journal_id:
+            raise UserError(
+                _("Select the bank/cheque book (journal) before printing.")
+            )
+        if not self.journal_id.cheque_layout_id:
+            raise UserError(
+                _(
+                    "Configure a Cheque Layout on journal '%s' before printing.",
+                )
+                % self.journal_id.display_name
+            )
+        return self.env.ref(
+            "finance_kmitl.action_report_cheque_print"
+        ).report_action(self)

--- a/finance_kmitl/models/kmitl_payment_type.py
+++ b/finance_kmitl/models/kmitl_payment_type.py
@@ -30,4 +30,10 @@ class KmitlPaymentType(models.Model):
         string="Override Account",
         help="Override the destination account. Leave empty to use partner's default.",
     )
+    is_cheque = fields.Boolean(
+        string="Paid/Received by Cheque",
+        help="Payments of this type are settled by cheque. They are exempt from "
+        "the bank-export gate and post directly, and a cheque is added to the "
+        "cheque control register when the payment is posted.",
+    )
 

--- a/finance_kmitl/report/report_cheque_print.xml
+++ b/finance_kmitl/report/report_cheque_print.xml
@@ -3,16 +3,20 @@
     <template id="report_cheque_print">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-set="layout" t-value="o.journal_id.cheque_layout_id"/>
-                <t t-set="fs" t-value="layout.font_size or 14"/>
-                <div class="page" t-attf-style="position: relative; font-family: 'THSarabunNew', Arial, sans-serif; font-size: {{fs}}pt;">
+                <t t-call="web.basic_layout">
+                    <t t-set="o" t-value="o.with_context(lang='th_TH')"/>
+                    <!-- Fall back to a default (in-memory) layout when the cheque
+                         book has none configured yet, so printing still works. -->
+                    <t t-set="layout" t-value="o.journal_id.cheque_layout_id or o.env['cheque.layout'].new({})"/>
 
-                    <t t-if="not layout">
-                        <p class="text-danger">
-                            กรุณาตั้งค่า Cheque Layout ให้สมุดเช็ค/ธนาคารนี้ก่อนพิมพ์
-                        </p>
-                    </t>
-                    <t t-else="">
+                    <style>
+                        * {
+                        font-family: "THSarabunNew", "Sarabun", Arial, sans-serif;
+                        }
+                    </style>
+
+                    <div class="page" t-attf-style="position: relative; font-size: {{layout.font_size or 14}}pt;">
+
                         <!-- A/C Payee Only crossing (top-left, diagonal) -->
                         <div t-if="o.crossed"
                              t-attf-style="position:absolute; top:{{layout.crossing_top}}mm; left:{{layout.crossing_left}}mm; transform: rotate(-60deg); transform-origin: left top;">
@@ -20,7 +24,7 @@
                         </div>
 
                         <!-- Date digits DDMMYYYY aligned to the pre-printed boxes -->
-                        <div t-attf-style="position:absolute; top:{{layout.date_top}}mm; left:{{layout.date_left}}mm; letter-spacing:{{layout.date_spacing}}mm; font-family: monospace;">
+                        <div t-attf-style="position:absolute; top:{{layout.date_top}}mm; left:{{layout.date_left}}mm; letter-spacing:{{layout.date_spacing}}mm;">
                             <span t-out="o.date_digits(layout.date_buddhist_year)"/>
                         </div>
 
@@ -42,9 +46,9 @@
                         <div t-attf-style="position:absolute; top:{{layout.amount_text_top}}mm; left:{{layout.amount_text_left}}mm; white-space:nowrap;">
                             <span t-out="o.amount_in_words()"/>
                         </div>
-                    </t>
 
-                </div>
+                    </div>
+                </t>
             </t>
         </t>
     </template>

--- a/finance_kmitl/report/report_cheque_print.xml
+++ b/finance_kmitl/report/report_cheque_print.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_cheque_print">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="layout" t-value="o.journal_id.cheque_layout_id"/>
+                <t t-set="fs" t-value="layout.font_size or 14"/>
+                <div class="page" t-attf-style="position: relative; font-family: 'THSarabunNew', Arial, sans-serif; font-size: {{fs}}pt;">
+
+                    <t t-if="not layout">
+                        <p class="text-danger">
+                            กรุณาตั้งค่า Cheque Layout ให้สมุดเช็ค/ธนาคารนี้ก่อนพิมพ์
+                        </p>
+                    </t>
+                    <t t-else="">
+                        <!-- A/C Payee Only crossing (top-left, diagonal) -->
+                        <div t-if="o.crossed"
+                             t-attf-style="position:absolute; top:{{layout.crossing_top}}mm; left:{{layout.crossing_left}}mm; transform: rotate(-60deg); transform-origin: left top;">
+                            <span style="border-top:1px solid #000; border-bottom:1px solid #000; padding:0.5mm 2mm; font-size:9pt; white-space:nowrap;">A/C PAYEE ONLY</span>
+                        </div>
+
+                        <!-- Date digits DDMMYYYY aligned to the pre-printed boxes -->
+                        <div t-attf-style="position:absolute; top:{{layout.date_top}}mm; left:{{layout.date_left}}mm; letter-spacing:{{layout.date_spacing}}mm; font-family: monospace;">
+                            <span t-out="o.date_digits(layout.date_buddhist_year)"/>
+                        </div>
+
+                        <!-- Payee -->
+                        <div t-attf-style="position:absolute; top:{{layout.payee_top}}mm; left:{{layout.payee_left}}mm; white-space:nowrap;">
+                            <span t-out="o.partner_id.name or ''"/>
+                        </div>
+
+                        <!-- Strike out 'หรือผู้ถือ' (or bearer) -->
+                        <div t-if="o.strike_bearer"
+                             t-attf-style="position:absolute; top:{{layout.bearer_top}}mm; left:{{layout.bearer_left}}mm; width:26mm; border-top:1.5px solid #000;"/>
+
+                        <!-- Amount in figures -->
+                        <div t-attf-style="position:absolute; top:{{layout.amount_figure_top}}mm; left:{{layout.amount_figure_left}}mm; white-space:nowrap;">
+                            <span t-out="'{:,.2f}'.format(o.amount)"/>
+                        </div>
+
+                        <!-- Amount in Thai words -->
+                        <div t-attf-style="position:absolute; top:{{layout.amount_text_top}}mm; left:{{layout.amount_text_left}}mm; white-space:nowrap;">
+                            <span t-out="o.amount_in_words()"/>
+                        </div>
+                    </t>
+
+                </div>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/finance_kmitl/report/report_cheque_print_action.xml
+++ b/finance_kmitl/report/report_cheque_print_action.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="paperformat_cheque" model="report.paperformat">
+        <field name="name">Cheque</field>
+        <field name="default" eval="False"/>
+        <field name="disable_shrinking" eval="True"/>
+        <field name="format">custom</field>
+        <field name="page_width">200</field>
+        <field name="page_height">95</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">0</field>
+        <field name="margin_bottom">0</field>
+        <field name="margin_left">0</field>
+        <field name="margin_right">0</field>
+        <field name="header_line" eval="False"/>
+        <field name="header_spacing">0</field>
+        <field name="dpi">110</field>
+    </record>
+
+    <record id="action_report_cheque_print" model="ir.actions.report">
+        <field name="name">Print Cheque</field>
+        <field name="model">cheque.register</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">finance_kmitl.report_cheque_print</field>
+        <field name="report_file">finance_kmitl.report_cheque_print</field>
+        <field name="binding_model_id" ref="model_cheque_register"/>
+        <field name="binding_type">report</field>
+        <field name="paperformat_id" ref="paperformat_cheque"/>
+    </record>
+</odoo>

--- a/finance_kmitl/security/ir.model.access.csv
+++ b/finance_kmitl/security/ir.model.access.csv
@@ -3,3 +3,6 @@ access_kmitl_payment_type_all,kmitl.payment.type.all,model_kmitl_payment_type,ba
 access_kmitl_payment_type_manager,kmitl.payment.type.manager,model_kmitl_payment_type,account.group_account_manager,1,1,1,1
 access_account_payment_budget_user,account.payment budget user,account.model_account_payment,budget.group_budget_user,1,0,0,0
 access_account_payment_budget_manager,account.payment budget manager,account.model_account_payment,budget.group_budget_manager,1,1,1,0
+access_cheque_register_user_out,cheque.register.user.out,model_cheque_register,group_finance_kmitl_user_out,1,1,1,0
+access_cheque_register_user_in,cheque.register.user.in,model_cheque_register,group_finance_kmitl_user_in,1,1,1,0
+access_cheque_register_manager,cheque.register.manager,model_cheque_register,group_finance_kmitl_manager,1,1,1,1

--- a/finance_kmitl/security/ir.model.access.csv
+++ b/finance_kmitl/security/ir.model.access.csv
@@ -6,3 +6,5 @@ access_account_payment_budget_manager,account.payment budget manager,account.mod
 access_cheque_register_user_out,cheque.register.user.out,model_cheque_register,group_finance_kmitl_user_out,1,1,1,0
 access_cheque_register_user_in,cheque.register.user.in,model_cheque_register,group_finance_kmitl_user_in,1,1,1,0
 access_cheque_register_manager,cheque.register.manager,model_cheque_register,group_finance_kmitl_manager,1,1,1,1
+access_cheque_layout_all,cheque.layout.all,model_cheque_layout,base.group_user,1,0,0,0
+access_cheque_layout_manager,cheque.layout.manager,model_cheque_layout,account.group_account_manager,1,1,1,1

--- a/finance_kmitl/views/account_journal_views.xml
+++ b/finance_kmitl/views/account_journal_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Assign a cheque print layout to a bank/cash journal (cheque book) -->
+    <record id="view_account_journal_form_cheque" model="ir.ui.view">
+        <field name="name">account.journal.form.cheque.kmitl</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='bank_account_number']" position="after">
+                <group name="cheque_settings" string="Cheque"
+                    attrs="{'invisible': [('type', 'not in', ('bank', 'cash'))]}">
+                    <field name="cheque_layout_id" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/finance_kmitl/views/account_payment_views.xml
+++ b/finance_kmitl/views/account_payment_views.xml
@@ -126,6 +126,14 @@
                 </notebook>
             </xpath>
 
+            <!-- Smart button: cheques linked to this payment in the register -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_cheque_register" type="object" class="oe_stat_button" icon="fa-credit-card"
+                    attrs="{'invisible': [('cheque_register_count', '=', 0)]}">
+                    <field name="cheque_register_count" widget="statinfo" string="Cheques"/>
+                </button>
+            </xpath>
+
         </field>
     </record>
 

--- a/finance_kmitl/views/cheque_layout_views.xml
+++ b/finance_kmitl/views/cheque_layout_views.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_cheque_layout_tree" model="ir.ui.view">
+        <field name="name">cheque.layout.tree</field>
+        <field name="model">cheque.layout</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="company_id" groups="base.group_multi_company" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_cheque_layout_form" model="ir.ui.view">
+        <field name="name">cheque.layout.form</field>
+        <field name="model">cheque.layout</field>
+        <field name="arch" type="xml">
+            <form string="Cheque Layout">
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" />
+                        <h1><field name="name" placeholder="e.g. KTB Cheque" /></h1>
+                    </div>
+                    <group>
+                        <group string="Layout Settings">
+                            <field name="active" />
+                            <field name="company_id" groups="base.group_multi_company" />
+                            <field name="font_size" />
+                            <field name="date_buddhist_year" />
+                            <field name="date_spacing" />
+                        </group>
+                        <group string="Cheque Books (assign on the journal)">
+                            <field name="journal_ids" nolabel="1" readonly="1">
+                                <tree>
+                                    <field name="name" />
+                                    <field name="type" />
+                                </tree>
+                            </field>
+                        </group>
+                    </group>
+                    <separator string="Field Positions (mm from top-left of the cheque)" />
+                    <group>
+                        <group string="Date (DDMMYYYY boxes)">
+                            <field name="date_top" />
+                            <field name="date_left" />
+                        </group>
+                        <group string="Payee">
+                            <field name="payee_top" />
+                            <field name="payee_left" />
+                        </group>
+                        <group string="Amount (figures)">
+                            <field name="amount_figure_top" />
+                            <field name="amount_figure_left" />
+                        </group>
+                        <group string="Amount (words)">
+                            <field name="amount_text_top" />
+                            <field name="amount_text_left" />
+                        </group>
+                        <group string="A/C Payee Only crossing">
+                            <field name="crossing_top" />
+                            <field name="crossing_left" />
+                        </group>
+                        <group string="'or bearer' strike">
+                            <field name="bearer_top" />
+                            <field name="bearer_left" />
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_cheque_layout" model="ir.actions.act_window">
+        <field name="name">Cheque Layouts</field>
+        <field name="res_model">cheque.layout</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+</odoo>

--- a/finance_kmitl/views/cheque_register_views.xml
+++ b/finance_kmitl/views/cheque_register_views.xml
@@ -40,6 +40,7 @@
                     <button name="action_bounce" string="Bounced" type="object" attrs="{'invisible': [('state', '!=', 'active')]}" />
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'in', ('cleared', 'cancelled'))]}" />
                     <button name="action_reset_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '=', 'draft')]}" groups="finance_kmitl.group_finance_kmitl_manager" />
+                    <button name="action_print_cheque" string="Print Cheque" type="object" class="btn-secondary" attrs="{'invisible': ['|', ('direction', '!=', 'outbound'), ('cheque_number', '=', False)]}" />
                     <field name="state" widget="statusbar" statusbar_visible="draft,active,cleared" />
                 </header>
                 <sheet>
@@ -55,6 +56,8 @@
                             <field name="cheque_date" />
                             <field name="journal_id" />
                             <field name="bank_id" />
+                            <field name="crossed" attrs="{'invisible': [('direction', '!=', 'outbound')]}" />
+                            <field name="strike_bearer" attrs="{'invisible': [('direction', '!=', 'outbound')]}" />
                         </group>
                         <group string="Payment Information">
                             <field name="partner_id" />

--- a/finance_kmitl/views/cheque_register_views.xml
+++ b/finance_kmitl/views/cheque_register_views.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <!-- Tree View -->
+    <record id="view_cheque_register_tree" model="ir.ui.view">
+        <field name="name">cheque.register.tree</field>
+        <field name="model">cheque.register</field>
+        <field name="arch" type="xml">
+            <tree string="Cheque Register">
+                <field name="name" />
+                <field name="cheque_number" />
+                <field name="cheque_date" />
+                <field name="partner_id" />
+                <field name="journal_id" optional="show" />
+                <field name="ref" optional="show" />
+                <field name="amount" sum="Total" />
+                <field name="currency_id" invisible="1" />
+                <field name="handover_date" optional="hide" />
+                <field name="clearing_date" optional="show" />
+                <field name="direction" optional="hide" />
+                <field name="state" widget="badge"
+                    decoration-info="state == 'draft'"
+                    decoration-warning="state == 'active'"
+                    decoration-success="state == 'cleared'"
+                    decoration-danger="state == 'bounced'"
+                    decoration-muted="state == 'cancelled'" />
+            </tree>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_cheque_register_form" model="ir.ui.view">
+        <field name="name">cheque.register.form</field>
+        <field name="model">cheque.register</field>
+        <field name="arch" type="xml">
+            <form string="Cheque Register">
+                <header>
+                    <button name="action_activate" string="Issue / Receive" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}" />
+                    <button name="action_clear" string="Clear (Cashed)" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'active')]}" />
+                    <button name="action_bounce" string="Bounced" type="object" attrs="{'invisible': [('state', '!=', 'active')]}" />
+                    <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'in', ('cleared', 'cancelled'))]}" />
+                    <button name="action_reset_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '=', 'draft')]}" groups="finance_kmitl.group_finance_kmitl_manager" />
+                    <field name="state" widget="statusbar" statusbar_visible="draft,active,cleared" />
+                </header>
+                <sheet>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" readonly="1" />
+                        </h1>
+                    </div>
+                    <group>
+                        <group string="Cheque Information">
+                            <field name="direction" widget="radio" attrs="{'readonly': [('state', '!=', 'draft')]}" />
+                            <field name="cheque_number" attrs="{'required': [('state', '!=', 'draft')], 'readonly': [('state', 'in', ('cleared', 'cancelled'))]}" />
+                            <field name="cheque_date" />
+                            <field name="journal_id" />
+                            <field name="bank_id" />
+                        </group>
+                        <group string="Payment Information">
+                            <field name="partner_id" />
+                            <field name="amount" />
+                            <field name="currency_id" invisible="1" />
+                            <field name="ref" />
+                            <field name="payment_id" readonly="1" attrs="{'invisible': [('payment_id', '=', False)]}" />
+                        </group>
+                        <group string="Dates &amp; Status">
+                            <field name="handover_date" />
+                            <field name="deposit_date" attrs="{'invisible': [('direction', '!=', 'inbound')]}" />
+                            <field name="clearing_date" />
+                        </group>
+                    </group>
+                    <group string="Notes">
+                        <field name="note" nolabel="1" placeholder="Remarks..." />
+                    </group>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <!-- Search View -->
+    <record id="view_cheque_register_search" model="ir.ui.view">
+        <field name="name">cheque.register.search</field>
+        <field name="model">cheque.register</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="cheque_number" />
+                <field name="partner_id" />
+                <field name="ref" />
+                <field name="journal_id" />
+                <filter name="outstanding" string="Outstanding" domain="[('state', '=', 'active')]" />
+                <filter name="cleared" string="Cleared" domain="[('state', '=', 'cleared')]" />
+                <filter name="bounced" string="Bounced" domain="[('state', '=', 'bounced')]" />
+                <separator />
+                <filter name="issued" string="Issued" domain="[('direction', '=', 'outbound')]" />
+                <filter name="received" string="Received" domain="[('direction', '=', 'inbound')]" />
+                <group expand="0" string="Group By">
+                    <filter name="group_state" string="Status" context="{'group_by': 'state'}" />
+                    <filter name="group_journal" string="Bank/Cheque Book" context="{'group_by': 'journal_id'}" />
+                    <filter name="group_direction" string="Direction" context="{'group_by': 'direction'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Actions -->
+    <record id="action_cheque_register_outbound" model="ir.actions.act_window">
+        <field name="name">Issued Cheque Register</field>
+        <field name="res_model">cheque.register</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('direction', '=', 'outbound')]</field>
+        <field name="context">{'default_direction': 'outbound', 'search_default_outstanding': 1}</field>
+    </record>
+
+    <record id="action_cheque_register_inbound" model="ir.actions.act_window">
+        <field name="name">Received Cheque Register</field>
+        <field name="res_model">cheque.register</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('direction', '=', 'inbound')]</field>
+        <field name="context">{'default_direction': 'inbound', 'search_default_outstanding': 1}</field>
+    </record>
+
+</odoo>

--- a/finance_kmitl/views/kmitl_payment_type_views.xml
+++ b/finance_kmitl/views/kmitl_payment_type_views.xml
@@ -34,6 +34,7 @@
                         </group>
                         <group string="Account Overrides">
                             <field name="override_account_id"/>
+                            <field name="is_cheque"/>
                         </group>
                     </group>
                 </sheet>

--- a/finance_kmitl/views/menuitem.xml
+++ b/finance_kmitl/views/menuitem.xml
@@ -76,6 +76,28 @@
         groups="finance_kmitl.group_finance_kmitl_user_out"
     />
 
+    <!-- Cheque Control Register -->
+    <menuitem
+        id="menu_cheque_register_root"
+        name="Cheque Register"
+        parent="menu_payment_root"
+        sequence="30"
+        groups="finance_kmitl.group_finance_kmitl_user_out,finance_kmitl.group_finance_kmitl_user_in" />
+    <menuitem
+        id="menu_cheque_register_outbound"
+        name="Issued Cheques"
+        parent="menu_cheque_register_root"
+        action="action_cheque_register_outbound"
+        sequence="10"
+        groups="finance_kmitl.group_finance_kmitl_user_out" />
+    <menuitem
+        id="menu_cheque_register_inbound"
+        name="Received Cheques"
+        parent="menu_cheque_register_root"
+        action="action_cheque_register_inbound"
+        sequence="20"
+        groups="finance_kmitl.group_finance_kmitl_user_in" />
+
     <!-- Settings submenu (manager only) -->
     <menuitem
         id="menu_payment_settings"

--- a/finance_kmitl/views/menuitem.xml
+++ b/finance_kmitl/views/menuitem.xml
@@ -127,5 +127,12 @@
         action="action_kmitl_payment_type"
         sequence="5"
     />
+    <menuitem
+        id="menu_settings_cheque_layout"
+        name="Cheque Layouts"
+        parent="menu_payment_settings"
+        action="action_cheque_layout"
+        sequence="15"
+    />
 
 </odoo>


### PR DESCRIPTION
## สรุป

เพิ่ม **ทะเบียนคุมเช็ค + สั่งพิมพ์เช็ค** เป็น**ส่วนขยายภายในโมดูล `finance_kmitl`** (ไม่แยกโมดูล) เพราะ finance_kmitl เป็นเจ้าของ `account.payment` + `kmitl.payment.type` + workflow อยู่แล้ว

ค้นแล้วไม่มีโมดูลสำเร็จรูป (OCA `l10n-thailand` ยังเป็น TODO "help wanted"; `l10n_latam_check` ผูกกับ Argentina; `bi_account_cheque` เป็น proprietary) จึงทำเองแบบบางๆ reuse ของเดิม

_แทนที่ #913 (ออกแบบใหม่ให้อยู่ใน finance_kmitl + branch ใหม่)_

## 1) ทะเบียนคุมเช็ค — `cheque.register`
- `direction` แยกเช็คจ่าย/รับ — เมนู "Cheque Register" ใต้ Finance
- lifecycle กดเอง: `ร่าง → คงค้าง → ขึ้นเงินแล้ว` + `เช็คเด้ง` / `ยกเลิก`
- **ผสม auto + manual**: cheque-type payment ที่ post สร้างรายการอัตโนมัติ (สถานะ `ร่าง`) + กรอกเองได้ + smart button เชื่อม payment↔ทะเบียน
- คุมเลขที่เช็คไม่ซ้ำต่อสมุดเช็ค (ขาจ่าย), tree/form/search + filter "เช็คคงค้าง"
- `kmitl.payment.type.is_cheque` → payment เช็คได้รับยกเว้นจาก guard bank-export-before-post

## 2) สั่งพิมพ์เช็ค (ใหม่)
- **`cheque.layout`**: ตั้งตำแหน่งพิมพ์ (offset X/Y เป็น มม.) ต่อธนาคาร/สมุดเช็ค — ผูกกับ `account.journal` (สมุดเช็ค); รองรับหลายธนาคาร
- ปุ่ม **Print Cheque** บนใบเช็คจ่าย → QWeb overlay พิมพ์ทับแบบเช็คจริง:
  - วันที่ (DDMMYYYY, เลือก ค.ศ./พ.ศ. ได้), ชื่อผู้รับ, จำนวนเงินตัวเลข, **จำนวนเงินตัวอักษรไทย** (`l10n_th_amount_to_text`)
  - **ขีดคร่อม "A/C PAYEE ONLY"** + **ขีดฆ่า "หรือผู้ถือ"** เปิด/ปิดได้ต่อใบ
- paperformat ขนาดเช็ค (margin 0), ฟอนต์ THSarabunNew
- พิมพ์ได้เฉพาะเช็คจ่ายที่มีเลขที่เช็ค + สมุดเช็คตั้ง layout แล้ว (มี guard)

## ยังไม่รวม (เฟสถัดไป)
- รายงาน PDF ทะเบียน (ยอดเช็คคงค้าง)
- ผูก bank statement reconciliation ตั้งวันที่ขึ้นเงินอัตโนมัติ

## วิธีทดสอบ
1. Upgrade `finance_kmitl`
2. **ทะเบียน**: Finance → Cheque Register → เช็คจ่าย → สร้าง/ออกเช็ค/ขึ้นเงิน
3. **พิมพ์เช็ค**: Settings → Cheque Layouts สร้าง layout → ผูกกับ bank journal (ฟอร์ม journal มีช่อง Cheque Layout) → เปิดใบเช็คจ่าย กดปุ่ม **Print Cheque** → ได้ PDF overlay (จูน offset จนตรงเช็คจริง)
4. **Auto + regression**: `is_cheque=True` post payment → มีเช็คอัตโนมัติ, post ไม่ติด bank export; payment ปกติยังต้อง export ก่อน post