### PR TITLE
[16.0][IMP] disbursement_accounting_kmitl: ย้ายเมนูใบขอเบิกไปอยู่ใต้เมนูเจ้าหนี้

### DIFF
--- a/disbursement_accounting_kmitl/views/disbursement_request_views.xml
+++ b/disbursement_accounting_kmitl/views/disbursement_request_views.xml
@@ -17,11 +17,12 @@
         </field>
     </record>
 
-    <!-- DR menu in the Accounting app (DR is the navigation document) -->
+    <!-- DR menu under the เจ้าหนี้ (payable) menu — first document in the
+         payable workflow (ใบขอเบิก → ใบตั้งหนี้ → ใบล้างเจ้าหนี้) -->
     <menuitem
         id="menu_accounting_disbursement_request"
         name="Disbursement Requests"
-        parent="accounting_kmitl.menu_accounting_root"
+        parent="accounting_kmitl.menu_payable"
         action="action_disbursement_request_accounting"
         sequence="5"
     />


### PR DESCRIPTION
## สรุป
ย้ายเมนู **"ใบขอเบิก"** (Disbursement Requests) จากที่แขวนอยู่ใต้เมนู root **Accounting** โดยตรง ให้ไปอยู่ใต้เมนู **"เจ้าหนี้"** (`accounting_kmitl.menu_payable`)

ใบขอเบิกเป็นเอกสารตัวแรกในสาย workflow เจ้าหนี้ (ใบขอเบิก → ใบตั้งหนี้ → ใบล้างเจ้าหนี้) จึงควรอยู่รวมกับเอกสารเจ้าหนี้ตัวอื่น

## การเปลี่ยนแปลง
- `disbursement_accounting_kmitl/views/disbursement_request_views.xml`: เปลี่ยน `parent` ของ menuitem `menu_accounting_disbursement_request` จาก `accounting_kmitl.menu_accounting_root` → `accounting_kmitl.menu_payable` (คง `sequence="5"` ให้แสดงเป็นรายการแรก)

ไม่แตะ `id`/`name`/`action` → คำแปล i18n เดิม (`Disbursement Requests` → `ใบขอเบิก`) ยังใช้ได้ตามเดิม ไม่ต้องแก้ `i18n/th.po`

## โครงสร้างเมนูหลังแก้
```
Accounting
└── เจ้าหนี้ (menu_payable)
    ├── ใบขอเบิก        (seq 5)   ← ย้ายมาที่นี่
    ├── ใบตั้งหนี้        (seq 10)
    └── ใบล้างเจ้าหนี้   (seq 20)
```

## Verification
1. อัปเกรด module (`-u disbursement_accounting_kmitl`)
2. เข้า Accounting → เจ้าหนี้ → เห็น "ใบขอเบิก" เป็นรายการแรก และเปิดได้ tree ของ disbursement.request (filter state=approved)
3. ยืนยันว่า "ใบขอเบิก" ไม่ปรากฏใต้ root Accounting โดยตรงอีกต่อไป

🤖 Generated with [Claude Code](https://claude.com/claude-code)