### PR TITLE
[16.0][ADD] accounting_kmitl: dashboard landing page

### DIFF
--- a/accounting_kmitl/__manifest__.py
+++ b/accounting_kmitl/__manifest__.py
@@ -20,8 +20,16 @@
         "wizard/account_move_exception_confirm_view.xml",
         "views/account_move_views.xml",
         "views/account_payment_method_views.xml",
+        "views/accounting_dashboard_views.xml",
         "views/menuitem.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "accounting_kmitl/static/src/dashboard/accounting_dashboard.scss",
+            "accounting_kmitl/static/src/dashboard/accounting_dashboard.js",
+            "accounting_kmitl/static/src/dashboard/accounting_dashboard.xml",
+        ],
+    },
     "installable": True,
     "auto_install": False,
     "application": True,

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -220,3 +220,84 @@ msgstr "ยืนยันโดยข้ามข้อยกเว้น"
 #: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_form_inherit_kmitl
 msgid "Click here to be able to submit this Journal Entry regardless of the exceptions."
 msgstr "คลิกที่นี่เพื่อยืนยันรายการบันทึกบัญชีนี้โดยไม่สนใจข้อยกเว้น"
+
+#. module: accounting_kmitl
+#: model:ir.model,name:accounting_kmitl.model_accounting_kmitl_dashboard
+msgid "KMITL Accounting Dashboard"
+msgstr "แดชบอร์ดบัญชี KMITL"
+
+#. module: accounting_kmitl
+#: model:ir.actions.client,name:accounting_kmitl.action_accounting_dashboard
+msgid "Accounting Dashboard"
+msgstr "แดชบอร์ดบัญชี"
+
+#. module: accounting_kmitl
+#: model:ir.ui.menu,name:accounting_kmitl.menu_accounting_dashboard
+msgid "Dashboard"
+msgstr "แดชบอร์ด"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Overview of pending work and outstanding balances"
+msgstr "ภาพรวมงานที่ค้างและยอดคงค้าง"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "My draft documents"
+msgstr "ฉบับร่างของฉัน"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Submitted (awaiting posting)"
+msgstr "ส่งแล้ว (รอลงบัญชี)"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Unpaid vendor bills"
+msgstr "ค้างจ่ายเจ้าหนี้"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Overdue vendor bills"
+msgstr "เจ้าหนี้เกินกำหนดชำระ"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Unpaid customer invoices"
+msgstr "ลูกหนี้ค้างรับ"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Documents with exceptions"
+msgstr "เอกสารที่มีข้อควรระวัง"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Quick actions"
+msgstr "การดำเนินการด่วน"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "New vendor bill"
+msgstr "สร้างใบตั้งหนี้"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "New customer invoice"
+msgstr "สร้างใบตั้งหนี้ลูกหนี้"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "New journal entry"
+msgstr "สร้างรายการสมุดรายวัน"

--- a/accounting_kmitl/models/__init__.py
+++ b/accounting_kmitl/models/__init__.py
@@ -1,2 +1,3 @@
+from . import accounting_kmitl_dashboard
 from . import account_move
 from . import exception_rule

--- a/accounting_kmitl/models/accounting_kmitl_dashboard.py
+++ b/accounting_kmitl/models/accounting_kmitl_dashboard.py
@@ -1,0 +1,73 @@
+from odoo import api, fields, models
+
+
+class AccountingKmitlDashboard(models.AbstractModel):
+    """Read-only aggregation service for the accounting landing dashboard.
+
+    Powers the KPI launchpad shown as the first page of the Accounting app.
+    Every figure is a plain ``search_count`` / ``read_group`` over
+    ``account.move``; each card also carries the exact ``domain`` it was built
+    from so the front-end can open a matching filtered list on click.
+
+    It never uses ``sudo``: record rules scope every count to what the current
+    user may see, so the card number always equals the list opened from it.
+    """
+
+    _name = "accounting.kmitl.dashboard"
+    _description = "KMITL Accounting Dashboard"
+
+    _UNPAID_STATES = ("not_paid", "partial")
+
+    @api.model
+    def get_dashboard_data(self):
+        """Return counts (and residual sums) for every KPI card.
+
+        :return: ``{"currency_symbol": str, "cards": {key: {count, [amount],
+            domain}}}``
+        """
+        uid = self.env.uid
+        today = fields.Date.context_today(self)
+        Move = self.env["account.move"]
+
+        unpaid_ap = [
+            ("move_type", "=", "in_invoice"),
+            ("state", "=", "posted"),
+            ("payment_state", "in", self._UNPAID_STATES),
+        ]
+        unpaid_ar = [
+            ("move_type", "=", "out_invoice"),
+            ("state", "=", "posted"),
+            ("payment_state", "in", self._UNPAID_STATES),
+        ]
+        # key -> (domain, needs residual sum)
+        definitions = {
+            "my_drafts": ([("state", "=", "draft"), ("create_uid", "=", uid)], False),
+            "submitted": (
+                [("state", "=", "submitted"), ("create_uid", "=", uid)],
+                False,
+            ),
+            "unpaid_ap": (unpaid_ap, True),
+            "overdue_ap": (unpaid_ap + [("invoice_date_due", "<", today)], True),
+            "unpaid_ar": (unpaid_ar, True),
+            "exceptions": (
+                [("exception_ids", "!=", False), ("ignore_exception", "=", False)],
+                False,
+            ),
+        }
+
+        cards = {}
+        for key, (domain, needs_amount) in definitions.items():
+            card = {"domain": domain}
+            if needs_amount:
+                # A single read_group yields both the count and the sum.
+                groups = Move.read_group(domain, ["amount_residual:sum"], [])
+                card["count"] = groups[0]["__count"] if groups else 0
+                card["amount"] = (groups[0]["amount_residual"] if groups else 0.0) or 0.0
+            else:
+                card["count"] = Move.search_count(domain)
+            cards[key] = card
+
+        return {
+            "currency_symbol": self.env.company.currency_id.symbol,
+            "cards": cards,
+        }

--- a/accounting_kmitl/models/accounting_kmitl_dashboard.py
+++ b/accounting_kmitl/models/accounting_kmitl_dashboard.py
@@ -1,16 +1,24 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class AccountingKmitlDashboard(models.AbstractModel):
     """Read-only aggregation service for the accounting landing dashboard.
 
     Powers the KPI launchpad shown as the first page of the Accounting app.
-    Every figure is a plain ``search_count`` / ``read_group`` over
-    ``account.move``; each card also carries the exact ``domain`` it was built
-    from so the front-end can open a matching filtered list on click.
 
-    It never uses ``sudo``: record rules scope every count to what the current
-    user may see, so the card number always equals the list opened from it.
+    Cards are returned as a plain ordered list of self-describing dicts so that
+    other modules can add their own card simply by inheriting
+    ``get_dashboard_data`` and appending to ``data["cards"]`` -- no front-end
+    change is required. Each card is::
+
+        {id, title, color, sequence, res_model, domain, count[, amount]}
+
+    ``amount`` is present only for money cards. The front-end sorts by
+    ``sequence`` and opens ``res_model`` / ``domain`` on click, so a card's
+    number always matches the list it opens.
+
+    Nothing here uses ``sudo``: record rules scope every figure to what the
+    current user may see.
     """
 
     _name = "accounting.kmitl.dashboard"
@@ -19,15 +27,45 @@ class AccountingKmitlDashboard(models.AbstractModel):
     _UNPAID_STATES = ("not_paid", "partial")
 
     @api.model
-    def get_dashboard_data(self):
-        """Return counts (and residual sums) for every KPI card.
+    def _make_card(self, card_id, title, color, sequence, res_model, domain):
+        """Build a count-only KPI card.
 
-        :return: ``{"currency_symbol": str, "cards": {key: {count, [amount],
-            domain}}}``
+        Reusable extension point: modules extending the dashboard with a card
+        over their own model should call this instead of hand-building the dict.
         """
+        return {
+            "id": card_id,
+            "title": title,
+            "color": color,
+            "sequence": sequence,
+            "res_model": res_model,
+            "domain": domain,
+            "count": self.env[res_model].search_count(domain),
+        }
+
+    @api.model
+    def _residual_card(self, card_id, title, color, sequence, domain):
+        """``account.move`` card carrying count + summed ``amount_residual``
+        (both come from a single ``read_group``)."""
+        groups = self.env["account.move"].read_group(
+            domain, ["amount_residual:sum"], []
+        )
+        return {
+            "id": card_id,
+            "title": title,
+            "color": color,
+            "sequence": sequence,
+            "res_model": "account.move",
+            "domain": domain,
+            "count": groups[0]["__count"] if groups else 0,
+            "amount": (groups[0]["amount_residual"] if groups else 0.0) or 0.0,
+        }
+
+    @api.model
+    def get_dashboard_data(self):
+        """Return ``{"currency_symbol": str, "cards": [card, ...]}``."""
         uid = self.env.uid
         today = fields.Date.context_today(self)
-        Move = self.env["account.move"]
 
         unpaid_ap = [
             ("move_type", "=", "in_invoice"),
@@ -39,33 +77,46 @@ class AccountingKmitlDashboard(models.AbstractModel):
             ("state", "=", "posted"),
             ("payment_state", "in", self._UNPAID_STATES),
         ]
-        # key -> (domain, needs residual sum)
-        definitions = {
-            "my_drafts": ([("state", "=", "draft"), ("create_uid", "=", uid)], False),
-            "submitted": (
-                [("state", "=", "submitted"), ("create_uid", "=", uid)],
-                False,
-            ),
-            "unpaid_ap": (unpaid_ap, True),
-            "overdue_ap": (unpaid_ap + [("invoice_date_due", "<", today)], True),
-            "unpaid_ar": (unpaid_ar, True),
-            "exceptions": (
-                [("exception_ids", "!=", False), ("ignore_exception", "=", False)],
-                False,
-            ),
-        }
 
-        cards = {}
-        for key, (domain, needs_amount) in definitions.items():
-            card = {"domain": domain}
-            if needs_amount:
-                # A single read_group yields both the count and the sum.
-                groups = Move.read_group(domain, ["amount_residual:sum"], [])
-                card["count"] = groups[0]["__count"] if groups else 0
-                card["amount"] = (groups[0]["amount_residual"] if groups else 0.0) or 0.0
-            else:
-                card["count"] = Move.search_count(domain)
-            cards[key] = card
+        cards = [
+            self._make_card(
+                "my_drafts",
+                _("My draft documents"),
+                "secondary",
+                10,
+                "account.move",
+                [("state", "=", "draft"), ("create_uid", "=", uid)],
+            ),
+            self._make_card(
+                "submitted",
+                _("Submitted (awaiting posting)"),
+                "info",
+                20,
+                "account.move",
+                [("state", "=", "submitted"), ("create_uid", "=", uid)],
+            ),
+            self._residual_card(
+                "unpaid_ap", _("Unpaid vendor bills"), "warning", 30, unpaid_ap
+            ),
+            self._residual_card(
+                "overdue_ap",
+                _("Overdue vendor bills"),
+                "danger",
+                40,
+                unpaid_ap + [("invoice_date_due", "<", today)],
+            ),
+            self._residual_card(
+                "unpaid_ar", _("Unpaid customer invoices"), "primary", 50, unpaid_ar
+            ),
+            self._make_card(
+                "exceptions",
+                _("Documents with exceptions"),
+                "danger",
+                60,
+                "account.move",
+                [("exception_ids", "!=", False), ("ignore_exception", "=", False)],
+            ),
+        ]
 
         return {
             "currency_symbol": self.env.company.currency_id.symbol,

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
@@ -1,0 +1,123 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { Component, onWillStart, useState } from "@odoo/owl";
+
+// Landing "work launchpad" for the Accounting app: a grid of KPI cards that
+// each open a filtered account.move list, plus quick-create buttons. All the
+// figures (and the domain behind every card) come from the
+// accounting.kmitl.dashboard server model.
+export class AccountingDashboard extends Component {
+    setup() {
+        this.orm = useService("orm");
+        this.action = useService("action");
+        this.state = useState({
+            loading: true,
+            data: { currency_symbol: "", cards: {} },
+        });
+
+        onWillStart(async () => {
+            this.state.data = await this.orm.call(
+                "accounting.kmitl.dashboard",
+                "get_dashboard_data",
+                []
+            );
+            this.state.loading = false;
+        });
+    }
+
+    // Card display metadata (render order + labels + accent colour). The values
+    // themselves are matched by id from the server payload.
+    get cardDefs() {
+        return [
+            { id: "my_drafts", title: _t("My draft documents"), color: "secondary" },
+            {
+                id: "submitted",
+                title: _t("Submitted (awaiting posting)"),
+                color: "info",
+            },
+            {
+                id: "unpaid_ap",
+                title: _t("Unpaid vendor bills"),
+                color: "warning",
+                money: true,
+            },
+            {
+                id: "overdue_ap",
+                title: _t("Overdue vendor bills"),
+                color: "danger",
+                money: true,
+            },
+            {
+                id: "unpaid_ar",
+                title: _t("Unpaid customer invoices"),
+                color: "primary",
+                money: true,
+            },
+            {
+                id: "exceptions",
+                title: _t("Documents with exceptions"),
+                color: "danger",
+            },
+        ];
+    }
+
+    get text() {
+        return {
+            title: _t("Accounting Dashboard"),
+            subtitle: _t("Overview of pending work and outstanding balances"),
+            quickActions: _t("Quick actions"),
+            newVendorBill: _t("New vendor bill"),
+            newCustomerInvoice: _t("New customer invoice"),
+            newJournalEntry: _t("New journal entry"),
+        };
+    }
+
+    cardValue(def) {
+        return this.state.data.cards[def.id] || { count: 0, amount: 0 };
+    }
+
+    formatAmount(value) {
+        return (value || 0).toLocaleString("th-TH", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    }
+
+    // Open the account.move list filtered to exactly the card's domain, so the
+    // list contents match the number shown on the card.
+    openCard(def) {
+        const card = this.cardValue(def);
+        if (!card.domain) {
+            return;
+        }
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            name: def.title,
+            res_model: "account.move",
+            domain: card.domain,
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            target: "current",
+        });
+    }
+
+    // Quick-create: open a blank account.move form of the requested type.
+    newDoc(moveType) {
+        this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "account.move",
+            views: [[false, "form"]],
+            target: "current",
+            context: { default_move_type: moveType },
+        });
+    }
+}
+
+AccountingDashboard.template = "accounting_kmitl.AccountingDashboard";
+
+registry.category("actions").add("accounting_kmitl.dashboard", AccountingDashboard);

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
@@ -6,16 +6,17 @@ import { _t } from "@web/core/l10n/translation";
 import { Component, onWillStart, useState } from "@odoo/owl";
 
 // Landing "work launchpad" for the Accounting app: a grid of KPI cards that
-// each open a filtered account.move list, plus quick-create buttons. All the
-// figures (and the domain behind every card) come from the
-// accounting.kmitl.dashboard server model.
+// each open a filtered list, plus quick-create buttons. The cards (labels,
+// colours, domains and counts) are fully defined by the
+// accounting.kmitl.dashboard server model, so other modules can add cards
+// without touching this component.
 export class AccountingDashboard extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
         this.state = useState({
             loading: true,
-            data: { currency_symbol: "", cards: {} },
+            data: { currency_symbol: "", cards: [] },
         });
 
         onWillStart(async () => {
@@ -28,40 +29,11 @@ export class AccountingDashboard extends Component {
         });
     }
 
-    // Card display metadata (render order + labels + accent colour). The values
-    // themselves are matched by id from the server payload.
-    get cardDefs() {
-        return [
-            { id: "my_drafts", title: _t("My draft documents"), color: "secondary" },
-            {
-                id: "submitted",
-                title: _t("Submitted (awaiting posting)"),
-                color: "info",
-            },
-            {
-                id: "unpaid_ap",
-                title: _t("Unpaid vendor bills"),
-                color: "warning",
-                money: true,
-            },
-            {
-                id: "overdue_ap",
-                title: _t("Overdue vendor bills"),
-                color: "danger",
-                money: true,
-            },
-            {
-                id: "unpaid_ar",
-                title: _t("Unpaid customer invoices"),
-                color: "primary",
-                money: true,
-            },
-            {
-                id: "exceptions",
-                title: _t("Documents with exceptions"),
-                color: "danger",
-            },
-        ];
+    // Cards as delivered by the server, in display order.
+    get cards() {
+        return [...(this.state.data.cards || [])].sort(
+            (a, b) => a.sequence - b.sequence
+        );
     }
 
     get text() {
@@ -75,10 +47,6 @@ export class AccountingDashboard extends Component {
         };
     }
 
-    cardValue(def) {
-        return this.state.data.cards[def.id] || { count: 0, amount: 0 };
-    }
-
     formatAmount(value) {
         return (value || 0).toLocaleString("th-TH", {
             minimumFractionDigits: 2,
@@ -86,17 +54,16 @@ export class AccountingDashboard extends Component {
         });
     }
 
-    // Open the account.move list filtered to exactly the card's domain, so the
-    // list contents match the number shown on the card.
-    openCard(def) {
-        const card = this.cardValue(def);
+    // Open the card's model filtered to exactly its domain, so the list
+    // contents match the number shown on the card.
+    openCard(card) {
         if (!card.domain) {
             return;
         }
         this.action.doAction({
             type: "ir.actions.act_window",
-            name: def.title,
-            res_model: "account.move",
+            name: card.title,
+            res_model: card.res_model,
             domain: card.domain,
             views: [
                 [false, "list"],

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
@@ -1,0 +1,22 @@
+.o_ak_dashboard {
+    overflow: auto;
+
+    .o_ak_card {
+        cursor: pointer;
+        transition: box-shadow 0.15s ease, transform 0.15s ease;
+
+        &:hover {
+            box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.12);
+            transform: translateY(-2px);
+        }
+    }
+
+    .o_ak_card_count {
+        font-size: 2rem;
+        line-height: 1.2;
+    }
+
+    .o_ak_card_amount {
+        font-size: 1rem;
+    }
+}

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
@@ -16,17 +16,17 @@
             </t>
             <t t-else="">
                 <div class="row g-3">
-                    <t t-foreach="cardDefs" t-as="def" t-key="def.id">
+                    <t t-foreach="cards" t-as="card" t-key="card.id">
                         <div class="col-12 col-sm-6 col-lg-4">
                             <div class="card o_ak_card h-100"
-                                 t-on-click="() => this.openCard(def)">
+                                 t-on-click="() => this.openCard(card)">
                                 <div class="card-body">
-                                    <div class="o_ak_card_title text-muted" t-esc="def.title"/>
-                                    <div t-attf-class="o_ak_card_count fw-bold text-{{def.color}}"
-                                         t-esc="cardValue(def).count"/>
-                                    <div t-if="def.money" class="o_ak_card_amount text-muted">
+                                    <div class="o_ak_card_title text-muted" t-esc="card.title"/>
+                                    <div t-attf-class="o_ak_card_count fw-bold text-{{card.color}}"
+                                         t-esc="card.count"/>
+                                    <div t-if="card.amount !== undefined" class="o_ak_card_amount text-muted">
                                         <t t-esc="state.data.currency_symbol"/>
-                                        <t t-esc="formatAmount(cardValue(def).amount)"/>
+                                        <t t-esc="formatAmount(card.amount)"/>
                                     </div>
                                 </div>
                             </div>

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="accounting_kmitl.AccountingDashboard" owl="1">
+        <div class="o_ak_dashboard p-3">
+
+            <div class="o_ak_header mb-3">
+                <h2 class="mb-0" t-esc="text.title"/>
+                <span class="text-muted" t-esc="text.subtitle"/>
+            </div>
+
+            <t t-if="state.loading">
+                <div class="text-center text-muted py-5">
+                    <i class="fa fa-circle-o-notch fa-spin fa-2x"/>
+                </div>
+            </t>
+            <t t-else="">
+                <div class="row g-3">
+                    <t t-foreach="cardDefs" t-as="def" t-key="def.id">
+                        <div class="col-12 col-sm-6 col-lg-4">
+                            <div class="card o_ak_card h-100"
+                                 t-on-click="() => this.openCard(def)">
+                                <div class="card-body">
+                                    <div class="o_ak_card_title text-muted" t-esc="def.title"/>
+                                    <div t-attf-class="o_ak_card_count fw-bold text-{{def.color}}"
+                                         t-esc="cardValue(def).count"/>
+                                    <div t-if="def.money" class="o_ak_card_amount text-muted">
+                                        <t t-esc="state.data.currency_symbol"/>
+                                        <t t-esc="formatAmount(cardValue(def).amount)"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+
+                <div class="o_ak_quick_actions mt-4">
+                    <h5 class="text-muted" t-esc="text.quickActions"/>
+                    <div class="d-flex flex-wrap gap-2">
+                        <button class="btn btn-primary" t-on-click="() => this.newDoc('in_invoice')">
+                            <i class="fa fa-plus me-1"/><t t-esc="text.newVendorBill"/>
+                        </button>
+                        <button class="btn btn-primary" t-on-click="() => this.newDoc('out_invoice')">
+                            <i class="fa fa-plus me-1"/><t t-esc="text.newCustomerInvoice"/>
+                        </button>
+                        <button class="btn btn-secondary" t-on-click="() => this.newDoc('entry')">
+                            <i class="fa fa-plus me-1"/><t t-esc="text.newJournalEntry"/>
+                        </button>
+                    </div>
+                </div>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/accounting_kmitl/tests/__init__.py
+++ b/accounting_kmitl/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dashboard

--- a/accounting_kmitl/tests/test_dashboard.py
+++ b/accounting_kmitl/tests/test_dashboard.py
@@ -1,0 +1,141 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command, fields
+from odoo.tests.common import TransactionCase, tagged
+
+CARD_KEYS = {
+    "my_drafts",
+    "submitted",
+    "unpaid_ap",
+    "overdue_ap",
+    "unpaid_ar",
+    "exceptions",
+}
+MONEY_CARDS = {"unpaid_ap", "overdue_ap", "unpaid_ar"}
+
+
+@tagged("post_install", "-at_install")
+class TestAccountingDashboard(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "general"), ("company_id", "=", cls.company.id)],
+            limit=1,
+        )
+        accounts = cls.env["account.account"].search(
+            [("company_id", "=", cls.company.id)], limit=2
+        )
+        cls.account_a, cls.account_b = accounts[0], accounts[1]
+
+        group_user = cls.env.ref("accounting_kmitl.group_accounting_kmitl_user")
+        account_manager = cls.env.ref("account.group_account_manager")
+        cls.maker = cls.env["res.users"].create(
+            {
+                "name": "Dashboard Maker",
+                "login": "kmitl_dashboard_maker",
+                "groups_id": [Command.set([group_user.id, account_manager.id])],
+            }
+        )
+        cls.other = cls.env["res.users"].create(
+            {
+                "name": "Dashboard Other",
+                "login": "kmitl_dashboard_other",
+                "groups_id": [Command.set([group_user.id, account_manager.id])],
+            }
+        )
+        cls.Dashboard = cls.env["accounting.kmitl.dashboard"]
+
+    def _entry(self, user, lines):
+        return (
+            self.env["account.move"]
+            .with_user(user)
+            .create(
+                {
+                    "move_type": "entry",
+                    "journal_id": self.journal.id,
+                    "date": fields.Date.today(),
+                    "line_ids": lines,
+                }
+            )
+        )
+
+    def _balanced_lines(self):
+        return [
+            Command.create(
+                {"account_id": self.account_a.id, "debit": 100.0, "credit": 0.0}
+            ),
+            Command.create(
+                {"account_id": self.account_b.id, "debit": 0.0, "credit": 100.0}
+            ),
+        ]
+
+    def _self_canceling_lines(self):
+        # Same account on both legs, equal amounts -> triggers the pre-defined
+        # (non-blocking) self-canceling-pair exception rule on submit.
+        return [
+            Command.create(
+                {"account_id": self.account_a.id, "debit": 100.0, "credit": 0.0}
+            ),
+            Command.create(
+                {"account_id": self.account_a.id, "debit": 0.0, "credit": 100.0}
+            ),
+        ]
+
+    def test_structure_and_domain_self_consistency(self):
+        """Every card exposes count + domain, and the count equals a fresh
+        search_count over that same domain (money cards also expose amount)."""
+        Move = self.env["account.move"].with_user(self.maker)
+        data = self.Dashboard.with_user(self.maker).get_dashboard_data()
+
+        self.assertIn("currency_symbol", data)
+        self.assertEqual(set(data["cards"]), CARD_KEYS)
+
+        for key, card in data["cards"].items():
+            self.assertIn("domain", card, key)
+            self.assertEqual(
+                card["count"], Move.search_count(card["domain"]), key
+            )
+            if key in MONEY_CARDS:
+                self.assertIn("amount", card, key)
+            else:
+                self.assertNotIn("amount", card, key)
+
+        # overdue_ap must be the unpaid_ap domain further narrowed by due date.
+        overdue = data["cards"]["overdue_ap"]["domain"]
+        self.assertTrue(
+            any(term[0] == "invoice_date_due" for term in overdue),
+            "overdue_ap domain must filter on invoice_date_due",
+        )
+
+    def test_my_drafts_scoped_to_current_user(self):
+        """my_drafts counts only the caller's own draft documents."""
+        before = self.Dashboard.with_user(self.maker).get_dashboard_data()
+        base = before["cards"]["my_drafts"]["count"]
+
+        self._entry(self.maker, self._balanced_lines())
+        self._entry(self.other, self._balanced_lines())  # not the caller's
+
+        after = self.Dashboard.with_user(self.maker).get_dashboard_data()
+        self.assertEqual(after["cards"]["my_drafts"]["count"], base + 1)
+
+    def test_submitted_card(self):
+        """A clean entry submits successfully and shows on the submitted card."""
+        move = self._entry(self.maker, self._balanced_lines())
+        move.with_user(self.maker).action_submit()
+        self.assertEqual(move.state, "submitted")
+
+        data = self.Dashboard.with_user(self.maker).get_dashboard_data()
+        self.assertGreaterEqual(data["cards"]["submitted"]["count"], 1)
+
+    def test_exception_card(self):
+        """Submitting a self-canceling pair is halted (popup) but flags the
+        move with an exception, so the exceptions card picks it up."""
+        move = self._entry(self.maker, self._self_canceling_lines())
+        move.with_user(self.maker).action_submit()  # returns a popup action
+        self.assertTrue(move.exception_ids)
+        self.assertEqual(move.state, "draft")
+
+        data = self.Dashboard.with_user(self.maker).get_dashboard_data()
+        self.assertGreaterEqual(data["cards"]["exceptions"]["count"], 1)

--- a/accounting_kmitl/tests/test_dashboard.py
+++ b/accounting_kmitl/tests/test_dashboard.py
@@ -47,6 +47,9 @@ class TestAccountingDashboard(TransactionCase):
         )
         cls.Dashboard = cls.env["accounting.kmitl.dashboard"]
 
+    def _cards_by_id(self, data):
+        return {card["id"]: card for card in data["cards"]}
+
     def _entry(self, user, lines):
         return (
             self.env["account.move"]
@@ -84,26 +87,27 @@ class TestAccountingDashboard(TransactionCase):
         ]
 
     def test_structure_and_domain_self_consistency(self):
-        """Every card exposes count + domain, and the count equals a fresh
-        search_count over that same domain (money cards also expose amount)."""
-        Move = self.env["account.move"].with_user(self.maker)
+        """Every card is self-describing and its count equals a fresh
+        search_count over its own res_model/domain (money cards also expose
+        amount)."""
         data = self.Dashboard.with_user(self.maker).get_dashboard_data()
-
         self.assertIn("currency_symbol", data)
-        self.assertEqual(set(data["cards"]), CARD_KEYS)
 
-        for key, card in data["cards"].items():
-            self.assertIn("domain", card, key)
-            self.assertEqual(
-                card["count"], Move.search_count(card["domain"]), key
-            )
+        cards = self._cards_by_id(data)
+        self.assertEqual(set(cards), CARD_KEYS)
+
+        for key, card in cards.items():
+            for attr in ("title", "color", "sequence", "res_model", "domain"):
+                self.assertIn(attr, card, "%s missing %s" % (key, attr))
+            model = self.env[card["res_model"]].with_user(self.maker)
+            self.assertEqual(card["count"], model.search_count(card["domain"]), key)
             if key in MONEY_CARDS:
                 self.assertIn("amount", card, key)
             else:
                 self.assertNotIn("amount", card, key)
 
         # overdue_ap must be the unpaid_ap domain further narrowed by due date.
-        overdue = data["cards"]["overdue_ap"]["domain"]
+        overdue = cards["overdue_ap"]["domain"]
         self.assertTrue(
             any(term[0] == "invoice_date_due" for term in overdue),
             "overdue_ap domain must filter on invoice_date_due",
@@ -112,13 +116,13 @@ class TestAccountingDashboard(TransactionCase):
     def test_my_drafts_scoped_to_current_user(self):
         """my_drafts counts only the caller's own draft documents."""
         before = self.Dashboard.with_user(self.maker).get_dashboard_data()
-        base = before["cards"]["my_drafts"]["count"]
+        base = self._cards_by_id(before)["my_drafts"]["count"]
 
         self._entry(self.maker, self._balanced_lines())
         self._entry(self.other, self._balanced_lines())  # not the caller's
 
         after = self.Dashboard.with_user(self.maker).get_dashboard_data()
-        self.assertEqual(after["cards"]["my_drafts"]["count"], base + 1)
+        self.assertEqual(self._cards_by_id(after)["my_drafts"]["count"], base + 1)
 
     def test_submitted_card(self):
         """A clean entry submits successfully and shows on the submitted card."""
@@ -127,7 +131,7 @@ class TestAccountingDashboard(TransactionCase):
         self.assertEqual(move.state, "submitted")
 
         data = self.Dashboard.with_user(self.maker).get_dashboard_data()
-        self.assertGreaterEqual(data["cards"]["submitted"]["count"], 1)
+        self.assertGreaterEqual(self._cards_by_id(data)["submitted"]["count"], 1)
 
     def test_exception_card(self):
         """Submitting a self-canceling pair is halted (popup) but flags the
@@ -138,4 +142,4 @@ class TestAccountingDashboard(TransactionCase):
         self.assertEqual(move.state, "draft")
 
         data = self.Dashboard.with_user(self.maker).get_dashboard_data()
-        self.assertGreaterEqual(data["cards"]["exceptions"]["count"], 1)
+        self.assertGreaterEqual(self._cards_by_id(data)["exceptions"]["count"], 1)

--- a/accounting_kmitl/views/accounting_dashboard_views.xml
+++ b/accounting_kmitl/views/accounting_dashboard_views.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Landing page: accounting work launchpad (KPI cards + quick actions) -->
+    <record id="action_accounting_dashboard" model="ir.actions.client">
+        <field name="name">Accounting Dashboard</field>
+        <field name="tag">accounting_kmitl.dashboard</field>
+    </record>
+
+</odoo>

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -10,6 +10,15 @@
         groups="accounting_kmitl.group_accounting_kmitl_user"
     />
 
+    <!-- Dashboard (landing page — lowest sequence so it opens first) -->
+    <menuitem
+        id="menu_accounting_dashboard"
+        name="Dashboard"
+        parent="menu_accounting_root"
+        action="action_accounting_dashboard"
+        sequence="5"
+    />
+
     <!-- เจ้าหนี้ (Accounts Payable) -->
     <menuitem
         id="menu_payable"

--- a/disbursement_accounting_kmitl/i18n/th.po
+++ b/disbursement_accounting_kmitl/i18n/th.po
@@ -138,3 +138,9 @@ msgstr "ใบตั้งหนี้ผู้ขาย"
 #, python-format
 msgid "Cannot cancel: bill(s) %s already posted. Reverse the bill(s) first."
 msgstr "ไม่สามารถยกเลิกได้: ใบตั้งหนี้ %s ลงบัญชีแล้ว กรุณายกเลิกใบตั้งหนี้ก่อน"
+
+#. module: disbursement_accounting_kmitl
+#: code:addons/disbursement_accounting_kmitl/models/accounting_kmitl_dashboard.py:0
+#, python-format
+msgid "Disbursement requests awaiting billing"
+msgstr "ใบขอเบิกอนุมัติแล้ว รอตั้งหนี้"

--- a/disbursement_accounting_kmitl/models/__init__.py
+++ b/disbursement_accounting_kmitl/models/__init__.py
@@ -1,2 +1,3 @@
+from . import accounting_kmitl_dashboard
 from . import account_move
 from . import disbursement_request

--- a/disbursement_accounting_kmitl/models/accounting_kmitl_dashboard.py
+++ b/disbursement_accounting_kmitl/models/accounting_kmitl_dashboard.py
@@ -1,0 +1,28 @@
+from odoo import _, api, models
+
+
+class AccountingKmitlDashboard(models.AbstractModel):
+    _inherit = "accounting.kmitl.dashboard"
+
+    @api.model
+    def get_dashboard_data(self):
+        """Add the "disbursement requests awaiting billing" KPI card.
+
+        A disbursement request stays ``approved`` until every active bill is
+        posted, at which point it advances to ``bills_posted`` (see
+        ``account.move._post`` in this module). So ``state == 'approved'`` is
+        exactly the accounting team's queue of approved requests that still
+        need a bill posted.
+        """
+        data = super().get_dashboard_data()
+        data["cards"].append(
+            self._make_card(
+                "disbursement_awaiting_bill",
+                _("Disbursement requests awaiting billing"),
+                "info",
+                25,
+                "disbursement.request",
+                [("state", "=", "approved")],
+            )
+        )
+        return data

--- a/disbursement_accounting_kmitl/tests/__init__.py
+++ b/disbursement_accounting_kmitl/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dashboard_card

--- a/disbursement_accounting_kmitl/tests/test_dashboard_card.py
+++ b/disbursement_accounting_kmitl/tests/test_dashboard_card.py
@@ -1,0 +1,28 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDisbursementDashboardCard(TransactionCase):
+    def _cards_by_id(self, data):
+        return {card["id"]: card for card in data["cards"]}
+
+    def test_disbursement_card_added_alongside_base_cards(self):
+        """The bridge appends its card without dropping the base cards, and the
+        card is self-consistent (count == search_count over its domain)."""
+        data = self.env["accounting.kmitl.dashboard"].get_dashboard_data()
+        cards = self._cards_by_id(data)
+
+        # base cards still present -> super() was chained
+        self.assertIn("unpaid_ap", cards)
+
+        card = cards.get("disbursement_awaiting_bill")
+        self.assertIsNotNone(card, "disbursement card missing")
+        self.assertEqual(card["res_model"], "disbursement.request")
+        self.assertEqual(card["domain"], [("state", "=", "approved")])
+        self.assertNotIn("amount", card)  # count-only card
+        self.assertEqual(
+            card["count"],
+            self.env["disbursement.request"].search_count(card["domain"]),
+        )


### PR DESCRIPTION
## สรุป
เพิ่มหน้า **Dashboard** เป็นหน้าแรกของ app `accounting_kmitl` แบบ *work launchpad* — แสดงงานที่ค้างและยอดคงค้างก่อนผู้ใช้จะเข้าไปที่รายการเอกสาร (เดิมคลิก "Accounting" แล้วเด้งไปหน้าใบตั้งหนี้ทันที)

ทำงานได้แบบ **standalone บน base `accounting_kmitl`** — ไม่พึ่ง `accounting_kmitl_workflow`, ไม่มีกราฟ, และไม่ทำซ้ำ dashboard ของ module `budget`

## การ์ด KPI (คลิกทะลุไปหน้ารายการที่กรองด้วย domain เดียวกับที่ใช้นับ)
| การ์ด | ตัวเลข |
|---|---|
| ฉบับร่างของฉัน | นับ `state=draft` ของผู้ใช้ |
| ส่งแล้ว (รอลงบัญชี) | นับ `state=submitted` ของผู้ใช้ |
| ค้างจ่ายเจ้าหนี้ | count + Σ`amount_residual` (`in_invoice`, posted, ยังไม่จ่าย) |
| เจ้าหนี้เกินกำหนดชำระ | count + Σ ยอด (เลย `invoice_date_due`) |
| ลูกหนี้ค้างรับ | count + Σ ยอด (`out_invoice`) |
| เอกสารที่มีข้อควรระวัง | นับ move ที่ติด exception (ยังไม่ ignore) |

พร้อมปุ่มลัด: สร้างใบตั้งหนี้ / ใบตั้งหนี้ลูกหนี้ / รายการสมุดรายวัน

## การเปลี่ยนแปลง
- **`accounting.kmitl.dashboard`** (AbstractModel ใหม่) — `get_dashboard_data()` รวมยอดด้วย `read_group`/`search_count` ยึด pattern จาก `budget.dashboard`; **ไม่ใช้ `sudo`** ให้ record rules คุม scope ต่อผู้ใช้ (ตัวเลขบนการ์ด = รายการที่เปิดจากการคลิกเสมอ)
- **OWL client action** (tag `accounting_kmitl.dashboard`) — การ์ด + ปุ่มลัด, เปิดรายการ/ฟอร์มผ่าน `action` service, reuse view มาตรฐานของ `account.move`
- **เมนู** `Dashboard` (sequence 5) กลายเป็นหน้า landing ของเมนู root Accounting — ไม่แตะเมนูเดิม
- **i18n** — source strings เป็นภาษาอังกฤษ แปลไทยผ่าน `i18n/th.po`
- **Tests** — โครงสร้าง/domain self-consistency, scope ตามผู้ใช้, การ์ด submitted และ exception

## Test plan
- [ ] `oca_run_tests` (มี `accounting_kmitl/tests/test_dashboard.py`)
- [ ] อัปเกรด module → เปิด app **Accounting** ต้อง land ที่ Dashboard
- [ ] สร้างใบตั้งหนี้ค้างร่าง → การ์ด "ฉบับร่างของฉัน" +1
- [ ] โพสต์ vendor bill ที่ยังไม่จ่าย → การ์ด "ค้างจ่ายเจ้าหนี้" แสดง count + ยอด, คลิกแล้วรายการตรงกับตัวเลข

🤖 Generated with [Claude Code](https://claude.com/claude-code)