### PR TITLE
[16.0][ADD] disbursement_accounting_kmitl: dashboard card for requests awaiting billing

### DIFF
--- a/disbursement_accounting_kmitl/i18n/th.po
+++ b/disbursement_accounting_kmitl/i18n/th.po
@@ -138,3 +138,9 @@ msgstr "ใบตั้งหนี้ผู้ขาย"
 #, python-format
 msgid "Cannot cancel: bill(s) %s already posted. Reverse the bill(s) first."
 msgstr "ไม่สามารถยกเลิกได้: ใบตั้งหนี้ %s ลงบัญชีแล้ว กรุณายกเลิกใบตั้งหนี้ก่อน"
+
+#. module: disbursement_accounting_kmitl
+#: code:addons/disbursement_accounting_kmitl/models/accounting_kmitl_dashboard.py:0
+#, python-format
+msgid "Disbursement requests awaiting billing"
+msgstr "ใบขอเบิกอนุมัติแล้ว รอตั้งหนี้"

--- a/disbursement_accounting_kmitl/models/__init__.py
+++ b/disbursement_accounting_kmitl/models/__init__.py
@@ -1,2 +1,3 @@
+from . import accounting_kmitl_dashboard
 from . import account_move
 from . import disbursement_request

--- a/disbursement_accounting_kmitl/models/accounting_kmitl_dashboard.py
+++ b/disbursement_accounting_kmitl/models/accounting_kmitl_dashboard.py
@@ -1,0 +1,28 @@
+from odoo import _, api, models
+
+
+class AccountingKmitlDashboard(models.AbstractModel):
+    _inherit = "accounting.kmitl.dashboard"
+
+    @api.model
+    def get_dashboard_data(self):
+        """Add the "disbursement requests awaiting billing" KPI card.
+
+        A disbursement request stays ``approved`` until every active bill is
+        posted, at which point it advances to ``bills_posted`` (see
+        ``account.move._post`` in this module). So ``state == 'approved'`` is
+        exactly the accounting team's queue of approved requests that still
+        need a bill posted.
+        """
+        data = super().get_dashboard_data()
+        data["cards"].append(
+            self._make_card(
+                "disbursement_awaiting_bill",
+                _("Disbursement requests awaiting billing"),
+                "info",
+                25,
+                "disbursement.request",
+                [("state", "=", "approved")],
+            )
+        )
+        return data

--- a/disbursement_accounting_kmitl/tests/__init__.py
+++ b/disbursement_accounting_kmitl/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dashboard_card

--- a/disbursement_accounting_kmitl/tests/test_dashboard_card.py
+++ b/disbursement_accounting_kmitl/tests/test_dashboard_card.py
@@ -1,0 +1,28 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDisbursementDashboardCard(TransactionCase):
+    def _cards_by_id(self, data):
+        return {card["id"]: card for card in data["cards"]}
+
+    def test_disbursement_card_added_alongside_base_cards(self):
+        """The bridge appends its card without dropping the base cards, and the
+        card is self-consistent (count == search_count over its domain)."""
+        data = self.env["accounting.kmitl.dashboard"].get_dashboard_data()
+        cards = self._cards_by_id(data)
+
+        # base cards still present -> super() was chained
+        self.assertIn("unpaid_ap", cards)
+
+        card = cards.get("disbursement_awaiting_bill")
+        self.assertIsNotNone(card, "disbursement card missing")
+        self.assertEqual(card["res_model"], "disbursement.request")
+        self.assertEqual(card["domain"], [("state", "=", "approved")])
+        self.assertNotIn("amount", card)  # count-only card
+        self.assertEqual(
+            card["count"],
+            self.env["disbursement.request"].search_count(card["domain"]),
+        )


### PR DESCRIPTION
> ⚠️ **Stacked PR** — base = `16.0-add-accounting_kmitl-dashboard` (PR #939). ต้อง merge #939 ก่อน (มี refactor data-driven ที่ PR นี้พึ่งพา) หลัง #939 merge เข้า `16.0` แล้ว GitHub จะ retarget PR นี้ไป `16.0` ให้อัตโนมัติ

## สรุป
เพิ่มการ์ด **"ใบขอเบิกอนุมัติแล้ว รอตั้งหนี้"** บน dashboard ของ app Accounting — เป็นคิวงานของฝ่ายบัญชี (ใบขอเบิกที่ผ่านการอนุมัติแล้ว แต่ยังตั้งหนี้ไม่ครบ)

## จัดการ addon ยังไง (สถาปัตยกรรม)
- `disbursement` ไม่รู้จัก `accounting_kmitl`, และ base `accounting_kmitl` ต้อง standalone → **`disbursement_accounting_kmitl`** (สะพานที่ depends ทั้งสองฝั่ง) คือบ้านที่ถูกต้องของการ์ดนี้
- PR #939 ปรับ `accounting.kmitl.dashboard` ให้ **data-driven** (การ์ด = list จาก server) → module นี้เพิ่มการ์ดด้วย **Python ล้วน ไม่แตะ JS**:
  ```python
  class AccountingKmitlDashboard(models.AbstractModel):
      _inherit = "accounting.kmitl.dashboard"

      @api.model
      def get_dashboard_data(self):
          data = super().get_dashboard_data()
          data["cards"].append(self._make_card(
              "disbursement_awaiting_bill", _("Disbursement requests awaiting billing"),
              "info", 25, "disbursement.request", [("state", "=", "approved")]))
          return data
  ```

## ทำไม domain แค่ `state=approved`
`disbursement.request` จะอยู่สถานะ `approved` จนกว่า bill **ทุกใบ**จะ posted ครบ แล้วจึงเลื่อนเป็น `bills_posted` (ดู `account.move._post` ใน module นี้) — ดังนั้น `state=approved` = "อนุมัติแล้ว แต่ยังตั้งหนี้ไม่ครบ" พอดี คลิกการ์ด → เปิด list `disbursement.request` กรอง `state=approved`

## การเปลี่ยนแปลง
- `models/accounting_kmitl_dashboard.py` (ใหม่) — `_inherit` + append การ์ด (ผ่าน `_make_card` helper ของ base)
- `models/__init__.py`, `i18n/th.po` (+1 คำแปล), `tests/test_dashboard_card.py` (ใหม่)

## Test plan
- [ ] `oca_run_tests` (มี `tests/test_dashboard_card.py`: การ์ดถูกเพิ่มโดยไม่ทับ base cards + count == search_count ของ domain)
- [ ] อัปเกรด module → เปิด Accounting dashboard เห็นการ์ด "ใบขอเบิกอนุมัติแล้ว รอตั้งหนี้"
- [ ] อนุมัติใบขอเบิก 1 ใบ (ยังไม่ตั้งหนี้) → count +1; ตั้งหนี้จน posted ครบ → count -1; คลิกการ์ดแล้วรายการตรงกับตัวเลข

🤖 Generated with [Claude Code](https://claude.com/claude-code)