### PR TITLE
[16.0][ADD] web_notebook_invalid_indicator: highlight notebook tab on save fail

### DIFF
--- a/web_notebook_invalid_indicator/__manifest__.py
+++ b/web_notebook_invalid_indicator/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Web Notebook Invalid Field Indicator",
+    "summary": "Highlight notebook tabs in red when they contain invalid fields after save fail",
+    "version": "16.0.1.0.0",
+    "author": "KMITL",
+    "website": "https://github.com/aginix/kmitl",
+    "category": "Web",
+    "depends": ["web"],
+    "data": [],
+    "assets": {
+        "web.assets_backend": [
+            "web_notebook_invalid_indicator/static/src/form_compiler_patch.js",
+            "web_notebook_invalid_indicator/static/src/notebook_invalid.scss",
+        ],
+    },
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/web_notebook_invalid_indicator/static/src/form_compiler_patch.js
+++ b/web_notebook_invalid_indicator/static/src/form_compiler_patch.js
@@ -2,6 +2,7 @@
 
 import { patch } from "@web/core/utils/patch";
 import { FormCompiler } from "@web/views/form/form_compiler";
+import { FormRenderer } from "@web/views/form/form_renderer";
 import { getModifier } from "@web/views/view_compiler";
 
 const INVALID_CLASS = "o_notebook_page_invalid";
@@ -18,6 +19,21 @@ function collectPageFieldNames(pageEl) {
     }
     return [...names];
 }
+
+patch(FormRenderer.prototype, "web_notebook_invalid_indicator", {
+    hasInvalidNotebookField(fieldNames) {
+        const record = this.props.record;
+        if (!record || !record._invalidFields || !record._invalidFields.size) {
+            return false;
+        }
+        for (const fieldName of fieldNames) {
+            if (record._invalidFields.has(fieldName)) {
+                return true;
+            }
+        }
+        return false;
+    },
+});
 
 patch(FormCompiler.prototype, "web_notebook_invalid_indicator", {
     compileNotebook(el, params) {
@@ -43,7 +59,7 @@ patch(FormCompiler.prototype, "web_notebook_invalid_indicator", {
             const fieldNames = collectPageFieldNames(child);
             const originalExpr = pageSlot.getAttribute("className") || '""';
             const invalidCheck = fieldNames.length
-                ? `${JSON.stringify(fieldNames)}.some(f => props.record.isInvalid(f))`
+                ? `this.hasInvalidNotebookField(${JSON.stringify(fieldNames)})`
                 : "false";
             pageSlot.setAttribute(
                 "className",

--- a/web_notebook_invalid_indicator/static/src/form_compiler_patch.js
+++ b/web_notebook_invalid_indicator/static/src/form_compiler_patch.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import { patch } from "@web/core/utils/patch";
+import { FormCompiler } from "@web/views/form/form_compiler";
+import { getModifier } from "@web/views/view_compiler";
+
+const INVALID_CLASS = "o_notebook_page_invalid";
+
+function collectPageFieldNames(pageEl) {
+    const own = pageEl.querySelectorAll("field[name]");
+    const nested = new Set(pageEl.querySelectorAll("notebook page field[name]"));
+    const names = new Set();
+    for (const field of own) {
+        if (nested.has(field)) {
+            continue;
+        }
+        names.add(field.getAttribute("name"));
+    }
+    return [...names];
+}
+
+patch(FormCompiler.prototype, "web_notebook_invalid_indicator", {
+    compileNotebook(el, params) {
+        const noteBook = this._super(el, params);
+
+        const pageSlots = [...noteBook.children].filter(
+            (c) => c.tagName === "t" && c.hasAttribute("t-set-slot")
+        );
+
+        let slotIdx = 0;
+        for (const child of el.children) {
+            if (child.tagName.toLowerCase() !== "page") {
+                continue;
+            }
+            const invisible = getModifier(child, "invisible");
+            if (this.isAlwaysInvisible(invisible, params)) {
+                continue;
+            }
+            const pageSlot = pageSlots[slotIdx++];
+            if (!pageSlot) {
+                continue;
+            }
+            const fieldNames = collectPageFieldNames(child);
+            if (!fieldNames.length) {
+                continue;
+            }
+            const originalExpr = pageSlot.getAttribute("className") || '""';
+            const invalidCheck = `${JSON.stringify(fieldNames)}.some(f => props.record.isInvalid(f))`;
+            pageSlot.setAttribute(
+                "className",
+                `(${originalExpr}) + (${invalidCheck} ? " ${INVALID_CLASS}" : "")`
+            );
+        }
+
+        return noteBook;
+    },
+});

--- a/web_notebook_invalid_indicator/static/src/form_compiler_patch.js
+++ b/web_notebook_invalid_indicator/static/src/form_compiler_patch.js
@@ -24,12 +24,12 @@ patch(FormCompiler.prototype, "web_notebook_invalid_indicator", {
         const noteBook = this._super(el, params);
 
         const pageSlots = [...noteBook.children].filter(
-            (c) => c.tagName === "t" && c.hasAttribute("t-set-slot")
+            (c) => c.nodeName.toLowerCase() === "t" && c.hasAttribute("t-set-slot")
         );
 
         let slotIdx = 0;
         for (const child of el.children) {
-            if (child.tagName.toLowerCase() !== "page") {
+            if (child.nodeName.toLowerCase() !== "page") {
                 continue;
             }
             const invisible = getModifier(child, "invisible");
@@ -41,11 +41,10 @@ patch(FormCompiler.prototype, "web_notebook_invalid_indicator", {
                 continue;
             }
             const fieldNames = collectPageFieldNames(child);
-            if (!fieldNames.length) {
-                continue;
-            }
             const originalExpr = pageSlot.getAttribute("className") || '""';
-            const invalidCheck = `${JSON.stringify(fieldNames)}.some(f => props.record.isInvalid(f))`;
+            const invalidCheck = fieldNames.length
+                ? `${JSON.stringify(fieldNames)}.some(f => props.record.isInvalid(f))`
+                : "false";
             pageSlot.setAttribute(
                 "className",
                 `(${originalExpr}) + (${invalidCheck} ? " ${INVALID_CLASS}" : "")`

--- a/web_notebook_invalid_indicator/static/src/notebook_invalid.scss
+++ b/web_notebook_invalid_indicator/static/src/notebook_invalid.scss
@@ -1,0 +1,16 @@
+.o_notebook_headers .nav-link.o_notebook_page_invalid {
+    color: $danger;
+    border-bottom-color: $danger;
+    font-weight: 600;
+
+    &::before {
+        content: "\f071";
+        font-family: "FontAwesome";
+        margin-right: 4px;
+    }
+
+    &.active {
+        color: $danger;
+        border-color: $danger $danger #fff;
+    }
+}


### PR DESCRIPTION
## Summary
- New universal module that highlights notebook tabs in red (with a warning icon) when a form save fails because of required/invalid fields inside that page — solves the common problem where users miss the small top-right notification.
- Works via a `FormCompiler.compileNotebook` patch that injects a dynamic `className` expression per page slot, reading `props.record.isInvalid(fieldName)` for the fields the page owns; Owl re-evaluates on every `model.notify()`, so tabs light up on save fail and clear the moment the user re-edits the offending field.
- No per-model configuration; auto-installs alongside `web`. Nested notebooks resolve to the nearest enclosing page.

## Test plan
- [ ] Install module, open a form with a required field inside a non-active tab (e.g. `product.template`, `res.partner`).
- [ ] Stay on the first tab, fill it, click Save → the tab containing the empty required field turns red with a ⚠ icon.
- [ ] Click into the red tab, fill the field, tab out → the tab returns to normal without needing another Save.
- [ ] Save again → record saves cleanly.
- [ ] Nested notebook: inner-page field invalidity reddens only the inner tab, not the outer.