### PR TITLE
[16.0][IMP] procurement_assignment_kmitl: move Assign buttons inline next to assigned_to

### DIFF
--- a/procurement_assignment_kmitl/views/purchase_request_views.xml
+++ b/procurement_assignment_kmitl/views/purchase_request_views.xml
@@ -6,36 +6,36 @@
         <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
         <field name="priority">40</field>
         <field name="arch" type="xml">
-            <xpath expr="//header/button[1]" position="before">
-                <button
-                    name="action_assignment_assign_me"
-                    type="object"
-                    string="Assign to me"
-                    class="oe_highlight"
-                    groups="purchase_request.group_purchase_request_user"
-                    attrs="{'invisible': [('assignment_can_assign_me', '=', False)]}"
-                />
-                <button
-                    name="action_assignment_open_wizard"
-                    type="object"
-                    string="Assign…"
-                    groups="purchase_request.group_purchase_request_manager"
-                />
-                <button
-                    name="action_assignment_unassign"
-                    type="object"
-                    string="Unassign"
-                    groups="purchase_request.group_purchase_request_manager"
-                    attrs="{'invisible': [('assigned_to', '=', False)]}"
-                />
-            </xpath>
-            <field name="assigned_to" position="before">
+            <field name="assigned_to" position="replace">
                 <field name="assignment_can_assign_me" invisible="1" />
+                <label for="assigned_to" />
+                <div class="o_row">
+                    <field name="assigned_to" readonly="1" nolabel="1" />
+                    <button
+                        name="action_assignment_assign_me"
+                        type="object"
+                        string="Assign to me"
+                        class="btn-link"
+                        groups="purchase_request.group_purchase_request_user"
+                        attrs="{'invisible': [('assignment_can_assign_me', '=', False)]}"
+                    />
+                    <button
+                        name="action_assignment_open_wizard"
+                        type="object"
+                        string="Assign…"
+                        class="btn-link"
+                        groups="purchase_request.group_purchase_request_manager"
+                    />
+                    <button
+                        name="action_assignment_unassign"
+                        type="object"
+                        string="Unassign"
+                        class="btn-link"
+                        groups="purchase_request.group_purchase_request_manager"
+                        attrs="{'invisible': [('assigned_to', '=', False)]}"
+                    />
+                </div>
             </field>
-            <xpath expr="//field[@name='assigned_to']" position="attributes">
-                <attribute name="readonly">1</attribute>
-                <attribute name="attrs" />
-            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary
- Header of `purchase.request` mixed ownership actions (Assign to me / Assign… / Unassign) with workflow buttons (Submit / Approve / Reject), and `Assign to me` used `oe_highlight` — competing with the workflow primary style.
- Moved the three buttons out of the header into an inline row next to the `assigned_to` field, styled as `btn-link`, keeping all existing `attrs` and `groups`. Scope: `purchase.request` only; `purchase.order` unchanged.

## Test plan
- [ ] As a purchase_request user, open a PR: header shows only workflow buttons; `Assign to me` appears as a link next to `Assigned To` when unassigned; clicking it self-assigns and the link hides.
- [ ] As a purchase_request manager: `Assign…` opens the wizard; `Unassign` appears only when assigned and clears the officer.
- [ ] `Assigned to me` / `Unassigned` search filters still work.