### PR TITLE
[16.0][IMP] kris_project: expand employer organization types

### DIFF
--- a/kris_project/i18n/th.po
+++ b/kris_project/i18n/th.po
@@ -1288,8 +1288,18 @@ msgstr "หน่วยงานของหัวหน้าโครงกา
 
 #. module: kris_project
 #: model:ir.model.fields.selection,name:kris_project.selection__kris_project__client_org_type__government
-msgid "Government"
-msgstr "หน่วยงานรัฐ"
+msgid "Government Agency"
+msgstr "ส่วนราชการ/หน่วยงานของรัฐ"
+
+#. module: kris_project
+#: model:ir.model.fields.selection,name:kris_project.selection__kris_project__client_org_type__public_organization
+msgid "Public Organization"
+msgstr "หน่วยงานในกำกับของรัฐ"
+
+#. module: kris_project
+#: model:ir.model.fields.selection,name:kris_project.selection__kris_project__client_org_type__independent_organization
+msgid "Independent Organization"
+msgstr "องค์กรอิสระ"
 
 #. module: kris_project
 #. odoo-javascript
@@ -1387,8 +1397,8 @@ msgstr "โครงการเสร็จสิ้น"
 
 #. module: kris_project
 #: model:ir.model.fields.selection,name:kris_project.selection__kris_project__client_org_type__private
-msgid "Private"
-msgstr "เอกชน"
+msgid "Private Company"
+msgstr "บริษัทเอกชน"
 
 #. module: kris_project
 #: model:ir.model.fields,field_description:kris_project.field_kris_project__attachment_ids

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -7,9 +7,11 @@ from odoo.tools import float_compare
 _logger = logging.getLogger(__name__)
 
 CLIENT_ORG_TYPE_SELECTION = [
-    ("government", "Government"),
+    ("government", "Government Agency"),
     ("state_enterprise", "State Enterprise"),
-    ("private", "Private"),
+    ("public_organization", "Public Organization"),
+    ("independent_organization", "Independent Organization"),
+    ("private", "Private Company"),
     ("other", "Other"),
 ]
 


### PR DESCRIPTION
## Summary
- Rename client organization labels: **หน่วยงานรัฐ** → **ส่วนราชการ/หน่วยงานของรัฐ**, **เอกชน** → **บริษัทเอกชน**
- Add two new options: **หน่วยงานในกำกับของรัฐ** (`public_organization`) and **องค์กรอิสระ** (`independent_organization`)
- Existing DB values for `government` / `private` keys are preserved; only labels change.

## Test plan
- [ ] Upgrade `kris_project` and open a `kris.project` form
- [ ] Verify the Client Organization dropdown shows all 6 Thai options with the new/renamed labels
- [ ] Confirm existing records previously set to หน่วยงานรัฐ/เอกชน now display the new labels