### PR TITLE
[16.0][ADD] kris_project: ตรวจสอบยอดรับจากผู้ว่าจ้างรวมตอนยืนยันโครงการ

### DIFF
--- a/kris_project/data/kris_project_exception_data.xml
+++ b/kris_project/data/kris_project_exception_data.xml
@@ -101,6 +101,22 @@ if self.state == 'draft' and not self.no_installment_tracking and self.installme
         <field name="active" eval="True"/>
     </record>
 
+    <record id="kris_excep_received_total_mismatch" model="exception.rule">
+        <field name="name">ยอดรับจากผู้ว่าจ้างรวมไม่ตรงกับมูลค่าโครงการ</field>
+        <field name="description">ผลรวมของยอดรับจากผู้ว่าจ้างทุกงวดไม่เท่ากับมูลค่าโครงการ</field>
+        <field name="sequence">45</field>
+        <field name="model">kris.project</field>
+        <field name="code">
+if self.state == 'draft' and not self.no_installment_tracking and self.installment_ids:
+    from odoo.tools import float_compare
+    prec = self.env['decimal.precision'].precision_get('Account')
+    total_received = sum(self.installment_ids.mapped('received_from_employer'))
+    if float_compare(total_received, self.project_value, precision_digits=prec) != 0:
+        failed = True
+        </field>
+        <field name="active" eval="True"/>
+    </record>
+
     <record id="kris_excep_installment_maintenance_mismatch" model="exception.rule">
         <field name="name">The maintenance fee for this period does not match.</field>
         <field name="description">The sum of institutional maintenance fees in the work period does not equal the value after deduction of maintenance fees.</field>


### PR DESCRIPTION
## สรุป

- เพิ่ม exception rule ใหม่ `kris_excep_received_total_mismatch` ตรวจสอบตอนยืนยันโครงการ (draft → in_progress)
- เมื่อโครงการ **มีงวดงานกำกับ** (`no_installment_tracking = False`) ผลรวมของ `received_from_employer` ทุกงวดต้องเท่ากับ `project_value` (มูลค่าโครงการ)
- ถ้าไม่ตรงกัน จะแสดง exception แจ้งเตือนเป็นภาษาไทย

## รายละเอียดการเปลี่ยนแปลง

- **ไฟล์:** `kris_project/data/kris_project_exception_data.xml`
- เพิ่ม `exception.rule` record ใหม่ (sequence 45) อยู่ระหว่าง installment total mismatch (seq 40) กับ maintenance mismatch (seq 50)
- ใช้ `float_compare` เปรียบเทียบค่าเงินเพื่อความแม่นยำ

## แผนทดสอบ

- [ ] สร้างโครงการที่ `no_installment_tracking = False` และเพิ่มงวดงานที่ผลรวม `received_from_employer` ≠ `project_value` → กดยืนยัน → ต้องแสดง exception แจ้งเตือน
- [ ] ปรับงวดงานให้ผลรวมตรงกัน → กดยืนยัน → ต้องผ่านได้
- [ ] โครงการที่ `no_installment_tracking = True` → ไม่ต้องตรวจสอบ rule นี้