### PR TITLE
[16.0][ADD] disbursement_assignment_kmitl: auto-assign verification officer

### DIFF
--- a/disbursement_assignment_kmitl/README.rst
+++ b/disbursement_assignment_kmitl/README.rst
@@ -1,0 +1,66 @@
+=============================
+Disbursement Assignment KMITL
+=============================
+
+Auto-assign a responsible **verification officer** (เจ้าหน้าที่หมวดตรวจ) to a
+disbursement request the moment the head of department signs it, so requests no
+longer pile up in one shared queue when different officers handle different
+kinds of money.
+
+Features
+========
+
+* **Rule-based auto-assignment.** When a request reaches the ``signed`` state
+  it is matched against a list of routing rules and the first matching rule's
+  officer is stored in ``Assigned Officer`` (``assigned_to``). Rules combine
+  any of these criteria; an empty criterion is a wildcard:
+
+  * Department (ส่วนงาน)
+  * Source (แหล่งเงิน)
+  * Fund (กองทุน)
+  * Activity (ด้าน/แผนงาน/กิจกรรม)
+  * Partner Type (ประเภทคู่ค้า)
+
+  Hierarchical dimensions match on the whole subtree: a rule set on a parent
+  department / fund / activity covers every child. Rules are ordered by
+  sequence and the first match wins, so an empty catch-all rule at the bottom
+  acts as the default officer.
+
+* **A To-Do for the officer.** Assignment schedules a "To Do" activity on the
+  request so the officer is notified. Reassigning moves the To-Do; validating,
+  resetting, or cancelling the request closes it.
+
+* **Manual override.** Officers can claim an unassigned (or, by default,
+  mis-routed) request with **Assign to me**; managers can reassign with
+  **Assign…** or clear the officer with **Unassign**.
+
+* **Advisory only.** Assignment never restricts who may validate a request --
+  it only drives filtering (``My Verifications`` / ``Unassigned``) and the
+  To-Do notification.
+
+* **Backlog routing.** *Apply Rules to Pending Requests* (gear menu on the rule
+  list) routes already-signed, still-unassigned requests after you add or edit
+  rules.
+
+Configuration
+=============
+
+* Rules live under **Disbursement ▸ Configuration ▸ Assignment Rules**
+  (managers only).
+* The system parameter ``disbursement_assignment_kmitl.allow_takeover_assigned``
+  (default ``True``) controls whether an officer may claim a request already
+  assigned to someone else. Set it to ``False`` to lock claims to the assigned
+  officer and managers.
+
+Credits
+=======
+
+Authors
+-------
+
+* Aginix Technologies
+
+License
+-------
+
+LGPL-3

--- a/disbursement_assignment_kmitl/__init__.py
+++ b/disbursement_assignment_kmitl/__init__.py
@@ -1,0 +1,4 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import models
+from . import wizards

--- a/disbursement_assignment_kmitl/__manifest__.py
+++ b/disbursement_assignment_kmitl/__manifest__.py
@@ -1,0 +1,23 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Disbursement Assignment KMITL",
+    "version": "16.0.1.0.0",
+    "summary": "Auto-assign a responsible verification officer to disbursement "
+    "requests by rules",
+    "category": "Disbursement",
+    "license": "LGPL-3",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "disbursement",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizards/assign_officer_wizard_views.xml",
+        "views/assignment_rule_views.xml",
+        "views/disbursement_request_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/disbursement_assignment_kmitl/i18n/th.po
+++ b/disbursement_assignment_kmitl/i18n/th.po
@@ -1,0 +1,113 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* disbursement_assignment_kmitl
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: disbursement_assignment_kmitl
+msgid "Disbursement Assignment Rule"
+msgstr "กฎการมอบหมายใบขอเบิก"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assign Disbursement Verification Officer"
+msgstr "มอบหมายเจ้าหน้าที่หมวดตรวจใบขอเบิก"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assignment Rules"
+msgstr "กฎการมอบหมาย"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assigned Officer"
+msgstr "เจ้าหน้าที่ผู้รับผิดชอบ"
+
+#. module: disbursement_assignment_kmitl
+msgid "Department"
+msgstr "ส่วนงาน"
+
+#. module: disbursement_assignment_kmitl
+msgid "Source"
+msgstr "แหล่งเงิน"
+
+#. module: disbursement_assignment_kmitl
+msgid "Fund"
+msgstr "กองทุน"
+
+#. module: disbursement_assignment_kmitl
+msgid "Activity"
+msgstr "กิจกรรม"
+
+#. module: disbursement_assignment_kmitl
+msgid "Partner Type"
+msgstr "ประเภทคู่ค้า"
+
+#. module: disbursement_assignment_kmitl
+msgid "Disbursement Request"
+msgstr "ใบขอเบิก"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assign to me"
+msgstr "รับงานนี้"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assign…"
+msgstr "มอบหมาย…"
+
+#. module: disbursement_assignment_kmitl
+msgid "Unassign"
+msgstr "ถอนผู้รับผิดชอบ"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assign"
+msgstr "มอบหมาย"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assign Officer"
+msgstr "มอบหมายเจ้าหน้าที่"
+
+#. module: disbursement_assignment_kmitl
+msgid "My Verifications"
+msgstr "งานตรวจของฉัน"
+
+#. module: disbursement_assignment_kmitl
+msgid "Unassigned"
+msgstr "ยังไม่มีผู้รับผิดชอบ"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assigned as responsible verification officer"
+msgstr "ได้รับมอบหมายเป็นเจ้าหน้าที่หมวดตรวจผู้รับผิดชอบ"
+
+#. module: disbursement_assignment_kmitl
+msgid "Apply Rules to Pending Requests"
+msgstr "นำกฎไปใช้กับใบขอเบิกที่รอตรวจ"
+
+#. module: disbursement_assignment_kmitl
+msgid "Assignment Rules Applied"
+msgstr "นำกฎการมอบหมายไปใช้แล้ว"
+
+#. module: disbursement_assignment_kmitl
+#, python-format
+msgid "%(assigned)s of %(total)s pending request(s) were assigned."
+msgstr "มอบหมายแล้ว %(assigned)s จาก %(total)s ใบที่รอตรวจ"
+
+#. module: disbursement_assignment_kmitl
+#, python-format
+msgid "This document is already assigned to %s."
+msgstr "เอกสารนี้มีผู้รับผิดชอบแล้วคือ %s"
+
+#. module: disbursement_assignment_kmitl
+msgid "Only a manager can unassign the officer."
+msgstr "เฉพาะผู้จัดการเท่านั้นที่ถอนผู้รับผิดชอบได้"
+
+#. module: disbursement_assignment_kmitl
+msgid "Only a manager can assign another officer."
+msgstr "เฉพาะผู้จัดการเท่านั้นที่มอบหมายผู้รับผิดชอบคนอื่นได้"

--- a/disbursement_assignment_kmitl/models/__init__.py
+++ b/disbursement_assignment_kmitl/models/__init__.py
@@ -1,0 +1,4 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import assignment_rule
+from . import disbursement_request

--- a/disbursement_assignment_kmitl/models/assignment_rule.py
+++ b/disbursement_assignment_kmitl/models/assignment_rule.py
@@ -1,0 +1,136 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+
+
+class DisbursementAssignmentRule(models.Model):
+    """Routing rule that maps a disbursement request to a verification officer.
+
+    When a request reaches the ``signed`` state it is matched against these
+    rules (ordered by ``sequence``) and the first matching rule's officer is
+    stored in ``disbursement.request.assigned_to``. Matching is advisory: it
+    only pre-fills the responsible officer and raises a To-Do; it never locks
+    who is allowed to validate the request.
+    """
+
+    _name = "disbursement.assignment.rule"
+    _description = "Disbursement Assignment Rule"
+    _order = "sequence, id"
+    _rec_name = "user_id"
+
+    # Dimension criteria used for matching, in stored-field order. An empty
+    # criterion behaves as a wildcard (matches any value on that dimension).
+    _CRITERIA = (
+        "department_analytic_id",
+        "source_analytic_id",
+        "fund_analytic_id",
+        "activity_analytic_id",
+    )
+
+    sequence = fields.Integer(default=10)
+    active = fields.Boolean(default=True)
+
+    # -- criteria: empty = wildcard --------------------------------------
+    # ``ondelete="restrict"`` prevents a rule from silently turning into a
+    # wildcard when the referenced analytic account / partner type is removed.
+    department_analytic_id = fields.Many2one(
+        "account.analytic.account",
+        string="Department",
+        ondelete="restrict",
+        domain=[("root_plan_id.code", "=", "departments")],
+    )
+    source_analytic_id = fields.Many2one(
+        "account.analytic.account",
+        string="Source",
+        ondelete="restrict",
+        domain=[("root_plan_id.code", "=", "sources")],
+    )
+    fund_analytic_id = fields.Many2one(
+        "account.analytic.account",
+        string="Fund",
+        ondelete="restrict",
+        domain=[("root_plan_id.code", "=", "funds")],
+    )
+    activity_analytic_id = fields.Many2one(
+        "account.analytic.account",
+        string="Activity",
+        ondelete="restrict",
+        domain=[("root_plan_id.code", "=", "activities")],
+    )
+    partner_type_id = fields.Many2one(
+        "res.partner.type",
+        string="Partner Type",
+        ondelete="restrict",
+    )
+
+    user_id = fields.Many2one(
+        "res.users",
+        string="Assigned Officer",
+        required=True,
+        domain=lambda self: [
+            (
+                "groups_id",
+                "in",
+                self.env.ref("disbursement.group_disbursement_officer").ids,
+            )
+        ],
+    )
+
+    @api.model
+    def _find_for_request(self, request):
+        """Return the first rule (by sequence) matching ``request``.
+
+        Hierarchical dimensions (department / fund / activity) match on the
+        whole ancestor subtree: a rule set on a parent account covers requests
+        on any of its descendants. This mirrors the parent_path matching the
+        budget engine uses (see budget_appropriation.py). A rule leaves a
+        criterion empty to act as a wildcard for that dimension.
+        """
+        # Pin ("active", "=", True) explicitly rather than relying on the
+        # implicit active_test: the "Apply Rules to Pending Requests" server
+        # action is bound to a list whose action context sets
+        # active_test=False, and that context leaks into this search.
+        domain = [("active", "=", True), ("user_id.active", "=", True)]
+        for field in self._CRITERIA:
+            ancestors = [
+                int(i)
+                for i in (request[field].parent_path or "").strip("/").split("/")
+                if i
+            ]
+            domain.append((field, "in", ancestors + [False]))
+        # Only single-partner requests carry a partner type; multi-partner
+        # requests (blank header partner) match partner-type-agnostic rules
+        # only -- guessing from line partners is magic an admin can't predict.
+        ptype = request.partner_type == "single" and request.partner_id.partner_type_id
+        domain.append(
+            ("partner_type_id", "in", ([ptype.id] if ptype else []) + [False])
+        )
+        return self.search(domain, limit=1)
+
+    @api.model
+    def action_apply_to_pending(self):
+        """Re-run the rules against already-signed, still-unassigned requests.
+
+        Exposed through a server action on the rule list so an admin can route
+        a backlog after adding or editing rules. Idempotent: requests that
+        already have a responsible officer are left untouched.
+        """
+        Request = self.env["disbursement.request"]
+        pending = Request.search(
+            [("state", "=", "signed"), ("assigned_to", "=", False)]
+        )
+        pending._assignment_auto_assign()
+        assigned = pending.filtered("assigned_to")
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "success",
+                "title": _("Assignment Rules Applied"),
+                "message": _(
+                    "%(assigned)s of %(total)s pending request(s) were assigned."
+                )
+                % {"assigned": len(assigned), "total": len(pending)},
+                "sticky": False,
+            },
+        }

--- a/disbursement_assignment_kmitl/models/disbursement_request.py
+++ b/disbursement_assignment_kmitl/models/disbursement_request.py
@@ -1,0 +1,176 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError, UserError
+from odoo.tools.misc import str2bool
+
+# The "To Do" activity raised on a request when an officer is assigned.
+ASSIGN_ACTIVITY_XMLID = "mail.mail_activity_data_todo"
+
+# ir.config_parameter that relaxes the self-claim guard. Defaults to True:
+# because assignment is advisory, an officer may claim a mis-routed request
+# out of the box. Set to False to lock claims to the assigned officer/manager.
+TAKEOVER_PARAM = "disbursement_assignment_kmitl.allow_takeover_assigned"
+
+OFFICER_GROUP = "disbursement.group_disbursement_officer"
+MANAGER_GROUP = "disbursement.group_disbursement_manager"
+
+
+class DisbursementRequest(models.Model):
+    _inherit = "disbursement.request"
+
+    assigned_to = fields.Many2one(
+        "res.users",
+        string="Assigned Officer",
+        copy=False,
+        tracking=True,
+        index=True,
+    )
+    # Not added to READONLY_STATES on purpose: it must stay writable at the
+    # ``signed`` state, which is exactly where officers are assigned.
+    assignment_can_assign_me = fields.Boolean(
+        compute="_compute_assignment_can_assign_me",
+    )
+
+    # -- guards ----------------------------------------------------------
+    def _assignment_takeover_allowed(self):
+        return str2bool(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(TAKEOVER_PARAM, default=True)
+        )
+
+    def _assignment_is_manager(self):
+        return self.env.user.has_group(MANAGER_GROUP)
+
+    def _assignment_can_claim(self):
+        """Whether the current user may self-assign this single request."""
+        self.ensure_one()
+        if not self.assigned_to:
+            return True
+        if self.assigned_to == self.env.user:
+            return False
+        return self._assignment_is_manager() or self._assignment_takeover_allowed()
+
+    @api.depends("assigned_to")
+    def _compute_assignment_can_assign_me(self):
+        for rec in self:
+            rec.assignment_can_assign_me = rec._assignment_can_claim()
+
+    # -- activity bookkeeping --------------------------------------------
+    def _assignment_activity_summary(self):
+        return _("Assigned as responsible verification officer")
+
+    def _assignment_notify(self, user):
+        self.ensure_one()
+        self.activity_schedule(
+            ASSIGN_ACTIVITY_XMLID,
+            user_id=user.id,
+            summary=self._assignment_activity_summary(),
+        )
+
+    def _assignment_clear_activity(self, user):
+        """Drop the open assignment to-do previously raised for ``user``."""
+        self.ensure_one()
+        activity_type = self.env.ref(ASSIGN_ACTIVITY_XMLID)
+        summary = self._assignment_activity_summary()
+        stale = self.activity_ids.filtered(
+            lambda a: a.user_id == user
+            and a.activity_type_id == activity_type
+            and a.summary == summary
+        )
+        stale.unlink()
+
+    def _assignment_close_activity(self):
+        """Close the open assignment to-do(s) once the verification stage ends.
+
+        Called when a request is validated, reset, or cancelled. Uses sudo so
+        the to-do is cleared regardless of who performs the action (assignment
+        is not locked, so a request may be validated by another officer).
+        """
+        activity_type = self.env.ref(ASSIGN_ACTIVITY_XMLID)
+        summary = self._assignment_activity_summary()
+        for rec in self:
+            stale = rec.sudo().activity_ids.filtered(
+                lambda a: a.activity_type_id == activity_type
+                and a.summary == summary
+            )
+            stale.unlink()
+
+    # -- button actions --------------------------------------------------
+    def action_assignment_assign_me(self):
+        me = self.env.user
+        for rec in self:
+            if rec.assigned_to == me:
+                continue
+            if not rec._assignment_can_claim():
+                raise UserError(
+                    _("This document is already assigned to %s.")
+                    % rec.assigned_to.display_name
+                )
+            if rec.assigned_to:
+                rec._assignment_clear_activity(rec.assigned_to)
+            rec.assigned_to = me
+        return True
+
+    def action_assignment_unassign(self):
+        if not self._assignment_is_manager():
+            raise AccessError(_("Only a manager can unassign the officer."))
+        for rec in self:
+            if rec.assigned_to:
+                rec._assignment_clear_activity(rec.assigned_to)
+            rec.assigned_to = False
+        return True
+
+    def action_assignment_open_wizard(self):
+        self.ensure_one()
+        if not self._assignment_is_manager():
+            raise AccessError(_("Only a manager can assign another officer."))
+        return {
+            "name": _("Assign Officer"),
+            "type": "ir.actions.act_window",
+            "res_model": "disbursement.assign.officer.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_request_id": self.id},
+        }
+
+    # -- auto-assign + workflow hooks ------------------------------------
+    def _assignment_auto_assign(self):
+        """Assign the matching officer to signed requests and raise a To-Do.
+
+        Requests that already carry a responsible officer (manual override or
+        a previous sign) keep their officer -- the rules never overwrite them.
+        The rule search is sudo'd so the automatic Sarabun sign path (run by a
+        head who may not read rules) still routes correctly.
+        """
+        Rule = self.env["disbursement.assignment.rule"].sudo()
+        for rec in self.filtered(lambda r: r.state == "signed"):
+            if not rec.assigned_to:
+                rule = Rule._find_for_request(rec)
+                if not rule:
+                    continue
+                rec.assigned_to = rule.user_id
+            if rec.assigned_to != self.env.user:
+                rec._assignment_clear_activity(rec.assigned_to)
+                rec._assignment_notify(rec.assigned_to)
+
+    def action_sign(self):
+        res = super().action_sign()
+        self._assignment_auto_assign()
+        return res
+
+    def action_validate(self):
+        res = super().action_validate()
+        self._assignment_close_activity()
+        return res
+
+    def action_draft(self):
+        res = super().action_draft()
+        self._assignment_close_activity()
+        return res
+
+    def action_cancel(self):
+        res = super().action_cancel()
+        self._assignment_close_activity()
+        return res

--- a/disbursement_assignment_kmitl/security/ir.model.access.csv
+++ b/disbursement_assignment_kmitl/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_disbursement_assignment_rule_user,disbursement.assignment.rule user,model_disbursement_assignment_rule,disbursement.group_disbursement_user,1,0,0,0
+access_disbursement_assignment_rule_manager,disbursement.assignment.rule manager,model_disbursement_assignment_rule,disbursement.group_disbursement_manager,1,1,1,1
+access_disbursement_assign_officer_wizard,disbursement.assign.officer.wizard,model_disbursement_assign_officer_wizard,disbursement.group_disbursement_officer,1,1,1,1

--- a/disbursement_assignment_kmitl/tests/__init__.py
+++ b/disbursement_assignment_kmitl/tests/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import test_assignment_rule

--- a/disbursement_assignment_kmitl/tests/test_assignment_rule.py
+++ b/disbursement_assignment_kmitl/tests/test_assignment_rule.py
@@ -1,0 +1,347 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo.exceptions import AccessError, UserError
+from odoo.tests.common import TransactionCase, tagged
+
+from ..models.disbursement_request import ASSIGN_ACTIVITY_XMLID, TAKEOVER_PARAM
+
+
+@tagged("post_install", "-at_install")
+class TestDisbursementAssignment(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.DR = cls.env["disbursement.request"]
+        cls.Rule = cls.env["disbursement.assignment.rule"]
+        cls.Wizard = cls.env["disbursement.assign.officer.wizard"]
+
+        # -- analytic dimensions ----------------------------------------
+        AAA = cls.env["account.analytic.account"]
+        dep_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_departments")
+        src_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_sources")
+        fund_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_funds")
+        act_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_activities")
+
+        cls.dept_parent = AAA.create(
+            {"name": "Faculty", "plan_id": dep_plan.id}
+        )
+        cls.dept_child = AAA.create(
+            {
+                "name": "Department",
+                "plan_id": dep_plan.id,
+                "parent_id": cls.dept_parent.id,
+            }
+        )
+        cls.source_gov = AAA.create(
+            {"name": "Government Budget", "plan_id": src_plan.id}
+        )
+        cls.source_rev = AAA.create(
+            {"name": "Revenue Budget", "plan_id": src_plan.id}
+        )
+        cls.fund_a = AAA.create({"name": "General Fund", "plan_id": fund_plan.id})
+        cls.activity_a = AAA.create(
+            {"name": "Education Support", "plan_id": act_plan.id}
+        )
+
+        # -- partner types & partners -----------------------------------
+        PType = cls.env["res.partner.type"]
+        cls.pt_a = PType.create({"name": "Type A", "company_type": "company"})
+        cls.pt_b = PType.create({"name": "Type B", "company_type": "company"})
+        Partner = cls.env["res.partner"]
+        cls.partner_a = Partner.create(
+            {"name": "Partner A", "partner_type_id": cls.pt_a.id}
+        )
+        cls.partner_b = Partner.create(
+            {"name": "Partner B", "partner_type_id": cls.pt_b.id}
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test Service", "type": "service"}
+        )
+
+        # -- users -------------------------------------------------------
+        users = cls.env["res.users"].with_context(no_reset_password=True)
+        g_officer = cls.env.ref("disbursement.group_disbursement_officer")
+        g_manager = cls.env.ref("disbursement.group_disbursement_manager")
+        g_user = cls.env.ref("base.group_user")
+        cls.officer_a = users.create(
+            {
+                "name": "Officer A",
+                "login": "dr_officer_a",
+                "groups_id": [(6, 0, [g_officer.id])],
+            }
+        )
+        cls.officer_b = users.create(
+            {
+                "name": "Officer B",
+                "login": "dr_officer_b",
+                "groups_id": [(6, 0, [g_officer.id])],
+            }
+        )
+        cls.manager = users.create(
+            {
+                "name": "DR Manager",
+                "login": "dr_manager",
+                "groups_id": [(6, 0, [g_manager.id])],
+            }
+        )
+        cls.outsider = users.create(
+            {
+                "name": "Outsider",
+                "login": "dr_outsider",
+                "groups_id": [(6, 0, [g_user.id])],
+            }
+        )
+
+    # -- helpers ---------------------------------------------------------
+    def _make_dr(
+        self,
+        source=None,
+        department=None,
+        partner=None,
+        partner_type="single",
+        sign=True,
+        sign_as=None,
+    ):
+        source = source or self.source_gov
+        department = department or self.dept_child
+        partner = partner or self.partner_a
+        line_vals = {
+            "product_id": self.product.id,
+            "name": "Test line",
+            "quantity": 1.0,
+            "price_unit": 100.0,
+        }
+        vals = {"partner_type": partner_type, "line_ids": [(0, 0, line_vals)]}
+        if partner_type == "single":
+            vals["partner_id"] = partner.id
+        else:
+            line_vals["partner_id"] = partner.id
+        dr = self.DR.create(vals)
+        dr.analytic_distribution = {
+            str(department.id): 100,
+            str(source.id): 100,
+            str(self.fund_a.id): 100,
+            str(self.activity_a.id): 100,
+        }
+        dr.action_submit()
+        if sign:
+            dr.with_user(sign_as or self.manager).action_sign()
+        return dr
+
+    def _todos(self, record, user):
+        todo = self.env.ref(ASSIGN_ACTIVITY_XMLID)
+        summary = record._assignment_activity_summary()
+        return record.activity_ids.filtered(
+            lambda a: a.user_id == user
+            and a.activity_type_id == todo
+            and a.summary == summary
+        )
+
+    def _reassign(self, request, user):
+        self.Wizard.with_user(self.manager).create(
+            {"request_id": request.id, "user_id": user.id}
+        ).action_assign()
+
+    # -- matching --------------------------------------------------------
+    def test_exact_match_raises_todo(self):
+        self.Rule.create(
+            {
+                "user_id": self.officer_a.id,
+                "department_analytic_id": self.dept_child.id,
+                "source_analytic_id": self.source_gov.id,
+                "fund_analytic_id": self.fund_a.id,
+                "activity_analytic_id": self.activity_a.id,
+                "partner_type_id": self.pt_a.id,
+            }
+        )
+        dr = self._make_dr(partner=self.partner_a)
+        self.assertEqual(dr.assigned_to, self.officer_a)
+        self.assertTrue(self._todos(dr, self.officer_a))
+
+    def test_wildcard_rule_matches(self):
+        self.Rule.create({"user_id": self.officer_a.id})
+        dr = self._make_dr()
+        self.assertEqual(dr.assigned_to, self.officer_a)
+
+    def test_and_of_multiple_criteria(self):
+        self.Rule.create(
+            {
+                "user_id": self.officer_a.id,
+                "department_analytic_id": self.dept_child.id,
+                "source_analytic_id": self.source_gov.id,
+            }
+        )
+        matched = self._make_dr(department=self.dept_child, source=self.source_gov)
+        self.assertEqual(matched.assigned_to, self.officer_a)
+        missed = self._make_dr(department=self.dept_child, source=self.source_rev)
+        self.assertFalse(missed.assigned_to)
+
+    def test_parent_rule_covers_child(self):
+        self.Rule.create(
+            {
+                "user_id": self.officer_a.id,
+                "department_analytic_id": self.dept_parent.id,
+            }
+        )
+        dr = self._make_dr(department=self.dept_child)
+        self.assertEqual(dr.assigned_to, self.officer_a)
+
+    def test_child_rule_does_not_cover_parent(self):
+        self.Rule.create(
+            {
+                "user_id": self.officer_a.id,
+                "department_analytic_id": self.dept_child.id,
+            }
+        )
+        dr = self._make_dr(department=self.dept_parent)
+        self.assertFalse(dr.assigned_to)
+
+    def test_sequence_decides_first_match(self):
+        self.Rule.create({"user_id": self.officer_a.id, "sequence": 5})
+        self.Rule.create({"user_id": self.officer_b.id, "sequence": 1})
+        dr = self._make_dr()
+        self.assertEqual(dr.assigned_to, self.officer_b)
+
+    def test_partner_type_match_and_mismatch(self):
+        self.Rule.create(
+            {"user_id": self.officer_a.id, "partner_type_id": self.pt_a.id}
+        )
+        self.Rule.create({"user_id": self.officer_b.id})
+        dr_a = self._make_dr(partner=self.partner_a)
+        self.assertEqual(dr_a.assigned_to, self.officer_a)
+        dr_b = self._make_dr(partner=self.partner_b)
+        self.assertEqual(dr_b.assigned_to, self.officer_b)
+
+    def test_multi_partner_matches_only_agnostic_rule(self):
+        self.Rule.create(
+            {"user_id": self.officer_a.id, "partner_type_id": self.pt_a.id}
+        )
+        self.Rule.create({"user_id": self.officer_b.id})
+        dr = self._make_dr(partner_type="multi", partner=self.partner_a)
+        self.assertEqual(dr.assigned_to, self.officer_b)
+
+    def test_no_rule_leaves_unassigned(self):
+        dr = self._make_dr()
+        self.assertFalse(dr.assigned_to)
+
+    def test_inactive_rule_skipped(self):
+        self.Rule.create({"user_id": self.officer_a.id, "active": False})
+        dr = self._make_dr()
+        self.assertFalse(dr.assigned_to)
+
+    def test_archived_officer_skipped(self):
+        self.officer_a.active = False
+        self.Rule.create({"user_id": self.officer_a.id})
+        dr = self._make_dr()
+        self.assertFalse(dr.assigned_to)
+
+    # -- notify / self-sign ---------------------------------------------
+    def test_self_sign_creates_no_todo(self):
+        self.Rule.create({"user_id": self.officer_a.id})
+        dr = self._make_dr(sign_as=self.officer_a)
+        self.assertEqual(dr.assigned_to, self.officer_a)
+        self.assertFalse(self._todos(dr, self.officer_a))
+
+    # -- manual override / re-sign --------------------------------------
+    def test_manual_assign_not_overwritten_and_resign_keeps_officer(self):
+        self.Rule.create({"user_id": self.officer_a.id})
+        dr = self._make_dr()
+        self.assertEqual(dr.assigned_to, self.officer_a)
+        # Manager reassigns to B.
+        self._reassign(dr, self.officer_b)
+        self.assertEqual(dr.assigned_to, self.officer_b)
+        self.assertFalse(self._todos(dr, self.officer_a))
+        self.assertEqual(len(self._todos(dr, self.officer_b)), 1)
+        # Reset to draft closes the to-do but keeps the officer.
+        dr.action_draft()
+        self.assertFalse(self._todos(dr, self.officer_b))
+        self.assertEqual(dr.assigned_to, self.officer_b)
+        # Re-sign keeps B (rule points to A) and notifies exactly once.
+        dr.action_submit()
+        dr.with_user(self.manager).action_sign()
+        self.assertEqual(dr.assigned_to, self.officer_b)
+        self.assertEqual(len(self._todos(dr, self.officer_b)), 1)
+
+    # -- validate closes the to-do (not locked) -------------------------
+    def test_validate_by_other_officer_closes_todo(self):
+        self.Rule.create({"user_id": self.officer_a.id})
+        dr = self._make_dr()
+        self.assertTrue(self._todos(dr, self.officer_a))
+        dr.with_user(self.officer_b).action_validate()
+        self.assertEqual(dr.state, "verified")
+        self.assertFalse(self._todos(dr, self.officer_a))
+
+    # -- takeover guard --------------------------------------------------
+    def test_takeover_default_true_allows_claim(self):
+        dr = self._make_dr()
+        dr.assigned_to = self.officer_a
+        dr.with_user(self.officer_b).action_assignment_assign_me()
+        self.assertEqual(dr.assigned_to, self.officer_b)
+
+    def test_takeover_disabled_blocks_claim(self):
+        self.env["ir.config_parameter"].sudo().set_param(TAKEOVER_PARAM, "False")
+        dr = self._make_dr()
+        dr.assigned_to = self.officer_a
+        with self.assertRaises(UserError):
+            dr.with_user(self.officer_b).action_assignment_assign_me()
+        self.assertEqual(dr.assigned_to, self.officer_a)
+
+    def test_can_claim_logic(self):
+        dr = self._make_dr()
+        self.assertTrue(dr.with_user(self.officer_a).assignment_can_assign_me)
+        dr.assigned_to = self.officer_a
+        self.assertFalse(dr.with_user(self.officer_a)._assignment_can_claim())
+        # takeover default True -> another officer may still claim
+        self.assertTrue(dr.with_user(self.officer_b)._assignment_can_claim())
+        self.env["ir.config_parameter"].sudo().set_param(TAKEOVER_PARAM, "False")
+        self.assertFalse(dr.with_user(self.officer_b)._assignment_can_claim())
+
+    # -- manager-only actions -------------------------------------------
+    def test_manager_unassign_clears_field_and_todo(self):
+        self.Rule.create({"user_id": self.officer_a.id})
+        dr = self._make_dr()
+        dr.with_user(self.manager).action_assignment_unassign()
+        self.assertFalse(dr.assigned_to)
+        self.assertFalse(self._todos(dr, self.officer_a))
+
+    def test_user_cannot_unassign(self):
+        dr = self._make_dr()
+        dr.assigned_to = self.officer_a
+        with self.assertRaises(AccessError):
+            dr.with_user(self.officer_a).action_assignment_unassign()
+
+    def test_user_cannot_open_wizard(self):
+        dr = self._make_dr()
+        with self.assertRaises(AccessError):
+            dr.with_user(self.officer_a).action_assignment_open_wizard()
+
+    # -- wizard ----------------------------------------------------------
+    def test_wizard_allowed_users_are_officer_group(self):
+        dr = self._make_dr()
+        wiz = self.Wizard.with_user(self.manager).create(
+            {"request_id": dr.id, "user_id": self.officer_a.id}
+        )
+        self.assertIn(self.officer_a, wiz.allowed_user_ids)
+        self.assertNotIn(self.outsider, wiz.allowed_user_ids)
+
+    # -- re-apply to backlog --------------------------------------------
+    def test_apply_to_pending_assigns_only_empty(self):
+        empty = self._make_dr()
+        self.assertFalse(empty.assigned_to)
+        taken = self._make_dr()
+        taken.assigned_to = self.officer_b
+        self.Rule.create({"user_id": self.officer_a.id})
+        self.Rule.action_apply_to_pending()
+        self.assertEqual(empty.assigned_to, self.officer_a)
+        self.assertEqual(taken.assigned_to, self.officer_b)
+
+    def test_apply_to_pending_ignores_archived_rule(self):
+        dr = self._make_dr()
+        self.assertFalse(dr.assigned_to)
+        rule = self.Rule.create({"user_id": self.officer_a.id})
+        rule.active = False
+        # The gear-menu action leaks active_test=False into the server action;
+        # matching must still skip archived rules.
+        self.Rule.with_context(active_test=False).action_apply_to_pending()
+        self.assertFalse(dr.assigned_to)

--- a/disbursement_assignment_kmitl/views/assignment_rule_views.xml
+++ b/disbursement_assignment_kmitl/views/assignment_rule_views.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_disbursement_assignment_rule_tree" model="ir.ui.view">
+        <field name="name">disbursement.assignment.rule.tree</field>
+        <field name="model">disbursement.assignment.rule</field>
+        <field name="arch" type="xml">
+            <tree string="Assignment Rules" editable="bottom">
+                <field name="sequence" widget="handle" />
+                <field name="department_analytic_id" options="{'no_create': True}" />
+                <field name="source_analytic_id" options="{'no_create': True}" />
+                <field name="fund_analytic_id" options="{'no_create': True}" />
+                <field name="activity_analytic_id" options="{'no_create': True}" />
+                <field name="partner_type_id" options="{'no_create': True}" />
+                <field name="user_id" options="{'no_create': True}" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_disbursement_assignment_rule" model="ir.actions.act_window">
+        <field name="name">Assignment Rules</field>
+        <field name="res_model">disbursement.assignment.rule</field>
+        <field name="view_mode">tree</field>
+        <field name="context">{'active_test': False}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                สร้างกฎเพื่อมอบหมายใบขอเบิกที่ลงนามแล้วให้เจ้าหน้าที่ผู้รับผิดชอบ
+            </p>
+            <p>
+                เว้นเงื่อนไขว่างไว้เพื่อให้เป็น wildcard (จับคู่ได้ทุกค่า) กฎจะถูกจับคู่จากบนลงล่าง
+                โดยกฎแรกที่ตรงเป็นผู้ชนะ กฎที่ตั้งบนส่วนงาน/กองทุน/กิจกรรมระดับแม่
+                จะครอบคลุมระดับลูกทั้งหมด
+            </p>
+        </field>
+    </record>
+
+    <!-- Gear-menu action to route already-signed requests after editing rules -->
+    <record id="action_apply_rules_to_pending" model="ir.actions.server">
+        <field name="name">Apply Rules to Pending Requests</field>
+        <field name="model_id" ref="model_disbursement_assignment_rule" />
+        <field name="binding_model_id" ref="model_disbursement_assignment_rule" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">action = model.action_apply_to_pending()</field>
+    </record>
+
+    <menuitem
+        id="menu_disbursement_assignment_rule"
+        name="Assignment Rules"
+        parent="disbursement.menu_disbursement_config"
+        action="action_disbursement_assignment_rule"
+        sequence="20"
+    />
+</odoo>

--- a/disbursement_assignment_kmitl/views/disbursement_request_views.xml
+++ b/disbursement_assignment_kmitl/views/disbursement_request_views.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Form: assignment buttons + responsible officer field -->
+    <record id="view_disbursement_request_form_assignment" model="ir.ui.view">
+        <field name="name">disbursement.request.form.assignment</field>
+        <field name="model">disbursement.request</field>
+        <field name="inherit_id" ref="disbursement.view_disbursement_request_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='action_submit']" position="before">
+                <button
+                    name="action_assignment_assign_me"
+                    type="object"
+                    string="Assign to me"
+                    class="oe_highlight"
+                    groups="disbursement.group_disbursement_officer"
+                    attrs="{'invisible': ['|', ('state', '!=', 'signed'), ('assignment_can_assign_me', '=', False)]}"
+                />
+                <button
+                    name="action_assignment_open_wizard"
+                    type="object"
+                    string="Assign…"
+                    groups="disbursement.group_disbursement_manager"
+                    attrs="{'invisible': [('state', '!=', 'signed')]}"
+                />
+                <button
+                    name="action_assignment_unassign"
+                    type="object"
+                    string="Unassign"
+                    groups="disbursement.group_disbursement_manager"
+                    attrs="{'invisible': ['|', ('state', '!=', 'signed'), ('assigned_to', '=', False)]}"
+                />
+            </xpath>
+            <xpath expr="//group[@id='other_information']" position="inside">
+                <field name="assignment_can_assign_me" invisible="1" />
+                <field name="assigned_to" readonly="1" />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Tree: responsible officer column -->
+    <record id="view_disbursement_request_tree_assignment" model="ir.ui.view">
+        <field name="name">disbursement.request.tree.assignment</field>
+        <field name="model">disbursement.request</field>
+        <field name="inherit_id" ref="disbursement.view_disbursement_request_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="assigned_to" optional="show" />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Search: my-work / unassigned filters + group by officer -->
+    <record id="view_disbursement_request_search_assignment" model="ir.ui.view">
+        <field name="name">disbursement.request.search.assignment</field>
+        <field name="model">disbursement.request</field>
+        <field name="inherit_id" ref="disbursement.view_disbursement_request_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='signed']" position="after">
+                <separator />
+                <filter
+                    name="my_verifications"
+                    string="My Verifications"
+                    domain="[('assigned_to', '=', uid)]"
+                />
+                <filter
+                    name="unassigned"
+                    string="Unassigned"
+                    domain="[('assigned_to', '=', False)]"
+                />
+            </xpath>
+            <xpath expr="//filter[@name='state']" position="after">
+                <filter
+                    name="assigned_officer"
+                    string="Assigned Officer"
+                    context="{'group_by': 'assigned_to'}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/disbursement_assignment_kmitl/wizards/__init__.py
+++ b/disbursement_assignment_kmitl/wizards/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import assign_officer_wizard

--- a/disbursement_assignment_kmitl/wizards/assign_officer_wizard.py
+++ b/disbursement_assignment_kmitl/wizards/assign_officer_wizard.py
@@ -1,0 +1,60 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError
+
+OFFICER_GROUP = "disbursement.group_disbursement_officer"
+
+
+class DisbursementAssignOfficerWizard(models.TransientModel):
+    # Dedicated name (not the procurement ``assign.officer.wizard``): reusing
+    # that name would make this an implicit cross-module inherit of a model we
+    # do not depend on.
+    _name = "disbursement.assign.officer.wizard"
+    _description = "Assign Disbursement Verification Officer"
+
+    request_id = fields.Many2one(
+        "disbursement.request",
+        string="Disbursement Request",
+        required=True,
+        ondelete="cascade",
+    )
+    user_id = fields.Many2one(
+        "res.users",
+        string="Assigned Officer",
+        required=True,
+        domain="[('id', 'in', allowed_user_ids)]",
+    )
+    allowed_user_ids = fields.Many2many(
+        "res.users",
+        compute="_compute_allowed_user_ids",
+    )
+
+    @api.depends("request_id")
+    def _compute_allowed_user_ids(self):
+        group = self.env.ref(OFFICER_GROUP, raise_if_not_found=False)
+        users = group.users if group else self.env["res.users"]
+        for wiz in self:
+            wiz.allowed_user_ids = users
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if res.get("request_id") and "user_id" in fields_list:
+            request = self.env["disbursement.request"].browse(res["request_id"])
+            if request.assigned_to:
+                res["user_id"] = request.assigned_to.id
+        return res
+
+    def action_assign(self):
+        self.ensure_one()
+        request = self.request_id
+        if not request._assignment_is_manager():
+            raise AccessError(_("Only a manager can assign another officer."))
+        old_officer = request.assigned_to
+        request.assigned_to = self.user_id
+        if old_officer and old_officer != self.user_id:
+            request._assignment_clear_activity(old_officer)
+        if self.user_id and self.user_id != self.env.user:
+            request._assignment_notify(self.user_id)
+        return {"type": "ir.actions.act_window_close"}

--- a/disbursement_assignment_kmitl/wizards/assign_officer_wizard_views.xml
+++ b/disbursement_assignment_kmitl/wizards/assign_officer_wizard_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="disbursement_assign_officer_wizard_form" model="ir.ui.view">
+        <field name="name">disbursement.assign.officer.wizard.form</field>
+        <field name="model">disbursement.assign.officer.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Assign Officer">
+                <group>
+                    <field name="request_id" invisible="1" />
+                    <field name="allowed_user_ids" invisible="1" />
+                    <field name="user_id" options="{'no_create': True}" />
+                </group>
+                <footer>
+                    <button
+                        name="action_assign"
+                        type="object"
+                        string="Assign"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds `disbursement_assignment_kmitl`: when a disbursement request is signed, it auto-assigns a responsible verification officer via configurable rules matching department / source / fund / activity / partner type (hierarchical subtree match, first-match by sequence, empty criterion = wildcard). The assigned officer receives a To-Do; officers can self-claim, managers can reassign via a wizard or clear the officer, and a gear-menu action re-routes the signed-but-unassigned backlog. Assignment is advisory only — it drives the *My Verifications* / *Unassigned* filters and notifications but never locks who may validate. Ships tree/search/form UI, security, Thai translations, and a full test suite; depends only on `disbursement`.