### PR TITLE
[16.0][IMP] disbursement_accounting_kmitl: show DR budget consumed on bill

### DIFF
--- a/disbursement_accounting_kmitl/i18n/th.po
+++ b/disbursement_accounting_kmitl/i18n/th.po
@@ -42,6 +42,26 @@ msgid "Disbursement Request Number"
 msgstr "เลขที่ใบขอเบิก"
 
 #. module: disbursement_accounting_kmitl
+#: model:ir.model.fields,field_description:disbursement_accounting_kmitl.field_account_move__disbursement_budget_consumed_amount
+msgid "Budget Consumed (from DR)"
+msgstr "มูลค่างบประมาณที่ตัดไปแล้ว (จาก DR)"
+
+#. module: disbursement_accounting_kmitl
+#: model:ir.model.fields,field_description:disbursement_accounting_kmitl.field_account_move__disbursement_budget_consumed_date
+msgid "Budget Consumed Date (DR)"
+msgstr "วันที่ตัดงบ (จาก DR)"
+
+#. module: disbursement_accounting_kmitl
+#: model:ir.model.fields,field_description:disbursement_accounting_kmitl.field_account_move__disbursement_budget_commitment_id
+msgid "Budget Commitment (DR)"
+msgstr "ใบผูกพันงบประมาณ (จาก DR)"
+
+#. module: disbursement_accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:disbursement_accounting_kmitl.view_account_move_form_inherit_disbursement
+msgid "Budget Consumed from DR"
+msgstr "งบประมาณที่ตัดจาก DR"
+
+#. module: disbursement_accounting_kmitl
 #: model:ir.model.fields,field_description:disbursement_accounting_kmitl.field_disbursement_request__bill_ids
 msgid "Vendor Bills"
 msgstr "ใบตั้งหนี้ผู้ขาย"

--- a/disbursement_accounting_kmitl/models/account_move.py
+++ b/disbursement_accounting_kmitl/models/account_move.py
@@ -17,6 +17,19 @@ class AccountMove(models.Model):
         related="disbursement_request_id.name",
         string="Disbursement Request Number",
     )
+    disbursement_budget_consumed_amount = fields.Monetary(
+        related="disbursement_request_id.budget_consumed_amount",
+        string="Budget Consumed (from DR)",
+        currency_field="currency_id",
+    )
+    disbursement_budget_consumed_date = fields.Datetime(
+        related="disbursement_request_id.budget_consumed_date",
+        string="Budget Consumed Date (DR)",
+    )
+    disbursement_budget_commitment_id = fields.Many2one(
+        related="disbursement_request_id.budget_commitment_id",
+        string="Budget Commitment (DR)",
+    )
 
     def action_view_disbursement_request(self):
         self.ensure_one()

--- a/disbursement_accounting_kmitl/views/account_move_views.xml
+++ b/disbursement_accounting_kmitl/views/account_move_views.xml
@@ -20,6 +20,16 @@
                     </div>
                 </button>
             </xpath>
+            <!-- Show the budget already consumed from the linked Disbursement Request -->
+            <xpath expr="//group[@name='budget_info']" position="after">
+                <group name="disbursement_budget" string="Budget Consumed from DR"
+                       attrs="{'invisible': [('disbursement_request_id', '=', False)]}">
+                    <field name="disbursement_request_id" invisible="1"/>
+                    <field name="disbursement_budget_consumed_amount"/>
+                    <field name="disbursement_budget_consumed_date"/>
+                    <field name="disbursement_budget_commitment_id"/>
+                </group>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## สรุป

Vendor bill (`account.move`) ที่ถูกสร้างจาก Disbursement Request (DR) จะแสดง **มูลค่างบประมาณที่ถูกตัดไปแล้วจาก DR** บนฟอร์มด้วย เพื่อให้ตรวจสอบยอดตัดงบได้ในหน้าเดียวโดยไม่ต้องเปิด DR

ปัจจุบันบนฟอร์ม bill เห็นเพียงปุ่ม smart button ลิงก์ไป DR แต่ไม่เห็นยอดงบที่ตัดไปแล้ว

## การเปลี่ยนแปลง

- **`models/account_move.py`** — เพิ่ม related fields 3 ตัวบน `account.move` (อ่านค่าจาก `disbursement_request_id`):
  - `disbursement_budget_consumed_amount` ← `budget_consumed_amount`
  - `disbursement_budget_consumed_date` ← `budget_consumed_date`
  - `disbursement_budget_commitment_id` ← `budget_commitment_id`
- **`views/account_move_views.xml`** — เพิ่มกลุ่ม "Budget Consumed from DR" ต่อจากกลุ่ม `budget_info` (Accounting Dimensions); ซ่อนทั้งกลุ่มอัตโนมัติเมื่อ bill ไม่ได้มาจาก DR
- **`i18n/th.po`** — เพิ่มคำแปลไทยของ label ทั้ง 3 ฟิลด์ + ชื่อกลุ่ม

ใช้ `related` fields (readonly โดย default) เพื่อไม่ต้องคำนวณซ้ำ — ค่าถูกตั้งไว้ที่ DR ตอนอนุมัติงบแล้ว ไม่แตะโมดูล `budget` / `disbursement`

## การทดสอบ

1. Upgrade โมดูล `disbursement_accounting_kmitl`
2. เปิด DR ที่อนุมัติแล้ว (มี `budget_consumed_amount` > 0) → กด Create Bill
3. เปิด bill → ในกลุ่ม Accounting Dimensions ต้องเห็นกลุ่มใหม่แสดง ยอดตัดงบ / วันที่ / ลิงก์ Budget Commitment ตรงกับ DR
4. เปิด bill ที่สร้างเอง (ไม่ผ่าน DR) → กลุ่มนี้ต้องถูกซ่อน
5. สลับภาษาเป็นไทย → label แสดงเป็นไทย