### PR TITLE
[16.0][FIX] disbursement: grant DR access to related models

### DIFF
--- a/disbursement/security/security.xml
+++ b/disbursement/security/security.xml
@@ -8,10 +8,19 @@
         </record>
 
         <!-- User Group -->
+        <!-- Inherit account (Billing) + budget groups so disbursement users
+             can read the related models the DR form relies on (account,
+             tax, journal, fiscal year, bills) and read/commit budget
+             (obligate on approve, reverse on cancel). Cascades to head /
+             officer / manager, which imply this group. -->
         <record id="group_disbursement_user" model="res.groups">
             <field name="name">Disbursement User</field>
             <field name="category_id" ref="disbursement.module_category_disbursement"/>
-            <field name="implied_ids" eval="[(6, 0, [ref('base.group_user')])]"/>
+            <field name="implied_ids" eval="[(6, 0, [
+                ref('base.group_user'),
+                ref('account.group_account_invoice'),
+                ref('budget.group_budget_user'),
+            ])]"/>
         </record>
 
         <!-- Head Group (inherits from User) -->


### PR DESCRIPTION
Users in the `disbursement_user` / `disbursement_manager` groups could not open the DR (`disbursement.request`) form because those groups only inherited `base.group_user`, leaving them without read access to the account records (account/tax/journal/fiscal year), the linked budget commitment, and vendor bills the form loads — raising `AccessError`.

This grants `group_disbursement_user` inheritance of `account.group_account_invoice` and `budget.group_budget_user`; since head/officer/manager already imply this group, the fix cascades to every tier, letting them read the related models and commit budget on approve/cancel.