### PR TITLE
[16.0][ADD] disbursement_tier_validation: two-tier disbursement approval

### DIFF
--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -123,7 +123,7 @@ msgstr ""
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "Are you sure you want to validate this request?"
-msgstr ""
+msgstr "ยืนยันการตรวจสอบใบขอเบิกนี้ใช่หรือไม่?"
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__message_attachment_count

--- a/disbursement_tier_validation/README.rst
+++ b/disbursement_tier_validation/README.rst
@@ -1,0 +1,37 @@
+===========================
+Disbursement Tier Validation
+===========================
+
+Adds a two-tier sequential approval to the disbursement request
+(``disbursement.request``) approval step, using OCA ``base_tier_validation``.
+
+What it does
+============
+
+* Gates only the ``verified -> approved`` transition. The ``sign`` and
+  ``verify`` steps (and the ``disbursement_sarabun`` coupling) are unchanged.
+* Requires two approvals **in sequence**:
+
+  #. หัวหน้างานบัญชี (Accounting Head)
+  #. ผู้อำนวยการกองคลัง (Finance Director)
+
+* The reviews are opened automatically when the officer validates
+  (``action_validate``). The second tier cannot approve before the first
+  (``approve_sequence``).
+* Approving the final tier obligates and consumes the budget exactly once via
+  the existing ``_action_approve_budget`` — nothing is consumed earlier.
+* Rejecting at any tier drops the reviews and returns the request to
+  ``draft`` for revision.
+* Validating/rejecting opens the ``base_tier_validation`` comment dialog; its
+  Thai translation is provided through ``i18n_th_tier_validation`` and this
+  module.
+
+Configuration
+=============
+
+Assign users the **Disbursement Accounting Head** and **Disbursement Finance
+Director** roles (Settings > Users > Roles). Holders of each role become the
+reviewers for the matching tier.
+
+The two tiers are defined as ``tier.definition`` records in
+``data/tier_definition.xml`` and can be adjusted per company.

--- a/disbursement_tier_validation/__init__.py
+++ b/disbursement_tier_validation/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/disbursement_tier_validation/__manifest__.py
+++ b/disbursement_tier_validation/__manifest__.py
@@ -1,0 +1,26 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Disbursement Tier Validation",
+    "version": "16.0.1.0.0",
+    "summary": "Two-tier sequential approval (Accounting Head -> Finance "
+    "Director) for disbursement requests",
+    "category": "Disbursement",
+    "license": "LGPL-3",
+    "author": "KMITL",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "disbursement",
+        "base_tier_validation",
+        "base_tier_validation_comment",
+        "i18n_th_tier_validation",
+        "base_user_role",
+    ],
+    "data": [
+        "security/security.xml",
+        "data/tier_definition.xml",
+        "views/disbursement_request_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/disbursement_tier_validation/data/tier_definition.xml
+++ b/disbursement_tier_validation/data/tier_definition.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <!-- Two sequential approval tiers for disbursement requests, approved in
+         order: หัวหน้างานบัญชี (Accounting Head) then ผู้อำนวยการกองคลัง (Finance
+         Director).
+
+         IMPORTANT — tier ordering: base_tier_validation.request_validation
+         searches definitions with order="sequence desc" and numbers the
+         resulting reviews 1..n, and approve_sequence approves the LOWEST review
+         number first. So the definition with the HIGHER `sequence` is reviewed
+         FIRST. Hence the first approver (Accounting Head) has sequence 20 and
+         the second (Finance Director) has sequence 10.
+
+         The has_*comment flags make Validate/Reject open the (translated)
+         comment dialog. -->
+    <record id="tier_definition_disbursement_accounting_head" model="tier.definition">
+        <field name="name">หัวหน้างานบัญชี</field>
+        <field name="model_id" ref="disbursement.model_disbursement_request" />
+        <field name="review_type">group</field>
+        <field name="reviewer_group_id" ref="group_disbursement_accounting_head" />
+        <field name="approve_sequence">True</field>
+        <field name="has_comment">True</field>
+        <field name="has_approve_comment">True</field>
+        <field name="has_reject_comment">True</field>
+        <field name="notify_on_create">True</field>
+        <field name="notify_on_accepted">True</field>
+        <field name="notify_on_rejected">True</field>
+        <field name="sequence">20</field>
+        <field name="active">True</field>
+    </record>
+
+    <record id="tier_definition_disbursement_finance_director" model="tier.definition">
+        <field name="name">ผู้อำนวยการกองคลัง</field>
+        <field name="model_id" ref="disbursement.model_disbursement_request" />
+        <field name="review_type">group</field>
+        <field name="reviewer_group_id" ref="group_disbursement_finance_director" />
+        <field name="approve_sequence">True</field>
+        <field name="has_comment">True</field>
+        <field name="has_approve_comment">True</field>
+        <field name="has_reject_comment">True</field>
+        <field name="notify_on_create">True</field>
+        <field name="notify_on_accepted">True</field>
+        <field name="notify_on_rejected">True</field>
+        <field name="sequence">10</field>
+        <field name="active">True</field>
+    </record>
+</odoo>

--- a/disbursement_tier_validation/i18n/th.po
+++ b/disbursement_tier_validation/i18n/th.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* disbursement_tier_validation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: disbursement_tier_validation
+#: code:addons/disbursement_tier_validation/models/disbursement_request.py:0
+#, python-format
+msgid "Approval rejected; returned to draft for revision."
+msgstr "ไม่อนุมัติ — ส่งกลับสถานะร่างเพื่อแก้ไข"
+
+#. module: disbursement_tier_validation
+#: model:res.groups,name:disbursement_tier_validation.group_disbursement_accounting_head
+#: model:res.users.role,name:disbursement_tier_validation.role_disbursement_accounting_head
+msgid "Disbursement Accounting Head"
+msgstr "หัวหน้างานบัญชี"
+
+#. module: disbursement_tier_validation
+#: model:res.groups,name:disbursement_tier_validation.group_disbursement_finance_director
+#: model:res.users.role,name:disbursement_tier_validation.role_disbursement_finance_director
+msgid "Disbursement Finance Director"
+msgstr "ผู้อำนวยการกองคลัง"

--- a/disbursement_tier_validation/models/__init__.py
+++ b/disbursement_tier_validation/models/__init__.py
@@ -1,0 +1,4 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import tier_definition
+from . import disbursement_request

--- a/disbursement_tier_validation/models/disbursement_request.py
+++ b/disbursement_tier_validation/models/disbursement_request.py
@@ -1,0 +1,76 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from lxml import etree
+
+from odoo import _, models
+
+
+class DisbursementRequest(models.Model):
+    _name = "disbursement.request"
+    _inherit = ["disbursement.request", "tier.validation"]
+
+    # Gate ONLY the verified -> approved transition with tier validation.
+    # sign/verify keep their existing behaviour (and sarabun coupling).
+    _state_from = ["verified"]
+    _state_to = ["approved"]
+    _tier_validation_manual_config = False
+
+    def _add_tier_validation_buttons(self, node, params):
+        """Hide the default Request/Restart/Reevaluate header buttons.
+
+        Reviews are opened automatically on ``action_validate`` and the
+        Validate/Reject buttons live in the injected tier label, so hiding
+        the header buttons keeps the form clean (mirrors
+        ``advance_payment_tier_validation``).
+        """
+        return etree.Element("div")
+
+    def action_validate(self):
+        """Once the officer verifies the request, open the two-tier approval
+        by requesting validation so the reviews (Accounting Head -> Finance
+        Director) are created automatically.
+        """
+        res = super().action_validate()
+        to_request = self.filtered(
+            lambda r: r.state == "verified" and r.need_validation
+        )
+        if to_request:
+            to_request.request_validation()
+        return res
+
+    def _validate_tier(self, tiers=False):
+        """Approve the disbursement only once BOTH tiers are validated.
+
+        We check ``validation_status == 'validated'`` (all reviews approved)
+        rather than "the current user has no more pending review": the two
+        reviewers are different people, so the latter would approve
+        prematurely right after the first (Accounting Head) tier.
+
+        ``skip_validation_check`` bypasses the tier write-guard so
+        ``_action_approve_budget`` can set ``budget_consumed_amount`` while the
+        record is still ``verified`` with open reviews.
+        """
+        super()._validate_tier(tiers)
+        for rec in self:
+            if rec.state == "verified" and rec.validation_status == "validated":
+                rec.with_context(skip_validation_check=True).action_approve()
+
+    def _rejected_tier(self, tiers=False):
+        """On rejection at any tier, drop the reviews and send the request back
+        to draft for revision (KMITL policy).
+        """
+        super()._rejected_tier(tiers=tiers)
+        for rec in self.filtered(lambda r: r.state == "verified"):
+            rec.review_ids.unlink()
+            rec.with_context(skip_validation_check=True).write(
+                {
+                    "state": "draft",
+                    "exception_ids": False,
+                    "main_exception_id": False,
+                    "ignore_exception": False,
+                }
+            )
+            rec.message_post(
+                body=_("Approval rejected; returned to draft for revision."),
+                subtype_xmlid="mail.mt_note",
+            )

--- a/disbursement_tier_validation/models/tier_definition.py
+++ b/disbursement_tier_validation/models/tier_definition.py
@@ -1,0 +1,14 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class TierDefinition(models.Model):
+    _inherit = "tier.definition"
+
+    @api.model
+    def _get_tier_validation_model_names(self):
+        """Allow tier definitions to target disbursement requests."""
+        res = super()._get_tier_validation_model_names()
+        res.append("disbursement.request")
+        return res

--- a/disbursement_tier_validation/security/security.xml
+++ b/disbursement_tier_validation/security/security.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="0">
+        <!-- Named approver groups used as tier reviewers. They imply the
+             existing Disbursement Officer access so holders can view and act
+             on disbursement requests. -->
+        <record id="group_disbursement_accounting_head" model="res.groups">
+            <field name="name">Disbursement Accounting Head</field>
+            <field name="category_id" ref="disbursement.module_category_disbursement" />
+            <field
+                name="implied_ids"
+                eval="[(4, ref('disbursement.group_disbursement_officer'))]"
+            />
+        </record>
+
+        <record id="group_disbursement_finance_director" model="res.groups">
+            <field name="name">Disbursement Finance Director</field>
+            <field name="category_id" ref="disbursement.module_category_disbursement" />
+            <field
+                name="implied_ids"
+                eval="[(4, ref('disbursement.group_disbursement_officer'))]"
+            />
+        </record>
+
+        <!-- Assignable roles (base_user_role) that grant the approver groups
+             above. Assigning the role is how a user becomes a tier reviewer
+             (and, later, the routing target for approval Todos). -->
+        <record id="role_disbursement_accounting_head" model="res.users.role">
+            <field name="name">Disbursement Accounting Head</field>
+            <field
+                name="implied_ids"
+                eval="[(6, 0, [ref('group_disbursement_accounting_head')])]"
+            />
+        </record>
+
+        <record id="role_disbursement_finance_director" model="res.users.role">
+            <field name="name">Disbursement Finance Director</field>
+            <field
+                name="implied_ids"
+                eval="[(6, 0, [ref('group_disbursement_finance_director')])]"
+            />
+        </record>
+    </data>
+</odoo>

--- a/disbursement_tier_validation/tests/__init__.py
+++ b/disbursement_tier_validation/tests/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import test_disbursement_tier_validation

--- a/disbursement_tier_validation/tests/test_disbursement_tier_validation.py
+++ b/disbursement_tier_validation/tests/test_disbursement_tier_validation.py
@@ -1,0 +1,138 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestDisbursementTierValidation(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.DR = cls.env["disbursement.request"]
+
+        # One analytic account per required dimension so the
+        # _check_analytic_distribution_complete constraint passes on submit.
+        Plan = cls.env["account.analytic.plan"]
+        Account = cls.env["account.analytic.account"]
+
+        def account_for(code):
+            plan = Plan.search([("code", "=", code)], limit=1)
+            if not plan:
+                plan = Plan.create({"name": code.title(), "code": code})
+            return Account.create({"name": "Test %s" % code, "plan_id": plan.id})
+
+        cls.analytic_distribution = {
+            str(account_for(code).id): 100
+            for code in ("sources", "departments", "funds", "activities")
+        }
+
+        cls.partner = cls.env["res.partner"].create({"name": "Test Vendor"})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test Service", "type": "service"}
+        )
+
+        cls.user_acct = cls._make_reviewer(
+            "dtv_acct_head",
+            "disbursement_tier_validation.role_disbursement_accounting_head",
+        )
+        cls.user_fin = cls._make_reviewer(
+            "dtv_fin_director",
+            "disbursement_tier_validation.role_disbursement_finance_director",
+        )
+
+    @classmethod
+    def _make_reviewer(cls, login, role_xmlid):
+        """Create a user whose only role is the given tier reviewer role.
+
+        Groups are granted through base_user_role from the role, so the user
+        lands in the tier's reviewer group.
+        """
+        role = cls.env.ref(role_xmlid)
+        return cls.env["res.users"].create(
+            {
+                "name": login,
+                "login": login,
+                "email": "%s@example.com" % login,
+                "role_line_ids": [(0, 0, {"role_id": role.id})],
+            }
+        )
+
+    def _new_verified_dr(self):
+        """Create a DR and walk it draft -> submitted -> signed -> verified.
+
+        Reaching 'verified' auto-requests the two tier reviews.
+        """
+        dr = self.DR.create(
+            {
+                "partner_id": self.partner.id,
+                "analytic_distribution": self.analytic_distribution,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "name": "Test line",
+                            "quantity": 1,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        dr.action_submit()
+        dr.action_sign()
+        dr.action_validate()
+        return dr
+
+    def test_reviews_created_on_validate(self):
+        dr = self._new_verified_dr()
+        reviews = dr.review_ids.sorted("sequence")
+        self.assertEqual(len(reviews), 2, "Two tier reviews must be created")
+        self.assertEqual(dr.validation_status, "pending")
+        # Accounting Head is reviewed first (review sequence 1), then Finance
+        # Director (review sequence 2).
+        self.assertEqual(reviews[0].name, "หัวหน้างานบัญชี")
+        self.assertEqual(reviews[1].name, "ผู้อำนวยการกองคลัง")
+        self.assertTrue(all(r.approve_sequence for r in reviews))
+
+    def test_sequential_first_tier_only(self):
+        """The second tier cannot review before the first is approved."""
+        dr = self._new_verified_dr()
+        reviews = dr.review_ids.sorted("sequence")
+        first, second = reviews[0], reviews[1]
+        self.assertTrue(first.with_user(self.user_acct).can_review)
+        self.assertFalse(second.with_user(self.user_fin).can_review)
+
+    def test_no_premature_approval(self):
+        """Approving only the first tier must NOT approve the request."""
+        dr = self._new_verified_dr()
+        first = dr.review_ids.sorted("sequence")[0]
+        dr.with_user(self.user_acct)._validate_tier(first)
+        self.assertEqual(dr.state, "verified", "Must stay verified after tier 1")
+        self.assertEqual(dr.validation_status, "pending")
+
+    def test_full_approval(self):
+        """Both tiers validated -> the request is approved exactly once."""
+        dr = self._new_verified_dr()
+        reviews = dr.review_ids.sorted("sequence")
+        with patch.object(
+            type(dr), "_action_approve_budget", autospec=True
+        ) as mocked_budget:
+            dr.with_user(self.user_acct)._validate_tier(reviews[0])
+            self.assertEqual(dr.state, "verified")
+            dr.with_user(self.user_fin)._validate_tier(reviews[1])
+            self.assertEqual(dr.state, "approved")
+        self.assertEqual(
+            mocked_budget.call_count, 1, "Budget must be consumed exactly once"
+        )
+        self.assertEqual(dr.validation_status, "validated")
+
+    def test_reject_returns_to_draft(self):
+        dr = self._new_verified_dr()
+        first = dr.review_ids.sorted("sequence")[0]
+        dr.with_user(self.user_acct)._rejected_tier(first)
+        self.assertEqual(dr.state, "draft", "Rejection returns the DR to draft")
+        self.assertFalse(dr.review_ids, "Reviews are cleared on rejection")

--- a/disbursement_tier_validation/views/disbursement_request_views.xml
+++ b/disbursement_tier_validation/views/disbursement_request_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_disbursement_request_form_tier" model="ir.ui.view">
+        <field name="name">disbursement.request.form.tier</field>
+        <field name="model">disbursement.request</field>
+        <field name="inherit_id" ref="disbursement.view_disbursement_request_form" />
+        <field name="arch" type="xml">
+            <!-- Fields consumed by the Approve button's attrs (also injected by
+                 the tier mixin; declared here so the button resolves them). -->
+            <button name="action_approve" position="before">
+                <field name="validation_status" invisible="1" />
+                <field name="need_validation" invisible="1" />
+            </button>
+            <!-- Approval is driven by the two-tier Validate/Reject buttons.
+                 The manual Approve stays only as a fallback, shown once fully
+                 validated (normally the auto-approve in _validate_tier fires
+                 first and moves the request out of 'verified'). -->
+            <button name="action_approve" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('state', '!=', 'verified'), ('validation_status', '!=', 'validated')]}</attribute>
+            </button>
+        </field>
+    </record>
+</odoo>

--- a/i18n_th_tier_validation/i18n/th.po
+++ b/i18n_th_tier_validation/i18n/th.po
@@ -188,7 +188,7 @@ msgstr ""
 #. module: base_tier_validation
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.view_comment_wizard
 msgid "Cancel"
-msgstr ""
+msgstr "ยกเลิก"
 
 #. module: base_tier_validation
 #. odoo-javascript
@@ -201,7 +201,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:base_tier_validation.view_comment_wizard
 #, python-format
 msgid "Comment"
-msgstr ""
+msgstr "ความเห็น"
 
 #. module: base_tier_validation
 #: model:ir.model,name:base_tier_validation.model_comment_wizard
@@ -211,7 +211,7 @@ msgstr ""
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_review__comment
 msgid "Comments"
-msgstr ""
+msgstr "ความเห็น"
 
 #. module: base_tier_validation
 #: model:ir.model.fields,field_description:base_tier_validation.field_tier_definition__company_id


### PR DESCRIPTION
Adds the `disbursement_tier_validation` module, which gates the `disbursement.request` `verified → approved` transition with a two-tier **sequential** approval — หัวหน้างานบัญชี (Accounting Head) then ผู้อำนวยการกองคลัง (Finance Director) — using OCA `base_tier_validation`, mirroring `advance_payment_tier_validation`. The `sign`/`verify` steps and their Sarabun coupling are unchanged; reviews are opened automatically when the officer validates, and the budget is still obligated and consumed exactly once at final approval. Rejecting at either tier returns the request to `draft` for revision, and reviewers are resolved from two `res.users.role`s. It also fills the Thai translations for the tier validate/comment dialog (`i18n_th_tier_validation`) and the `disbursement` validate confirmation so the approval dialogs display in Thai. Includes tier definitions, security groups/roles, the form-button change, and tests.