### PR TITLE
[16.0][FIX] kris_project: loosen monetary tolerance for decimal fixed amount

### DIFF
--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -322,9 +322,6 @@ class KrisProject(models.Model):
         "receipt_ids",
     )
     def _compute_warnings(self):
-        # Allocation / installment sums are treated as matching when within
-        # 0.02 baht — absorbs cumulative Monetary rounding when % distributions
-        # are applied on a decimal fixed base amount.
         prec = self.env["decimal.precision"].precision_get("Account")
         for rec in self:
             rec.warn_cancel_with_receipts = bool(rec.receipt_ids) and rec.state in (
@@ -342,17 +339,30 @@ class KrisProject(models.Model):
             alloc_total = sum(rec.allocation_line_ids.mapped("estimated_amount"))
             rec.warn_allocation_mismatch = (
                 bool(rec.allocation_line_ids)
-                and abs(alloc_total - rec.maintenance_deduction_amount) > 0.02
+                and float_compare(
+                    alloc_total, rec.maintenance_deduction_amount, precision_digits=prec
+                )
+                != 0
             )
             if rec.installment_ids:
                 maint_total = sum(rec.installment_ids.mapped("maintenance_fee"))
                 rec.warn_installment_maintenance_mismatch = (
                     not rec.no_installment_tracking
-                    and abs(maint_total - rec.maintenance_deduction_amount) > 0.02
+                    and float_compare(
+                        maint_total,
+                        rec.maintenance_deduction_amount,
+                        precision_digits=prec,
+                    )
+                    != 0
                 )
                 rec.warn_installment_total_mismatch = (
                     not rec.no_installment_tracking
-                    and abs(rec.total_installment_amount - rec.project_value) > 0.02
+                    and float_compare(
+                        rec.total_installment_amount,
+                        rec.project_value,
+                        precision_digits=prec,
+                    )
+                    != 0
                 )
                 extra_total = sum(rec.installment_ids.mapped("extra_income"))
                 rec.warn_extra_overshoot = (

--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -322,6 +322,9 @@ class KrisProject(models.Model):
         "receipt_ids",
     )
     def _compute_warnings(self):
+        # Allocation / installment sums are treated as matching when within
+        # 0.02 baht — absorbs cumulative Monetary rounding when % distributions
+        # are applied on a decimal fixed base amount.
         prec = self.env["decimal.precision"].precision_get("Account")
         for rec in self:
             rec.warn_cancel_with_receipts = bool(rec.receipt_ids) and rec.state in (
@@ -339,30 +342,17 @@ class KrisProject(models.Model):
             alloc_total = sum(rec.allocation_line_ids.mapped("estimated_amount"))
             rec.warn_allocation_mismatch = (
                 bool(rec.allocation_line_ids)
-                and float_compare(
-                    alloc_total, rec.maintenance_deduction_amount, precision_digits=prec
-                )
-                != 0
+                and abs(alloc_total - rec.maintenance_deduction_amount) > 0.02
             )
             if rec.installment_ids:
                 maint_total = sum(rec.installment_ids.mapped("maintenance_fee"))
                 rec.warn_installment_maintenance_mismatch = (
                     not rec.no_installment_tracking
-                    and float_compare(
-                        maint_total,
-                        rec.maintenance_deduction_amount,
-                        precision_digits=prec,
-                    )
-                    != 0
+                    and abs(maint_total - rec.maintenance_deduction_amount) > 0.02
                 )
                 rec.warn_installment_total_mismatch = (
                     not rec.no_installment_tracking
-                    and float_compare(
-                        rec.total_installment_amount,
-                        rec.project_value,
-                        precision_digits=prec,
-                    )
-                    != 0
+                    and abs(rec.total_installment_amount - rec.project_value) > 0.02
                 )
                 extra_total = sum(rec.installment_ids.mapped("extra_income"))
                 rec.warn_extra_overshoot = (

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -2,7 +2,6 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -2,6 +2,7 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -86,14 +87,14 @@ class KrisProjectAllocationLine(models.Model):
 
     @api.constrains("estimated_amount")
     def _check_estimated_amount_sum(self):
-        # Allow up to 0.02 baht of cumulative Monetary rounding drift when a
-        # template's % lines are applied on a decimal fixed base amount.
         for line in self:
             base = line.project_id.maintenance_deduction_amount
             if not base:
                 continue
-            total = sum(line.project_id.allocation_line_ids.mapped("estimated_amount"))
-            if total - base > 0.02:
+            rounding = line.currency_id.rounding or 0.01
+            lines = line.project_id.allocation_line_ids
+            total = sum(lines.mapped("estimated_amount"))
+            if float_compare(total, base, precision_rounding=rounding * len(lines)) > 0:
                 raise ValidationError(
                     _(
                         "ผลรวมประมาณการจัดสรรต้องไม่เกินมูลค่าหักค่าบำรุง (%.2f บาท)"

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -86,12 +86,14 @@ class KrisProjectAllocationLine(models.Model):
 
     @api.constrains("estimated_amount")
     def _check_estimated_amount_sum(self):
+        # Allow up to 0.02 baht of cumulative Monetary rounding drift when a
+        # template's % lines are applied on a decimal fixed base amount.
         for line in self:
             base = line.project_id.maintenance_deduction_amount
             if not base:
                 continue
             total = sum(line.project_id.allocation_line_ids.mapped("estimated_amount"))
-            if total > base + 1e-9:
+            if total - base > 0.02:
                 raise ValidationError(
                     _(
                         "ผลรวมประมาณการจัดสรรต้องไม่เกินมูลค่าหักค่าบำรุง (%.2f บาท)"

--- a/kris_project/models/kris_project_allocation.py
+++ b/kris_project/models/kris_project_allocation.py
@@ -85,20 +85,3 @@ class KrisProjectAllocationLine(models.Model):
         for line in self:
             line.actual_amount = sum(line.receipt_allocation_ids.mapped("amount"))
 
-    @api.constrains("estimated_amount")
-    def _check_estimated_amount_sum(self):
-        for line in self:
-            base = line.project_id.maintenance_deduction_amount
-            if not base:
-                continue
-            rounding = line.currency_id.rounding or 0.01
-            lines = line.project_id.allocation_line_ids
-            total = sum(lines.mapped("estimated_amount"))
-            if float_compare(total, base, precision_rounding=rounding * len(lines)) > 0:
-                raise ValidationError(
-                    _(
-                        "ผลรวมประมาณการจัดสรรต้องไม่เกินมูลค่าหักค่าบำรุง (%.2f บาท)"
-                    )
-                    % base
-                )
-


### PR DESCRIPTION
## สรุป

แก้ปัญหาที่ไม่สามารถ save โปรเจกต์หรือนำแม่แบบมาใช้ใหม่ได้ เมื่อ **ค่าบำรุง (Maintenance Deduction)** ตั้งเป็น "ระบุจำนวนเงิน" แล้วกรอกเป็นทศนิยม (เช่น 5,000.50 บาท)

### สาเหตุ

เมื่อกดใช้แม่แบบการจัดสรร ระบบคำนวณ `estimated_amount = base × %` ในแต่ละบรรทัด
แต่ `estimated_amount` เป็น Monetary (ปัดเป็น 2 ทศนิยม) — ผลรวมของทุกบรรทัดที่ปัดแล้วจึงอาจต่างจาก base ไม่เกิน ±0.02 บาท

ระบบเดิมใช้ tolerance = `1e-9` (0.000000001) ซึ่งแคบเกินไป ทำให้ทริกเกอร์ทั้ง:
- `@api.constrains` → "ผลรวมประมาณการจัดสรรต้องไม่เกินมูลค่าหักค่าบำรุง"
- `exception.rule` → "The total allocated revenue does not equal the value minus maintenance fees. กรุณาตรวจสอบการจัดสรร"

### การแก้ไข

- **`kris_project_allocation.py`** — `_check_estimated_amount_sum`: เปลี่ยน `total > base + 1e-9` → `total - base > 0.02`
- **`kris_project.py`** — `_compute_warnings`: เปลี่ยน 3 warn flag จาก `float_compare(precision_digits=2) != 0` → `abs(diff) > 0.02`
  - `warn_allocation_mismatch`
  - `warn_installment_maintenance_mismatch`
  - `warn_installment_total_mismatch`

### ไม่ได้แตะ

- สูตรคำนวณค่าบำรุงและฟังก์ชันใช้แม่แบบ — ไม่เปลี่ยนวิธีกระจายเงิน
- `warn_maintenance_exceeds_expense`, `warn_extra_overshoot` — คนละแกนการตรวจสอบ
- `_check_extra_income_total` ใน receipt/installment — ไม่เกี่ยวกับ bug นี้

## วิธีทดสอบ

- [ ] สร้างโปรเจกต์ ตั้ง maintenance deduction = "ระบุจำนวนเงิน" กรอก 5,000.50 บาท → ใช้แม่แบบ 33.33/33.33/33.34% → save ผ่าน
- [ ] ทดสอบเคสจำนวนเต็ม (5,000 บาท) → ยังทำงานเหมือนเดิม
- [ ] แก้บรรทัดจัดสรรให้ผลรวมเกิน base 1 บาท → ยังขึ้น error ตามเดิม
- [ ] ทดสอบงวดงานที่มี maintenance_fee บนฐานทศนิยม → ไม่ขึ้น warning ถ้าต่างไม่เกิน 0.02 บาท