### PR TITLE
[16.0][FIX] hr_employee_name_detail_kmitl: support res.users in employee_detail_many2one

### DIFF
--- a/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
+++ b/hr_employee_name_detail_kmitl/static/src/employee_detail_many2one/employee_detail_many2one_field.js
@@ -9,9 +9,12 @@ import { onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 const DETAIL_FIELDS = ["academic_standing_title", "work_email", "department_id", "kid"];
 
 /**
- * Many2one widget for ``hr.employee`` that renders the academic standing title,
- * work email, department (faculty / department) and KID as an icon-prefixed
- * detail card below the field, instead of plain ``name_get`` extra lines.
+ * Many2one widget that renders the academic standing title, work email,
+ * department (faculty / department) and KID as an icon-prefixed detail card
+ * below the field, instead of plain ``name_get`` extra lines.
+ *
+ * Supports fields pointing to ``hr.employee`` directly, or to ``res.users``
+ * (in which case the linked ``employee_id`` is resolved first).
  *
  * Usage: ``<field name="employee_id" widget="employee_detail_many2one"/>``
  */
@@ -34,7 +37,21 @@ export class EmployeeDetailMany2OneField extends Many2OneField {
             this.detail.data = null;
             return;
         }
-        const [record = {}] = await this.orm.read(this.relation, [value[0]], DETAIL_FIELDS, {
+        let employeeId = value[0];
+        if (this.relation === "res.users") {
+            const [user = {}] = await this.orm.read(
+                "res.users",
+                [value[0]],
+                ["employee_id"],
+                { context: this.context }
+            );
+            if (!user.employee_id) {
+                this.detail.data = null;
+                return;
+            }
+            employeeId = user.employee_id[0];
+        }
+        const [record = {}] = await this.orm.read("hr.employee", [employeeId], DETAIL_FIELDS, {
             context: this.context,
         });
         let department = false;

--- a/purchase_request_kmitl/__manifest__.py
+++ b/purchase_request_kmitl/__manifest__.py
@@ -7,6 +7,7 @@
     "website": "https://github.com/aginix/kmitl",
     "depends": [
         "hr",
+        "hr_employee_name_detail_kmitl",
         "purchase_exception",
         "purchase_request_exception",
         "purchase_request_operating_unit",

--- a/purchase_request_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_kmitl/views/purchase_request_views.xml
@@ -177,6 +177,7 @@
                         />
                         <field
                             name="requested_by"
+                            widget="employee_detail_many2one"
                             attrs="{'readonly': [('is_editable','=', False)]}"
                         />
                         <field

--- a/purchase_request_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_kmitl/views/purchase_request_views.xml
@@ -177,7 +177,7 @@
                         />
                         <field
                             name="requested_by"
-                            widget="employee_detail_many2one"
+                            widget="employee_detail_many2one" 
                             attrs="{'readonly': [('is_editable','=', False)]}"
                         />
                         <field


### PR DESCRIPTION
## Summary
- Generalize `employee_detail_many2one` so it resolves `res.users` → `employee_id` before reading `hr.employee` detail fields, keeping the existing `hr.employee` path unchanged.
- Apply the widget to `requested_by` on `purchase.request` (Many2one to `res.users`) and add `hr_employee_name_detail_kmitl` as a dependency of `purchase_request_kmitl`.
- Fixes `ValueError: Invalid field 'academic_standing_title' on model 'res.users'` when using the widget on user fields.

## Test plan
- [ ] Update both modules and open a `purchase.request`; selecting a user with a linked employee shows the detail card, and a user without one shows nothing (no error).
- [ ] Verify `kris.project.manager_id` still renders the detail card as before.