### PR TITLE
[16.0][IMP] agx_approval: owner as employee, drop department_id

### DIFF
--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -84,15 +84,6 @@ class ApprovalRequest(models.Model):
         states=READONLY_STATES,
     )
 
-    department_id = fields.Many2one(
-        string="Department",
-        comodel_name="hr.department",
-        default=lambda self: self.env.user.employee_id.department_id,
-        required=True,
-        tracking=True,
-        states=READONLY_STATES,
-    )
-
     name = fields.Char(
         string="Name",
         default="/",
@@ -112,8 +103,8 @@ class ApprovalRequest(models.Model):
 
     owner_id = fields.Many2one(
         string="Request Owner",
-        comodel_name="res.users",
-        default=lambda self: self.env.uid,
+        comodel_name="hr.employee",
+        default=lambda self: self.env.user.employee_id,
         required=True,
         tracking=True,
         states=READONLY_STATES,
@@ -328,10 +319,6 @@ class ApprovalRequest(models.Model):
                 if analytic:
                     distribution[str(analytic.id)] = 100
             self.analytic_distribution = distribution or False
-
-    @api.onchange("owner_id")
-    def _onchange_owner_id(self):
-        self.department_id = self.owner_id.employee_id.department_id
 
     @api.model
     def _search_source_analytic_id(self, operator, value):

--- a/agx_approval/reports/report_approval_request.xml
+++ b/agx_approval/reports/report_approval_request.xml
@@ -44,7 +44,7 @@
                         <div class="row">
                             <div class="col">
                                 หน่วยงาน
-                                <span class="ms-2" t-field="o.department_id" />
+                                <span class="ms-2" t-field="o.owner_id.department_id" />
                             </div>
                         </div>
                         <div class="row">
@@ -60,7 +60,7 @@
                             ผู้ขออนุมัติ
                             <span t-field="o.owner_id" class="fw-bolder text-decoration-underline" />
                             <span class="ms-2">สังกัด</span>
-                            <span t-field="o.department_id" class="fw-bolder text-decoration-underline" />
+                            <span t-field="o.owner_id.department_id" class="fw-bolder text-decoration-underline" />
                         </p>
 
                         <div class="row">

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -46,7 +46,6 @@
                             <field name="category_id" attrs="{'readonly': [('id', '!=', False)]}" />
                             <field name="payment_type" required="1" widget="radio" options="{'horizontal': true}"/>
                             <field name="owner_id" />
-                            <field name="department_id" readonly="1"/>
                             <field name="user_id" readonly="1"/>
                             <field name="has_period" invisible="1" />
                             <field name="has_city" invisible="1" />
@@ -146,7 +145,6 @@
                 <field name="name" />
                 <field name="date" />
                 <field name="category_id" />
-                <field name="department_id" />
                 <field name="owner_id" />
                 <field name="account_fiscal_year_id" options="{'no_open': True}" />
                 <field name="state" widget="badge" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-danger="state == 'rejected'"/>
@@ -160,7 +158,6 @@
         <field name="arch" type="xml">
             <search string="Approval Request">
                 <field name="name" />
-                <field name="department_id" />
                 <field name="category_id" />
                 <field name="account_fiscal_year_id" />
                 <filter name="filter_draft" string="Draft" domain="[('state', '=', 'draft')]" />

--- a/agx_approval_advance_payment/models/approval_request.py
+++ b/agx_approval_advance_payment/models/approval_request.py
@@ -35,7 +35,7 @@ class ApprovalRequest(models.Model):
             rec.show_create_advance_payment_button = (
                 rec.state == "approved"
                 and rec.payment_type == "advance"
-                and rec.owner_id == self.env.user
+                and rec.owner_id.user_id == self.env.user
                 and not rec.advance_payment_id
             )
 
@@ -67,8 +67,8 @@ class ApprovalRequest(models.Model):
         self.ensure_one()
         loan_type = self.env.ref("advance_payment.loan_type_other")
         return {
-            "requested_by": self.owner_id.id,
-            "department_id": self.department_id.id,
+            "requested_by": self.owner_id.user_id.id or self.env.user.id,
+            "department_id": self.owner_id.department_id.id,
             "loan_reason": self.description or "",
             "loan_amount": self.total_amount,
             "loan_type_id": loan_type.id,

--- a/agx_approval_sarabun/controllers/portal.py
+++ b/agx_approval_sarabun/controllers/portal.py
@@ -14,7 +14,7 @@ class ApprovalRequestPortal(CustomerPortal):
         if "approval_request_count" in counters:
             approval_request_count = (
                 request.env["approval.request"].search_count(
-                    [("owner_id", "=", request.env.user.id)]
+                    [("owner_id.user_id", "=", request.env.user.id)]
                 )
                 if request.env["approval.request"].check_access_rights(
                     "read", raise_exception=False
@@ -35,7 +35,7 @@ class ApprovalRequestPortal(CustomerPortal):
         values = self._prepare_portal_layout_values()
         ApprovalRequest = request.env["approval.request"]
 
-        domain = [("owner_id", "=", request.env.user.id)]
+        domain = [("owner_id.user_id", "=", request.env.user.id)]
 
         # Sorting
         searchbar_sortings = {

--- a/agx_approval_sarabun/reports/report_approval_request.xml
+++ b/agx_approval_sarabun/reports/report_approval_request.xml
@@ -95,7 +95,7 @@
                             />
                             <span class="ms-2">สังกัด</span>
                             <span
-                                t-field="o.department_id"
+                                t-field="o.owner_id.department_id"
                                 class="fw-bolder text-decoration-underline"
                             />
                         </p>
@@ -280,7 +280,7 @@
                 <div>ลงชื่อ <t t-out="'.' * 80" /></div>
                 <div class="text-center">( <span t-field="o.owner_id" /> )</div>
                 <div class="text-center">
-                    คณบดี <span t-out="o.department_id.master_department_id.name" />
+                    คณบดี <span t-out="o.owner_id.department_id.master_department_id.name" />
                 </div>
             </div>
         </div>

--- a/agx_approval_sarabun/views/portal_templates.xml
+++ b/agx_approval_sarabun/views/portal_templates.xml
@@ -47,7 +47,7 @@
                                 <span t-field="req.date"/>
                             </td>
                             <td>
-                                <span t-field="req.department_id"/>
+                                <span t-field="req.owner_id.department_id"/>
                             </td>
                             <td>
                                 <span t-field="req.category_id"/>
@@ -108,7 +108,7 @@
                                         <img class="rounded-circle mt-1 o_portal_contact_img" t-att-src="image_data_uri(approval_request.owner_id.avatar_128)" alt="Contact"/>
                                     </div>
                                     <div class="col ps-0">
-                                        <span t-field="approval_request.owner_id" t-options='{"widget": "contact", "fields": ["name", "phone"], "no_marker": True}'/>
+                                        <span t-field="approval_request.owner_id"/>
                                         <a href="#discussion" class="small">
                                             <i class="fa fa-fw fa-comments"/>
                                             <b>Send message</b>

--- a/kmitl_demo/data/approval.request.xml
+++ b/kmitl_demo/data/approval.request.xml
@@ -9,8 +9,7 @@
         <!-- 1) International travel - 3 expense lines for one traveler -->
         <record id="approval_request_demo_01" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_02" />
-            <field name="department_id" ref="kmitl_demo.01" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_005" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_005" />
             <field name="user_id" ref="kmitl_demo.user_demo_005" />
             <field name="date" eval="'2025-03-15'" />
             <field name="date_start" eval="'2025-04-10'" />
@@ -44,8 +43,7 @@
         <!-- 2) Local field work - 3 expense lines for one staff member -->
         <record id="approval_request_demo_02" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_01" />
-            <field name="department_id" ref="kmitl_demo.01" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_006" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_006" />
             <field name="user_id" ref="kmitl_demo.user_demo_006" />
             <field name="date" eval="'2025-03-20'" />
             <field name="date_start" eval="'2025-04-02'" />
@@ -79,8 +77,7 @@
         <!-- 3) Operational support - single line for one payee -->
         <record id="approval_request_demo_03" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_04" />
-            <field name="department_id" ref="kmitl_demo.02" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_008" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_008" />
             <field name="user_id" ref="kmitl_demo.user_demo_008" />
             <field name="date" eval="'2025-03-22'" />
             <field name="payment_type">direct</field>
@@ -101,8 +98,7 @@
         <!-- 4) MC / ceremony fee - 2 lines for one host -->
         <record id="approval_request_demo_04" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_05" />
-            <field name="department_id" ref="kmitl_demo.01" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_010" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_010" />
             <field name="user_id" ref="kmitl_demo.user_demo_010" />
             <field name="date" eval="'2025-04-01'" />
             <field name="payment_type">direct</field>
@@ -128,8 +124,7 @@
         <!-- 5) International travel - 4 expense lines for one traveler -->
         <record id="approval_request_demo_05" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_02" />
-            <field name="department_id" ref="kmitl_demo.02" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_012" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_012" />
             <field name="user_id" ref="kmitl_demo.user_demo_012" />
             <field name="date" eval="'2025-04-05'" />
             <field name="date_start" eval="'2025-05-12'" />
@@ -172,8 +167,7 @@
         <!-- 6) Meeting expenses - 3 attendees -->
         <record id="approval_request_demo_06" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_03" />
-            <field name="department_id" ref="kmitl_demo.01" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_005" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_005" />
             <field name="user_id" ref="kmitl_demo.user_demo_005" />
             <field name="date" eval="'2025-04-08'" />
             <field name="date_start" eval="'2025-04-15'" />
@@ -206,8 +200,7 @@
         <!-- 7) Field work - team of 4 -->
         <record id="approval_request_demo_07" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_01" />
-            <field name="department_id" ref="kmitl_demo.01" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_006" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_006" />
             <field name="user_id" ref="kmitl_demo.user_demo_006" />
             <field name="date" eval="'2025-04-10'" />
             <field name="date_start" eval="'2025-05-05'" />
@@ -246,8 +239,7 @@
         <!-- 8) Large meeting - 5 attendees x 2 expense types each -->
         <record id="approval_request_demo_08" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_03" />
-            <field name="department_id" ref="kmitl_demo.02" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_008" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_008" />
             <field name="user_id" ref="kmitl_demo.user_demo_008" />
             <field name="date" eval="'2025-04-12'" />
             <field name="date_start" eval="'2025-04-25'" />
@@ -315,8 +307,7 @@
         <!-- 9) Two MCs sharing one ceremony -->
         <record id="approval_request_demo_09" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_05" />
-            <field name="department_id" ref="kmitl_demo.01" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_010" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_010" />
             <field name="user_id" ref="kmitl_demo.user_demo_010" />
             <field name="date" eval="'2025-04-18'" />
             <field name="payment_type">direct</field>
@@ -342,8 +333,7 @@
         <!-- 10) Training session - 3 trainers, different expense types -->
         <record id="approval_request_demo_10" model="approval.request">
             <field name="category_id" ref="agx_approval.approval_category_03" />
-            <field name="department_id" ref="kmitl_demo.02" />
-            <field name="owner_id" ref="kmitl_demo.user_demo_012" />
+            <field name="owner_id" ref="kmitl_demo.employee_demo_012" />
             <field name="user_id" ref="kmitl_demo.user_demo_012" />
             <field name="date" eval="'2025-04-22'" />
             <field name="date_start" eval="'2025-05-10'" />


### PR DESCRIPTION
## What
- Change `approval.request.owner_id` from `res.users` → **`hr.employee`** (default `env.user.employee_id`).
- Remove the redundant **`department_id`** field from `approval.request`, along with the `_onchange_owner_id` that only existed to derive it.

## Why
The department is already carried by the employee (`hr.employee.department_id`). Storing `department_id` separately duplicated the data and could drift out of sync. With `owner_id` now an employee, the department is a single source of truth.

## Changes
- **Model** `agx_approval/models/approval_request.py`: `owner_id` → `hr.employee`; drop `department_id`; drop `_onchange_owner_id`.
- **Views** `approval_request_views.xml`: remove `department_id` from form / tree / search.
- **Reports & portal**: department shown in official documents is now derived from `owner_id.department_id`
  - `agx_approval` report (หน่วยงาน / สังกัด)
  - `agx_approval_sarabun` report (สังกัด / คณบดี via `owner_id.department_id.master_department_id.name`)
  - `agx_approval_sarabun` portal list column; contact widget simplified to a plain name (hr.employee is not partner-shaped).
- **Bridges** reach the requesting user via `owner_id.user_id`:
  - `agx_approval_advance_payment`: button check `owner_id.user_id == env.user`; `requested_by = owner_id.user_id.id or env.user.id`; `department_id = owner_id.department_id.id`.
  - `agx_approval_sarabun` portal controller domains use `owner_id.user_id`.
- **Demo** `kmitl_demo/data/approval.request.xml`: `owner_id` refs `user_demo_00X` → `employee_demo_00X`; `department_id` lines removed. (`hr.employee.xml` already loads before `approval.request.xml`.)

## Notes / follow-ups
- **Migration**: existing DBs store `res.users` ids in `owner_id`; after the comodel change these would be read as `hr.employee` ids. A remap migration (`res.users` → `hr.employee` via `user_id`) is **not** included here — fine for dev/demo reloads, required before applying to real data.
- No new user-facing strings introduced (fields removed / repointed), so no new i18n entries needed.