### PR TITLE
[16.0][IMP] accounting_kmitl_reports: sources filter as flat multi-select

### DIFF
--- a/accounting_kmitl_reports/models/dimension_filter_mixin.py
+++ b/accounting_kmitl_reports/models/dimension_filter_mixin.py
@@ -7,6 +7,9 @@ from odoo.tools import date_utils
 # order. Read from each move line's ``analytic_distribution`` (a JSON of
 # {analytic_account_id: percentage}).
 DIMENSION_CODES = ("departments", "sources", "funds", "activities")
+# Flat dimensions have no parent/child hierarchy: their selection must match
+# the picked analytic accounts exactly and is never expanded to descendants.
+FLAT_DIMENSION_CODES = ("sources",)
 # Display order of the dimension chips shown in the shared expand-detail panel.
 DETAIL_DIM_PLANS = ("funds", "departments", "activities", "sources")
 # Lines never shown in the detail panel.
@@ -35,8 +38,9 @@ class DimensionFilterMixin(models.AbstractModel):
         dimension only the exact selected analytic accounts match; otherwise
         (the default) the selection is expanded to include all of its
         descendants, since the KMITL dimensions are hierarchical. Flat
-        dimensions (e.g. ``sources``) have no descendants, so the toggle has
-        no effect on them.
+        dimensions (``FLAT_DIMENSION_CODES``, e.g. ``sources``) have no
+        hierarchy, so they always match the selected accounts exactly
+        regardless of the toggle.
         """
         analytic = self.env["account.analytic.account"]
         use_child = "parent_id" in analytic._fields
@@ -46,7 +50,11 @@ class DimensionFilterMixin(models.AbstractModel):
             ids = (dims or {}).get(code) or []
             if not ids:
                 continue
-            if use_child and not dim_only_self.get(code):
+            if (
+                use_child
+                and code not in FLAT_DIMENSION_CODES
+                and not dim_only_self.get(code)
+            ):
                 ids = analytic.search([("id", "child_of", ids)]).ids
             leaves.append(("analytic_distribution", "in", ids))
         return leaves

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
@@ -37,7 +37,6 @@ export class AgedPartnerBalance extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
-                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
@@ -73,9 +73,6 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
-                        withOnlySelf="true"
-                        onlySelf="state.dimOnlySelf.sources"
-                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/cash_flow/cash_flow.js
+++ b/accounting_kmitl_reports/static/src/cash_flow/cash_flow.js
@@ -33,7 +33,6 @@ export class CashFlow extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
-                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/cash_flow/cash_flow.xml
+++ b/accounting_kmitl_reports/static/src/cash_flow/cash_flow.xml
@@ -97,9 +97,6 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
-                        withOnlySelf="true"
-                        onlySelf="state.dimOnlySelf.sources"
-                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/general_journal/general_journal.js
+++ b/accounting_kmitl_reports/static/src/general_journal/general_journal.js
@@ -55,7 +55,6 @@ export class GeneralJournal extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
-                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/general_journal/general_journal.xml
+++ b/accounting_kmitl_reports/static/src/general_journal/general_journal.xml
@@ -106,9 +106,6 @@
                             placeholder="labels.sources"
                             selected="state.sources"
                             onChange="(sel) => this.onSelectionChange('sources', sel)"
-                            withOnlySelf="true"
-                            onlySelf="state.dimOnlySelf.sources"
-                            onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                         />
                     </div>
                     <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/general_ledger/general_ledger.js
+++ b/accounting_kmitl_reports/static/src/general_ledger/general_ledger.js
@@ -65,7 +65,6 @@ export class GeneralLedger extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
-                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml
+++ b/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml
@@ -110,9 +110,6 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
-                        withOnlySelf="true"
-                        onlySelf="state.dimOnlySelf.sources"
-                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.js
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.js
@@ -49,7 +49,6 @@ export class TrialBalance extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
-                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml
@@ -151,9 +151,6 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
-                        withOnlySelf="true"
-                        onlySelf="state.dimOnlySelf.sources"
-                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">


### PR DESCRIPTION
The Sources (แหล่งเงิน) dimension filter in all five reports (Trial Balance, General Ledger, General Journal, Cash Flow, Aged Partner Balance) is now a plain multi-select: it no longer expands the selection through the analytic hierarchy (`child_of`) and no longer shows the "only the specified entry" toggle. On the backend this is driven by a new `FLAT_DIMENSION_CODES` set in the dimension filter mixin, so Sources always matches the picked analytic accounts exactly. On the frontend the toggle props/state are dropped for Sources only, while it stays multi-select. The other hierarchical dimensions (departments, funds, activities) keep their hierarchy expansion and per-dimension toggle unchanged.
