### PR TITLE
[16.0][IMP] agx_approval: configurable payee partner types per category

### DIFF
--- a/agx_approval/__manifest__.py
+++ b/agx_approval/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Aginix Approval",
-    "version": "16.0.1.0.8",
+    "version": "16.0.1.1.0",
     "category": "Accounting",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",
@@ -13,6 +13,7 @@
         "base_exception",
         "account_fiscal_year_enhance",
         "l10n_th_amount_to_text",
+        "partner_type_aginix",
     ],
     "data": [
         "security/security.xml",

--- a/agx_approval/i18n/th.po
+++ b/agx_approval/i18n/th.po
@@ -894,3 +894,44 @@ msgstr "แก้ไขยอดเบิกจริง"
 msgid "Update Actual Amount Wizard Line"
 msgstr ""
 
+#. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_category__allow_internal_partner
+msgid "Allow Internal Personnel"
+msgstr "อนุญาตบุคลากรภายใน"
+
+#. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_category__allow_external_partner
+msgid "Allow External Person"
+msgstr "อนุญาตบุคคลภายนอก"
+
+#. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_category__allow_student_partner
+msgid "Allow Student"
+msgstr "อนุญาตนักศึกษา"
+
+#. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_request_line__allowed_partner_type_ids
+msgid "Allowed Partner Types"
+msgstr "ประเภทผู้รับเงินที่อนุญาต"
+
+#. module: agx_approval
+#: model:ir.model.fields,help:agx_approval.field_approval_category__allow_internal_partner
+msgid ""
+"Allow selecting internal personnel (บุคลากรภายใน) as the payee on request "
+"lines of this category."
+msgstr "อนุญาตให้เลือกบุคลากรภายในเป็นผู้รับเงินในรายการของหมวดนี้"
+
+#. module: agx_approval
+#: model:ir.model.fields,help:agx_approval.field_approval_category__allow_external_partner
+msgid ""
+"Allow selecting external persons (บุคคลภายนอก) — companies and others — as "
+"the payee on request lines of this category."
+msgstr "อนุญาตให้เลือกบุคคลภายนอก (บริษัทและอื่น ๆ) เป็นผู้รับเงินในรายการของหมวดนี้"
+
+#. module: agx_approval
+#: model:ir.model.fields,help:agx_approval.field_approval_category__allow_student_partner
+msgid ""
+"Allow selecting students (นักศึกษา) as the payee on request lines of this "
+"category."
+msgstr "อนุญาตให้เลือกนักศึกษาเป็นผู้รับเงินในรายการของหมวดนี้"
+

--- a/agx_approval/models/approval_category.py
+++ b/agx_approval/models/approval_category.py
@@ -58,6 +58,24 @@ class ApprovalCategory(models.Model):
         comodel_name="product.product",
     )
 
+    allow_internal_partner = fields.Boolean(
+        string="Allow Internal Personnel",
+        help="Allow selecting internal personnel (บุคลากรภายใน) as the payee "
+        "on request lines of this category.",
+    )
+
+    allow_external_partner = fields.Boolean(
+        string="Allow External Person",
+        help="Allow selecting external persons (บุคคลภายนอก) — companies and "
+        "others — as the payee on request lines of this category.",
+    )
+
+    allow_student_partner = fields.Boolean(
+        string="Allow Student",
+        help="Allow selecting students (นักศึกษา) as the payee on request "
+        "lines of this category.",
+    )
+
     budget_account_id = fields.Many2one(
         "budget.account",
         string="Budget Account",

--- a/agx_approval/models/approval_request_line.py
+++ b/agx_approval/models/approval_request_line.py
@@ -19,6 +19,8 @@ class ApprovalRequestLine(models.Model):
     partner_id = fields.Many2one(
         string="Payee",
         comodel_name="res.partner",
+        domain="[('partner_type_id', 'in', allowed_partner_type_ids)]"
+        " if allowed_partner_type_ids else []",
         required=True
     )
 
@@ -26,6 +28,12 @@ class ApprovalRequestLine(models.Model):
         string='Allowed Product IDs',
         compute='_compute_allowed_product_ids',
         comodel_name="product.product"
+    )
+
+    allowed_partner_type_ids = fields.Many2many(
+        string="Allowed Partner Types",
+        compute="_compute_allowed_partner_type_ids",
+        comodel_name="res.partner.type",
     )
 
     product_id = fields.Many2one(
@@ -77,6 +85,24 @@ class ApprovalRequestLine(models.Model):
     def _compute_allowed_product_ids(self):
         for record in self:
             record.allowed_product_ids = record.request_id.category_id.allowed_product_ids
+
+    @api.depends(
+        "request_id.category_id.allow_internal_partner",
+        "request_id.category_id.allow_external_partner",
+        "request_id.category_id.allow_student_partner",
+    )
+    def _compute_allowed_partner_type_ids(self):
+        for record in self:
+            category = record.request_id.category_id
+            types = self.env["res.partner.type"]
+            if category.allow_internal_partner:
+                types |= self.env.ref("partner_type_aginix.partner_type_employee")
+            if category.allow_external_partner:
+                types |= self.env.ref("partner_type_aginix.partner_type_other")
+                types |= self.env.ref("partner_type_aginix.partner_type_company")
+            if category.allow_student_partner:
+                types |= self.env.ref("partner_type_aginix.partner_type_student")
+            record.allowed_partner_type_ids = types
 
     def _get_payee_bank(self):
         self.ensure_one()

--- a/agx_approval/views/approval_category_views.xml
+++ b/agx_approval/views/approval_category_views.xml
@@ -15,6 +15,9 @@
                         <field name="has_city" />
                         <field name="has_country_id" />
                         <field name="allowed_product_ids" widget="many2many_tags"/>
+                        <field name="allow_internal_partner"/>
+                        <field name="allow_external_partner"/>
+                        <field name="allow_student_partner"/>
                         <field name="budget_account_id" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
                         <field name="activity_analytic_id" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>
                         <field name="department_analytic_id" options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"/>

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -109,6 +109,7 @@
                             <field name="line_ids" attrs="{'readonly': [('state', '!=', 'draft')]}">
                                 <tree editable="bottom">
                                     <field name="allowed_product_ids" invisible="1"/>
+                                    <field name="allowed_partner_type_ids" invisible="1"/>
                                     <field name="sequence" widget="handle"/>
                                     <field name="currency_id" invisible="1"/>
                                     <field name="partner_id"/>


### PR DESCRIPTION
## What
Let each **approval category** declare which partner types may be selected as the **payee** (`partner_id` / ผู้ขอค่าใช้จ่าย) on its request lines:

- **บุคลากรภายใน** (Internal Personnel)
- **บุคคลภายนอก** (External Person)
- **นักศึกษา** (Student)

## Why
Different request categories should only allow certain kinds of payees. This reuses the existing `partner_type_aginix` classification (`res.partner.type` via `partner_id.partner_type_id`) instead of introducing a new one.

## How
- **`approval.category`**: three booleans — `allow_internal_partner`, `allow_external_partner`, `allow_student_partner`.
- **`approval.request.line`**: computed `allowed_partner_type_ids` resolves the booleans to `res.partner.type` records, and `partner_id` gets a domain `[('partner_type_id', 'in', allowed_partner_type_ids)]`. Mirrors the existing `allowed_product_ids` → `product_id` pattern.
- Mapping (as agreed):
  - internal → `partner_type_employee`
  - external → `partner_type_other` **+** `partner_type_company`
  - student → `partner_type_student`

## Behaviour / decisions
- **No flag set = no restriction** (all partners selectable) — keeps existing categories working unchanged.
- The domain only guides selection in the UI; it does not validate pre-existing line data (same as `product_id`).

## Files
- `agx_approval/__manifest__.py` — add `partner_type_aginix` dependency; version → `16.0.1.1.0`
- `agx_approval/models/approval_category.py` — three boolean flags
- `agx_approval/models/approval_request_line.py` — `allowed_partner_type_ids` compute + `partner_id` domain
- `agx_approval/views/approval_category_views.xml` — flags in the category form
- `agx_approval/views/approval_request_views.xml` — expose `allowed_partner_type_ids` (invisible) for domain evaluation
- `agx_approval/i18n/th.po` — Thai translations (labels + help)