### PR TITLE
[16.0][IMP] agx_approval: ready-to-bill handoff before disbursement

### DIFF
--- a/agx_approval/__manifest__.py
+++ b/agx_approval/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Aginix Approval",
-    "version": "16.0.1.0.8",
+    "version": "16.0.1.1.0",
     "category": "Accounting",
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/agx_approval/i18n/th.po
+++ b/agx_approval/i18n/th.po
@@ -890,6 +890,12 @@ msgid "Update Actual Amount Wizard"
 msgstr "แก้ไขยอดเบิกจริง"
 
 #. module: agx_approval
+#: model:ir.model.fields.selection,name:agx_approval.selection__approval_request__state__ready_to_bill
+#: model_terms:ir.ui.view,arch_db:agx_approval.approval_request_view_search
+msgid "Ready to Bill"
+msgstr "พร้อมส่งเบิกจริง"
+
+#. module: agx_approval
 #: model:ir.model,name:agx_approval.model_approval_update_actual_amount_wizard_line
 msgid "Update Actual Amount Wizard Line"
 msgstr ""

--- a/agx_approval/models/approval_request.py
+++ b/agx_approval/models/approval_request.py
@@ -19,6 +19,7 @@ class ApprovalRequest(models.Model):
         "to_verify": [("readonly", True)],
         "submitted": [("readonly", True)],
         "approved": [("readonly", True)],
+        "ready_to_bill": [("readonly", True)],
         "billed": [("readonly", True)],
         "rejected": [("readonly", True)],
     }
@@ -198,6 +199,7 @@ class ApprovalRequest(models.Model):
         ("submitted", "Submitted"),
         ("validated", "Validated"),
         ("approved", "Approved"),
+        ("ready_to_bill", "Ready to Bill"),
         ("billed", "Billed"),
         ("rejected", "Rejected"),
     ],
@@ -463,7 +465,7 @@ class ApprovalRequest(models.Model):
 
     def action_bill(self):
         for record in self:
-            if record.state != "approved":
+            if record.state not in ("approved", "ready_to_bill"):
                 raise UserError(_("Only approved requests can be billed."))
             record.state = "billed"
         return True
@@ -644,6 +646,7 @@ class ApprovalRequest(models.Model):
                 "submitted",
                 "validated",
                 "approved",
+                "ready_to_bill",
                 "billed",
                 "rejected"
             ):

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -15,7 +15,7 @@
                     <button name="action_approve" string="อนุมัติ" type="object" class="oe_highlight" attrs="{'invisible': [('state', 'not in', ['submitted', 'validated'])]}" groups="agx_approval.group_approval_manager"/>
                     <button name="action_draft" string="Reset to draft" type="object" class="btn btn-secondary" attrs="{'invisible': [('state', 'not in', ['to_verify', 'submitted'])]}" groups="agx_approval.group_approval_manager"/>
                     <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'approved')]}" groups="agx_approval.group_approval_manager"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,to_verify,submitted,approved,billed" />
+                    <field name="state" widget="statusbar" statusbar_visible="draft,to_verify,submitted,approved,ready_to_bill,billed" />
                 </header>
                 <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('exceptions_summary', '=', False)]}">
                     <p>
@@ -149,7 +149,7 @@
                 <field name="department_id" />
                 <field name="owner_id" />
                 <field name="account_fiscal_year_id" options="{'no_open': True}" />
-                <field name="state" widget="badge" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-danger="state == 'rejected'"/>
+                <field name="state" widget="badge" decoration-success="state in ('billed', 'approved')" decoration-muted="state == 'draft'" decoration-warning="state in ('to_verify', 'submitted')" decoration-info="state == 'ready_to_bill'" decoration-danger="state == 'rejected'"/>
             </tree>
         </field>
     </record>
@@ -167,6 +167,7 @@
                 <filter name="filter_submitted" string="Submitted" domain="[('state', '=', 'submitted')]" />
                 <filter name="filter_validated" string="Validated" domain="[('state', '=', 'validated')]" />
                 <filter name="filter_approved" string="Approved" domain="[('state', '=', 'approved')]" />
+                <filter name="filter_ready_to_bill" string="Ready to Bill" domain="[('state', '=', 'ready_to_bill')]" />
                 <filter name="filter_billed" string="Billed" domain="[('state', '=', 'billed')]" />
                 <filter name="filter_rejected" string="Rejected" domain="[('state', '=', 'rejected')]" />
                 <separator />

--- a/agx_approval_advance_payment/__manifest__.py
+++ b/agx_approval_advance_payment/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Approval - Advance Payment Bridge",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "author": "KMITL",
     "category": "KMITL",
     "depends": [

--- a/agx_approval_advance_payment/models/approval_request.py
+++ b/agx_approval_advance_payment/models/approval_request.py
@@ -58,8 +58,10 @@ class ApprovalRequest(models.Model):
                     and not rec.has_active_disbursement
                 )
             else:
+                # Direct/prepaid go through the ready_to_bill handoff: the
+                # finance officer bills only once clerical staff confirmed.
                 rec.show_create_disbursement_button = (
-                    rec.state in ("approved", "billed")
+                    rec.state == "ready_to_bill"
                     and not rec.has_active_disbursement
                 )
 

--- a/agx_approval_disbursement/__manifest__.py
+++ b/agx_approval_disbursement/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Aginix Approval Disbursement",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "Accounting",
     "author": "KMITL",
     "depends": ["agx_approval", "disbursement"],

--- a/agx_approval_disbursement/i18n/th.po
+++ b/agx_approval_disbursement/i18n/th.po
@@ -140,3 +140,31 @@ msgid ""
 "This record has been created from: <a href=\"%(link)s\" "
 "target=\"_blank\">%(name)s</a>"
 msgstr ""
+
+#. module: agx_approval_disbursement
+#: model_terms:ir.ui.view,arch_db:agx_approval_disbursement.approval_request_view_form
+msgid "Confirm Ready to Bill"
+msgstr "ยืนยันพร้อมส่งเบิกจริง"
+
+#. module: agx_approval_disbursement
+#. odoo-python
+#: code:addons/agx_approval_disbursement/models/approval_request.py:0
+#, python-format
+msgid "Only approved requests can be marked ready to bill."
+msgstr "เฉพาะคำขอที่อนุมัติแล้วเท่านั้นที่ทำเครื่องหมายพร้อมส่งเบิกจริงได้"
+
+#. module: agx_approval_disbursement
+#. odoo-python
+#: code:addons/agx_approval_disbursement/models/approval_request.py:0
+#, python-format
+msgid "Only direct or prepaid requests use the ready-to-bill step."
+msgstr "เฉพาะคำขอแบบจ่ายตรงหรือจ่ายล่วงหน้าเท่านั้นที่ใช้ขั้นตอนพร้อมส่งเบิกจริง"
+
+#. module: agx_approval_disbursement
+#. odoo-python
+#: code:addons/agx_approval_disbursement/models/approval_request.py:0
+#, python-format
+msgid ""
+"Please attach at least one disbursement document before marking this "
+"request ready to bill."
+msgstr "กรุณาแนบเอกสารเบิกจริงอย่างน้อย 1 ไฟล์ก่อนทำเครื่องหมายพร้อมส่งเบิกจริง"

--- a/agx_approval_disbursement/models/approval_request.py
+++ b/agx_approval_disbursement/models/approval_request.py
@@ -1,8 +1,31 @@
 from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class ApprovalRequest(models.Model):
     _inherit = "approval.request"
+
+    def action_ready_to_bill(self):
+        """Clerical staff marks a direct/prepaid request ready for the finance
+        officer to bill. Requires at least one disbursement document."""
+        self.ensure_one()
+        if self.state != "approved":
+            raise UserError(
+                _("Only approved requests can be marked ready to bill.")
+            )
+        if self.payment_type not in ("direct", "prepaid"):
+            raise UserError(
+                _("Only direct or prepaid requests use the ready-to-bill step.")
+            )
+        if not self.disbursement_attachment_ids:
+            raise UserError(
+                _(
+                    "Please attach at least one disbursement document before "
+                    "marking this request ready to bill."
+                )
+            )
+        self.state = "ready_to_bill"
+        return True
 
     disbursement_request_ids = fields.One2many(
         comodel_name="disbursement.request",

--- a/agx_approval_disbursement/views/approval_request_views.xml
+++ b/agx_approval_disbursement/views/approval_request_views.xml
@@ -11,11 +11,20 @@
             <xpath expr="//header/button[@name='action_to_verify']" position="after">
                 <field name="has_active_disbursement" invisible="1" />
                 <button
+                    name="action_ready_to_bill"
+                    string="Confirm Ready to Bill"
+                    type="object"
+                    class="oe_highlight"
+                    groups="agx_approval.group_approval_user"
+                    attrs="{'invisible': ['|', '|', ('state', '!=', 'approved'), ('payment_type', 'not in', ['direct', 'prepaid']), ('has_active_disbursement', '=', True)]}"
+                />
+                <button
                     name="action_create_disbursement_request"
                     string="Create Bill"
                     type="object"
                     class="oe_highlight"
-                    attrs="{'invisible': ['|', ('state', 'not in', ['approved', 'billed']), ('has_active_disbursement', '=', True)]}"
+                    groups="disbursement.group_disbursement_user"
+                    attrs="{'invisible': ['|', ('state', '!=', 'ready_to_bill'), ('has_active_disbursement', '=', True)]}"
                 />
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
@@ -35,7 +44,7 @@
             </xpath>
             <xpath expr="//group[@name='attachment']" position="after">
                 <group string="Attachment for Disbursement"
-                    attrs="{'invisible': [('state', 'not in', ['approved', 'billed'])]}">
+                    attrs="{'invisible': [('state', 'not in', ['approved', 'ready_to_bill', 'billed'])]}">
                     <field name="disbursement_attachment_ids"
                         widget="many2many_binary"
                         attrs="{'readonly': [('disbursement_request_count', '>', 0)]}">


### PR DESCRIPTION
## Problem
After an approval request (AR) is `approved`, clerical staff attach the disbursement documents and record the actual amount — but there was **no signal telling the finance officer whether an AR is actually ready to be disbursed** (`ส่งเบิกจริง`). The "Create Bill" button appeared the moment an AR was approved (even with no documents), so readiness was invisible.

## Solution
Add a **`ready_to_bill`** state ("พร้อมส่งเบิกจริง") between `approved` and `billed`, with a clerical → finance handoff. **Scope: `direct` / `prepaid` only** — `advance` keeps its existing flow.

```
… approved → ready_to_bill → billed
```

| Action | from → to | who | guard |
|---|---|---|---|
| Confirm Ready to Bill (new) | approved → ready_to_bill | clerical `agx_approval.group_approval_user` | direct/prepaid + ≥1 disbursement attachment |
| Create Bill (existing) | ready_to_bill → billed | finance `disbursement.group_disbursement_user` | direct/prepaid |

Finance discovers ready requests **passively** — a "Ready to Bill" search filter + statusbar/tree badge (no active notification, matching the pull-based disbursement assignment model).

## Changes
- **`agx_approval`** — `ready_to_bill` state value (+ READONLY_STATES, `is_editable`), `action_bill` accepts `ready_to_bill`, statusbar/search filter/tree badge, i18n; version → `16.0.1.1.0`.
- **`agx_approval_disbursement`** — `action_ready_to_bill()` (guarded on `disbursement_attachment_ids`), "Confirm Ready to Bill" button (clerical group), "Create Bill" moved to `ready_to_bill` + finance group, disbursement-attachment section visible from `approved`, i18n; version → `16.0.1.1.0`.
- **`agx_approval_advance_payment`** — `show_create_disbursement_button` (direct/prepaid branch) keyed on `ready_to_bill`; version → `16.0.1.0.1`.

## Notes
- `Create Bill` now requires `group_disbursement_user` (applies to advance too — creating a `disbursement.request` should require disbursement rights).
- The `excep_no_disbursement_evidence` blocking rule is kept (still guards the advance path that bills from `approved`; it does not double-fire for direct/prepaid, which already pass the ready-to-bill guard).
- **Deferred** (from design session): a Cancel/escape action while in `ready_to_bill`, and showing the actual-amount wizard in `ready_to_bill`.
- **Cross-PR:** based on `origin/16.0`; overlaps a few files with #957 (approval_request.py, view, th.po, manifest version) — whichever merges first, the other needs a trivial rebase.