### PR TITLE
[16.0][IMP] kris_project: reset closed projects to draft

### DIFF
--- a/kris_project/models/kris_project.py
+++ b/kris_project/models/kris_project.py
@@ -560,10 +560,17 @@ class KrisProject(models.Model):
         self.write({"state": "cancel", "ignore_exception": False})
 
     def action_draft(self):
+        allowed = (
+            "cancel",
+            "in_progress",
+            "done",
+            "terminated",
+            "conditional_close",
+        )
         for rec in self:
-            if rec.state not in ("cancel", "in_progress"):
+            if rec.state not in allowed:
                 raise UserError(
-                    _("Only cancelled or in-progress projects can be reset to draft.")
+                    _("This project cannot be reset to draft from its current state.")
                 )
         self.write({
             "state": "draft",

--- a/kris_project/tests/__init__.py
+++ b/kris_project/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import common
+from . import test_action_draft
 from . import test_copy
 from . import test_kris_project_compute
 from . import test_kris_project_dashboard

--- a/kris_project/tests/test_action_draft.py
+++ b/kris_project/tests/test_action_draft.py
@@ -1,0 +1,57 @@
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+from .common import KrisProjectCommon
+
+
+@tagged("post_install", "-at_install")
+class TestKrisProjectActionDraft(KrisProjectCommon):
+    """Guardrails and state coverage for kris.project.action_draft."""
+
+    def _project_in_state(self, state):
+        p = self._make_project()
+        p.state = state
+        return p
+
+    def test_reset_from_cancel(self):
+        p = self._project_in_state("cancel")
+        p.action_draft()
+        self.assertEqual(p.state, "draft")
+
+    def test_reset_from_in_progress(self):
+        p = self._project_in_state("in_progress")
+        p.action_draft()
+        self.assertEqual(p.state, "draft")
+
+    def test_reset_from_done(self):
+        p = self._project_in_state("done")
+        p.action_draft()
+        self.assertEqual(p.state, "draft")
+
+    def test_reset_from_terminated(self):
+        p = self._project_in_state("terminated")
+        p.action_draft()
+        self.assertEqual(p.state, "draft")
+
+    def test_reset_from_conditional_close(self):
+        p = self._project_in_state("conditional_close")
+        p.action_draft()
+        self.assertEqual(p.state, "draft")
+
+    def test_reset_clears_exception_flags(self):
+        p = self._project_in_state("done")
+        p.ignore_exception = True
+        p.action_draft()
+        self.assertFalse(p.ignore_exception)
+        self.assertFalse(p.main_exception_id)
+        self.assertFalse(p.exception_ids)
+
+    def test_reset_from_draft_raises(self):
+        p = self._make_project()
+        with self.assertRaises(UserError):
+            p.action_draft()
+
+    def test_reset_from_suspended_raises(self):
+        p = self._project_in_state("suspended")
+        with self.assertRaises(UserError):
+            p.action_draft()

--- a/kris_project/views/kris_project_views.xml
+++ b/kris_project/views/kris_project_views.xml
@@ -122,7 +122,7 @@
                         name="action_draft"
                         string="Reset to Draft"
                         type="object"
-                        states="cancel,in_progress"
+                        states="cancel,in_progress,done,terminated,conditional_close"
                         groups="kris_project.group_kris_project_manager"
                     />
                     <field


### PR DESCRIPTION
## Summary
- Extend the manager-only **Reset to Draft** button on KRIS Project to also cover the closed states (`done`, `terminated`, `conditional_close`), so a KRIS Manager can recover from a wrongly-closed project without a DB fix.
- Widen the `action_draft` guard in `kris_project/models/kris_project.py` to match, and add tests in `kris_project/tests/test_action_draft.py` covering each allowed source state plus rejection from `draft` / `suspended`.

## Test plan
- [ ] Upgrade `kris_project`, log in as a KRIS Manager, and confirm the button shows and works for projects in `cancel`, `in_progress`, `done`, `terminated`, `conditional_close`.
- [ ] Log in as a KRIS Officer and confirm the button is not rendered on the same records.
- [ ] Run module tests (`oca_run_tests`).