### PR TITLE
[16.0][FIX] disbursement: complete Thai menu translations

### DIFF
--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -989,6 +989,12 @@ msgid "Net Total"
 msgstr "มูลค่าสุทธิ"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__active
+msgid "Active"
+msgstr "ใช้งาน"
+
+#. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__activity_analytic_id
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__activity_analytic_id
 msgid "Activity"
 msgstr "กิจกรรม"
@@ -1020,6 +1026,7 @@ msgid "Bill Posted"
 msgstr "ตั้งหนี้แล้ว"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__department_analytic_id
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__department_analytic_id
 msgid "Department"
 msgstr "ส่วนงาน"
@@ -1040,6 +1047,7 @@ msgid "Done"
 msgstr "เสร็จสิ้น"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__fund_analytic_id
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__fund_analytic_id
 msgid "Fund"
 msgstr "กองทุน"
@@ -1071,6 +1079,7 @@ msgid "Partner Information"
 msgstr "ข้อมูลคู่ค้า"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__partner_type_id
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__partner_type
 msgid "Partner Type"
 msgstr "จ่ายตาม"
@@ -1140,6 +1149,7 @@ msgid "Signed"
 msgstr "ลงนามแล้ว"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__source_analytic_id
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__source_analytic_id
 msgid "Source"
 msgstr "แหล่งเงิน"
@@ -1297,6 +1307,7 @@ msgid "Assignment Rules"
 msgstr "กฎการมอบหมาย"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_assignment_rule__user_id
 msgid "Assigned Officer"
 msgstr "เจ้าหน้าที่ผู้รับผิดชอบ"
 

--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -238,7 +238,7 @@ msgstr ""
 #. module: disbursement
 #: model:ir.ui.menu,name:disbursement.menu_disbursement_config
 msgid "Configuration"
-msgstr ""
+msgstr "ตั้งค่า"
 
 #. module: disbursement
 #: model_terms:ir.ui.view,arch_db:disbursement.portal_disbursement_request_page
@@ -302,7 +302,7 @@ msgstr "การขอเบิก"
 #. module: disbursement
 #: model:ir.actions.act_window,name:disbursement.action_disbursement_exception_rule
 msgid "Disbursement Exception Rules"
-msgstr ""
+msgstr "กฎข้อยกเว้นการขอเบิก"
 
 #. module: disbursement
 #: model:ir.model,name:disbursement.model_disbursement_exception_confirm
@@ -395,7 +395,7 @@ msgstr ""
 #. module: disbursement
 #: model:ir.ui.menu,name:disbursement.menu_disbursement_exception_rules
 msgid "Exception Rules"
-msgstr ""
+msgstr "กฎข้อยกเว้น"
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__exception_ids
@@ -1291,6 +1291,8 @@ msgid "Assign Disbursement Verification Officer"
 msgstr "มอบหมายเจ้าหน้าที่หมวดตรวจใบขอเบิก"
 
 #. module: disbursement
+#: model:ir.actions.act_window,name:disbursement.action_disbursement_assignment_rule
+#: model:ir.ui.menu,name:disbursement.menu_disbursement_assignment_rule
 msgid "Assignment Rules"
 msgstr "กฎการมอบหมาย"
 
@@ -1361,14 +1363,19 @@ msgid "Disbursement Verification"
 msgstr "หมวดตรวจ"
 
 #. module: disbursement
+#: model:ir.ui.menu,name:disbursement.menu_disbursement_verification
 msgid "Verification"
 msgstr "หมวดตรวจ"
 
 #. module: disbursement
+#: model:ir.actions.act_window,name:disbursement.action_disbursement_my_verifications
+#: model:ir.ui.menu,name:disbursement.menu_disbursement_my_verifications
 msgid "My Work"
 msgstr "งานของฉัน"
 
 #. module: disbursement
+#: model:ir.actions.act_window,name:disbursement.action_disbursement_all
+#: model:ir.ui.menu,name:disbursement.menu_disbursement_all_requests
 msgid "All Disbursement Requests"
 msgstr "ใบขอเบิกทั้งหมด"
 


### PR DESCRIPTION
Disbursement menu labels showed in English because their `th.po` entries either had an empty `msgstr` or lacked a `#:` reference line, which Odoo silently skips on import. This binds the six Disbursement menus (Configuration, Exception Rules, Verification, My Work, All Disbursement Requests, Assignment Rules) and their backing window actions to the existing Thai translations, with no XML changes. Terms reuse the wording already used elsewhere in the repo (e.g. `หมวดตรวจ`, `งานของฉัน`, `กฎการมอบหมาย`). Verify by upgrading the module with `-u disbursement --language=th_TH` and checking the การขอเบิก app menu in Thai. (Supersedes #970, which auto-closed when its head branch was renamed.)