### PR TITLE
[16.0][IMP] agx_approval: add per-line note on approval request line

### DIFF
--- a/agx_approval/i18n/th.po
+++ b/agx_approval/i18n/th.po
@@ -562,6 +562,11 @@ msgid "Next Activity Type"
 msgstr ""
 
 #. module: agx_approval
+#: model:ir.model.fields,field_description:agx_approval.field_approval_request_line__note
+msgid "Note"
+msgstr "หมายเหตุ"
+
+#. module: agx_approval
 #: model:ir.model.fields,field_description:agx_approval.field_approval_request__message_needaction_counter
 msgid "Number of Actions"
 msgstr ""

--- a/agx_approval/models/approval_request_line.py
+++ b/agx_approval/models/approval_request_line.py
@@ -43,6 +43,10 @@ class ApprovalRequestLine(models.Model):
         required=True
     )
 
+    note = fields.Text(
+        string="Note",
+    )
+
     company_id = fields.Many2one(
         string="Company",
         comodel_name="res.company",

--- a/agx_approval/views/approval_request_views.xml
+++ b/agx_approval/views/approval_request_views.xml
@@ -113,6 +113,7 @@
                                     <field name="currency_id" invisible="1"/>
                                     <field name="partner_id"/>
                                     <field name="product_id"/>
+                                    <field name="note"/>
                                     <field name="total_amount" sum="Total"/>
                                     <field name="actual_amount" attrs="{'column_invisible': [('parent.state', 'not in', ['approved', 'billed'])]}" readonly="1" sum="Total"/>
                                 </tree>

--- a/agx_approval_disbursement/models/approval_request_line.py
+++ b/agx_approval_disbursement/models/approval_request_line.py
@@ -11,7 +11,7 @@ class ApprovalRequestLine(models.Model):
         )
         return {
             "product_id": self.product_id.id,
-            "name": self.product_id.display_name,
+            "name": self.note or self.product_id.display_name,
             "quantity": 1,
             "price_unit": self.actual_amount,
             "account_id": account.id if account else False,

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -160,7 +160,6 @@
                             <field name="wht_line_ids" nolabel="1">
                                 <tree create="0" delete="0" edit="0">
                                     <field name="partner_id" string="Disburser"/>
-                                    <field name="name" string="Name"/>
                                     <field name="wht_tax_id" string="WHT Item"/>
                                     <field name="price_subtotal" string="Amount Before WHT"/>
                                     <field name="amount_wht" string="WHT Deduction"/>

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -133,7 +133,7 @@
                                     <field name="partner_id" required="1" />
                                     <field name="partner_bank_id" optional="hide" />
                                     <field name="product_id" />
-                                    <field name="name" optional="hide" />
+                                    <field name="name" optional="show" />
                                     <field name="quantity" />
                                     <field name="price_unit" />
                                     <field name="tax_ids" widget="many2many_tags" optional="hide" />


### PR DESCRIPTION
## สรุป
เพิ่มช่อง **หมายเหตุ (Note)** แบบข้อความหลายบรรทัดในแต่ละบรรทัดของ `approval.request.line`
เพื่อให้ผู้ใช้ระบุหมายเหตุประจำบรรทัดได้ และให้หมายเหตุนี้ carry over ไปแสดงที่บรรทัดของใบเบิก (disbursement request line)

## การเปลี่ยนแปลง
- **`agx_approval/models/approval_request_line.py`** — เพิ่ม field `note = fields.Text(string="Note")` (ไม่บังคับกรอก)
- **`agx_approval/views/approval_request_views.xml`** — เพิ่มคอลัมน์ Note ใน tree หน้า Request Lines (แก้ไขได้เฉพาะสถานะ draft)
- **`agx_approval/i18n/th.po`** — เพิ่มคำแปล `Note` → `หมายเหตุ`
- **`agx_approval_disbursement/models/approval_request_line.py`** — `_prepare_disbursement_request_line_vals()` ส่งหมายเหตุไปที่ช่อง Description (`name`) ของบรรทัดใบเบิก โดย fallback เป็นชื่อสินค้าเมื่อไม่ได้กรอก
- **`disbursement/views/disbursement_request_views.xml`** — แสดงคอลัมน์ Description (`name`) เป็นค่าเริ่มต้นในตารางหน้า **Request Lines** (`optional="show"`) เพื่อให้เห็นหมายเหตุที่ carry over มา

## หมายเหตุการออกแบบ
- ใช้ `string="Note"` แทน `"Description"` เพราะ msgid `"Description"` ถูกใช้ไปแล้วในโมดูล (แปลว่า "เหตุผล/ความจำเป็น") หากใช้ซ้ำคำแปลจะชนกัน
- ปลายทาง `disbursement.request.line.name` เป็น `required=True` จึงต้อง fallback เป็นชื่อสินค้าเพื่อไม่ให้การสร้างใบเบิกล้มเหลว

## การทดสอบ
1. อัปเดตโมดูล `-u agx_approval,agx_approval_disbursement,disbursement`
2. เปิด Approval Request สถานะ draft → หน้า Request Lines เห็นคอลัมน์ "หมายเหตุ" กรอกได้
3. state != draft → คอลัมน์ read-only
4. กรอกหมายเหตุบางบรรทัด → สร้าง Disbursement Request → หน้า Request Lines เห็นคอลัมน์ Description = หมายเหตุที่กรอก, บรรทัดที่ไม่กรอก = ชื่อสินค้า