### PR TITLE
[16.0][IMP] disbursement: generalize return-to-source and add return-to-verification

### DIFF
--- a/agx_approval_disbursement/__manifest__.py
+++ b/agx_approval_disbursement/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Aginix Approval Disbursement",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "Accounting",
     "author": "KMITL",
     "depends": ["agx_approval", "disbursement"],

--- a/agx_approval_disbursement/migrations/16.0.1.3.0/pre-migration.py
+++ b/agx_approval_disbursement/migrations/16.0.1.3.0/pre-migration.py
@@ -1,0 +1,25 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+
+def migrate(cr, version):
+    """Carry the AR-specific ``returned_to_approval`` flag over to the generic
+    ``returned_to_source`` field (now owned by the ``disbursement`` module), so
+    any in-flight returns keep their banner and validation guard after the
+    return-to-source refactor. ``disbursement`` upgrades first (dependency), so
+    ``returned_to_source`` already exists here."""
+    cr.execute(
+        """
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'disbursement_request'
+          AND column_name = 'returned_to_approval'
+        """
+    )
+    if not cr.fetchone():
+        return
+    cr.execute(
+        """
+        UPDATE disbursement_request
+        SET returned_to_source = TRUE
+        WHERE returned_to_approval IS TRUE
+        """
+    )

--- a/agx_approval_disbursement/models/approval_request.py
+++ b/agx_approval_disbursement/models/approval_request.py
@@ -14,7 +14,9 @@ RETURNED_READONLY_STATES = {
 
 
 class ApprovalRequest(models.Model):
-    _inherit = "approval.request"
+    _name = "approval.request"
+    _inherit = ["approval.request", "disbursement.return.source.mixin"]
+    _disbursement_return_state = "billed"
 
     state = fields.Selection(
         selection_add=[("returned", "Returned")],
@@ -44,65 +46,34 @@ class ApprovalRequest(models.Model):
             if rec.state == "returned":
                 rec.is_editable = False
 
-    def action_return(self):
-        """Bounce a billed request back to the requester for correction.
-
-        Triggered when its disbursement request is returned by the verification
-        officer (see disbursement_request._action_return_for_edit). The
-        disbursement request is kept as-is at 'signed'; only the approval
-        request moves to 'returned', where a limited set of fields can be
-        corrected before confirming."""
-        for record in self:
-            if record.state != "billed":
-                raise UserError(_("Only billed requests can be returned."))
-            record.state = "returned"
-        return True
-
-    def action_confirm_correction(self):
-        """Confirm a returned request's correction: push the corrected payee
-        bank, description and disbursement evidence onto the existing (signed)
-        disbursement request, clear its returned banner, and move the approval
-        request back to 'billed'. The disbursement request stays at 'signed'
-        for the officer to continue verification."""
+    # -- return-to-source contract (disbursement.return.source.mixin) -----
+    def _disbursement_get_request(self):
         self.ensure_one()
-        if self.state != "returned":
-            raise UserError(
-                _("Only returned requests can confirm a correction.")
-            )
-        disbursement = self.disbursement_request_ids.filtered(
-            lambda d: d.returned_to_approval and d.state != "cancel"
-        )[:1] or self.disbursement_request_ids.filtered(
-            lambda d: d.state != "cancel"
-        )[:1]
-        self.state = "billed"
-        if disbursement:
-            disbursement.sudo()._apply_approval_correction(self)
-            self.message_post(
-                body=_(
-                    "Correction confirmed; disbursement %(dr)s updated.",
-                    dr=disbursement.name,
-                )
-            )
-        return True
+        return self._disbursement_pick_request(self.disbursement_request_ids)
 
-    def _copy_new_evidence_to_disbursement(self, disbursement):
-        """Copy disbursement-evidence attachments added during the correction
-        onto the disbursement request, skipping any already present (matched by
-        checksum) so re-confirming never duplicates files."""
+    def _disbursement_apply_correction(self, dr):
+        """Push the corrected payee bank, description and disbursement evidence
+        onto the still-signed DR. The banner/To-Do/state bookkeeping is handled
+        generically by disbursement.request._apply_source_correction."""
         self.ensure_one()
-        existing = set(
-            self.env["ir.attachment"].sudo().search([
-                ("res_model", "=", "disbursement.request"),
-                ("res_id", "=", disbursement.id),
-            ]).mapped("checksum")
-        )
-        for attachment in self.disbursement_attachment_ids:
-            if attachment.checksum in existing:
-                continue
-            attachment.sudo().copy({
-                "res_model": "disbursement.request",
-                "res_id": disbursement.id,
-            })
+        dr.note = self.description
+        payee_bank = {
+            payee.partner_id.id: payee.partner_bank_id.id
+            for payee in self.payee_ids
+            if payee.partner_bank_id
+        }
+        for line in dr.line_ids:
+            bank = payee_bank.get(line.partner_id.id)
+            if bank:
+                line.partner_bank_id = bank
+        self._disbursement_copy_evidence(dr)
+
+    def _disbursement_evidence_attachments(self):
+        return self.disbursement_attachment_ids
+
+    def _disbursement_correction_user(self):
+        self.ensure_one()
+        return self.user_id or self.create_uid
 
     def action_ready_to_bill(self):
         """Clerical staff marks a direct/prepaid request ready for the finance

--- a/agx_approval_disbursement/models/disbursement_request.py
+++ b/agx_approval_disbursement/models/disbursement_request.py
@@ -1,32 +1,6 @@
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
-# Dedicated activity types (see data/mail_activity_type_data.xml) so the
-# return/correction To-Dos can be routed and auto-resolved by activity_type_id
-# -- language-independent, unlike matching on the translated summary text.
-_ACT_AR_CORRECT = "agx_approval_disbursement.mail_activity_ar_correct"
-_ACT_AR_DONE = "agx_approval_disbursement.mail_activity_ar_done"
-_ACT_DR_AWAIT = "agx_approval_disbursement.mail_activity_dr_await"
-_ACT_DR_CONTINUE = "agx_approval_disbursement.mail_activity_dr_continue"
-
-
-def _schedule_todo(record, user, act_xmlid, note=False):
-    """Raise a To-Do of the given activity type on ``record`` for ``user``
-    (no-op without a user). The activity type's translated name is the title."""
-    if user:
-        record.activity_schedule(act_xmlid, user_id=user.id, note=note or "")
-
-
-def _resolve_todos(record, act_xmlid):
-    """Auto-resolve (remove) the open activities of ``act_xmlid`` on ``record``.
-
-    Matches on activity_type_id, so resolution works regardless of the language
-    the activity was scheduled in."""
-    act_type = record.env.ref(act_xmlid)
-    record.activity_ids.filtered(
-        lambda a: a.activity_type_id == act_type
-    ).unlink()
-
 
 class DisbursementRequest(models.Model):
     _inherit = "disbursement.request"
@@ -45,142 +19,11 @@ class DisbursementRequest(models.Model):
         ondelete={'approval.request': 'set null'},
     )
 
-    returned_to_approval = fields.Boolean(
-        string="Returned to Approval Request",
-        copy=False,
-        help="Set when this request was returned: it is kept as-is at 'signed' "
-             "and its approval request is bounced to 'returned' for correction. "
-             "Cleared once the correction is confirmed.",
-    )
-
-    def action_validate(self):
-        """Block validation while a correction is pending on the approval side.
-
-        The request is kept at 'signed' when returned, so without this guard the
-        officer could validate/approve (and obligate budget) against the stale
-        data before the requester confirms the correction."""
-        for record in self:
-            if record.returned_to_approval:
-                raise UserError(
-                    _(
-                        "This request was returned to its approval request. "
-                        "Please wait for the corrected approval to be confirmed "
-                        "before validating."
-                    )
-                )
-        res = super().action_validate()
-        # The officer acted on the correction: auto-resolve the "continue
-        # verification" / "submitted" To-Dos on both sides.
-        for record in self:
-            _resolve_todos(record, _ACT_DR_CONTINUE)
-            if record.approval_request_id:
-                _resolve_todos(record.approval_request_id.sudo(), _ACT_AR_DONE)
-        return res
-
-    def _action_return_for_edit(self, reason):
-        """Return an approval-linked request to its approval request instead of
-        to draft.
-
-        For a request created from an approval request, returning it keeps the
-        DR as-is at 'signed' (no cancel, no budget change) and bounces the
-        approval request to 'returned' so the requester can correct a limited
-        set of fields in place. Requests with no approval request keep the
-        standard signed -> draft return-for-correction behaviour."""
-        ar_linked = self.filtered("approval_request_id")
-        for record in ar_linked:
-            record._return_to_approval_request(reason)
-        remaining = self - ar_linked
-        if remaining:
-            return super(
-                DisbursementRequest, remaining
-            )._action_return_for_edit(reason)
-        return True
-
-    def _return_to_approval_request(self, reason):
-        """Bounce the linked approval request without touching this DR.
-
-        The DR is kept as-is at 'signed' (no cancel, no budget change); only the
-        approval request moves to 'returned' for correction. A banner is shown
-        on the DR and a To-Do is raised for the approval request's owner."""
-        self.ensure_one()
-        if self.state != "signed":
-            raise UserError(
-                _("Only a request under verification (signed) can be returned.")
-            )
-        self.returned_to_approval = True
-        # The officer may not have write access to approval.request; sudo the
-        # approval-side state change, chatter and To-Do.
-        approval = self.approval_request_id.sudo()
-        approval.action_return()
-        self.message_post(body=_("Returned to approval request: %s") % reason)
-        # Emphatic, hard-to-miss notice on the approval request chatter.
-        approval.message_post(
-            body=_(
-                "<p><b>Returned for correction</b></p>"
-                "<p>Disbursement <b>%(dr)s</b> was returned by the "
-                "verification officer.<br/>"
-                "Reason: <b>%(reason)s</b><br/>"
-                "Please correct the payee bank, description or disbursement "
-                "evidence, then click <b>Confirm Correction</b>.</p>",
-                dr=self.name,
-                reason=reason,
-            ),
-            subtype_xmlid="mail.mt_comment",
-        )
-        # Raise To-Dos on both sides: the requester must correct, the officer
-        # is notified their return is pending.
-        _schedule_todo(
-            approval,
-            approval.user_id or approval.create_uid,
-            _ACT_AR_CORRECT,
-            reason,
-        )
-        _schedule_todo(
-            self, self.assigned_to or self.user_id, _ACT_DR_AWAIT, reason
-        )
-        return True
-
-    def _apply_approval_correction(self, approval):
-        """Push a returned approval request's corrected payee bank, description
-        and disbursement evidence onto this request, then clear the returned
-        banner. The DR is kept at 'signed' for the officer to continue
-        verification."""
-        self.ensure_one()
-        self.note = approval.description
-        payee_bank = {
-            payee.partner_id.id: payee.partner_bank_id.id
-            for payee in approval.payee_ids
-            if payee.partner_bank_id
-        }
-        for line in self.line_ids:
-            bank = payee_bank.get(line.partner_id.id)
-            if bank:
-                line.partner_bank_id = bank
-        approval._copy_new_evidence_to_disbursement(self)
-        self.returned_to_approval = False
-        approval_sudo = approval.sudo()
-        # Auto-resolve the return To-Dos on both sides now the correction is in.
-        _resolve_todos(self, _ACT_DR_AWAIT)
-        _resolve_todos(approval_sudo, _ACT_AR_CORRECT)
-        # Notify both sides that the correction has been submitted.
-        _schedule_todo(
-            self,
-            self.assigned_to or self.user_id,
-            _ACT_DR_CONTINUE,
-            approval.description,
-        )
-        _schedule_todo(
-            approval_sudo,
-            approval.user_id or approval.create_uid,
-            _ACT_AR_DONE,
-        )
-        self.message_post(
-            body=_(
-                "Approval correction applied: payee bank, description and "
-                "evidence updated. Please continue verification."
-            )
-        )
-        return True
+    def _get_return_source(self):
+        """An approval-request-linked DR returns to its approval request for
+        correction (see disbursement.return.source.mixin / the generic
+        _action_return_for_edit dispatcher)."""
+        return self.approval_request_id or super()._get_return_source()
 
     def action_view_approval_request(self):
         self.ensure_one()

--- a/agx_approval_disbursement/views/disbursement_request_views.xml
+++ b/agx_approval_disbursement/views/disbursement_request_views.xml
@@ -8,13 +8,9 @@
             ref="disbursement.view_disbursement_request_form"
         />
         <field name="arch" type="xml">
-            <xpath expr="//header" position="after">
-                <field name="returned_to_approval" invisible="1" />
-                <div class="alert alert-warning" role="alert" style="margin-bottom:0px;"
-                    attrs="{'invisible': [('returned_to_approval', '=', False)]}">
-                    <p><strong>Returned:</strong> This disbursement request was returned to its approval request for correction.</p>
-                </div>
-            </xpath>
+            <!-- The "returned to source" banner and the hide-Return-when-returned
+                 behaviour are now generic (base disbursement view + assignment
+                 view, keyed on returned_to_source). -->
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="approval_request_id" invisible="1" />
                 <button
@@ -24,32 +20,6 @@
                     icon="fa-check-circle"
                     string="Approval"
                     attrs="{'invisible': [('approval_request_id', '=', False)]}"
-                />
-            </xpath>
-        </field>
-    </record>
-
-    <!-- Hide the Return button once returned, until the requester confirms the
-         correction (returned_to_approval is cleared). -->
-    <record id="view_disbursement_request_form_assignment_return" model="ir.ui.view">
-        <field name="name">disbursement.request.form.assignment.return.approval</field>
-        <field name="model">disbursement.request</field>
-        <field
-            name="inherit_id"
-            ref="disbursement.view_disbursement_request_form_assignment"
-        />
-        <field name="arch" type="xml">
-            <!-- Replace (not just re-attr) the button so its "Return" label is a
-                 translatable term owned by this module's view; the core
-                 disbursement translation for it is not applied. -->
-            <xpath expr="//button[@name='action_return_open_wizard']" position="replace">
-                <button
-                    name="action_return_open_wizard"
-                    type="object"
-                    string="Return"
-                    class="btn-warning"
-                    groups="disbursement.group_disbursement_officer"
-                    attrs="{'invisible': ['|', ('state', '!=', 'signed'), ('returned_to_approval', '=', True)]}"
                 />
             </xpath>
         </field>

--- a/disbursement/__manifest__.py
+++ b/disbursement/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Disbursement",
-    "version": "16.0.4.2.0",
+    "version": "16.0.4.3.0",
     "category": "Disbursement",
     "license": "LGPL-3",
     "author": "KMITL",
@@ -21,6 +21,7 @@
         "security/security.xml",
         "security/ir.model.access.csv",
         "data/sequence.xml",
+        "data/mail_activity_type_data.xml",
         "wizards/disbursement_exception_confirm.xml",
         "wizards/assign_officer_wizard_views.xml",
         "wizards/return_request_wizard_views.xml",

--- a/disbursement/data/mail_activity_type_data.xml
+++ b/disbursement/data/mail_activity_type_data.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Generic return/correction To-Do activity types. Matched by
+         activity_type_id (language-independent) rather than by translated
+         summary text. The source-side types carry no res_model so they can be
+         raised on any correctable source document (approval.request,
+         purchase.order, purchase.request.approval, work.acceptance, ...). -->
+    <record id="mail_activity_source_correct" model="mail.activity.type">
+        <field name="name">Correct and confirm the returned document</field>
+    </record>
+    <record id="mail_activity_source_done" model="mail.activity.type">
+        <field name="name">Correction submitted to the disbursement officer</field>
+    </record>
+    <record id="mail_activity_dr_await" model="mail.activity.type">
+        <field name="name">Disbursement returned - awaiting source correction</field>
+        <field name="res_model">disbursement.request</field>
+    </record>
+    <record id="mail_activity_dr_continue" model="mail.activity.type">
+        <field name="name">Source corrected - continue verification</field>
+        <field name="res_model">disbursement.request</field>
+    </record>
+</odoo>

--- a/disbursement/data/mail_activity_type_data.xml
+++ b/disbursement/data/mail_activity_type_data.xml
@@ -19,4 +19,10 @@
         <field name="name">Source corrected - continue verification</field>
         <field name="res_model">disbursement.request</field>
     </record>
+    <!-- Raised on the officer when an approver/accounting returns a request to
+         verification, so the re-check is never missed. -->
+    <record id="mail_activity_dr_reverify" model="mail.activity.type">
+        <field name="name">Disbursement returned - please re-verify</field>
+        <field name="res_model">disbursement.request</field>
+    </record>
 </odoo>

--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -1395,147 +1395,182 @@ msgid "No disbursement request is assigned to you."
 msgstr "ยังไม่มีใบขอเบิกที่มอบหมายให้คุณ"
 
 #. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form_assignment
 msgid "Return"
 msgstr "ตีกลับ"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
+#: model_terms:ir.ui.view,arch_db:disbursement.disbursement_return_request_wizard_form
 msgid "Return for Correction"
 msgstr "ตีกลับเพื่อแก้ไข"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__returned_for_edit
 msgid "Returned for Correction"
 msgstr "ถูกตีกลับเพื่อแก้ไข"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_return_request_wizard__reason
 msgid "Reason"
 msgstr "เหตุผล"
 
 #. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.disbursement_return_request_wizard_form
 msgid "Reason for returning this request…"
 msgstr "ระบุเหตุผลที่ตีกลับใบขอเบิกนี้…"
 
 #. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form_assignment
 msgid "Resubmit to Verification"
 msgstr "ส่งกลับหมวดตรวจ"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 #, python-format
 msgid "Returned for correction: %s"
 msgstr "ตีกลับเพื่อแก้ไข: %s"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 msgid "Returned for correction"
 msgstr "ตีกลับเพื่อแก้ไข"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 msgid "Corrected and returned to verification."
 msgstr "แก้ไขแล้ว ส่งกลับหมวดตรวจ"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 #, python-format
 msgid "Only a request under verification (signed) can be returned."
 msgstr "ตีกลับได้เฉพาะใบที่อยู่ระหว่างหมวดตรวจ (สถานะ signed) เท่านั้น"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 #, python-format
 msgid "Only a returned request in draft can be resubmitted."
 msgstr "ส่งกลับได้เฉพาะใบที่ถูกตีกลับและอยู่สถานะ draft เท่านั้น"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 #, python-format
 msgid "Cannot resubmit a disbursement request with no lines."
 msgstr "ส่งกลับไม่ได้ เพราะใบขอเบิกไม่มีรายการ"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form_assignment
 msgid "Return to Verification"
 msgstr "ตีกลับให้หมวดตรวจ"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__returned_to_verification
 msgid "Returned to Verification"
 msgstr "ถูกตีกลับให้หมวดตรวจ"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__return_verification_reason
 msgid "Return to Verification Reason"
 msgstr "เหตุผลการตีกลับให้หมวดตรวจ"
 
 #. module: disbursement
-#, python-format
-msgid "Returned to verification: %s"
-msgstr "ตีกลับให้หมวดตรวจ: %s"
-
-#. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "Returned to verification:"
 msgstr "ตีกลับให้หมวดตรวจ:"
 
 #. module: disbursement
-#, python-format
-msgid ""
-"Only a verified or approved request can be returned to verification."
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
+msgid "Only a verified or approved request can be returned to verification."
 msgstr "ตีกลับให้หมวดตรวจได้เฉพาะใบที่ตรวจสอบแล้ว (verified) หรืออนุมัติแล้ว (approved) เท่านั้น"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__returned_to_source
 msgid "Returned to Source"
 msgstr "ถูกตีกลับไปต้นเรื่อง"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_request__return_source_reason
 msgid "Return to Source Reason"
 msgstr "เหตุผลการตีกลับไปต้นเรื่อง"
 
 #. module: disbursement
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_form
 msgid "Returned to source for correction:"
 msgstr "ถูกตีกลับไปแก้ไขที่ต้นเรื่อง:"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_return_source_mixin__disbursement_return_note
 msgid "Correction Note"
 msgstr "หมายเหตุการแก้ไข"
 
 #. module: disbursement
+#: model:ir.model.fields,field_description:disbursement.field_disbursement_return_source_mixin__disbursement_return_bank_id
 msgid "Correction Bank Account"
 msgstr "บัญชีธนาคารที่แก้ไข"
 
 #. module: disbursement
-#, python-format
-msgid "Returned to source document: %s"
-msgstr "ตีกลับไปต้นเรื่อง: %s"
-
-#. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
 msgid "This document cannot be returned in its current state."
 msgstr "ไม่สามารถตีกลับเอกสารนี้ในสถานะปัจจุบันได้"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
 msgid "Only returned documents can confirm a correction."
 msgstr "ยืนยันการแก้ไขได้เฉพาะเอกสารที่ถูกตีกลับเท่านั้น"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
 #, python-format
 msgid "Correction confirmed; disbursement %s updated."
 msgstr "ยืนยันการแก้ไขแล้ว อัปเดตใบขอเบิก %s เรียบร้อย"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
 msgid ""
 "Source correction applied: payee bank, description and evidence updated. "
 "Please continue verification."
 msgstr "นำการแก้ไขจากต้นเรื่องมาใช้แล้ว: อัปเดตบัญชีธนาคารผู้รับเงิน คำอธิบาย และเอกสารหลักฐาน กรุณาดำเนินการตรวจสอบต่อ"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
 msgid ""
 "This request was returned to its source document. Please wait for the "
 "correction to be confirmed before validating."
 msgstr "ใบขอเบิกนี้ถูกตีกลับไปยังต้นเรื่องแล้ว กรุณารอการยืนยันการแก้ไขก่อนตรวจสอบ"
 
 #. module: disbursement
+#: model:mail.activity.type,name:disbursement.mail_activity_source_correct
 msgid "Correct and confirm the returned document"
 msgstr "แก้ไขและยืนยันเอกสารที่ถูกตีกลับ"
 
 #. module: disbursement
+#: model:mail.activity.type,name:disbursement.mail_activity_source_done
 msgid "Correction submitted to the disbursement officer"
 msgstr "ส่งการแก้ไขให้เจ้าหน้าที่เบิกจ่ายแล้ว"
 
 #. module: disbursement
+#: model:mail.activity.type,name:disbursement.mail_activity_dr_await
 msgid "Disbursement returned - awaiting source correction"
 msgstr "ใบขอเบิกถูกตีกลับ - รอการแก้ไขจากต้นเรื่อง"
 
 #. module: disbursement
+#: model:mail.activity.type,name:disbursement.mail_activity_dr_continue
 msgid "Source corrected - continue verification"
 msgstr "ต้นเรื่องแก้ไขแล้ว - ดำเนินการตรวจสอบต่อ"
 
@@ -1545,6 +1580,8 @@ msgid "Disbursement returned - please re-verify"
 msgstr "ใบขอเบิกถูกตีกลับ - กรุณาตรวจสอบใหม่"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
 #, python-format
 msgid ""
 "<p><b>Returned to source for correction</b></p>"
@@ -1560,6 +1597,8 @@ msgstr ""
 "เหตุผล: <b>%(reason)s</b></p>"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 #, python-format
 msgid ""
 "<p><b>Returned for correction</b></p>"
@@ -1571,6 +1610,8 @@ msgstr ""
 "<br/>เหตุผล: <b>%s</b></p>"
 
 #. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_request_assignment.py:0
 #, python-format
 msgid ""
 "<p><b>Returned to verification</b></p>"
@@ -1580,3 +1621,20 @@ msgstr ""
 "<p><b>ตีกลับให้หมวดตรวจ</b></p>"
 "<p>ตีกลับให้เจ้าหน้าที่ตรวจสอบเพื่อตรวจสอบใหม่"
 "<br/>เหตุผล: <b>%s</b></p>"
+
+#. module: disbursement
+#. odoo-python
+#: code:addons/disbursement/models/disbursement_return_source.py:0
+#, python-format
+msgid ""
+"<p><b>Returned for correction</b></p>"
+"<p>Disbursement <b>%(dr)s</b> was returned by the "
+"verification officer.<br/>Reason: <b>%(reason)s</b><br/>"
+"Please correct the payee bank, description or evidence, then "
+"click <b>Confirm Correction</b>.</p>"
+msgstr ""
+"<p><b>ถูกตีกลับเพื่อแก้ไข</b></p>"
+"<p>ใบขอเบิก <b>%(dr)s</b> ถูกตีกลับโดยเจ้าหน้าที่ตรวจสอบ"
+"<br/>เหตุผล: <b>%(reason)s</b><br/>"
+"กรุณาแก้ไขเลขบัญชีผู้รับเงิน คำอธิบาย หรือหลักฐาน แล้วกด "
+"<b>ยืนยันการแก้ไข</b></p>"

--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -1445,3 +1445,96 @@ msgstr "ส่งกลับได้เฉพาะใบที่ถูกต
 #, python-format
 msgid "Cannot resubmit a disbursement request with no lines."
 msgstr "ส่งกลับไม่ได้ เพราะใบขอเบิกไม่มีรายการ"
+
+#. module: disbursement
+msgid "Return to Verification"
+msgstr "ตีกลับให้หมวดตรวจ"
+
+#. module: disbursement
+msgid "Returned to Verification"
+msgstr "ถูกตีกลับให้หมวดตรวจ"
+
+#. module: disbursement
+msgid "Return to Verification Reason"
+msgstr "เหตุผลการตีกลับให้หมวดตรวจ"
+
+#. module: disbursement
+#, python-format
+msgid "Returned to verification: %s"
+msgstr "ตีกลับให้หมวดตรวจ: %s"
+
+#. module: disbursement
+msgid "Returned to verification:"
+msgstr "ตีกลับให้หมวดตรวจ:"
+
+#. module: disbursement
+#, python-format
+msgid ""
+"Only a verified or approved request can be returned to verification."
+msgstr "ตีกลับให้หมวดตรวจได้เฉพาะใบที่ตรวจสอบแล้ว (verified) หรืออนุมัติแล้ว (approved) เท่านั้น"
+
+#. module: disbursement
+msgid "Returned to Source"
+msgstr "ถูกตีกลับไปต้นเรื่อง"
+
+#. module: disbursement
+msgid "Return to Source Reason"
+msgstr "เหตุผลการตีกลับไปต้นเรื่อง"
+
+#. module: disbursement
+msgid "Returned to source for correction:"
+msgstr "ถูกตีกลับไปแก้ไขที่ต้นเรื่อง:"
+
+#. module: disbursement
+msgid "Correction Note"
+msgstr "หมายเหตุการแก้ไข"
+
+#. module: disbursement
+msgid "Correction Bank Account"
+msgstr "บัญชีธนาคารที่แก้ไข"
+
+#. module: disbursement
+#, python-format
+msgid "Returned to source document: %s"
+msgstr "ตีกลับไปต้นเรื่อง: %s"
+
+#. module: disbursement
+msgid "This document cannot be returned in its current state."
+msgstr "ไม่สามารถตีกลับเอกสารนี้ในสถานะปัจจุบันได้"
+
+#. module: disbursement
+msgid "Only returned documents can confirm a correction."
+msgstr "ยืนยันการแก้ไขได้เฉพาะเอกสารที่ถูกตีกลับเท่านั้น"
+
+#. module: disbursement
+#, python-format
+msgid "Correction confirmed; disbursement %s updated."
+msgstr "ยืนยันการแก้ไขแล้ว อัปเดตใบขอเบิก %s เรียบร้อย"
+
+#. module: disbursement
+msgid ""
+"Source correction applied: payee bank, description and evidence updated. "
+"Please continue verification."
+msgstr "นำการแก้ไขจากต้นเรื่องมาใช้แล้ว: อัปเดตบัญชีธนาคารผู้รับเงิน คำอธิบาย และเอกสารหลักฐาน กรุณาดำเนินการตรวจสอบต่อ"
+
+#. module: disbursement
+msgid ""
+"This request was returned to its source document. Please wait for the "
+"correction to be confirmed before validating."
+msgstr "ใบขอเบิกนี้ถูกตีกลับไปยังต้นเรื่องแล้ว กรุณารอการยืนยันการแก้ไขก่อนตรวจสอบ"
+
+#. module: disbursement
+msgid "Correct and confirm the returned document"
+msgstr "แก้ไขและยืนยันเอกสารที่ถูกตีกลับ"
+
+#. module: disbursement
+msgid "Correction submitted to the disbursement officer"
+msgstr "ส่งการแก้ไขให้เจ้าหน้าที่เบิกจ่ายแล้ว"
+
+#. module: disbursement
+msgid "Disbursement returned - awaiting source correction"
+msgstr "ใบขอเบิกถูกตีกลับ - รอการแก้ไขจากต้นเรื่อง"
+
+#. module: disbursement
+msgid "Source corrected - continue verification"
+msgstr "ต้นเรื่องแก้ไขแล้ว - ดำเนินการตรวจสอบต่อ"

--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -1538,3 +1538,45 @@ msgstr "ใบขอเบิกถูกตีกลับ - รอการแ
 #. module: disbursement
 msgid "Source corrected - continue verification"
 msgstr "ต้นเรื่องแก้ไขแล้ว - ดำเนินการตรวจสอบต่อ"
+
+#. module: disbursement
+#: model:mail.activity.type,name:disbursement.mail_activity_dr_reverify
+msgid "Disbursement returned - please re-verify"
+msgstr "ใบขอเบิกถูกตีกลับ - กรุณาตรวจสอบใหม่"
+
+#. module: disbursement
+#, python-format
+msgid ""
+"<p><b>Returned to source for correction</b></p>"
+"<p>This request was returned to its source document "
+"<b>%(source)s</b> by the verification officer. It stays under "
+"verification until the correction is confirmed.<br/>"
+"Reason: <b>%(reason)s</b></p>"
+msgstr ""
+"<p><b>ตีกลับไปแก้ไขที่ต้นเรื่อง</b></p>"
+"<p>ใบขอเบิกนี้ถูกตีกลับไปยังต้นเรื่อง <b>%(source)s</b> "
+"โดยเจ้าหน้าที่ตรวจสอบ และยังคงอยู่ระหว่างการตรวจสอบ "
+"จนกว่าจะมีการยืนยันการแก้ไข<br/>"
+"เหตุผล: <b>%(reason)s</b></p>"
+
+#. module: disbursement
+#, python-format
+msgid ""
+"<p><b>Returned for correction</b></p>"
+"<p>Returned to the requester and reset to draft so it can be "
+"corrected and resubmitted.<br/>Reason: <b>%s</b></p>"
+msgstr ""
+"<p><b>ตีกลับเพื่อแก้ไข</b></p>"
+"<p>ตีกลับให้ผู้ขอเบิกและเปลี่ยนสถานะกลับเป็นร่าง เพื่อแก้ไขและส่งใหม่"
+"<br/>เหตุผล: <b>%s</b></p>"
+
+#. module: disbursement
+#, python-format
+msgid ""
+"<p><b>Returned to verification</b></p>"
+"<p>Returned to the verification officer for re-checking."
+"<br/>Reason: <b>%s</b></p>"
+msgstr ""
+"<p><b>ตีกลับให้หมวดตรวจ</b></p>"
+"<p>ตีกลับให้เจ้าหน้าที่ตรวจสอบเพื่อตรวจสอบใหม่"
+"<br/>เหตุผล: <b>%s</b></p>"

--- a/disbursement/models/__init__.py
+++ b/disbursement/models/__init__.py
@@ -8,3 +8,6 @@ from . import assignment_rule
 # Imported after disbursement_request so its action_sign/validate/draft/cancel
 # overrides sit on top of the base model in the method resolution order.
 from . import disbursement_request_assignment
+# Imported last so the generic return-to-source dispatcher (_action_return_for_edit)
+# and the action_validate guard sit on top of the assignment overrides in the MRO.
+from . import disbursement_return_source

--- a/disbursement/models/disbursement_request.py
+++ b/disbursement/models/disbursement_request.py
@@ -813,6 +813,10 @@ class DisbursementRequest(models.Model):
         consume line for the DR amount, leaving the BC open for other DRs.
         """
         self.ensure_one()
+        # Idempotent: a request returned to verification (approved -> signed)
+        # keeps its obligation, so re-approving must not double-cut the budget.
+        if self._has_own_budget_obligation():
+            return
         commitment = self._check_commitment_obligable()
         first_reserve = self._get_commitment_reserve_line(commitment)
         self.env["budget.commitment.line"].create(
@@ -911,6 +915,21 @@ class DisbursementRequest(models.Model):
         )
         own.action_cancel()
         return True
+
+    def _has_own_budget_obligation(self):
+        """Whether this request already has a posted obligate line on its
+        commitment (used to keep _action_approve_budget idempotent across a
+        return-to-verification round trip)."""
+        self.ensure_one()
+        commitment = self.budget_commitment_id
+        return bool(commitment) and bool(
+            commitment.line_ids.filtered(
+                lambda l: l.state == "posted"
+                and l.move_type == "obligate"
+                and l.res_model == "disbursement.request"
+                and l.res_id == self.id
+            )
+        )
 
     def action_cancel(self):
         """Cancel the request.

--- a/disbursement/models/disbursement_request_assignment.py
+++ b/disbursement/models/disbursement_request_assignment.py
@@ -37,6 +37,18 @@ class DisbursementRequest(models.Model):
         string="Returned for Correction",
         copy=False,
     )
+    # Set when an approver (verified) or the accounting room (approved) returns
+    # the request to the verification officer for a re-check. The request goes
+    # back to 'signed'; cleared once the officer re-validates it.
+    returned_to_verification = fields.Boolean(
+        string="Returned to Verification",
+        copy=False,
+        tracking=True,
+    )
+    return_verification_reason = fields.Text(
+        string="Return to Verification Reason",
+        copy=False,
+    )
 
     # -- guards ----------------------------------------------------------
     def _assignment_takeover_allowed(self):
@@ -203,6 +215,49 @@ class DisbursementRequest(models.Model):
         self._assignment_auto_assign()
         self.message_post(body=_("Corrected and returned to verification."))
 
+    # -- return to verification (approver / accounting -> officer) -------
+    def action_return_verification_open_wizard(self):
+        """Open the reason wizard for returning the request to the verification
+        officer (used by the approver at 'verified' and accounting at 'approved')."""
+        self.ensure_one()
+        return {
+            "name": _("Return to Verification"),
+            "type": "ir.actions.act_window",
+            "res_model": "disbursement.return.request.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_request_id": self.id,
+                "default_mode": "verification",
+            },
+        }
+
+    def _action_return_to_verification(self, reason):
+        """Send a verified/approved request back to the verification officer.
+
+        Moves the request to 'signed' (where the officer re-verifies), records
+        the reason, and re-raises the officer's To-Do. The budget is left
+        untouched: an approved request keeps its obligation/consumption, and a
+        re-approval will not double-cut it (see _action_approve_budget)."""
+        self.ensure_one()
+        if self.state not in ("verified", "approved"):
+            raise UserError(
+                _("Only a verified or approved request can be returned to "
+                  "verification.")
+            )
+        self.returned_to_verification = True
+        self.return_verification_reason = reason
+        self.state = "signed"
+        self.message_post(body=_("Returned to verification: %s") % reason)
+        self._assignment_auto_assign()
+        return True
+
+    def _clear_returned_to_verification(self):
+        for rec in self:
+            if rec.returned_to_verification:
+                rec.returned_to_verification = False
+                rec.return_verification_reason = False
+
     # -- auto-assign + workflow hooks ------------------------------------
     def _assignment_auto_assign(self):
         """Assign the matching officer to signed requests and raise a To-Do.
@@ -231,14 +286,17 @@ class DisbursementRequest(models.Model):
     def action_validate(self):
         res = super().action_validate()
         self._assignment_close_activity()
+        self._clear_returned_to_verification()
         return res
 
     def action_draft(self):
         res = super().action_draft()
         self._assignment_close_activity()
+        self._clear_returned_to_verification()
         return res
 
     def action_cancel(self):
         res = super().action_cancel()
         self._assignment_close_activity()
+        self._clear_returned_to_verification()
         return res

--- a/disbursement/models/disbursement_request_assignment.py
+++ b/disbursement/models/disbursement_request_assignment.py
@@ -7,6 +7,10 @@ from odoo.tools.misc import str2bool
 # The "To Do" activity raised on a request when an officer is assigned.
 ASSIGN_ACTIVITY_XMLID = "mail.mail_activity_data_todo"
 
+# The "please re-verify" To-Do raised when an approver/accounting returns a
+# request to the verification officer (see _action_return_to_verification).
+_ACT_REVERIFY_XMLID = "disbursement.mail_activity_dr_reverify"
+
 # ir.config_parameter that relaxes the self-claim guard. Defaults to True:
 # because assignment is advisory, an officer may claim a mis-routed request
 # out of the box. Set to False to lock claims to the assigned officer/manager.
@@ -185,7 +189,12 @@ class DisbursementRequest(models.Model):
         # verification to-do.
         self.action_draft()
         self.message_post(
-            body=_("Returned for correction: %s") % reason,
+            body=_(
+                "<p><b>Returned for correction</b></p>"
+                "<p>Returned to the requester and reset to draft so it can be "
+                "corrected and resubmitted.<br/>Reason: <b>%s</b></p>"
+            ) % reason,
+            subtype_xmlid="mail.mt_comment",
         )
         if self.user_id:
             self.activity_schedule(
@@ -248,15 +257,37 @@ class DisbursementRequest(models.Model):
         self.returned_to_verification = True
         self.return_verification_reason = reason
         self.state = "signed"
-        self.message_post(body=_("Returned to verification: %s") % reason)
-        self._assignment_auto_assign()
+        # Always raise a "please re-verify" To-Do so the officer (or, failing
+        # that, the creator) is aware -- do not rely on the assignment-rule
+        # re-notification, which only fires when a rule/officer matches.
+        recipient = self.assigned_to or self.user_id
+        if recipient:
+            self.activity_schedule(
+                _ACT_REVERIFY_XMLID,
+                user_id=recipient.id,
+                note=reason or "",
+            )
+        self.message_post(
+            body=_(
+                "<p><b>Returned to verification</b></p>"
+                "<p>Returned to the verification officer for re-checking."
+                "<br/>Reason: <b>%s</b></p>"
+            ) % reason,
+            subtype_xmlid="mail.mt_comment",
+        )
         return True
 
     def _clear_returned_to_verification(self):
+        act_type = self.env.ref(_ACT_REVERIFY_XMLID, raise_if_not_found=False)
         for rec in self:
-            if rec.returned_to_verification:
-                rec.returned_to_verification = False
-                rec.return_verification_reason = False
+            if not rec.returned_to_verification:
+                continue
+            rec.returned_to_verification = False
+            rec.return_verification_reason = False
+            if act_type:
+                rec.activity_ids.filtered(
+                    lambda a: a.activity_type_id == act_type
+                ).unlink()
 
     # -- auto-assign + workflow hooks ------------------------------------
     def _assignment_auto_assign(self):

--- a/disbursement/models/disbursement_return_source.py
+++ b/disbursement/models/disbursement_return_source.py
@@ -1,0 +1,284 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+# Generic return/correction To-Do activity types (data/mail_activity_type_data.xml).
+# Matched by activity_type_id (language-independent), so resolution works
+# regardless of the language an activity was scheduled in.
+_ACT_SOURCE_CORRECT = "disbursement.mail_activity_source_correct"
+_ACT_SOURCE_DONE = "disbursement.mail_activity_source_done"
+_ACT_DR_AWAIT = "disbursement.mail_activity_dr_await"
+_ACT_DR_CONTINUE = "disbursement.mail_activity_dr_continue"
+
+
+def _schedule_todo(record, user, act_xmlid, note=False):
+    """Raise a To-Do of the given activity type on ``record`` for ``user``
+    (no-op without a user). The activity type's translated name is the title."""
+    if user:
+        record.activity_schedule(act_xmlid, user_id=user.id, note=note or "")
+
+
+def _resolve_todos(record, act_xmlid):
+    """Auto-resolve (remove) the open activities of ``act_xmlid`` on ``record``."""
+    act_type = record.env.ref(act_xmlid)
+    record.activity_ids.filtered(
+        lambda a: a.activity_type_id == act_type
+    ).unlink()
+
+
+class DisbursementReturnSourceMixin(models.AbstractModel):
+    """Contract for a source document that a disbursement request can be
+    returned to for correction-in-place.
+
+    When the verification officer returns a signed DR, the DR is kept as-is at
+    ``signed`` (no cancel, no budget change) and its source document is bounced
+    into a ``returned`` state where a limited set of fields can be corrected.
+    Confirming the correction pushes those fields back onto the DR and returns
+    the source to its prior state.
+
+    Each concrete source model (approval.request, purchase.order,
+    purchase.request.approval, work.acceptance) inherits this mixin, adds a
+    ``returned`` state to its own selection, sets ``_disbursement_return_state``
+    and implements the hooks below.
+    """
+
+    _name = "disbursement.return.source.mixin"
+    _description = "Correctable Disbursement Source"
+
+    # State the source sits in while a DR exists; a return cycles
+    # _disbursement_return_state -> 'returned' -> _disbursement_return_state.
+    _disbursement_return_state = None
+
+    # Staging fields edited while the source is 'returned'; the default
+    # _disbursement_apply_correction pushes them onto the DR on confirm. A source
+    # with a richer correction surface (e.g. approval.request's per-payee banks)
+    # overrides _disbursement_apply_correction and ignores these.
+    disbursement_return_note = fields.Text(
+        string="Correction Note",
+        copy=False,
+        help="Corrected description/note pushed onto the disbursement request "
+             "when the correction is confirmed.",
+    )
+    disbursement_return_bank_id = fields.Many2one(
+        comodel_name="res.partner.bank",
+        string="Correction Bank Account",
+        copy=False,
+        help="Corrected payee bank account pushed onto the disbursement request "
+             "lines when the correction is confirmed.",
+    )
+
+    def _disbursement_return(self, dr, reason):
+        """Move this source into ``returned`` for correction. Called (sudo) by
+        the DR side when a signed DR is returned by the verification officer."""
+        for rec in self:
+            if rec.state != rec._disbursement_return_state:
+                raise UserError(
+                    _("This document cannot be returned in its current state.")
+                )
+            rec.state = "returned"
+        return True
+
+    def action_confirm_correction(self):
+        """Requester confirms the correction: push the corrected fields onto the
+        still-signed DR and return this source to its prior state."""
+        self.ensure_one()
+        if self.state != "returned":
+            raise UserError(
+                _("Only returned documents can confirm a correction.")
+            )
+        dr = self._disbursement_get_request()
+        self.state = self._disbursement_return_state
+        if dr:
+            dr.sudo()._apply_source_correction(self)
+            self.message_post(
+                body=_("Correction confirmed; disbursement %s updated.")
+                % dr.name
+            )
+        return True
+
+    # -- hooks each concrete source implements ---------------------------
+    def _disbursement_get_request(self):
+        """Return the single disbursement.request to push the correction to."""
+        raise NotImplementedError
+
+    def _disbursement_pick_request(self, requests):
+        """Pick the DR a confirmed correction targets: the one flagged returned,
+        else the first non-cancelled. Shared helper for _disbursement_get_request."""
+        return requests.filtered(
+            lambda d: d.returned_to_source and d.state != "cancel"
+        )[:1] or requests.filtered(lambda d: d.state != "cancel")[:1]
+
+    def _disbursement_apply_correction(self, dr):
+        """Push this source's corrected fields onto the still-signed ``dr``.
+
+        Default: push the staging note/bank + copy evidence. Sources with a
+        richer correction surface override this. The generic banner/To-Do/state
+        bookkeeping is handled by the DR side (``_apply_source_correction``)."""
+        self.ensure_one()
+        if self.disbursement_return_note:
+            dr.note = self.disbursement_return_note
+        if self.disbursement_return_bank_id:
+            dr.line_ids.write(
+                {"partner_bank_id": self.disbursement_return_bank_id.id}
+            )
+        self._disbursement_copy_evidence(dr)
+
+    def _disbursement_correction_user(self):
+        """User to notify to perform the correction (the source owner)."""
+        self.ensure_one()
+        return self.create_uid
+
+    # -- evidence attachments --------------------------------------------
+    def _disbursement_evidence_attachments(self):
+        """Return the ir.attachment recordset holding correction evidence to
+        copy to the DR. Concrete source overrides to point at its own field."""
+        return self.env["ir.attachment"].browse()
+
+    def _disbursement_copy_evidence(self, dr):
+        """Copy newly-attached evidence onto the DR, skipping any already present
+        (matched by checksum) so re-confirming never duplicates files."""
+        self.ensure_one()
+        existing = set(
+            self.env["ir.attachment"].sudo().search([
+                ("res_model", "=", "disbursement.request"),
+                ("res_id", "=", dr.id),
+            ]).mapped("checksum")
+        )
+        for attachment in self._disbursement_evidence_attachments():
+            if attachment.checksum in existing:
+                continue
+            attachment.sudo().copy({
+                "res_model": "disbursement.request",
+                "res_id": dr.id,
+            })
+
+
+class DisbursementRequest(models.Model):
+    """Generic return-to-source layer on the DR.
+
+    Loaded after ``disbursement_request_assignment`` so the ``_action_return_for_edit``
+    dispatcher and the ``action_validate`` guard sit on top of the base
+    signed -> draft return-for-correction behaviour in the MRO.
+    """
+
+    _inherit = "disbursement.request"
+
+    returned_to_source = fields.Boolean(
+        string="Returned to Source",
+        copy=False,
+        tracking=True,
+        help="Set when this request was returned to its source document for "
+             "correction: the DR is kept at 'signed' and the source is bounced "
+             "to 'returned'. Cleared once the correction is confirmed.",
+    )
+    return_source_reason = fields.Text(
+        string="Return to Source Reason",
+        copy=False,
+    )
+
+    def _get_return_source(self):
+        """Return the source record (a ``disbursement.return.source.mixin``) to
+        bounce a return to, or an empty recordset. Bridges override and
+        super-chain; the most specific source wins (e.g. WA over PO, which the
+        module dependency order guarantees in the MRO)."""
+        self.ensure_one()
+        return self.env["disbursement.return.source.mixin"]
+
+    def _return_source_officer(self):
+        self.ensure_one()
+        return self.assigned_to or self.user_id
+
+    # -- return-for-correction dispatch ----------------------------------
+    def _action_return_for_edit(self, reason):
+        """Dispatch a return: DRs with a correctable source bounce the source to
+        'returned' (DR kept at 'signed'); the rest fall back to the base
+        signed -> draft return-for-correction."""
+        to_source = self.filtered(lambda d: d._get_return_source())
+        for record in to_source:
+            record._return_to_source(record._get_return_source(), reason)
+        remaining = self - to_source
+        if remaining:
+            return super()._action_return_for_edit(reason)
+        return True
+
+    def _return_to_source(self, source, reason):
+        """Bounce ``source`` to 'returned' without touching this DR (kept at
+        'signed', no budget change). Records the reason, posts chatter on both
+        sides, and raises To-Dos for the requester and the officer."""
+        self.ensure_one()
+        if self.state != "signed":
+            raise UserError(
+                _("Only a request under verification (signed) can be returned.")
+            )
+        self.returned_to_source = True
+        self.return_source_reason = reason
+        # The officer may not have write access to the source document; sudo the
+        # source-side state change, chatter and To-Do.
+        source = source.sudo()
+        source._disbursement_return(self, reason)
+        self.message_post(body=_("Returned to source document: %s") % reason)
+        source.message_post(
+            body=_(
+                "<p><b>Returned for correction</b></p>"
+                "<p>Disbursement <b>%(dr)s</b> was returned by the "
+                "verification officer.<br/>Reason: <b>%(reason)s</b><br/>"
+                "Please correct the payee bank, description or evidence, then "
+                "click <b>Confirm Correction</b>.</p>",
+                dr=self.name,
+                reason=reason,
+            ),
+            subtype_xmlid="mail.mt_comment",
+        )
+        _schedule_todo(
+            source, source._disbursement_correction_user(), _ACT_SOURCE_CORRECT, reason
+        )
+        _schedule_todo(self, self._return_source_officer(), _ACT_DR_AWAIT, reason)
+        return True
+
+    def _apply_source_correction(self, source):
+        """Pull ``source``'s corrected fields onto this signed DR, clear the
+        returned banner, and resolve/raise the return To-Dos on both sides."""
+        self.ensure_one()
+        source._disbursement_apply_correction(self)
+        self.returned_to_source = False
+        self.return_source_reason = False
+        source_sudo = source.sudo()
+        _resolve_todos(self, _ACT_DR_AWAIT)
+        _resolve_todos(source_sudo, _ACT_SOURCE_CORRECT)
+        _schedule_todo(self, self._return_source_officer(), _ACT_DR_CONTINUE)
+        _schedule_todo(
+            source_sudo, source._disbursement_correction_user(), _ACT_SOURCE_DONE
+        )
+        self.message_post(
+            body=_(
+                "Source correction applied: payee bank, description and "
+                "evidence updated. Please continue verification."
+            )
+        )
+        return True
+
+    def action_validate(self):
+        """Block validation while a correction is pending on the source side.
+
+        The DR is kept at 'signed' when returned, so without this guard the
+        officer could validate/approve (and obligate budget) against the stale
+        data before the requester confirms the correction."""
+        for record in self:
+            if record.returned_to_source:
+                raise UserError(
+                    _(
+                        "This request was returned to its source document. "
+                        "Please wait for the correction to be confirmed before "
+                        "validating."
+                    )
+                )
+        res = super().action_validate()
+        # The officer acted on the correction: auto-resolve the "continue
+        # verification" / "correction submitted" To-Dos on both sides.
+        for record in self:
+            _resolve_todos(record, _ACT_DR_CONTINUE)
+            source = record._get_return_source()
+            if source:
+                _resolve_todos(source.sudo(), _ACT_SOURCE_DONE)
+        return res

--- a/disbursement/models/disbursement_return_source.py
+++ b/disbursement/models/disbursement_return_source.py
@@ -217,7 +217,16 @@ class DisbursementRequest(models.Model):
         # source-side state change, chatter and To-Do.
         source = source.sudo()
         source._disbursement_return(self, reason)
-        self.message_post(body=_("Returned to source document: %s") % reason)
+        self.message_post(
+            body=_(
+                "<p><b>Returned to source for correction</b></p>"
+                "<p>This request was returned to its source document "
+                "<b>%(source)s</b> by the verification officer. It stays under "
+                "verification until the correction is confirmed.<br/>"
+                "Reason: <b>%(reason)s</b></p>"
+            ) % {"source": source.display_name, "reason": reason},
+            subtype_xmlid="mail.mt_comment",
+        )
         source.message_post(
             body=_(
                 "<p><b>Returned for correction</b></p>"

--- a/disbursement/tests/__init__.py
+++ b/disbursement/tests/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import test_assignment_rule
+from . import test_return_verification

--- a/disbursement/tests/test_return_verification.py
+++ b/disbursement/tests/test_return_verification.py
@@ -1,0 +1,123 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReturnToVerification(TransactionCase):
+    """Flow 2/3 return-to-verification: an approver (verified) or the accounting
+    room (approved) sends the request back to the officer (signed). No budget is
+    touched; the flag clears once the officer re-validates."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.DR = cls.env["disbursement.request"]
+        AAA = cls.env["account.analytic.account"]
+        dep_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_departments")
+        src_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_sources")
+        fund_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_funds")
+        act_plan = cls.env.ref("account_analytic_kmitl.analytic_plan_activities")
+        cls.dept = AAA.create({"name": "Dept", "plan_id": dep_plan.id})
+        cls.source = AAA.create({"name": "Gov", "plan_id": src_plan.id})
+        cls.fund = AAA.create({"name": "Fund", "plan_id": fund_plan.id})
+        cls.activity = AAA.create({"name": "Act", "plan_id": act_plan.id})
+        cls.partner = cls.env["res.partner"].create({"name": "Vendor"})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Svc", "type": "service"}
+        )
+        users = cls.env["res.users"].with_context(no_reset_password=True)
+        cls.manager = users.create(
+            {
+                "name": "Mgr",
+                "login": "rv_mgr",
+                "groups_id": [
+                    (4, cls.env.ref("disbursement.group_disbursement_manager").id)
+                ],
+            }
+        )
+
+    def _make_signed_dr(self):
+        dr = self.DR.create(
+            {
+                "line_ids": [
+                    (0, 0, {
+                        "product_id": self.product.id,
+                        "name": "line",
+                        "quantity": 1.0,
+                        "price_unit": 100.0,
+                        "partner_id": self.partner.id,
+                    })
+                ]
+            }
+        )
+        dr.analytic_distribution = {
+            str(self.dept.id): 100,
+            str(self.source.id): 100,
+            str(self.fund.id): 100,
+            str(self.activity.id): 100,
+        }
+        dr.action_submit()
+        dr.action_sign()
+        self.assertEqual(dr.state, "signed")
+        return dr
+
+    def _make_verified_dr(self):
+        dr = self._make_signed_dr()
+        dr.action_validate()
+        self.assertEqual(dr.state, "verified")
+        return dr
+
+    def test_return_from_verified_goes_to_signed(self):
+        dr = self._make_verified_dr()
+        dr._action_return_to_verification("please recheck")
+        self.assertEqual(dr.state, "signed")
+        self.assertTrue(dr.returned_to_verification)
+        self.assertEqual(dr.return_verification_reason, "please recheck")
+
+    def test_flag_cleared_on_revalidate(self):
+        dr = self._make_verified_dr()
+        dr._action_return_to_verification("recheck")
+        self.assertTrue(dr.returned_to_verification)
+        dr.action_validate()
+        self.assertEqual(dr.state, "verified")
+        self.assertFalse(dr.returned_to_verification)
+        self.assertFalse(dr.return_verification_reason)
+
+    def test_cannot_return_from_wrong_state(self):
+        dr = self.DR.create(
+            {
+                "line_ids": [
+                    (0, 0, {
+                        "product_id": self.product.id,
+                        "name": "line",
+                        "quantity": 1.0,
+                        "price_unit": 100.0,
+                        "partner_id": self.partner.id,
+                    })
+                ]
+            }
+        )
+        # draft -> cannot return to verification
+        with self.assertRaises(UserError):
+            dr._action_return_to_verification("x")
+
+    def test_return_for_edit_fallback_to_draft_without_source(self):
+        """The generic _action_return_for_edit dispatcher falls back to the base
+        signed -> draft behaviour for a DR with no correctable source."""
+        dr = self._make_signed_dr()
+        self.assertFalse(dr._get_return_source())
+        dr._action_return_for_edit("fix it")
+        self.assertEqual(dr.state, "draft")
+        self.assertTrue(dr.returned_for_edit)
+
+    def test_wizard_verification_mode_routes_to_return(self):
+        dr = self._make_verified_dr()
+        wizard = self.env["disbursement.return.request.wizard"].create(
+            {"request_id": dr.id, "reason": "via wizard", "mode": "verification"}
+        )
+        wizard.action_return()
+        self.assertEqual(dr.state, "signed")
+        self.assertTrue(dr.returned_to_verification)
+        self.assertEqual(dr.return_verification_reason, "via wizard")

--- a/disbursement/views/disbursement_request_assignment_views.xml
+++ b/disbursement/views/disbursement_request_assignment_views.xml
@@ -35,7 +35,7 @@
                     string="Return"
                     class="btn-warning"
                     groups="disbursement.group_disbursement_officer"
-                    attrs="{'invisible': [('state', '!=', 'signed')]}"
+                    attrs="{'invisible': ['|', ('state', '!=', 'signed'), ('returned_to_source', '=', True)]}"
                 />
                 <button
                     name="action_resubmit_verification"
@@ -43,6 +43,14 @@
                     string="Resubmit to Verification"
                     class="oe_highlight"
                     attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('returned_for_edit', '=', False)]}"
+                />
+                <button
+                    name="action_return_verification_open_wizard"
+                    type="object"
+                    string="Return to Verification"
+                    class="btn-warning"
+                    groups="disbursement.group_disbursement_manager"
+                    attrs="{'invisible': [('state', '!=', 'verified')]}"
                 />
             </xpath>
             <xpath expr="//group[@id='other_information']" position="inside">

--- a/disbursement/views/disbursement_request_views.xml
+++ b/disbursement/views/disbursement_request_views.xml
@@ -56,6 +56,18 @@
                     <span> เมื่อ </span>
                     <field name="budget_consumed_date" class="oe_inline" nolabel="1"/>
                 </div>
+                <!-- Returned to source for correction -->
+                <div class="alert alert-warning" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('returned_to_source', '=', False)]}">
+                    <field name="returned_to_source" invisible="1"/>
+                    <strong>Returned to source for correction:</strong>
+                    <field name="return_source_reason" class="oe_inline" nolabel="1" readonly="1"/>
+                </div>
+                <!-- Returned to the verification officer for a re-check -->
+                <div class="alert alert-warning" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('returned_to_verification', '=', False)]}">
+                    <field name="returned_to_verification" invisible="1"/>
+                    <strong>Returned to verification:</strong>
+                    <field name="return_verification_reason" class="oe_inline" nolabel="1" readonly="1"/>
+                </div>
                 <!-- Exception Alert -->
                 <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('exceptions_summary','=',False)]}">
                     <p>

--- a/disbursement/wizards/return_request_wizard.py
+++ b/disbursement/wizards/return_request_wizard.py
@@ -14,8 +14,17 @@ class DisbursementReturnRequestWizard(models.TransientModel):
         ondelete="cascade",
     )
     reason = fields.Text(string="Reason", required=True)
+    # "edit": return for correction (bounce to the source, or signed -> draft).
+    # "verification": approver/accounting return to the verification officer.
+    mode = fields.Selection(
+        selection=[("edit", "Edit"), ("verification", "Verification")],
+        default="edit",
+    )
 
     def action_return(self):
         self.ensure_one()
-        self.request_id._action_return_for_edit(self.reason)
+        if self.mode == "verification":
+            self.request_id._action_return_to_verification(self.reason)
+        else:
+            self.request_id._action_return_for_edit(self.reason)
         return {"type": "ir.actions.act_window_close"}

--- a/disbursement/wizards/return_request_wizard_views.xml
+++ b/disbursement/wizards/return_request_wizard_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <form string="Return for Correction">
                 <field name="request_id" invisible="1" />
+                <field name="mode" invisible="1" />
                 <group>
                     <field name="reason" placeholder="Reason for returning this request…" />
                 </group>

--- a/disbursement_accounting_kmitl/__manifest__.py
+++ b/disbursement_accounting_kmitl/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Disbursement ↔ KMITL Accounting Bridge",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "KMITL/Accounting",
     "summary": "DR ↔ Bill: enable vendor bill creation from disbursement "
     "requests and pipeline status sync",

--- a/disbursement_accounting_kmitl/i18n/th.po
+++ b/disbursement_accounting_kmitl/i18n/th.po
@@ -164,3 +164,16 @@ msgstr "ไม่สามารถยกเลิกได้: ใบตั้�
 #, python-format
 msgid "Disbursement requests awaiting billing"
 msgstr "ใบขอเบิกอนุมัติแล้ว รอตั้งหนี้"
+
+#. module: disbursement_accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:disbursement_accounting_kmitl.view_disbursement_request_form_inherit_accounting
+msgid "Return to Verification"
+msgstr "ตีกลับให้หมวดตรวจ"
+
+#. module: disbursement_accounting_kmitl
+#. odoo-python
+#: code:addons/disbursement_accounting_kmitl/models/disbursement_request.py:0
+#, python-format
+msgid ""
+"Cannot return to verification: bill(s) %s exist. Cancel the bill(s) first."
+msgstr "ตีกลับให้หมวดตรวจไม่ได้: มีใบตั้งหนี้ %s อยู่ กรุณายกเลิกใบตั้งหนี้ก่อน"

--- a/disbursement_accounting_kmitl/models/disbursement_request.py
+++ b/disbursement_accounting_kmitl/models/disbursement_request.py
@@ -328,3 +328,20 @@ class DisbursementRequest(models.Model):
             if draft_bills:
                 draft_bills.button_cancel()
         return super().action_cancel()
+
+    def _action_return_to_verification(self, reason):
+        """Accounting may return a request to verification only before a bill
+        exists; once billed the accountant must cancel the bill(s) first."""
+        for record in self:
+            active_bills = record.bill_ids.filtered(
+                lambda b: b.state != "cancel"
+            )
+            if active_bills:
+                raise UserError(
+                    _(
+                        "Cannot return to verification: bill(s) %s exist. "
+                        "Cancel the bill(s) first."
+                    )
+                    % ", ".join(active_bills.mapped("name"))
+                )
+        return super()._action_return_to_verification(reason)

--- a/disbursement_accounting_kmitl/views/disbursement_request_views.xml
+++ b/disbursement_accounting_kmitl/views/disbursement_request_views.xml
@@ -48,6 +48,12 @@
                         class="oe_highlight"
                         attrs="{'invisible': ['|', ('state', '!=', 'approved'), ('bill_count', '>', 0)]}"
                         groups="accounting_kmitl.group_accounting_kmitl_user"/>
+                <button name="action_return_verification_open_wizard"
+                        string="Return to Verification"
+                        type="object"
+                        class="btn-warning"
+                        attrs="{'invisible': ['|', ('state', '!=', 'approved'), ('bill_count', '>', 0)]}"
+                        groups="accounting_kmitl.group_accounting_kmitl_user"/>
             </xpath>
 
             <!-- Bills smart button -->

--- a/purchase_order_disbursement/__manifest__.py
+++ b/purchase_order_disbursement/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Purchase Order Disbursement',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.1.0',
     'summary': """ Purchase Order Disbursement Summary """,
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/purchase_order_disbursement/i18n/th.po
+++ b/purchase_order_disbursement/i18n/th.po
@@ -85,3 +85,28 @@ msgstr "ไลน์คำสั่งซื้อ"
 #: model:ir.model.fields,field_description:purchase_order_disbursement.field_purchase_order__disbursement_request_total
 msgid "Total Disbursement Request"
 msgstr "จำนวนใบขอเบิก"
+
+#. module: purchase_order_disbursement
+#: model_terms:ir.ui.view,arch_db:purchase_order_disbursement.view_purchase_order_form
+msgid "Confirm Correction"
+msgstr "ยืนยันการแก้ไข"
+
+#. module: purchase_order_disbursement
+#: model_terms:ir.ui.view,arch_db:purchase_order_disbursement.view_purchase_order_form
+msgid "Disbursement Correction"
+msgstr "การแก้ไขใบขอเบิก"
+
+#. module: purchase_order_disbursement
+#: model:ir.model.fields,field_description:purchase_order_disbursement.field_purchase_order__disbursement_return_attachment_ids
+msgid "Correction Evidence"
+msgstr "เอกสารหลักฐานการแก้ไข"
+
+#. module: purchase_order_disbursement
+#: model:ir.model.fields,field_description:purchase_order_disbursement.field_purchase_order__disbursement_return_note
+msgid "Correction Note"
+msgstr "หมายเหตุการแก้ไข"
+
+#. module: purchase_order_disbursement
+#: model:ir.model.fields,field_description:purchase_order_disbursement.field_purchase_order__disbursement_return_bank_id
+msgid "Correction Bank Account"
+msgstr "บัญชีธนาคารที่แก้ไข"

--- a/purchase_order_disbursement/models/disbursement_request.py
+++ b/purchase_order_disbursement/models/disbursement_request.py
@@ -29,6 +29,12 @@ class DisbursementRequest(models.Model):
             else:
                 rec.purchase_id = False
 
+    def _get_return_source(self):
+        """A PO-linked DR returns to its purchase order for correction. (A DR
+        that also has a Work Acceptance is routed to the WA by the WA bridge,
+        which overrides this and wins via the module dependency order.)"""
+        return self.purchase_id or super()._get_return_source()
+
     def _compute_analytic(self):
         """Merge analytic_distribution from first PO line when reference is a PO."""
         super()._compute_analytic()

--- a/purchase_order_disbursement/models/purchase_order.py
+++ b/purchase_order_disbursement/models/purchase_order.py
@@ -4,7 +4,22 @@ from odoo.exceptions import UserError, ValidationError
 
 
 class PurchaseOrder(models.Model):
-    _inherit = 'purchase.order'
+    _name = 'purchase.order'
+    _inherit = ['purchase.order', 'disbursement.return.source.mixin']
+    _disbursement_return_state = "purchase"
+
+    state = fields.Selection(
+        selection_add=[("returned", "Returned")],
+        ondelete={"returned": "set default"},
+    )
+    disbursement_return_attachment_ids = fields.Many2many(
+        comodel_name="ir.attachment",
+        relation="purchase_order_dr_return_attachment_rel",
+        column1="order_id",
+        column2="attachment_id",
+        string="Correction Evidence",
+        copy=False,
+    )
 
     disbursement_request_ids = fields.One2many(
         comodel_name='disbursement.request',
@@ -46,6 +61,14 @@ class PurchaseOrder(models.Model):
             order.hide_create_disbursement_request_button = (
                 order.state != "purchase" or not order.is_disbursement_request_allowed
             )
+
+    # -- return-to-source contract (disbursement.return.source.mixin) -----
+    def _disbursement_get_request(self):
+        self.ensure_one()
+        return self._disbursement_pick_request(self.disbursement_request_ids)
+
+    def _disbursement_evidence_attachments(self):
+        return self.disbursement_return_attachment_ids
 
     def _prepare_disbursement_request_vals(self):
         return {

--- a/purchase_order_disbursement/views/purchase_order_views.xml
+++ b/purchase_order_disbursement/views/purchase_order_views.xml
@@ -15,6 +15,23 @@
                     <field name='disbursement_request_ids' invisible="1"/>
                 </button>
             </xpath>
+            <!-- Return-to-source correction: Confirm button + statusbar + fields -->
+            <xpath expr="//field[@name='state'][@widget='statusbar']" position="before">
+                <button name="action_confirm_correction" type="object" string="Confirm Correction" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'returned')]}"/>
+            </xpath>
+            <xpath expr="//field[@name='state'][@widget='statusbar']" position="attributes">
+                <attribute name="statusbar_visible">draft,sent,purchase,returned</attribute>
+            </xpath>
+            <xpath expr="//notebook" position="before">
+                <div class="alert alert-warning" role="alert" attrs="{'invisible': [('state', '!=', 'returned')]}">
+                    <p><strong>Returned for correction.</strong> The disbursement officer returned the linked disbursement request. Correct the payee bank account and note and/or attach evidence below, then click <b>Confirm Correction</b>.</p>
+                </div>
+                <group name="disbursement_correction" string="Disbursement Correction" attrs="{'invisible': [('state', '!=', 'returned')]}">
+                    <field name="disbursement_return_bank_id" domain="[('partner_id', '=', partner_id)]" options="{'no_create': True}"/>
+                    <field name="disbursement_return_note"/>
+                    <field name="disbursement_return_attachment_ids" widget="many2many_binary"/>
+                </group>
+            </xpath>
         </field>
     </record>
 

--- a/purchase_request_approval_disbursement/__manifest__.py
+++ b/purchase_request_approval_disbursement/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Purchase Request Approval Disbursement',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.1.0',
     'summary': """ Purchase Request Approval Disbursement Summary """,
     "author": "Aginix Technologies",
     "website": "https://github.com/aginix/kmitl",

--- a/purchase_request_approval_disbursement/i18n/th.po
+++ b/purchase_request_approval_disbursement/i18n/th.po
@@ -157,3 +157,28 @@ msgstr "อยู่ระหว่างเบิกจ่าย"
 #: model_terms:ir.ui.view,arch_db:purchase_request_approval_disbursement.view_purchase_request_approval_form
 msgid "Purchase Request Approval Form"
 msgstr "แบบรายงานคำขอซื้อ/จ้าง (พจ.1)"
+
+#. module: purchase_request_approval_disbursement
+#: model_terms:ir.ui.view,arch_db:purchase_request_approval_disbursement.view_purchase_request_approval_form
+msgid "Confirm Correction"
+msgstr "ยืนยันการแก้ไข"
+
+#. module: purchase_request_approval_disbursement
+#: model_terms:ir.ui.view,arch_db:purchase_request_approval_disbursement.view_purchase_request_approval_form
+msgid "Disbursement Correction"
+msgstr "การแก้ไขใบขอเบิก"
+
+#. module: purchase_request_approval_disbursement
+#: model:ir.model.fields,field_description:purchase_request_approval_disbursement.field_purchase_request_approval__disbursement_return_attachment_ids
+msgid "Correction Evidence"
+msgstr "เอกสารหลักฐานการแก้ไข"
+
+#. module: purchase_request_approval_disbursement
+#: model:ir.model.fields,field_description:purchase_request_approval_disbursement.field_purchase_request_approval__disbursement_return_note
+msgid "Correction Note"
+msgstr "หมายเหตุการแก้ไข"
+
+#. module: purchase_request_approval_disbursement
+#: model:ir.model.fields,field_description:purchase_request_approval_disbursement.field_purchase_request_approval__disbursement_return_bank_id
+msgid "Correction Bank Account"
+msgstr "บัญชีธนาคารที่แก้ไข"

--- a/purchase_request_approval_disbursement/models/disbursement_request.py
+++ b/purchase_request_approval_disbursement/models/disbursement_request.py
@@ -29,6 +29,11 @@ class DisbursementRequest(models.Model):
             else:
                 rec.purchase_request_approval_id = False
 
+    def _get_return_source(self):
+        """A PRA-linked DR returns to its purchase request approval for
+        correction."""
+        return self.purchase_request_approval_id or super()._get_return_source()
+
     def action_view_purchase_approval(self):
         self.ensure_one()
         if not self.purchase_request_approval_id:

--- a/purchase_request_approval_disbursement/models/purchase_request_approval.py
+++ b/purchase_request_approval_disbursement/models/purchase_request_approval.py
@@ -4,7 +4,22 @@ from odoo.exceptions import UserError, ValidationError
 
 
 class PurchaseRequestApproval(models.Model):
-    _inherit = 'purchase.request.approval'
+    _name = 'purchase.request.approval'
+    _inherit = ['purchase.request.approval', 'disbursement.return.source.mixin']
+    _disbursement_return_state = "approved"
+
+    state = fields.Selection(
+        selection_add=[("returned", "Returned")],
+        ondelete={"returned": "set default"},
+    )
+    disbursement_return_attachment_ids = fields.Many2many(
+        comodel_name="ir.attachment",
+        relation="purchase_request_approval_dr_return_attachment_rel",
+        column1="approval_id",
+        column2="attachment_id",
+        string="Correction Evidence",
+        copy=False,
+    )
 
     use_purchase_order = fields.Boolean(
         string='Use Purchase Order',
@@ -112,6 +127,14 @@ class PurchaseRequestApproval(models.Model):
                 approval.billing_status = "cancel"
             else:
                 approval.billing_status = state_map.get(active[0].state, "draft")
+
+    # -- return-to-source contract (disbursement.return.source.mixin) -----
+    def _disbursement_get_request(self):
+        self.ensure_one()
+        return self._disbursement_pick_request(self.disbursement_request_ids)
+
+    def _disbursement_evidence_attachments(self):
+        return self.disbursement_return_attachment_ids
 
     def _prepare_disbursement_request_vals(self):
         return {

--- a/purchase_request_approval_disbursement/views/purchase_request_approval_views.xml
+++ b/purchase_request_approval_disbursement/views/purchase_request_approval_views.xml
@@ -82,6 +82,26 @@
                     </group>
                 </group>
             </xpath>
+            <!-- Return-to-source correction: Confirm button + statusbar + fields -->
+            <xpath expr="//field[@name='state'][@widget='statusbar']" position="before">
+                <button name="action_confirm_correction" type="object" string="Confirm Correction" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'returned')]}"/>
+            </xpath>
+            <xpath expr="//field[@name='state'][@widget='statusbar']" position="attributes">
+                <attribute name="statusbar_visible">draft,validate,to_approve,approved,returned</attribute>
+            </xpath>
+            <xpath expr="//header" position="after">
+                <div class="alert alert-warning" role="alert" attrs="{'invisible': [('state', '!=', 'returned')]}">
+                    <p><strong>Returned for correction.</strong> The disbursement officer returned the linked disbursement request. Correct the payee bank account and note and/or attach evidence below, then click <b>Confirm Correction</b>.</p>
+                </div>
+            </xpath>
+            <xpath expr="//sheet" position="inside">
+                <group name="disbursement_correction" string="Disbursement Correction" attrs="{'invisible': [('state', '!=', 'returned')]}">
+                    <field name="partner_id" invisible="1"/>
+                    <field name="disbursement_return_bank_id" domain="[('partner_id', '=', partner_id)]" options="{'no_create': True}"/>
+                    <field name="disbursement_return_note"/>
+                    <field name="disbursement_return_attachment_ids" widget="many2many_binary"/>
+                </group>
+            </xpath>
         </field>
     </record>
 

--- a/purchase_work_acceptance_disbursement/__manifest__.py
+++ b/purchase_work_acceptance_disbursement/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Purchase Work Acceptance Disbursement',
-    'version': '16.0.1.1.0',
+    'version': '16.0.1.2.0',
     'summary': """ Purchase Work Acceptance Disbursement Summary """,
     "category": "KMITL",
     "author": "Aginix Technologies",

--- a/purchase_work_acceptance_disbursement/i18n/th.po
+++ b/purchase_work_acceptance_disbursement/i18n/th.po
@@ -141,3 +141,28 @@ msgstr "มูลค่าก่อนภาษีหลังหักค่า
 #: model:ir.model.fields,field_description:purchase_work_acceptance_disbursement.field_purchase_order__wa_fines_total
 msgid "Amount disbursed"
 msgstr "จำนวนเงินที่เบิกแล้ว"
+
+#. module: purchase_work_acceptance_disbursement
+#: model_terms:ir.ui.view,arch_db:purchase_work_acceptance_disbursement.view_work_acceptance_form_inherit_disbursement
+msgid "Confirm Correction"
+msgstr "ยืนยันการแก้ไข"
+
+#. module: purchase_work_acceptance_disbursement
+#: model_terms:ir.ui.view,arch_db:purchase_work_acceptance_disbursement.view_work_acceptance_form_inherit_disbursement
+msgid "Disbursement Correction"
+msgstr "การแก้ไขใบขอเบิก"
+
+#. module: purchase_work_acceptance_disbursement
+#: model:ir.model.fields,field_description:purchase_work_acceptance_disbursement.field_work_acceptance__disbursement_return_attachment_ids
+msgid "Correction Evidence"
+msgstr "เอกสารหลักฐานการแก้ไข"
+
+#. module: purchase_work_acceptance_disbursement
+#: model:ir.model.fields,field_description:purchase_work_acceptance_disbursement.field_work_acceptance__disbursement_return_note
+msgid "Correction Note"
+msgstr "หมายเหตุการแก้ไข"
+
+#. module: purchase_work_acceptance_disbursement
+#: model:ir.model.fields,field_description:purchase_work_acceptance_disbursement.field_work_acceptance__disbursement_return_bank_id
+msgid "Correction Bank Account"
+msgstr "บัญชีธนาคารที่แก้ไข"

--- a/purchase_work_acceptance_disbursement/models/disbursement_request.py
+++ b/purchase_work_acceptance_disbursement/models/disbursement_request.py
@@ -51,6 +51,13 @@ class DisbursementRequest(models.Model):
         for rec in self:
             rec.wa_count = len(rec.wa_ids)
 
+    def _get_return_source(self):
+        """A DR backed by a Work Acceptance returns to the WA (not the PO its
+        ``reference`` points at): the correctable data lives on the WA. This
+        bridge depends on purchase_order_disbursement, so this override wins over
+        the PO one in the MRO."""
+        return self.wa_ids[:1] or super()._get_return_source()
+
     def action_sign(self):
         """Override: mark WA as disbursed เมื่อ submitted → unlock สร้าง WA ใหม่ได้"""
         res = super().action_sign()

--- a/purchase_work_acceptance_disbursement/models/work_acceptance.py
+++ b/purchase_work_acceptance_disbursement/models/work_acceptance.py
@@ -4,7 +4,22 @@ from odoo.exceptions import UserError
 
 
 class WorkAcceptance(models.Model):
-    _inherit = "work.acceptance"
+    _name = "work.acceptance"
+    _inherit = ["work.acceptance", "disbursement.return.source.mixin"]
+    _disbursement_return_state = "accept"
+
+    state = fields.Selection(
+        selection_add=[("returned", "Returned")],
+        ondelete={"returned": "set default"},
+    )
+    disbursement_return_attachment_ids = fields.Many2many(
+        comodel_name="ir.attachment",
+        relation="work_acceptance_dr_return_attachment_rel",
+        column1="wa_id",
+        column2="attachment_id",
+        string="Correction Evidence",
+        copy=False,
+    )
 
     is_disbursed = fields.Boolean(
         string="Disbursed",
@@ -20,6 +35,29 @@ class WorkAcceptance(models.Model):
         copy=False,
         ondelete="set null",
     )
+
+    # -- return-to-source contract (disbursement.return.source.mixin) -----
+    def _disbursement_get_request(self):
+        self.ensure_one()
+        return self._disbursement_pick_request(self.disbursement_request_id)
+
+    def _disbursement_evidence_attachments(self):
+        return self.disbursement_return_attachment_ids
+
+    def _disbursement_return(self, dr, reason):
+        # skip_validation_check: the WA is 'accept' with its tier reviews already
+        # cleared; the return (accept -> returned) must not re-trigger the tier
+        # write guard.
+        return super(
+            WorkAcceptance, self.with_context(skip_validation_check=True)
+        )._disbursement_return(dr, reason)
+
+    def action_confirm_correction(self):
+        # skip_validation_check: returned -> accept must not spawn a new tier
+        # review (the acceptance was already validated).
+        return super(
+            WorkAcceptance, self.with_context(skip_validation_check=True)
+        ).action_confirm_correction()
 
     @api.constrains("state")
     def _check_pending_disbursement_before_accept(self):

--- a/purchase_work_acceptance_disbursement/views/work_acceptance_views.xml
+++ b/purchase_work_acceptance_disbursement/views/work_acceptance_views.xml
@@ -11,6 +11,25 @@
                       readonly="1"
                       attrs="{'invisible': [('disbursement_request_id', '=', False)]}"/>
               </xpath>
+              <!-- Return-to-source correction: Confirm button + statusbar + fields -->
+              <xpath expr="//header//field[@name='state']" position="before">
+                  <button name="action_confirm_correction" type="object" string="Confirm Correction" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'returned')]}"/>
+              </xpath>
+              <xpath expr="//header//field[@name='state']" position="attributes">
+                  <attribute name="statusbar_visible">draft,in_review,accept,returned</attribute>
+              </xpath>
+              <xpath expr="//header" position="after">
+                  <div class="alert alert-warning" role="alert" attrs="{'invisible': [('state', '!=', 'returned')]}">
+                      <p><strong>Returned for correction.</strong> The disbursement officer returned the linked disbursement request. Correct the payee bank account and note and/or attach evidence below, then click <b>Confirm Correction</b>.</p>
+                  </div>
+              </xpath>
+              <xpath expr="//sheet" position="inside">
+                  <group name="disbursement_correction" string="Disbursement Correction" attrs="{'invisible': [('state', '!=', 'returned')]}">
+                      <field name="disbursement_return_bank_id" domain="[('partner_id', '=', partner_id)]" options="{'no_create': True}"/>
+                      <field name="disbursement_return_note"/>
+                      <field name="disbursement_return_attachment_ids" widget="many2many_binary"/>
+                  </group>
+              </xpath>
           </field>
       </record>
 


### PR DESCRIPTION
## Summary

Improves the disbursement request (DR) "return" (ตีกลับ) workflow in two ways:

**1. Generalized return-to-source correction (ตีกลับแก้ที่ต้นเรื่อง)**
Until now only an `approval.request` (AR) could receive a bounced DR for in-place correction. This adds a generic `disbursement.return.source.mixin` and extends the same *correct-in-place* pattern to **Purchase Order**, **Purchase Request Approval**, and **Work Acceptance**. The verification officer's existing **Return** button now routes automatically to whichever source the DR came from; the DR stays at `signed` (no budget change) while the source moves to a `returned` state where the requester may correct the **payee bank account, note and evidence attachments**, then **Confirm Correction** pushes them back onto the DR.

**2. Return-to-verification (ตีกลับไปหาหมวดตรวจ)**
- An **approver** (`verified`) can send a DR back to the verification officer (`signed`).
- The **accounting room** (`approved`, before a bill exists) can do the same.
- The budget obligation is **not reversed**; `_action_approve_budget` is made idempotent so re-approval never double-cuts the budget.

## What's included

| Area | Modules |
|---|---|
| Mixin + generic DR layer + activity types | `disbursement` |
| Refactor AR onto the mixin (+ migration `returned_to_approval` → `returned_to_source`) | `agx_approval_disbursement` |
| Return-to-source for PO / PRA / WA | `purchase_order_disbursement`, `purchase_request_approval_disbursement`, `purchase_work_acceptance_disbursement` |
| Return-to-verification (flow 2 & 3) + bill guard | `disbursement`, `disbursement_accounting_kmitl` |
| Wizard `mode`, banners, buttons, Thai i18n, version bumps | all of the above |

## Key design decisions

- **WA returns to the WA, not its PO** — the correctable data (lines, fine) lives on the work acceptance; routed via `wa_ids` and wins over the PO route through the module dependency order.
- **Correctable surface is deliberately narrow**: payee bank + note + evidence only (mirrors the AR ADR); structural fields (lines/amounts/budget) stay locked.
- **No budget reversal on return-to-verification** — the obligation is preserved and re-approval is idempotent.

## Testing / verification notes

- Syntax-checked all Python and validated all XML.
- Added tests for return-to-verification (flow 2), flag lifecycle, wizard `mode` routing, and the dispatcher fallback to `signed → draft` for source-less DRs (`disbursement/tests/test_return_verification.py`).
- **Not yet run against a live DB** (per repo policy of not auto-running tests). Please run `oca_install_addons` + `oca_run_tests` before merge — in particular to confirm the AR refactor does not regress and that all inherited-view xpaths load.

## Risks

- Refactor of the working AR flow (mitigated by the shared mixin + migration; needs regression run).
- Bridge-module `.po` `#:` references are best-effort; a translation export is recommended to finalize Thai strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
