### PR TITLE
[16.0][ADD] kris_project_assignment: assigned officer mixin + Todo

### DIFF
--- a/kris_project/CONTEXT.md
+++ b/kris_project/CONTEXT.md
@@ -1,68 +1,101 @@
 # KRIS Project
 
-Module for managing projects run under the KRIS unit (operating unit `99`). KMITL personnel who take on external academic-service or research work must channel it through KRIS; KRIS staff own the project data.
+Module for managing projects run under the KRIS unit (operating unit `99`). KMITL
+personnel who take on external academic-service or research work must channel it through
+KRIS; KRIS staff own the project data.
 
 ## Language
 
 ### People & roles
 
-**Project Manager** (หัวหน้าโครงการ / ผู้จัดการโครงการ):
-The internal KMITL employee who leads the project — a **data attribute** of the project record (`manager_id`, `hr.employee`), linked to a login via `hr.employee.user_id`. Has a login and read-only access to their own projects. Distinct namespace from the security tier `group_kris_project_manager` (= KRIS Admin); the same coexistence Odoo's own `project` module ships (`project.project.user_id` is labelled "Project Manager" alongside `group_project_manager`).
-_Avoid_: Leader, owner, responsible
+**Project Manager** (หัวหน้าโครงการ / ผู้จัดการโครงการ): The internal KMITL employee who
+leads the project — a **data attribute** of the project record (`manager_id`,
+`hr.employee`), linked to a login via `hr.employee.user_id`. Has a login and read-only
+access to their own projects. Distinct namespace from the security tier
+`group_kris_project_manager` (= KRIS Admin); the same coexistence Odoo's own `project`
+module ships (`project.project.user_id` is labelled "Project Manager" alongside
+`group_project_manager`). _Avoid_: Leader, owner, responsible
 
-**KRIS Officer** (เจ้าหน้าที่ KRIS):
-KRIS staff member who creates and manages all project data. The record's `user_id` ("Responsible") is the owning KRIS Officer, not the Project Leader.
+**KRIS Officer** (เจ้าหน้าที่ KRIS): KRIS staff member who creates and manages all
+project data. The record's `user_id` ("Responsible") is the owning KRIS Officer, not the
+Project Leader. This is the _fixed_ owner — it stays put across state transitions.
 _Avoid_: User, responsible person
 
-**KRIS Admin**:
-KRIS staff member responsible for module configuration (categories, types, allocation templates, exception rules). The highest security tier — `group_kris_project_manager` (Odoo's `manager` convention). Note: a security tier, not the project's `manager_id`.
+**Current Handler / Assigned Officer** (เจ้าหน้าที่ผู้รับผิดชอบปัจจุบัน): The KRIS
+Officer currently on the hook for acting on a project — a _rotating_ role, tracked in
+`assigned_to` (res.users) and provided by the `kris_project_assignment` add-on via the
+shared `assignment.mixin`. Distinct from `user_id` above: `user_id` is the fixed owner;
+`assigned_to` is who must action the record right now. Set through the Assign to me /
+Assign… / Unassign banner injected above the sheet; also surfaces in the unified Todo
+inbox when `base_assignment_todo` is installed. The open Todo is cleared automatically
+when the project reaches a closed state (`done` / `cancel` / `terminated` /
+`conditional_close`); the `assigned_to` field itself is retained as history. _Avoid_:
+"Responsible" (that means `user_id`), "assignee" (unqualified — the Todo inbox uses
+"Assigned Officer")
 
-**OU Executive** (ผู้บริหารหน่วยงาน) — *future*:
-An executive of a faculty/office who needs read-only access to projects belonging to their own Operating Unit.
+**KRIS Admin**: KRIS staff member responsible for module configuration (categories,
+types, allocation templates, exception rules). The highest security tier —
+`group_kris_project_manager` (Odoo's `manager` convention). Note: a security tier, not
+the project's `manager_id`.
+
+**OU Executive** (ผู้บริหารหน่วยงาน) — _future_: An executive of a faculty/office who
+needs read-only access to projects belonging to their own Operating Unit.
 
 ### Concepts
 
-**Operating Unit (OU)**:
-A faculty or office, identified by a numeric code (`01` Engineering … `99` KRIS). Provided by the `operating_unit` module. Intended as the scoping dimension for OU Executive read access.
+**Operating Unit (OU)**: A faculty or office, identified by a numeric code (`01`
+Engineering … `99` KRIS). Provided by the `operating_unit` module. Intended as the
+scoping dimension for OU Executive read access.
 
-**Maintenance Deduction** (ค่าบำรุง / ค่าบำรุงสถาบัน):
-The institutional fee KRIS deducts from a project's operating expense; the deducted total is the pool that is then allocated to departments. One of three **methods** determines the amount:
+**Maintenance Deduction** (ค่าบำรุง / ค่าบำรุงสถาบัน): The institutional fee KRIS
+deducts from a project's operating expense; the deducted total is the pool that is then
+allocated to departments. One of three **methods** determines the amount:
 
 - **Tiered** (ขั้นบันได): progressive rate brackets applied to the operating expense.
-- **Custom %** (กำหนดเปอร์เซ็นต์เอง): a manually entered percentage of the operating expense.
-- **Fixed Amount** (ระบุจำนวนเงิน): a manually entered baht figure used verbatim, independent of the operating expense.
+- **Custom %** (กำหนดเปอร์เซ็นต์เอง): a manually entered percentage of the operating
+  expense.
+- **Fixed Amount** (ระบุจำนวนเงิน): a manually entered baht figure used verbatim,
+  independent of the operating expense.
 
-_Avoid_: "Custom" unqualified — ambiguous now that both Custom % and Fixed Amount are manually entered. Name the method (Custom % vs Fixed Amount).
+_Avoid_: "Custom" unqualified — ambiguous now that both Custom % and Fixed Amount are
+manually entered. Name the method (Custom % vs Fixed Amount).
 
 ### Project & money
 
-**Installment** (งวดงาน):
-A scheduled milestone of contracted work, each with its own due date and payment amount; a project's value is broken down into these. `kris.project.installment`.
-_Avoid_: work period, work phase, payment schedule, payment installment
+**Installment** (งวดงาน): A scheduled milestone of contracted work, each with its own
+due date and payment amount; a project's value is broken down into these.
+`kris.project.installment`. _Avoid_: work period, work phase, payment schedule, payment
+installment
 
-**Receipt** (รายรับ):
-A single recorded payment received against a project — one document with a number, date and amount. `kris.project.receipt`.
-_Avoid_: revenue (a single one is never "a revenue")
+**Receipt** (รายรับ): A single recorded payment received against a project — one
+document with a number, date and amount. `kris.project.receipt`. _Avoid_: revenue (a
+single one is never "a revenue")
 
-**Revenue**:
-The aggregate received on a project — the running sum of its Receipts. A total, not a record.
+**Revenue**: The aggregate received on a project — the running sum of its Receipts. A
+total, not a record.
 
-**Project Value** (มูลค่าโครงการ):
-The total contracted value of a project; the baseline its operating expense, maintenance deduction and installment totals are derived from or checked against.
+**Project Value** (มูลค่าโครงการ): The total contracted value of a project; the baseline
+its operating expense, maintenance deduction and installment totals are derived from or
+checked against.
 
-**Installment-free project** (ไม่มีงวดงานกำกับ):
-A project whose งวด schedule isn't fixed or known up front (typically test/trial work), so it is not governed by งวด targets. Flag `no_installment_tracking`; see ADR-0001 for what this relaxes.
+**Installment-free project** (ไม่มีงวดงานกำกับ): A project whose งวด schedule isn't
+fixed or known up front (typically test/trial work), so it is not governed by งวด
+targets. Flag `no_installment_tracking`; see ADR-0001 for what this relaxes.
 
 ### Contracts
 
 A project is governed by two distinct contracts that must not be conflated:
 
-**Project Code** (รหัสโครงการ):
-KRIS's internal identifier for the project (`project_code`, e.g. `สญ.67-004`). Historically mislabelled "เลขที่สัญญา" / `contract_number`, but its values were always internal codes, never an external contract identifier.
-_Avoid_: "contract number" (ambiguous with the employer's).
+**Project Code** (รหัสโครงการ): KRIS's internal identifier for the project
+(`project_code`, e.g. `สญ.67-004`). Historically mislabelled "เลขที่สัญญา" /
+`contract_number`, but its values were always internal codes, never an external contract
+identifier. _Avoid_: "contract number" (ambiguous with the employer's).
 
-**Institute–Employer Contract** (สัญญาสถาบัน-ผู้ว่าจ้าง):
-The external contract between KMITL (the institute) and the Employer. Identified by `contract_number` (the employer's own contract id); period bounded by `date_contract_start` / `date_contract_end`.
+**Institute–Employer Contract** (สัญญาสถาบัน-ผู้ว่าจ้าง): The external contract between
+KMITL (the institute) and the Employer. Identified by `contract_number` (the employer's
+own contract id); period bounded by `date_contract_start` / `date_contract_end`.
 
-**KRIS–Project Manager Contract/MOU** (สัญญา/บันทึกข้อตกลง KRIS-หัวหน้าโครงการ):
-The internal agreement between the KRIS unit and the Project Manager that authorises the work and its compensation. Identified by its issue date (`kris_contract_date`). May be either a สัญญา (contract) or a บันทึกข้อตกลง (MOU) — same field covers both.
+**KRIS–Project Manager Contract/MOU** (สัญญา/บันทึกข้อตกลง KRIS-หัวหน้าโครงการ): The
+internal agreement between the KRIS unit and the Project Manager that authorises the
+work and its compensation. Identified by its issue date (`kris_contract_date`). May be
+either a สัญญา (contract) or a บันทึกข้อตกลง (MOU) — same field covers both.

--- a/kris_project_assignment/README.rst
+++ b/kris_project_assignment/README.rst
@@ -1,0 +1,59 @@
+=======================
+KRIS Project Assignment
+=======================
+
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
+    :alt: Beta
+.. |badge2| image:: https://img.shields.io/badge/license-LGPL--3-blue.png
+    :alt: License: LGPL-3
+
+|badge1| |badge2|
+
+Assign a KRIS Officer as the *current handler* on a KRIS project — the
+person responsible for acting on it right now — through the shared
+Assign to me / Assign… / Unassign banner from ``base_assignment``.
+
+**Table of contents**
+
+.. contents::
+   :local:
+
+Description
+===========
+
+This add-on inherits ``assignment.mixin`` on ``kris.project`` and declares
+the ``assigned_to`` field expected by the mixin. Officers self-claim
+unassigned projects; managers reassign or unassign. The assignment
+notification is a native ``mail.activity`` that also surfaces in the
+unified Todo inbox when ``base_assignment_todo`` is installed.
+
+Configuration
+=============
+
+None. Group membership drives who can claim (`kris_project.group_kris_project_officer`)
+and who can reassign / unassign (`kris_project.group_kris_project_manager`).
+
+Usage
+=====
+
+* **Assign to me** — visible on any unassigned project to a KRIS Officer.
+* **Assign…** / **Unassign** — visible to a KRIS Project Manager.
+* **Assigned to me** and **Unassigned** search filters plus a
+  *Group by Assigned Officer* option.
+* Any open assignment To-Do is cleared automatically when the project
+  reaches a closed state (``done`` / ``cancel`` / ``terminated`` /
+  ``conditional_close``); the ``assigned_to`` field itself is preserved
+  as history.
+
+Credits
+=======
+
+Authors
+-------
+
+* Aginix Technologies
+
+License
+=======
+
+LGPL-3

--- a/kris_project_assignment/__init__.py
+++ b/kris_project_assignment/__init__.py
@@ -1,0 +1,1 @@
+from . import models  # noqa: F401

--- a/kris_project_assignment/__manifest__.py
+++ b/kris_project_assignment/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "KRIS Project Assignment",
+    "version": "16.0.1.0.0",
+    "category": "KMITL",
+    "summary": "Assign a KRIS Officer as the current handler on a KRIS project",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "depends": [
+        "base_assignment",
+        "kris_project",
+    ],
+    "data": [
+        "views/kris_project_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "license": "LGPL-3",
+}

--- a/kris_project_assignment/docs/adr/0001-assignment-alongside-user_id.md
+++ b/kris_project_assignment/docs/adr/0001-assignment-alongside-user_id.md
@@ -1,0 +1,47 @@
+# `assigned_to` alongside `user_id` on `kris.project`
+
+`kris.project` already has `user_id` (`res.users`, string "Responsible") — the KRIS
+Officer who owns the record. `assignment.mixin` from `base_assignment` requires a field
+called `assigned_to`. This add-on introduces `assigned_to` as a **separate field**
+rather than renaming `user_id`.
+
+## Two roles, not one
+
+- `user_id` — the _fixed_ owner. Set at create (defaults to the creating user) and
+  rarely changes; drives per-user record rules and the "My Project" filter that already
+  exists in `kris_project`.
+- `assigned_to` — the _current handler_. A rotating role: an officer may claim an
+  unassigned project (Assign to me), a manager may reassign or unassign (Assign… /
+  Unassign). The associated `mail.activity` acts as a Todo-inbox reminder for the
+  assignee.
+
+These are two distinct concepts. A project owned (created) by Officer A may be
+_currently handled_ by Officer B during a specific phase without Officer A losing
+ownership. Collapsing both into one field would remove that distinction.
+
+## Why not rename `user_id`
+
+- Odoo convention treats `user_id` as the "responsible / owner" field across many core
+  models (`sale.order`, `purchase.order`, `mrp.production`, `project.project` — every
+  one keeps `user_id` for the owner and layers a separate concept for the current
+  actor).
+- CONTEXT.md already documents `user_id` as "the owning KRIS Officer", and the search
+  view exposes a `my_projects` filter (`user_id = uid`) users are familiar with.
+- Renaming an existing column with data in it needs a pre-migration and breaks any
+  downstream module that references `kris.project.user_id`.
+- The precedent set by `disbursement_assignment` (which added `assigned_to` alongside
+  disbursement.request's existing `user_id` for the creator) is the same shape.
+
+## Why not skip `user_id` entirely
+
+Removing `user_id` would break `my_projects` (users see it in daily use), existing
+record-rule scopes, and any external report that groups by "responsible". The cost of
+keeping both fields is a small amount of duplication in the form ("Responsible" and
+"Assigned Officer" appearing next to each other); the cost of removing `user_id` is
+measurable regression across the module.
+
+## Guarantee
+
+The two fields never diverge silently: assignment lifecycle events fire through the
+mixin's public API (`action_assignment_*`, wizard) and update only `assigned_to`.
+`user_id` continues to be written the way it always was.

--- a/kris_project_assignment/i18n/th.po
+++ b/kris_project_assignment/i18n/th.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* kris_project_assignment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-13 00:00+0000\n"
+"PO-Revision-Date: 2026-07-13 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: kris_project_assignment
+#: model:ir.model.fields,field_description:kris_project_assignment.field_kris_project__assigned_to
+#: model_terms:ir.ui.view,arch_db:kris_project_assignment.view_kris_project_search_assignment
+msgid "Assigned Officer"
+msgstr "เจ้าหน้าที่ผู้รับผิดชอบ"
+
+#. module: kris_project_assignment
+#. odoo-python
+#: code:addons/kris_project_assignment/models/kris_project.py:0
+#, python-format
+msgid "Assigned as responsible KRIS officer"
+msgstr "ถูกมอบหมายเป็นเจ้าหน้าที่ KRIS ผู้รับผิดชอบ"
+
+#. module: kris_project_assignment
+#: model_terms:ir.ui.view,arch_db:kris_project_assignment.view_kris_project_search_assignment
+msgid "Assigned to me"
+msgstr "งานที่มอบหมายให้ฉัน"
+
+#. module: kris_project_assignment
+#: model:ir.model,name:kris_project_assignment.model_kris_project
+msgid "KRIS Project"
+msgstr "โครงการ KRIS"
+
+#. module: kris_project_assignment
+#: model_terms:ir.ui.view,arch_db:kris_project_assignment.view_kris_project_search_assignment
+msgid "Unassigned"
+msgstr "ยังไม่มีคนรับผิดชอบ"

--- a/kris_project_assignment/models/__init__.py
+++ b/kris_project_assignment/models/__init__.py
@@ -1,1 +1,1 @@
-from . import kris_project  # noqa: F401
+from . import kris_project

--- a/kris_project_assignment/models/__init__.py
+++ b/kris_project_assignment/models/__init__.py
@@ -1,0 +1,1 @@
+from . import kris_project  # noqa: F401

--- a/kris_project_assignment/models/kris_project.py
+++ b/kris_project_assignment/models/kris_project.py
@@ -1,0 +1,62 @@
+from odoo import _, fields, models
+
+# Project states that mark a KRIS project as *closed* — no further handler
+# action is expected once one of these is reached, so any open assignment
+# To-Do on the record is cleared to keep assignee inboxes tidy.
+CLOSE_STATES = ("done", "cancel", "terminated", "conditional_close")
+
+
+class KrisProject(models.Model):
+    _name = "kris.project"
+    _inherit = ["kris.project", "assignment.mixin"]
+
+    _assign_user_group = "kris_project.group_kris_project_officer"
+    _assign_manager_group = "kris_project.group_kris_project_manager"
+
+    # New field: the KRIS Officer currently handling the project. Distinct
+    # from ``user_id`` ("Responsible" — the fixed owner/creator); see the
+    # module ADR-0001 and kris_project/CONTEXT.md for the semantic split.
+    assigned_to = fields.Many2one(
+        comodel_name="res.users",
+        string="Assigned Officer",
+        copy=False,
+        tracking=True,
+        index=True,
+    )
+
+    def _assignment_activity_summary(self):
+        return _("Assigned as responsible KRIS officer")
+
+    # No takeover: manager-only reassign. Deliberately not overriding
+    # ``_assignment_takeover_param`` — the base default returns ``None``,
+    # which the mixin reads as "takeover feature disabled".
+
+    def write(self, vals):
+        # Bulk-close open assignment To-Dos when the project transitions
+        # into a closed state, catching every entry point (direct write,
+        # action_cancel, and the state wizard which writes state=... via
+        # the ORM).
+        close_targets = self.env["kris.project"]
+        if "state" in vals and vals["state"] in CLOSE_STATES:
+            close_targets = self.filtered(lambda r: r.state != vals["state"])
+        res = super().write(vals)
+        if close_targets:
+            close_targets._assignment_close_activity()
+        return res
+
+    def _assignment_close_activity(self):
+        """Bulk-close every open assignment To-Do on this record.
+
+        The base ``_assignment_clear_activity(user)`` is per-user; project
+        close is state-driven and the actor may not be the assignee, so we
+        sweep every open activity of the assignment type regardless of who
+        scheduled it. Mirrors ``disbursement_assignment``'s helper of the
+        same name.
+        """
+        activity_type = self.env.ref(self._assignment_activity_xmlid())
+        summary = self._assignment_activity_summary()
+        for rec in self:
+            stale = rec.sudo().activity_ids.filtered(
+                lambda a: a.activity_type_id == activity_type and a.summary == summary
+            )
+            stale.unlink()

--- a/kris_project_assignment/readme/CONTRIBUTORS.rst
+++ b/kris_project_assignment/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Aginix Technologies

--- a/kris_project_assignment/readme/DESCRIPTION.rst
+++ b/kris_project_assignment/readme/DESCRIPTION.rst
@@ -1,0 +1,14 @@
+This add-on wires ``kris.project`` into the reusable ``assignment.mixin``
+provided by ``base_assignment``. It adds an *Assigned Officer* concept
+(``assigned_to``) — the KRIS Officer currently responsible for acting on
+a project — alongside the existing ``user_id`` ("Responsible", the fixed
+owner). Users interact with it through the standard
+Assign to me / Assign… / Unassign banner injected above the project form.
+
+When ``base_assignment_todo`` is also installed, assignment notifications
+surface in the unified Todo inbox as an *Acknowledgement*-category
+activity — the assignee dismisses it with **Mark as Read**.
+
+The open To-Do is cleared automatically when the project reaches a closed
+state (``done`` / ``cancel`` / ``terminated`` / ``conditional_close``), so
+inboxes stay clean.

--- a/kris_project_assignment/readme/USAGE.rst
+++ b/kris_project_assignment/readme/USAGE.rst
@@ -1,0 +1,25 @@
+Usage
+=====
+
+Any KRIS Project officer (``kris_project.group_kris_project_officer``)
+may claim an *unassigned* project through the **Assign to me** button in
+the banner. Reassigning to another officer, or unassigning an already
+assigned project, is manager-only
+(``kris_project.group_kris_project_manager``).
+
+Filtering
+---------
+
+The project search view gains two new filters and a group-by:
+
+* **Assigned to me** — projects where ``assigned_to = current user``.
+* **Unassigned** — projects with no ``assigned_to``.
+* **Group by Assigned Officer**.
+
+Todo inbox
+----------
+
+Install ``base_assignment_todo`` alongside this module to surface
+assignment notifications in the unified Todo inbox
+(``mail_activity_todo``). No extra configuration is needed — the bridge
+tags the assignment activity type on install.

--- a/kris_project_assignment/tests/__init__.py
+++ b/kris_project_assignment/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_kris_project_assignment  # noqa: F401

--- a/kris_project_assignment/tests/test_kris_project_assignment.py
+++ b/kris_project_assignment/tests/test_kris_project_assignment.py
@@ -1,0 +1,176 @@
+from odoo.exceptions import AccessError, UserError
+from odoo.tests.common import TransactionCase, tagged
+
+ASSIGN_ACTIVITY_XMLID = "base_assignment.mail_activity_assignment"
+
+
+@tagged("post_install", "-at_install")
+class TestKrisProjectAssignment(TransactionCase):
+    """Cover the assignment.mixin integration on kris.project.
+
+    Semantics: ``assigned_to`` is the *current handler*, distinct from the
+    fixed ``user_id`` ("Responsible"). See kris_project_assignment ADR-0001.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Project = cls.env["kris.project"]
+        cls.Wizard = cls.env["assign.officer.wizard"]
+
+        Users = cls.env["res.users"].with_context(no_reset_password=True)
+        g_officer = cls.env.ref("kris_project.group_kris_project_officer")
+        g_manager = cls.env.ref("kris_project.group_kris_project_manager")
+        g_viewer = cls.env.ref("kris_project.group_kris_project_viewer")
+
+        cls.officer_a = Users.create(
+            {
+                "name": "KRIS Officer A",
+                "login": "kris_officer_a",
+                "groups_id": [(6, 0, [g_officer.id])],
+            }
+        )
+        cls.officer_b = Users.create(
+            {
+                "name": "KRIS Officer B",
+                "login": "kris_officer_b",
+                "groups_id": [(6, 0, [g_officer.id])],
+            }
+        )
+        cls.manager = Users.create(
+            {
+                "name": "KRIS Manager",
+                "login": "kris_manager",
+                "groups_id": [(6, 0, [g_manager.id])],
+            }
+        )
+        cls.viewer = Users.create(
+            {
+                "name": "KRIS Viewer",
+                "login": "kris_viewer",
+                "groups_id": [(6, 0, [g_viewer.id])],
+            }
+        )
+
+        cls.category = cls.env["kris.project.category"].create(
+            {"name": "Assignment Test Category"}
+        )
+        cls.ptype = cls.env["kris.project.type"].create(
+            {"name": "Assignment Test Type", "category_id": cls.category.id}
+        )
+
+    def _make_project(self):
+        return self.Project.create(
+            {
+                "project_name": "Assignment Test Project",
+                "project_category_id": self.category.id,
+                "project_type_id": self.ptype.id,
+            }
+        )
+
+    def _assignment_activities(self, project, user=None):
+        activity_type = self.env.ref(ASSIGN_ACTIVITY_XMLID)
+        acts = project.activity_ids.filtered(
+            lambda a: a.activity_type_id == activity_type
+        )
+        if user is not None:
+            acts = acts.filtered(lambda a: a.user_id == user)
+        return acts
+
+    # ------------------------------------------------------------------
+    # Claim
+    # ------------------------------------------------------------------
+    def test_officer_can_claim_unassigned(self):
+        project = self._make_project()
+        project.with_user(self.officer_a).action_assignment_assign_me()
+        self.assertEqual(project.assigned_to, self.officer_a)
+        self.assertEqual(len(self._assignment_activities(project, self.officer_a)), 1)
+
+    def test_officer_cannot_claim_already_assigned(self):
+        project = self._make_project()
+        project.with_user(self.officer_a).action_assignment_assign_me()
+        with self.assertRaises(UserError):
+            project.with_user(self.officer_b).action_assignment_assign_me()
+        # Officer A still holds the record.
+        self.assertEqual(project.assigned_to, self.officer_a)
+
+    # ------------------------------------------------------------------
+    # Manager reassign via wizard
+    # ------------------------------------------------------------------
+    def test_manager_can_reassign_via_wizard(self):
+        project = self._make_project()
+        project.with_user(self.officer_a).action_assignment_assign_me()
+        self.assertEqual(len(self._assignment_activities(project, self.officer_a)), 1)
+        wiz = self.Wizard.with_user(self.manager).create(
+            {
+                "res_model": "kris.project",
+                "res_id": project.id,
+                "user_id": self.officer_b.id,
+            }
+        )
+        wiz.action_assign()
+        self.assertEqual(project.assigned_to, self.officer_b)
+        self.assertFalse(self._assignment_activities(project, self.officer_a))
+        self.assertEqual(len(self._assignment_activities(project, self.officer_b)), 1)
+
+    def test_non_manager_cannot_open_wizard(self):
+        project = self._make_project()
+        with self.assertRaises(AccessError):
+            project.with_user(self.officer_a).action_assignment_open_wizard()
+
+    # ------------------------------------------------------------------
+    # Unassign
+    # ------------------------------------------------------------------
+    def test_manager_can_unassign(self):
+        project = self._make_project()
+        project.with_user(self.officer_a).action_assignment_assign_me()
+        project.with_user(self.manager).action_assignment_unassign()
+        self.assertFalse(project.assigned_to)
+        self.assertFalse(self._assignment_activities(project))
+
+    def test_non_manager_cannot_unassign(self):
+        project = self._make_project()
+        project.with_user(self.officer_a).action_assignment_assign_me()
+        with self.assertRaises(AccessError):
+            project.with_user(self.officer_b).action_assignment_unassign()
+
+    # ------------------------------------------------------------------
+    # Auto-clear on close state
+    # ------------------------------------------------------------------
+    def test_activity_cleared_on_close_state(self):
+        for state in ("done", "cancel", "terminated", "conditional_close"):
+            with self.subTest(state=state):
+                project = self._make_project()
+                project.with_user(self.officer_a).action_assignment_assign_me()
+                self.assertEqual(
+                    len(self._assignment_activities(project, self.officer_a)),
+                    1,
+                )
+                project.write({"state": state})
+                # Assignment field is preserved as history; only the open
+                # To-Do is cleared.
+                self.assertEqual(project.assigned_to, self.officer_a)
+                self.assertFalse(self._assignment_activities(project))
+
+    # ------------------------------------------------------------------
+    # Banner injection smoke-test
+    # ------------------------------------------------------------------
+    def test_banner_injected_in_form_view(self):
+        view = self.Project.get_view(view_type="form")
+        arch = view["arch"]
+        if isinstance(arch, (bytes, bytearray)):
+            arch = arch.decode("utf-8")
+        # Sanity: three telltale strings from base_assignment's banner
+        # template survive the get_view rewrite.
+        self.assertIn("action_assignment_assign_me", arch)
+        self.assertIn("action_assignment_open_wizard", arch)
+        self.assertIn("action_assignment_unassign", arch)
+
+    # ------------------------------------------------------------------
+    # Copy safety
+    # ------------------------------------------------------------------
+    def test_copy_does_not_carry_assignment(self):
+        project = self._make_project()
+        project.with_user(self.officer_a).action_assignment_assign_me()
+        clone = project.copy()
+        self.assertFalse(clone.assigned_to)

--- a/kris_project_assignment/views/kris_project_views.xml
+++ b/kris_project_assignment/views/kris_project_views.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--
+      The Assign to me / Assign… / Unassign banner is injected above the
+      sheet by assignment.mixin's get_view — this file only adds the
+      ``assigned_to`` field to the form/tree/search views and a couple of
+      filters. See kris_project_assignment/models/kris_project.py.
+    -->
+
+    <record id="view_kris_project_form_assignment" model="ir.ui.view">
+        <field name="name">kris.project.form.assignment</field>
+        <field name="model">kris.project</field>
+        <field name="inherit_id" ref="kris_project.view_kris_project_form" />
+        <field name="priority">40</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="assigned_to" widget="many2one_avatar_user" readonly="1" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_kris_project_tree_assignment" model="ir.ui.view">
+        <field name="name">kris.project.tree.assignment</field>
+        <field name="model">kris.project</field>
+        <field name="inherit_id" ref="kris_project.view_kris_project_tree" />
+        <field name="priority">40</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field
+                    name="assigned_to"
+                    widget="many2one_avatar_user"
+                    optional="hide"
+                />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_kris_project_search_assignment" model="ir.ui.view">
+        <field name="name">kris.project.search.assignment</field>
+        <field name="model">kris.project</field>
+        <field name="inherit_id" ref="kris_project.view_kris_project_search" />
+        <field name="priority">40</field>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='my_projects']" position="after">
+                <filter
+                    name="assigned_to_me"
+                    string="Assigned to me"
+                    domain="[('assigned_to', '=', uid)]"
+                />
+                <filter
+                    name="unassigned"
+                    string="Unassigned"
+                    domain="[('assigned_to', '=', False)]"
+                />
+            </xpath>
+            <xpath expr="//filter[@name='group_department']" position="after">
+                <filter
+                    name="group_assigned_to"
+                    string="Assigned Officer"
+                    context="{'group_by': 'assigned_to'}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## สรุปสั้น

โมดูลใหม่ **`kris_project_assignment`** ที่นำ `assignment.mixin` จาก `base_assignment` (และ Todo-inbox bridge จาก `base_assignment_todo`) มาใช้กับ `kris.project` เพื่อให้เจ้าหน้าที่ KRIS มอบหมาย/รับ *เจ้าหน้าที่ผู้รับผิดชอบปัจจุบัน* (Current Handler) ของโครงการได้จาก banner Assign to me / Assign… / Unassign เหมือน purchase / disbursement

> โมดูลนี้แตกจาก branch `madara1150/mail-activity-todo-assign-buttons` (ซึ่งเป็นเจ้าของ `base_assignment` และ `base_assignment_todo`) — PR base ตั้งเป็น branch ดังกล่าว ยังไม่ merge เข้า `16.0` ตรง ๆ เพราะ dependency ยังไม่อยู่บน `16.0`

## ที่มา / แรงจูงใจ

`kris.project` ปัจจุบันมีแค่ `user_id` ("Responsible" = KRIS Officer ผู้ถือกรรมสิทธิ์ซึ่งคงเดิม) — ยังไม่มีคอนเซปต์ **"ผู้ต้อง action ตอนนี้"** ที่หมุนตาม lifecycle ของงาน ทำให้:
- Manager กระจายงานให้ officer คนอื่นดูแลชั่วคราวไม่ได้
- ไม่มี Todo กระตุ้นให้เจ้าหน้าที่รู้ว่ามีโครงการรออยู่

PR นี้เพิ่มฟิลด์ `assigned_to` **แยกจาก `user_id`** เพื่อรองรับ role ที่หมุนได้ พร้อม banner + wizard + Todo แบบมาตรฐานที่ `base_assignment` เตรียมไว้

## รายละเอียดการเปลี่ยนแปลง

### ฟิลด์ใหม่ `assigned_to` (Current Handler)

- Many2one → `res.users`, มี `tracking=True`, `index=True`, `copy=False`
- ต่างจาก `user_id` ("Responsible" = *fixed owner*): `assigned_to` = *rotating handler* — เอกสารประกอบใน `kris_project/CONTEXT.md` (People & Roles) และ `kris_project_assignment/docs/adr/0001-assignment-alongside-user_id.md`

### Group mapping

| hook | group |
|---|---|
| `_assign_user_group` | `kris_project.group_kris_project_officer` (self-claim ได้) |
| `_assign_manager_group` | `kris_project.group_kris_project_manager` (reassign / unassign ได้) |

**Takeover ปิด** — `_assignment_takeover_param()` return `None` (default ของ mixin); officer claim ได้เฉพาะโครงการที่ยังว่าง; reassign / unassign เป็นสิทธิ์ manager เท่านั้น (ไม่มี `res.config.settings` toggle ให้บริหาร)

### Auto-clear activity เมื่อโครงการปิด

`write()` override บน `kris.project` — เมื่อ state เปลี่ยนเป็น `done` / `cancel` / `terminated` / `conditional_close` จะ sweep `mail.activity` ของ assignment ทุกตัวที่ค้างอยู่ (ครอบคลุมทุก entry: direct `write()`, `action_cancel`, และ state wizard) ตัวฟิลด์ `assigned_to` **ยังคงค่าเดิมไว้เป็นประวัติ**

### View

- **Form** — เพิ่ม `assigned_to` (readonly, `many2one_avatar_user`) ถัดจาก `user_id` (banner บน sheet เป็นทาง input)
- **Tree** — เพิ่ม column `assigned_to` (optional="hide")
- **Search** — เพิ่ม filter `Assigned to me` / `Unassigned` + group-by

Banner สีเหลือง/ฟ้า (Assign to me / Assign… / Unassign) ถูกฝังอัตโนมัติเหนือ `<sheet>` โดย mixin's `get_view` — ไม่ต้องแก้ view XML ในโมดูลนี้

### i18n

`i18n/th.po` มีคำแปลไทยครบทุก msgid ใหม่ (field label, activity summary override, filter labels)

### Tests

`tests/test_kris_project_assignment.py` ครอบคลุม:

1. Officer claim โครงการที่ยังว่าง → `assigned_to` set + activity ถูก schedule
2. Officer claim โครงการที่มี assignee → `UserError` (takeover ปิด)
3. Manager reassign ผ่าน wizard → activity ของคนเก่าปลด/คนใหม่ถูก schedule
4. Non-manager เปิด wizard → `AccessError`
5. Manager unassign → `assigned_to = False`, activity ปลด
6. Non-manager unassign → `AccessError`
7. Auto-clear activity เมื่อ state → close (แต่ละ state ตรวจ subTest)
8. Banner ถูกฝังใน form arch (smoke)
9. Duplicate โครงการไม่ carry `assigned_to`

## เอกสาร

- `kris_project/CONTEXT.md` — เพิ่ม glossary "Current Handler / Assigned Officer" คู่กับ "KRIS Officer" (สาระ: `user_id` fixed, `assigned_to` rotating)
- `kris_project_assignment/docs/adr/0001-assignment-alongside-user_id.md` — บันทึกเหตุผลที่ **ไม่** rename `user_id` เป็น `assigned_to`

## จุดที่ตรวจสอบแล้วว่าไม่กระทบ

- ✅ **MRO** — mixin ไม่ inherit `mail.thread` (per `base_assignment` ADR-0001) → ไม่ชนกับ chain `mail.thread → mail.activity.mixin → base.exception` ของ `kris.project`
- ✅ **Downstream inheritors** — `kris_project_extra_allocation`, `kris_project_in_cash_in_kind` (ทั้งคู่ `_inherit = "kris.project"`) ไม่ override `write()` ในทางที่ชนกัน
- ✅ **State wizard** — `kris_project/wizard/kris_project_state_wizard.py.action_apply` เรียก `write({"state": target})` → `write()` override จับได้
- ✅ **`activity_ids`** — `kris.project` มี `mail.activity.mixin` แล้ว (mixin ใช้ `activity_schedule`/`activity_ids` ผ่าน consumer)
- ✅ **Copy** — `copy=False` → project ที่ duplicate มาไม่แบก assignment
- ✅ **Depend อะไร** — แค่ `base_assignment` + `kris_project` (Todo-inbox surface มาจาก `base_assignment_todo` ที่ติดตั้งแยก — ตรงกับ pattern `disbursement_assignment` / `procurement_assignment_kmitl`)

## Test plan

- [ ] `oca_install_addons -m kris_project_assignment`
- [ ] `oca_init_test_database`
- [ ] `oca_run_tests --module kris_project_assignment` → 9 case ต้องเขียว
- [ ] `oca_run_tests --module kris_project` → regression ต้องยังเขียว
- [ ] **Manual smoke**:
  - เปิด KRIS Project ใหม่ → banner เหลืองพร้อมปุ่ม Assign to me
  - Login KRIS Officer → กด Assign to me → banner ฟ้า, Assigned Officer: X, Todo inbox โผล่ (ถ้าติด `base_assignment_todo` + `mail_activity_todo`)
  - Login KRIS Manager → เปิด wizard เลือก officer อื่น → Todo ย้ายให้เจ้าใหม่
  - ปิดโครงการ (state → `done` ผ่าน state wizard) → Todo ที่ค้างของ officer หาย, `assigned_to` ยังคงค่าเดิม
  - Non-manager กด Unassign → AccessError
- [ ] **i18n check**: เปลี่ยน user language เป็นไทย → banner + filter + activity summary + field label เป็นไทยทั้งหมด