### PR TITLE
[16.0][IMP] accounting_kmitl: add analytics charts to dashboard

### DIFF
--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -331,3 +331,50 @@ msgstr "ไม่มีข้อมูล"
 #: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
 msgid "documents"
 msgstr "เอกสาร"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Payables / receivables aging"
+msgstr "อายุหนี้ค้างจ่าย / ค้างรับ"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Payment forecast"
+msgstr "ประมาณการชำระเงิน"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Top vendors by amount due"
+msgstr "เจ้าหนี้ค้างจ่ายสูงสุด"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Not due"
+msgstr "ยังไม่ครบกำหนด"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Payables"
+msgstr "เจ้าหนี้"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Receivables"
+msgstr "ลูกหนี้"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Overdue"
+msgstr "เกินกำหนด"
+
+#. module: accounting_kmitl
+#: code:addons/accounting_kmitl/models/accounting_kmitl_dashboard.py:0
+msgid "(no vendor)"
+msgstr "(ไม่ระบุเจ้าหนี้)"

--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -301,3 +301,33 @@ msgstr "สร้างใบตั้งหนี้ลูกหนี้"
 #: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
 msgid "New journal entry"
 msgstr "สร้างรายการสมุดรายวัน"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Most-used expense codes"
+msgstr "รหัสค่าใช้จ่ายที่ใช้บ่อยที่สุด"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "Fiscal year"
+msgstr "ปีงบประมาณ"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "All"
+msgstr "ทั้งหมด"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "No data"
+msgstr "ไม่มีข้อมูล"
+
+#. module: accounting_kmitl
+#. odoo-javascript
+#: code:addons/accounting_kmitl/static/src/dashboard/accounting_dashboard.js:0
+msgid "documents"
+msgstr "เอกสาร"

--- a/accounting_kmitl/models/accounting_kmitl_dashboard.py
+++ b/accounting_kmitl/models/accounting_kmitl_dashboard.py
@@ -122,3 +122,67 @@ class AccountingKmitlDashboard(models.AbstractModel):
             "currency_symbol": self.env.company.currency_id.symbol,
             "cards": cards,
         }
+
+    @api.model
+    def get_expense_frequency(self, fiscal_year_id=None, limit=20):
+        """Top-N expense accounts ranked by number of distinct posted documents.
+
+        Mirrors the legacy "most-used expense codes" report: for each expense
+        account (``account_type == 'expense'`` -- i.e. every KMITL 5xxx code),
+        count the *distinct* ``account.move`` that touch it on a posted line,
+        optionally within a fiscal year.
+
+        ``read_group`` cannot ``COUNT(DISTINCT ...)``, so we run an aggregate
+        query. It still honours record rules (no ``sudo``): the WHERE clause is
+        built from the ORM via ``_where_calc`` + ``_apply_ir_rules``, so every
+        figure stays scoped to what the current user may see.
+
+        Returns ``{"items": [{id, code, name, count}, ...]}`` sorted desc.
+        """
+        domain = [
+            ("parent_state", "=", "posted"),
+            ("account_id.account_type", "=", "expense"),
+        ]
+        if fiscal_year_id:
+            fy = self.env["account.fiscal.year"].browse(fiscal_year_id)
+            if fy.exists() and fy.date_from and fy.date_to:
+                domain += [("date", ">=", fy.date_from), ("date", "<=", fy.date_to)]
+
+        aml = self.env["account.move.line"]
+        aml.flush_model()
+        query = aml._where_calc(domain)
+        aml._apply_ir_rules(query, "read")
+        from_clause, where_clause, params = query.get_sql()
+        # ``from_clause`` (not a hard-coded table) is required because record
+        # rules may add JOINs; qualify columns to avoid ambiguity. The ``%s``
+        # placeholders (from ``where_clause`` and LIMIT) are filled by execute.
+        self.env.cr.execute(
+            f"""
+            SELECT account_move_line.account_id AS account_id,
+                   COUNT(DISTINCT account_move_line.move_id) AS doc_count
+            FROM {from_clause}
+            WHERE {where_clause}
+            GROUP BY account_move_line.account_id
+            ORDER BY doc_count DESC, account_move_line.account_id
+            LIMIT %s
+            """,
+            params + [limit],
+        )
+        rows = self.env.cr.dictfetchall()
+
+        accounts = self.env["account.account"].browse(
+            [row["account_id"] for row in rows]
+        )
+        by_id = {account.id: account for account in accounts}
+        items = []
+        for row in rows:
+            account = by_id.get(row["account_id"])
+            items.append(
+                {
+                    "id": row["account_id"],
+                    "code": account.code if account else "",
+                    "name": account.name if account else "",
+                    "count": row["doc_count"],
+                }
+            )
+        return {"items": items}

--- a/accounting_kmitl/models/accounting_kmitl_dashboard.py
+++ b/accounting_kmitl/models/accounting_kmitl_dashboard.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from odoo import _, api, fields, models
 
 
@@ -186,3 +188,90 @@ class AccountingKmitlDashboard(models.AbstractModel):
                 }
             )
         return {"items": items}
+
+    @api.model
+    def get_analytics(self):
+        """As-of-today cash & payables analytics for the dashboard charts.
+
+        Unlike the expense chart, these are current-state figures (not scoped
+        by fiscal year), mirroring the operational cards. All aggregation uses
+        ORM ``read_group`` so record rules apply (no ``sudo``). Amounts are the
+        summed ``amount_residual`` (outstanding balance) in company currency.
+
+        Returns::
+
+            {
+              # bucketed by overdue days from the due date:
+              #   [not-due, 1-30, 31-60, 61-90, 90+]
+              "aging": {"ap": [5 amounts], "ar": [5 amounts]},
+              # AP bucketed by days until the due date:
+              #   [overdue, 0-7, 8-30, 31-60, 61-90, 90+]
+              "forecast": [6 amounts],
+              # top 10 vendors by outstanding payable:
+              "top_vendors": [{"id", "name", "amount"}, ...],
+            }
+        """
+        today = fields.Date.context_today(self)
+        move = self.env["account.move"]
+        due = "invoice_date_due"
+
+        def amount(domain):
+            groups = move.read_group(domain, ["amount_residual:sum"], [])
+            return (groups[0]["amount_residual"] if groups else 0.0) or 0.0
+
+        unpaid = [
+            ("state", "=", "posted"),
+            ("payment_state", "in", self._UNPAID_STATES),
+        ]
+        ap = unpaid + [("move_type", "=", "in_invoice")]
+        ar = unpaid + [("move_type", "=", "out_invoice")]
+
+        p30, p60, p90 = (today - timedelta(days=d) for d in (30, 60, 90))
+
+        def aging(base):
+            # A missing due date is treated as not-yet-due.
+            return [
+                amount(base + ["|", (due, "=", False), (due, ">=", today)]),
+                amount(base + [(due, ">=", p30), (due, "<", today)]),
+                amount(base + [(due, ">=", p60), (due, "<", p30)]),
+                amount(base + [(due, ">=", p90), (due, "<", p60)]),
+                amount(base + [(due, "<", p90)]),
+            ]
+
+        f7, f30, f60, f90 = (today + timedelta(days=d) for d in (7, 30, 60, 90))
+        # A missing due date is treated as already due (needs attention).
+        forecast = [
+            amount(ap + ["|", (due, "=", False), (due, "<", today)]),
+            amount(ap + [(due, ">=", today), (due, "<=", f7)]),
+            amount(ap + [(due, ">", f7), (due, "<=", f30)]),
+            amount(ap + [(due, ">", f30), (due, "<=", f60)]),
+            amount(ap + [(due, ">", f60), (due, "<=", f90)]),
+            amount(ap + [(due, ">", f90)]),
+        ]
+
+        vendor_groups = move.read_group(
+            ap, ["amount_residual:sum"], ["partner_id"]
+        )
+        vendor_groups = sorted(
+            vendor_groups,
+            key=lambda group: (group.get("amount_residual") or 0.0),
+            reverse=True,
+        )[:10]
+        top_vendors = [
+            {
+                "id": group["partner_id"][0] if group["partner_id"] else 0,
+                "name": (
+                    group["partner_id"][1]
+                    if group["partner_id"]
+                    else _("(no vendor)")
+                ),
+                "amount": group["amount_residual"] or 0.0,
+            }
+            for group in vendor_groups
+        ]
+
+        return {
+            "aging": {"ap": aging(ap), "ar": aging(ar)},
+            "forecast": forecast,
+            "top_vendors": top_vendors,
+        }

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
@@ -28,6 +28,8 @@ export class AccountingDashboard extends Component {
             fiscalYearId: false,
             expense: { items: [] },
             expenseLoading: true,
+            analytics: { aging: { ap: [], ar: [] }, forecast: [], top_vendors: [] },
+            analyticsLoading: true,
         });
 
         onWillStart(async () => {
@@ -53,10 +55,21 @@ export class AccountingDashboard extends Component {
                     []
                 ),
                 this.loadExpense(),
+                this.loadAnalytics(),
             ]);
             this.state.data = data;
             this.state.loading = false;
         });
+    }
+
+    // Current-state cash & payables analytics (not fiscal-year scoped).
+    async loadAnalytics() {
+        this.state.analytics = await this.orm.call(
+            "accounting.kmitl.dashboard",
+            "get_analytics",
+            []
+        );
+        this.state.analyticsLoading = false;
     }
 
     // Reload just the expense chart for the currently selected fiscal year.
@@ -94,6 +107,123 @@ export class AccountingDashboard extends Component {
             fiscalYear: _t("Fiscal year"),
             all: _t("All"),
             noData: _t("No data"),
+            agingTitle: _t("Payables / receivables aging"),
+            forecastTitle: _t("Payment forecast"),
+            topVendorsTitle: _t("Top vendors by amount due"),
+        };
+    }
+
+    // Compact currency-agnostic number for chart axes/labels (e.g. 1.2M, 340K).
+    _compact(value) {
+        const n = value || 0;
+        const abs = Math.abs(n);
+        if (abs >= 1e6) {
+            return (n / 1e6).toFixed(1) + "M";
+        }
+        if (abs >= 1e3) {
+            return (n / 1e3).toFixed(0) + "K";
+        }
+        return String(Math.round(n));
+    }
+
+    // AP vs AR outstanding balance, grouped by overdue-days bucket.
+    get agingChartOption() {
+        const aging = this.state.analytics.aging || { ap: [], ar: [] };
+        const labels = [_t("Not due"), "1-30", "31-60", "61-90", "90+"];
+        const payables = _t("Payables");
+        const receivables = _t("Receivables");
+        return {
+            tooltip: {
+                trigger: "axis",
+                axisPointer: { type: "shadow" },
+                valueFormatter: (v) => this.formatAmount(v),
+            },
+            legend: { data: [payables, receivables], bottom: 0 },
+            grid: { left: 8, right: 16, top: 16, bottom: 40, containLabel: true },
+            xAxis: { type: "category", data: labels },
+            yAxis: {
+                type: "value",
+                axisLabel: { formatter: (v) => this._compact(v) },
+            },
+            series: [
+                {
+                    name: payables,
+                    type: "bar",
+                    itemStyle: { color: "#d97706" },
+                    data: aging.ap,
+                },
+                {
+                    name: receivables,
+                    type: "bar",
+                    itemStyle: { color: "#3b82f6" },
+                    data: aging.ar,
+                },
+            ],
+        };
+    }
+
+    // Outstanding payables bucketed by days until due (bucket 0 = overdue, red).
+    get forecastChartOption() {
+        const forecast = this.state.analytics.forecast || [];
+        const labels = [_t("Overdue"), "0-7", "8-30", "31-60", "61-90", "90+"];
+        return {
+            tooltip: {
+                trigger: "axis",
+                axisPointer: { type: "shadow" },
+                valueFormatter: (v) => this.formatAmount(v),
+            },
+            grid: { left: 8, right: 16, top: 16, bottom: 24, containLabel: true },
+            xAxis: { type: "category", data: labels },
+            yAxis: {
+                type: "value",
+                axisLabel: { formatter: (v) => this._compact(v) },
+            },
+            series: [
+                {
+                    type: "bar",
+                    data: forecast.map((value, i) => ({
+                        value,
+                        itemStyle: { color: i === 0 ? "#dc3545" : "#15803d" },
+                    })),
+                    barMaxWidth: 40,
+                },
+            ],
+        };
+    }
+
+    // Top vendors by outstanding payable (horizontal bar, highest on top).
+    get topVendorsChartOption() {
+        const rev = [...(this.state.analytics.top_vendors || [])].reverse();
+        const sym = this.state.data.currency_symbol || "";
+        return {
+            grid: { left: 8, right: 72, top: 8, bottom: 8, containLabel: true },
+            tooltip: {
+                trigger: "axis",
+                axisPointer: { type: "shadow" },
+                valueFormatter: (v) => sym + this.formatAmount(v),
+            },
+            xAxis: {
+                type: "value",
+                axisLabel: { formatter: (v) => this._compact(v) },
+            },
+            yAxis: {
+                type: "category",
+                data: rev.map((v) => v.name),
+                axisLabel: { fontSize: 11, width: 160, overflow: "truncate" },
+            },
+            series: [
+                {
+                    type: "bar",
+                    data: rev.map((v) => v.amount),
+                    itemStyle: { color: "#d97706" },
+                    barMaxWidth: 22,
+                    label: {
+                        show: true,
+                        position: "right",
+                        formatter: (p) => this._compact(p.value),
+                    },
+                },
+            ],
         };
     }
 

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.js
@@ -4,12 +4,19 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { Component, onWillStart, useState } from "@odoo/owl";
+// Reuse the ECharts OWL wrapper shipped by the ``budget`` module (a hard
+// dependency of accounting_kmitl), so no charting library is added here.
+import { EChart } from "@budget/overview/echart";
 
 // Landing "work launchpad" for the Accounting app: a grid of KPI cards that
 // each open a filtered list, plus quick-create buttons. The cards (labels,
 // colours, domains and counts) are fully defined by the
 // accounting.kmitl.dashboard server model, so other modules can add cards
 // without touching this component.
+//
+// Below the cards it also shows a "most-used expense codes" horizontal bar
+// chart, filterable by fiscal year (the filter scopes the chart only -- the
+// cards stay live operational queues).
 export class AccountingDashboard extends Component {
     setup() {
         this.orm = useService("orm");
@@ -17,16 +24,55 @@ export class AccountingDashboard extends Component {
         this.state = useState({
             loading: true,
             data: { currency_symbol: "", cards: [] },
+            fiscalYears: [],
+            fiscalYearId: false,
+            expense: { items: [] },
+            expenseLoading: true,
         });
 
         onWillStart(async () => {
-            this.state.data = await this.orm.call(
-                "accounting.kmitl.dashboard",
-                "get_dashboard_data",
-                []
+            this.state.fiscalYears = await this.orm.searchRead(
+                "account.fiscal.year",
+                [],
+                ["id", "name", "date_from", "date_to"],
+                { order: "date_from desc" }
             );
+            // Default to the fiscal year covering today, else the latest one,
+            // else "All" (no fiscal year records) -- mirrors budget_overview.
+            const today = new Date().toISOString().slice(0, 10);
+            const covering = this.state.fiscalYears.find(
+                (fy) => fy.date_from <= today && fy.date_to >= today
+            );
+            this.state.fiscalYearId =
+                (covering || this.state.fiscalYears[0] || {}).id || false;
+
+            const [data] = await Promise.all([
+                this.orm.call(
+                    "accounting.kmitl.dashboard",
+                    "get_dashboard_data",
+                    []
+                ),
+                this.loadExpense(),
+            ]);
+            this.state.data = data;
             this.state.loading = false;
         });
+    }
+
+    // Reload just the expense chart for the currently selected fiscal year.
+    async loadExpense() {
+        this.state.expenseLoading = true;
+        this.state.expense = await this.orm.call(
+            "accounting.kmitl.dashboard",
+            "get_expense_frequency",
+            [this.state.fiscalYearId || false]
+        );
+        this.state.expenseLoading = false;
+    }
+
+    onPeriodChange(ev) {
+        this.state.fiscalYearId = parseInt(ev.target.value) || false;
+        this.loadExpense();
     }
 
     // Cards as delivered by the server, in display order.
@@ -44,6 +90,44 @@ export class AccountingDashboard extends Component {
             newVendorBill: _t("New vendor bill"),
             newCustomerInvoice: _t("New customer invoice"),
             newJournalEntry: _t("New journal entry"),
+            expenseTitle: _t("Most-used expense codes"),
+            fiscalYear: _t("Fiscal year"),
+            all: _t("All"),
+            noData: _t("No data"),
+        };
+    }
+
+    // ECharts option for the Top-N most-used expense codes (horizontal bar).
+    // Items arrive sorted desc; ECharts draws a category axis bottom-up, so we
+    // reverse to put rank #1 on top.
+    get expenseChartOption() {
+        const rev = [...(this.state.expense.items || [])].reverse();
+        const docWord = _t("documents");
+        return {
+            grid: { left: 8, right: 56, top: 8, bottom: 8, containLabel: true },
+            tooltip: {
+                trigger: "axis",
+                axisPointer: { type: "shadow" },
+                formatter: (ps) => {
+                    const it = rev[ps[0].dataIndex];
+                    return `<strong>${it.code}</strong><br/>${it.name}<br/>${ps[0].value} ${docWord}`;
+                },
+            },
+            xAxis: { type: "value", minInterval: 1 },
+            yAxis: {
+                type: "category",
+                data: rev.map((i) => i.name),
+                axisLabel: { fontSize: 11, width: 180, overflow: "truncate" },
+            },
+            series: [
+                {
+                    type: "bar",
+                    data: rev.map((i) => i.count),
+                    itemStyle: { color: "#3b82f6" },
+                    barMaxWidth: 22,
+                    label: { show: true, position: "right" },
+                },
+            ],
         };
     }
 
@@ -86,5 +170,6 @@ export class AccountingDashboard extends Component {
 }
 
 AccountingDashboard.template = "accounting_kmitl.AccountingDashboard";
+AccountingDashboard.components = { EChart };
 
 registry.category("actions").add("accounting_kmitl.dashboard", AccountingDashboard);

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
@@ -26,4 +26,9 @@
         width: 100%;
         height: 600px;
     }
+
+    .o_ak_chart_sm .o_echart {
+        width: 100%;
+        height: 340px;
+    }
 }

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
@@ -19,4 +19,11 @@
     .o_ak_card_amount {
         font-size: 1rem;
     }
+
+    // ECharts measures its host at init, so the wrapper div needs an explicit
+    // height (budget's own .o_echart height rule is scoped to its overview).
+    .o_ak_chart .o_echart {
+        width: 100%;
+        height: 600px;
+    }
 }

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.scss
@@ -1,4 +1,8 @@
 .o_ak_dashboard {
+    // Fill the action area and scroll internally; without an explicit height
+    // the div grows past the viewport and Odoo's action container clips it
+    // (no scrollbar) once the charts make the page taller than the screen.
+    height: 100%;
     overflow: auto;
 
     .o_ak_card {

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
@@ -34,6 +34,38 @@
                     </t>
                 </div>
 
+                <div class="o_ak_chart mt-4">
+                    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-2">
+                        <h5 class="text-muted mb-0" t-esc="text.expenseTitle"/>
+                        <div class="o_ak_period">
+                            <label class="me-2 text-muted" t-esc="text.fiscalYear"/>
+                            <select class="form-select form-select-sm d-inline-block w-auto"
+                                    t-on-change="onPeriodChange">
+                                <option value="0" t-att-selected="!state.fiscalYearId">
+                                    <t t-esc="text.all"/>
+                                </option>
+                                <t t-foreach="state.fiscalYears" t-as="fy" t-key="fy.id">
+                                    <option t-att-value="fy.id"
+                                            t-att-selected="fy.id === state.fiscalYearId">
+                                        <t t-esc="fy.name"/>
+                                    </option>
+                                </t>
+                            </select>
+                        </div>
+                    </div>
+                    <t t-if="state.expenseLoading">
+                        <div class="text-center text-muted py-5">
+                            <i class="fa fa-circle-o-notch fa-spin fa-2x"/>
+                        </div>
+                    </t>
+                    <t t-elif="state.expense.items.length">
+                        <EChart option="expenseChartOption"/>
+                    </t>
+                    <t t-else="">
+                        <div class="text-muted py-3" t-esc="text.noData"/>
+                    </t>
+                </div>
+
                 <div class="o_ak_quick_actions mt-4">
                     <h5 class="text-muted" t-esc="text.quickActions"/>
                     <div class="d-flex flex-wrap gap-2">

--- a/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
+++ b/accounting_kmitl/static/src/dashboard/accounting_dashboard.xml
@@ -34,6 +34,44 @@
                     </t>
                 </div>
 
+                <div class="row g-3 mt-1">
+                    <div class="col-12 col-lg-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="text-muted mb-2" t-esc="text.agingTitle"/>
+                                <div class="o_ak_chart_sm">
+                                    <EChart option="agingChartOption"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="text-muted mb-2" t-esc="text.forecastTitle"/>
+                                <div class="o_ak_chart_sm">
+                                    <EChart option="forecastChartOption"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <h6 class="text-muted mb-2" t-esc="text.topVendorsTitle"/>
+                                <t t-if="state.analytics.top_vendors.length">
+                                    <div class="o_ak_chart_sm">
+                                        <EChart option="topVendorsChartOption"/>
+                                    </div>
+                                </t>
+                                <t t-else="">
+                                    <div class="text-muted py-3" t-esc="text.noData"/>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="o_ak_chart mt-4">
                     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2 mb-2">
                         <h5 class="text-muted mb-0" t-esc="text.expenseTitle"/>

--- a/accounting_kmitl/tests/test_dashboard.py
+++ b/accounting_kmitl/tests/test_dashboard.py
@@ -47,6 +47,24 @@ class TestAccountingDashboard(TransactionCase):
         )
         cls.Dashboard = cls.env["accounting.kmitl.dashboard"]
 
+        # Dedicated accounts for the expense-frequency chart tests.
+        def _make_account(code, name, account_type):
+            return cls.env["account.account"].create(
+                {
+                    "name": name,
+                    "code": code,
+                    "account_type": account_type,
+                    "company_id": cls.company.id,
+                }
+            )
+
+        cls.exp1 = _make_account("TEXP001", "Test Expense 1", "expense")
+        cls.exp2 = _make_account("TEXP002", "Test Expense 2", "expense")
+        cls.exp3 = _make_account("TEXP003", "Test Expense 3", "expense")
+        cls.credit_account = _make_account(
+            "TLIA001", "Test Liability", "liability_current"
+        )
+
     def _cards_by_id(self, data):
         return {card["id"]: card for card in data["cards"]}
 
@@ -85,6 +103,37 @@ class TestAccountingDashboard(TransactionCase):
                 {"account_id": self.account_a.id, "debit": 0.0, "credit": 100.0}
             ),
         ]
+
+    def _post_expense(self, account, date=None):
+        """Create + post a balanced entry that debits ``account``."""
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": self.journal.id,
+                "date": date or fields.Date.today(),
+                "line_ids": [
+                    Command.create(
+                        {"account_id": account.id, "debit": 100.0, "credit": 0.0}
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.credit_account.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
+    def _expense_row(self, account, **kwargs):
+        items = (
+            self.Dashboard.with_user(self.maker)
+            .get_expense_frequency(**kwargs)["items"]
+        )
+        return next((row for row in items if row["id"] == account.id), None)
 
     def test_structure_and_domain_self_consistency(self):
         """Every card is self-describing and its count equals a fresh
@@ -143,3 +192,119 @@ class TestAccountingDashboard(TransactionCase):
 
         data = self.Dashboard.with_user(self.maker).get_dashboard_data()
         self.assertGreaterEqual(self._cards_by_id(data)["exceptions"]["count"], 1)
+
+    def test_expense_frequency_counts_distinct_documents(self):
+        """Two separate posted documents on the same expense account count 2,
+        and the row carries the account code/name."""
+        self._post_expense(self.exp1)
+        self._post_expense(self.exp1)
+
+        row = self._expense_row(self.exp1)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["count"], 2)
+        self.assertEqual(row["code"], self.exp1.code)
+        self.assertEqual(row["name"], self.exp1.name)
+
+    def test_expense_frequency_multiple_lines_same_doc_count_once(self):
+        """Two lines on the same account within ONE document count as one
+        distinct document (metric is COUNT(DISTINCT move_id), not lines)."""
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": self.journal.id,
+                "date": fields.Date.today(),
+                "line_ids": [
+                    Command.create(
+                        {"account_id": self.exp2.id, "debit": 100.0, "credit": 0.0}
+                    ),
+                    Command.create(
+                        {"account_id": self.exp2.id, "debit": 100.0, "credit": 0.0}
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.credit_account.id,
+                            "debit": 0.0,
+                            "credit": 200.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+
+        row = self._expense_row(self.exp2)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["count"], 1)
+
+    def test_expense_frequency_excludes_draft_and_non_expense(self):
+        """Draft (unposted) usage is ignored, and non-expense accounts never
+        appear in the ranking."""
+        self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": self.journal.id,
+                "date": fields.Date.today(),
+                "line_ids": [
+                    Command.create(
+                        {"account_id": self.exp3.id, "debit": 100.0, "credit": 0.0}
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.credit_account.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                        }
+                    ),
+                ],
+            }
+        )  # left in draft on purpose
+
+        items = (
+            self.Dashboard.with_user(self.maker).get_expense_frequency()["items"]
+        )
+        self.assertFalse(
+            any(row["id"] == self.exp3.id for row in items),
+            "draft usage must not be counted",
+        )
+        self.assertFalse(
+            any(row["id"] == self.credit_account.id for row in items),
+            "non-expense account must never appear",
+        )
+
+    def test_expense_frequency_limit_and_ordering(self):
+        """Result respects the limit and is sorted by count descending."""
+        self._post_expense(self.exp1)
+        self._post_expense(self.exp1)
+        self._post_expense(self.exp2)
+
+        items = (
+            self.Dashboard.with_user(self.maker).get_expense_frequency(limit=1)[
+                "items"
+            ]
+        )
+        self.assertLessEqual(len(items), 1)
+
+        counts = [
+            row["count"]
+            for row in self.Dashboard.with_user(self.maker).get_expense_frequency()[
+                "items"
+            ]
+        ]
+        self.assertEqual(counts, sorted(counts, reverse=True))
+
+    def test_expense_frequency_fiscal_year_filter(self):
+        """The fiscal_year_id argument restricts the count to that period."""
+        fy = self.env["account.fiscal.year"].create(
+            {
+                "name": "FY-TEST-2020",
+                "date_from": "2020-01-01",
+                "date_to": "2020-12-31",
+                "company_id": self.company.id,
+            }
+        )
+        self._post_expense(self.exp1, date="2020-06-01")  # inside the FY
+        self._post_expense(self.exp1)  # today -> outside the FY
+
+        row = self._expense_row(self.exp1, fiscal_year_id=fy.id)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["count"], 1)

--- a/accounting_kmitl/tests/test_dashboard.py
+++ b/accounting_kmitl/tests/test_dashboard.py
@@ -1,5 +1,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import timedelta
+
 from odoo import Command, fields
 from odoo.tests.common import TransactionCase, tagged
 
@@ -47,13 +49,14 @@ class TestAccountingDashboard(TransactionCase):
         )
         cls.Dashboard = cls.env["accounting.kmitl.dashboard"]
 
-        # Dedicated accounts for the expense-frequency chart tests.
-        def _make_account(code, name, account_type):
+        # Dedicated accounts for the chart tests.
+        def _make_account(code, name, account_type, reconcile=False):
             return cls.env["account.account"].create(
                 {
                     "name": name,
                     "code": code,
                     "account_type": account_type,
+                    "reconcile": reconcile,
                     "company_id": cls.company.id,
                 }
             )
@@ -63,6 +66,27 @@ class TestAccountingDashboard(TransactionCase):
         cls.exp3 = _make_account("TEXP003", "Test Expense 3", "expense")
         cls.credit_account = _make_account(
             "TLIA001", "Test Liability", "liability_current"
+        )
+        cls.income = _make_account("TINC001", "Test Income", "income")
+        cls.payable = _make_account(
+            "TPAY001", "Test Payable", "liability_payable", reconcile=True
+        )
+        cls.receivable = _make_account(
+            "TREC001", "Test Receivable", "asset_receivable", reconcile=True
+        )
+
+        Partner = cls.env["res.partner"]
+        cls.vendor_a = Partner.create(
+            {"name": "Vendor A", "property_account_payable_id": cls.payable.id}
+        )
+        cls.vendor_b = Partner.create(
+            {"name": "Vendor B", "property_account_payable_id": cls.payable.id}
+        )
+        cls.customer = Partner.create(
+            {
+                "name": "Customer A",
+                "property_account_receivable_id": cls.receivable.id,
+            }
         )
 
     def _cards_by_id(self, data):
@@ -134,6 +158,39 @@ class TestAccountingDashboard(TransactionCase):
             .get_expense_frequency(**kwargs)["items"]
         )
         return next((row for row in items if row["id"] == account.id), None)
+
+    def _post_invoice(self, move_type, partner, amount, due):
+        """Create + post an unpaid invoice with a single line and a due date."""
+        line_account = self.exp1 if move_type == "in_invoice" else self.income
+        move = (
+            self.env["account.move"]
+            .with_user(self.maker)
+            .create(
+                {
+                    "move_type": move_type,
+                    "partner_id": partner.id,
+                    "invoice_date": fields.Date.today(),
+                    "invoice_date_due": due,
+                    "invoice_payment_term_id": False,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "line",
+                                "account_id": line_account.id,
+                                "quantity": 1.0,
+                                "price_unit": amount,
+                                "tax_ids": [Command.set([])],
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        move.action_post()
+        return move
+
+    def _analytics(self):
+        return self.Dashboard.with_user(self.maker).get_analytics()
 
     def test_structure_and_domain_self_consistency(self):
         """Every card is self-describing and its count equals a fresh
@@ -308,3 +365,50 @@ class TestAccountingDashboard(TransactionCase):
         row = self._expense_row(self.exp1, fiscal_year_id=fy.id)
         self.assertIsNotNone(row)
         self.assertEqual(row["count"], 1)
+
+    def test_analytics_aging_ap_bucket(self):
+        """An overdue payable lands in the correct aging bucket (delta is
+        isolated from any pre-existing data)."""
+        before = self._analytics()["aging"]["ap"]
+        self._post_invoice(
+            "in_invoice",
+            self.vendor_a,
+            111.0,
+            fields.Date.today() - timedelta(days=45),  # 31-60 bucket
+        )
+        after = self._analytics()["aging"]["ap"]
+        self.assertAlmostEqual(after[2] - before[2], 111.0, places=2)
+
+    def test_analytics_forecast_bucket(self):
+        """A payable due within a week lands in the 0-7 forecast bucket."""
+        before = self._analytics()["forecast"]
+        self._post_invoice(
+            "in_invoice",
+            self.vendor_a,
+            222.0,
+            fields.Date.today() + timedelta(days=5),  # 0-7 bucket
+        )
+        after = self._analytics()["forecast"]
+        self.assertAlmostEqual(after[1] - before[1], 222.0, places=2)
+
+    def test_analytics_top_vendors_sorted_by_amount(self):
+        """Vendors are ranked by outstanding payable, largest first."""
+        self._post_invoice(
+            "in_invoice", self.vendor_a, 999999.0, fields.Date.today()
+        )
+        self._post_invoice(
+            "in_invoice", self.vendor_b, 888888.0, fields.Date.today()
+        )
+
+        top = self._analytics()["top_vendors"]
+        self.assertLessEqual(len(top), 10)
+        ids = [row["id"] for row in top]
+        self.assertIn(self.vendor_a.id, ids)
+        self.assertIn(self.vendor_b.id, ids)
+        self.assertLess(
+            ids.index(self.vendor_a.id),
+            ids.index(self.vendor_b.id),
+            "the larger balance must rank first",
+        )
+        row_a = next(row for row in top if row["id"] == self.vendor_a.id)
+        self.assertAlmostEqual(row_a["amount"], 999999.0, places=2)


### PR DESCRIPTION
## What

Extends the Accounting dashboard (KPI launchpad, #939) with a set of analytics
charts, reproducing/replacing legacy reports and giving the finance team
cash-flow visibility at a glance. All charts reuse the `budget` module's
`EChart` wrapper (ECharts already bundled via the `budget` dependency) — **no
new dependency, no manifest change**.

### Charts added

1. **Most-used expense codes** (Top 20, horizontal bar) — ranked by number of
   **distinct posted documents** on expense accounts (`account_type='expense'`,
   i.e. every KMITL `5xxx` code). Filterable by **fiscal year** (with an "All"
   option); the selector scopes this chart only.
2. **Payables / receivables aging** (grouped bar) — outstanding balance bucketed
   by overdue days: not-due / 1-30 / 31-60 / 61-90 / 90+, for both AP and AR.
3. **Payment forecast** (bar) — outstanding payables bucketed by days until due
   (overdue / 0-7 / 8-30 / 31-60 / 61-90 / 90+); the overdue bar is highlighted red.
4. **Top vendors by amount due** (horizontal bar) — top 10 vendors by outstanding
   payable.

## How

- **Server** — three model methods on `accounting.kmitl.dashboard`:
  - `get_expense_frequency(fiscal_year_id, limit)` — `COUNT(DISTINCT move_id)`.
    Since `read_group` cannot `COUNT(DISTINCT)`, the aggregate is built via
    `_where_calc` → `_apply_ir_rules(query, "read")` → `get_sql()` so it **still
    respects record rules** (no `sudo`).
  - `get_analytics()` — current-state aging / forecast / top-vendor datasets via
    ORM `read_group` (record-rule scoped). Not fiscal-year scoped, mirroring the
    operational cards.
  - `get_dashboard_data()` (the existing cards) is **left untouched**.
- **Front-end** — the OWL dashboard component loads all datasets in parallel on
  start, exposes one getter per chart returning an ECharts `option`, and renders
  them with `<EChart/>`. The fiscal-year `<select>` mirrors `budget_overview`.

## Notes

- Expense-code counts differ slightly from the legacy CSV: the old report
  counted line occurrences ("จำนวนครั้ง"), whereas this counts **distinct
  documents** (chosen metric).
- Amounts use the summed `amount_residual` (outstanding balance), consistent
  with the existing money cards.

## Tests

`tests/test_dashboard.py` adds coverage for both new methods: distinct-document
counting, drafts/non-expense exclusion, limit + ordering, fiscal-year filter,
aging/forecast bucketing (isolated via before/after deltas), and top-vendor
ranking.