### PR TITLE
[16.0][IMP] disbursement: add verification return filters

### DIFF
--- a/disbursement/i18n/th.po
+++ b/disbursement/i18n/th.po
@@ -1475,6 +1475,7 @@ msgstr "ตีกลับให้หมวดตรวจ"
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__returned_to_verification
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search_assignment
 msgid "Returned to Verification"
 msgstr "ถูกตีกลับให้หมวดตรวจ"
 
@@ -1496,6 +1497,7 @@ msgstr "ตีกลับให้หมวดตรวจได้เฉพา
 
 #. module: disbursement
 #: model:ir.model.fields,field_description:disbursement.field_disbursement_request__returned_to_source
+#: model_terms:ir.ui.view,arch_db:disbursement.view_disbursement_request_search_assignment
 msgid "Returned to Source"
 msgstr "ถูกตีกลับไปต้นเรื่อง"
 

--- a/disbursement/views/disbursement_request_assignment_views.xml
+++ b/disbursement/views/disbursement_request_assignment_views.xml
@@ -98,6 +98,17 @@
                     string="Unassigned"
                     domain="[('assigned_to', '=', False)]"
                 />
+                <separator />
+                <filter
+                    name="returned_to_source"
+                    string="Returned to Source"
+                    domain="[('returned_to_source', '=', True)]"
+                />
+                <filter
+                    name="returned_to_verification"
+                    string="Returned to Verification"
+                    domain="[('returned_to_verification', '=', True)]"
+                />
             </xpath>
             <xpath expr="//filter[@name='state']" position="after">
                 <filter


### PR DESCRIPTION
## สรุป
เพิ่ม 2 search filter ในเมนู **หมวดตรวจ** (Verification) ของโมดูล `disbursement` เพื่อให้เจ้าหน้าที่หมวดตรวจคัดกรองใบขอเบิก (DR) ที่เกี่ยวกับการ "ตีกลับ" ได้ ซึ่งเดิมยังไม่มี filter

| Filter | ความหมาย | domain | label ไทย |
|---|---|---|---|
| **Returned to Source** | หมวดตรวจตีกลับไปต้นเรื่องเพื่อแก้ไข (DR ยังค้างที่ `signed`) | `[('returned_to_source', '=', True)]` | ถูกตีกลับไปต้นเรื่อง |
| **Returned to Verification** | ผู้อนุมัติ/ห้องบัญชีตีกลับกลับมาให้หมวดตรวจตรวจใหม่ (กลับมา `signed`) | `[('returned_to_verification', '=', True)]` | ถูกตีกลับให้หมวดตรวจ |

ทั้งสอง field เป็น Boolean stored บน `disbursement.request` อยู่แล้ว จึงนำมาใส่ domain ได้ตรง ๆ

## รายละเอียด
- `views/disbursement_request_assignment_views.xml` — เพิ่ม 2 `<filter>` (คั่นด้วย separator) ต่อจาก `my_verifications` / `unassigned` ใน search view `view_disbursement_request_search_assignment`
- `i18n/th.po` — ใช้ label เดียวกับ field เดิมเพื่อความสอดคล้อง และเพิ่มบรรทัด `#:` reference ของ view arch เข้าไปใน entry ที่มีอยู่ (merge reference ไม่สร้าง msgid ซ้ำ) ให้ label ของ filter แปลไทยตอน import

## ขอบเขต
แก้ระดับ view + i18n เท่านั้น ไม่แตะ business logic / ไม่เพิ่ม field
- Filter กรองด้วย flag อย่างเดียว ไม่ผูกกับผู้ใช้ (ผู้ใช้กดร่วมกับ "My Verifications" เองได้)
- Filter #1 ใช้ `returned_to_source` เท่านั้น (ไม่รวม `returned_for_edit`)

## การทดสอบ
1. restart Odoo ด้วย `-u disbursement`
2. Disbursement → หมวดตรวจ → My Work / All → เปิด Filters จะเห็น 2 ตัวใหม่ใต้กลุ่มงานตรวจ
3. DR ที่ `returned_to_source=True` โผล่ที่ filter แรก, `returned_to_verification=True` โผล่ที่ filter สอง
4. เช็ก label แสดงเป็นไทยถูกต้อง