### PR TITLE
[16.0][IMP] accounting_kmitl_reports: restore sources "only" filter and Thai general ledger PDF

### DIFF
--- a/accounting_kmitl_reports/__manifest__.py
+++ b/accounting_kmitl_reports/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "KMITL Accounting Reports",
-    "version": "16.0.8.0.0",
+    "version": "16.0.9.0.0",
     "category": "KMITL/Accounting",
     "summary": "KMITL accounting reports: Trial Balance, General Ledger, "
     "Profit and Loss, Balance Sheet, Cash Flow Statement, "

--- a/accounting_kmitl_reports/data/report_action_general_ledger_kmitl.xml
+++ b/accounting_kmitl_reports/data/report_action_general_ledger_kmitl.xml
@@ -7,12 +7,12 @@
         <field name="page_height">0</field>
         <field name="page_width">0</field>
         <field name="orientation">Landscape</field>
-        <field name="margin_top">55</field>
-        <field name="margin_bottom">18</field>
-        <field name="margin_left">7</field>
-        <field name="margin_right">7</field>
+        <field name="margin_top">32</field>
+        <field name="margin_bottom">8</field>
+        <field name="margin_left">5</field>
+        <field name="margin_right">5</field>
         <field name="header_line" eval="False" />
-        <field name="header_spacing">50</field>
+        <field name="header_spacing">4</field>
         <field name="dpi">90</field>
     </record>
 

--- a/accounting_kmitl_reports/i18n/th.po
+++ b/accounting_kmitl_reports/i18n/th.po
@@ -521,6 +521,7 @@ msgstr "ส่งออก CSV"
 #: code:addons/accounting_kmitl_reports/models/aged_partner_balance_kmitl.py:0
 #: code:addons/accounting_kmitl_reports/models/general_ledger_kmitl.py:0
 #: code:addons/accounting_kmitl_reports/models/trial_balance_kmitl.py:0
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl_reports.general_ledger_kmitl
 msgid "Account Code"
 msgstr "รหัสบัญชี"
 

--- a/accounting_kmitl_reports/models/dimension_filter_mixin.py
+++ b/accounting_kmitl_reports/models/dimension_filter_mixin.py
@@ -7,9 +7,6 @@ from odoo.tools import date_utils
 # order. Read from each move line's ``analytic_distribution`` (a JSON of
 # {analytic_account_id: percentage}).
 DIMENSION_CODES = ("departments", "sources", "funds", "activities")
-# Flat dimensions have no parent/child hierarchy: their selection must match
-# the picked analytic accounts exactly and is never expanded to descendants.
-FLAT_DIMENSION_CODES = ("sources",)
 # Display order of the dimension chips shown in the shared expand-detail panel.
 DETAIL_DIM_PLANS = ("funds", "departments", "activities", "sources")
 # Lines never shown in the detail panel.
@@ -37,10 +34,7 @@ class DimensionFilterMixin(models.AbstractModel):
         ``dim_only_self``: optional ``{code: bool}``. When truthy for a
         dimension only the exact selected analytic accounts match; otherwise
         (the default) the selection is expanded to include all of its
-        descendants, since the KMITL dimensions are hierarchical. Flat
-        dimensions (``FLAT_DIMENSION_CODES``, e.g. ``sources``) have no
-        hierarchy, so they always match the selected accounts exactly
-        regardless of the toggle.
+        descendants, since the KMITL dimensions are hierarchical.
         """
         analytic = self.env["account.analytic.account"]
         use_child = "parent_id" in analytic._fields
@@ -50,11 +44,7 @@ class DimensionFilterMixin(models.AbstractModel):
             ids = (dims or {}).get(code) or []
             if not ids:
                 continue
-            if (
-                use_child
-                and code not in FLAT_DIMENSION_CODES
-                and not dim_only_self.get(code)
-            ):
+            if use_child and not dim_only_self.get(code):
                 ids = analytic.search([("id", "child_of", ids)]).ids
             leaves.append(("analytic_distribution", "in", ids))
         return leaves

--- a/accounting_kmitl_reports/models/general_ledger_kmitl.py
+++ b/accounting_kmitl_reports/models/general_ledger_kmitl.py
@@ -1,7 +1,8 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import _, api, fields, models
-from odoo.tools import format_date, html2plaintext
+from odoo.addons.thai_date_utils.models.thai_date_mixin import MONTHS_TH_SHORT
+from odoo.tools import html2plaintext
 
 
 class GeneralLedgerReportKmitl(models.AbstractModel):
@@ -352,6 +353,19 @@ class GeneralLedgerReportKmitl(models.AbstractModel):
         ``0.00`` — used by the carried-forward column totals."""
         return "{:,.2f}".format(value or 0.0)
 
+    @api.model
+    def _kmitl_format_date_be(self, value):
+        """Format an ISO date string / date as a Thai Buddhist-era short date,
+        e.g. ``"2 ต.ค. 2568"``. Date-only (no timezone shift) so it can format
+        both the header range and each line's date on the PDF / XLSX / CSV
+        without touching the shared compute (the on-screen table keeps ISO)."""
+        if not value:
+            return ""
+        date = fields.Date.to_date(value)
+        if not date:
+            return value
+        return "%s %s %s" % (date.day, MONTHS_TH_SHORT[date.month], date.year + 543)
+
     # ------------------------------------------------------------------
     # PDF / XLSX export — return the report action so the OWL client action
     # can ``doAction`` it. Filters travel in ``data`` so the output mirrors the
@@ -395,6 +409,7 @@ class GeneralLedgerReportKmitl(models.AbstractModel):
         data = data or {}
         options = data.get("options") or {}
         result = self.get_general_ledger_data(options)
+        accounts = result["accounts"]
         company = self.env["res.company"].browse(
             options.get("company_id") or self.env.company.id
         )
@@ -403,11 +418,16 @@ class GeneralLedgerReportKmitl(models.AbstractModel):
             "doc_model": "general.ledger.report.wizard.kmitl",
             "docs": self.env["general.ledger.report.wizard.kmitl"].browse(docids or []),
             "res_company": company,
-            "accounts": result["accounts"],
+            "accounts": accounts,
             "format_amount": self._kmitl_format_amount,
             "format_total": self._kmitl_format_total,
-            "date_from_label": format_date(self.env, options.get("date_from")),
-            "date_to_label": format_date(self.env, options.get("date_to")),
+            "format_date_be": self._kmitl_format_date_be,
+            # When exactly one account is reported, show its name/code in the
+            # header (and drop the in-table section row) — mirrors the KMITL
+            # per-account ledger layout.
+            "single_account": accounts[0] if len(accounts) == 1 else False,
+            "date_from_label": self._kmitl_format_date_be(options.get("date_from")),
+            "date_to_label": self._kmitl_format_date_be(options.get("date_to")),
         }
 
 
@@ -457,17 +477,31 @@ class GeneralLedgerXlsxKmitl(models.AbstractModel):
 
         sheet.merge_range(0, 0, 0, 6, company.display_name, bold)
         sheet.merge_range(1, 0, 1, 6, _("General Ledger"), bold)
+        # When a single account is reported, show its name/code (mirrors the PDF).
+        single_account = accounts[0] if len(accounts) == 1 else False
+        header_row = 2
+        if single_account:
+            sheet.merge_range(
+                header_row,
+                0,
+                header_row,
+                6,
+                "%s %s %s"
+                % (single_account["name"], _("Account Code"), single_account["code"]),
+                bold,
+            )
+            header_row += 1
         sheet.merge_range(
-            2,
+            header_row,
             0,
-            2,
+            header_row,
             6,
             "%s %s %s %s"
             % (
                 _("From"),
-                options.get("date_from") or "",
+                report._kmitl_format_date_be(options.get("date_from")),
                 _("to"),
-                options.get("date_to") or "",
+                report._kmitl_format_date_be(options.get("date_to")),
             ),
         )
 
@@ -480,7 +514,7 @@ class GeneralLedgerXlsxKmitl(models.AbstractModel):
             _("Credit"),
             _("Balance"),
         ]
-        row_top = 4
+        row_top = header_row + 2
         for col, label in enumerate(headers):
             sheet.write(row_top, col, label, head)
 
@@ -505,7 +539,7 @@ class GeneralLedgerXlsxKmitl(models.AbstractModel):
                 # Alternate row shading for readability.
                 row_cell = cell_alt if idx % 2 else cell
                 row_num = num_alt if idx % 2 else num
-                sheet.write(r, 0, line["date"], row_cell)
+                sheet.write(r, 0, report._kmitl_format_date_be(line["date"]), row_cell)
                 sheet.write(r, 1, line["issue"], row_cell)
                 sheet.write(r, 2, line["account"], row_cell)
                 sheet.write(r, 3, line["narration"], row_cell)
@@ -563,7 +597,7 @@ class GeneralLedgerCsvKmitl(models.AbstractModel):
                     [
                         acc["code"],
                         acc["name"],
-                        line["date"],
+                        report._kmitl_format_date_be(line["date"]),
                         line["issue"],
                         line["account"],
                         line["partner"],

--- a/accounting_kmitl_reports/report/general_ledger_kmitl_template.xml
+++ b/accounting_kmitl_reports/report/general_ledger_kmitl_template.xml
@@ -10,18 +10,18 @@
                                 <img
                                     t-if="res_company.logo"
                                     t-att-src="image_data_uri(res_company.logo)"
-                                    style="max-height: 60px; max-width: 60px;"
+                                    style="max-height: 40px; max-width: 40px;"
                                     alt="Logo"
                                 />
                             </td>
-                            <td style="border: none; text-align: center; vertical-align: middle; line-height: 1.6;">
-                                <div style="font-size: 14pt; font-weight: bold; margin-bottom: 4px;">
+                            <td style="border: none; text-align: center; vertical-align: middle; line-height: 1.2;">
+                                <div style="font-size: 14pt; font-weight: bold; margin-bottom: 1px;">
                                     <t t-out="res_company.display_name" />
                                 </div>
-                                <div style="font-size: 16pt; font-weight: bold; margin-bottom: 6px;">General Ledger</div>
+                                <div style="font-size: 16pt; font-weight: bold; margin-bottom: 1px;">General Ledger</div>
                                 <div
                                     t-if="single_account"
-                                    style="font-size: 12pt; font-weight: bold; margin-bottom: 6px;"
+                                    style="font-size: 12pt; font-weight: bold; margin-bottom: 1px;"
                                 >
                                     <t t-out="single_account['name']" />
                                     <span>Account Code</span>

--- a/accounting_kmitl_reports/report/general_ledger_kmitl_template.xml
+++ b/accounting_kmitl_reports/report/general_ledger_kmitl_template.xml
@@ -19,6 +19,14 @@
                                     <t t-out="res_company.display_name" />
                                 </div>
                                 <div style="font-size: 16pt; font-weight: bold; margin-bottom: 6px;">General Ledger</div>
+                                <div
+                                    t-if="single_account"
+                                    style="font-size: 12pt; font-weight: bold; margin-bottom: 6px;"
+                                >
+                                    <t t-out="single_account['name']" />
+                                    <span>Account Code</span>
+                                    <t t-out="single_account['code']" />
+                                </div>
                                 <div style="font-size: 12pt;">
                                     <span>From</span>
                                     <t t-out="date_from_label" />
@@ -85,7 +93,7 @@
                         </thead>
                         <tbody>
                             <t t-foreach="accounts" t-as="acc">
-                                <tr class="acc">
+                                <tr class="acc" t-if="not single_account">
                                     <td colspan="7">
                                         <t t-out="acc['code']" /> - <t t-out="acc['name']" />
                                     </td>
@@ -95,7 +103,7 @@
                                     <td class="text-right" t-out="format_amount(acc['initial_balance'])" />
                                 </tr>
                                 <tr t-foreach="acc['lines']" t-as="line" t-att-class="'gl-stripe' if line_index % 2 else ''">
-                                    <td t-out="line['date']" />
+                                    <td t-out="format_date_be(line['date'])" />
                                     <td t-out="line['issue']" />
                                     <td t-out="line['account']" />
                                     <td t-out="line['narration']" />

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.js
@@ -37,6 +37,7 @@ export class AgedPartnerBalance extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
+                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
+++ b/accounting_kmitl_reports/static/src/aged_partner_balance/aged_partner_balance.xml
@@ -73,6 +73,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/cash_flow/cash_flow.js
+++ b/accounting_kmitl_reports/static/src/cash_flow/cash_flow.js
@@ -33,6 +33,7 @@ export class CashFlow extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
+                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/cash_flow/cash_flow.xml
+++ b/accounting_kmitl_reports/static/src/cash_flow/cash_flow.xml
@@ -97,6 +97,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/general_journal/general_journal.js
+++ b/accounting_kmitl_reports/static/src/general_journal/general_journal.js
@@ -55,6 +55,7 @@ export class GeneralJournal extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
+                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/general_journal/general_journal.xml
+++ b/accounting_kmitl_reports/static/src/general_journal/general_journal.xml
@@ -106,6 +106,9 @@
                             placeholder="labels.sources"
                             selected="state.sources"
                             onChange="(sel) => this.onSelectionChange('sources', sel)"
+                            withOnlySelf="true"
+                            onlySelf="state.dimOnlySelf.sources"
+                            onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                         />
                     </div>
                     <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/general_ledger/general_ledger.js
+++ b/accounting_kmitl_reports/static/src/general_ledger/general_ledger.js
@@ -65,6 +65,7 @@ export class GeneralLedger extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
+                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml
+++ b/accounting_kmitl_reports/static/src/general_ledger/general_ledger.xml
@@ -110,6 +110,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.js
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.js
@@ -49,6 +49,7 @@ export class TrialBalance extends Component {
             // (default) a selected node also matches its descendants.
             dimOnlySelf: {
                 departments: false,
+                sources: false,
                 funds: false,
                 activities: false,
             },

--- a/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml
+++ b/accounting_kmitl_reports/static/src/trial_balance/trial_balance.xml
@@ -151,6 +151,9 @@
                         placeholder="labels.sources"
                         selected="state.sources"
                         onChange="(sel) => this.onSelectionChange('sources', sel)"
+                        withOnlySelf="true"
+                        onlySelf="state.dimOnlySelf.sources"
+                        onOnlySelfChange="(val) => this.onToggleDimOnlySelf('sources', val)"
                     />
                 </div>
                 <div class="col-md-3">


### PR DESCRIPTION
## Summary

Two related changes to `accounting_kmitl_reports`, shipped together.

### 1. Restore the "only" filter on Sources (แหล่งเงิน)
The per-dimension **"Only the specified entry"** (`เฉพาะรายการที่เลือก (ไม่รวมระดับย่อย)`)
checkbox was removed from the Sources dimension in #955, which reclassified Sources as a flat
multi-select. This reverts that: Sources gets the toggle back and again behaves like
Departments / Funds / Activities.

- Re-added `withOnlySelf` / `onlySelf` / `onOnlySelfChange` to the Sources `<MultiRecordSelect>`
  in all 5 reports (general ledger, trial balance, general journal, cash flow, aged partner balance).
- Re-added `sources: false` to each report's `dimOnlySelf` state.
- Removed `FLAT_DIMENSION_CODES` in `dimension_filter_mixin.py` so a selected Source expands to its
  descendants when the toggle is off, and matches exactly when it is on.

### 2. Thai General Ledger PDF / Excel / CSV
Bring the exported General Ledger ("บัญชีแยกประเภท") in line with the requested Thai layout.

- **Thai Buddhist-era short dates** (e.g. `2 ต.ค. 2568`) for the header range (`ตั้งแต่ … ถึง …`)
  and every line, via a new `_kmitl_format_date_be()` helper that reuses `MONTHS_TH_SHORT` from
  `thai_date_utils`.
- **Single-account header subtitle** — when the report covers exactly one account, its
  `<name> รหัสบัญชี <code>` shows in the header and the in-table section row is suppressed
  (matches the per-account ledger layout). Multiple accounts keep the existing section rows.
- Applied to **PDF, Excel and CSV**. The shared on-screen compute (`get_general_ledger_data`) is
  **untouched**, so the OWL client-action table is unchanged (keeps ISO dates).
- Reused the existing `Account Code` → `รหัสบัญชี` translation (added the QWeb template reference).

Out of scope (per request): no Cheque column, no "Showing page X of Y, Results…" line.

## Test plan
- [ ] `-u accounting_kmitl_reports` to reload assets, report and translations.
- [ ] In each of the 5 reports, the **Sources** filter shows the "เฉพาะรายการที่เลือก
      (ไม่รวมระดับย่อย)" checkbox again; toggling it changes descendant expansion.
- [ ] General Ledger → **Print PDF** for a single account: header shows the institution name,
      `บัญชีแยกประเภท`, `<account> รหัสบัญชี <code>`, and `ตั้งแต่ … ถึง …` in Thai B.E.; line dates in
      Thai B.E.; `ยอดยกมา` / `ยอดยกไป` present.
- [ ] Multiple accounts → PDF keeps per-account section rows, Thai B.E. dates.
- [ ] **Export Excel** / **Export CSV**: dates render Thai B.E.; the on-screen table dates are
      unchanged.
