### PR TITLE
[16.0][IMP] budget: reservation picker feedback

### DIFF
--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Budgeting",
-    "version": "16.0.1.5.0",
+    "version": "16.0.1.5.1",
     "summary": """ KMITL Budgeting""",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Budgeting",
-    "version": "16.0.1.5.1",
+    "version": "16.0.1.5.2",
     "summary": """ KMITL Budgeting""",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget/static/src/reservation_picker/budget_reservation_picker.js
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.js
@@ -33,6 +33,50 @@ export class BudgetReservationPicker extends BudgetDashboard {
         this.accountDomain = ctx.account_domain || false;
         this.state.selectedId = false;
         this.state.amounts = {};
+        // Free-text search on the budget-account code (feedback: not autocomplete).
+        this.state.accountSearch = "";
+        // The picker must open with a blank filter bar — never pre-seeded from the
+        // host's current selection (feedback: no default filters). The host still
+        // passes its dimensions as context defaults (the read-only dashboard uses
+        // them), so clear them here after super.setup() read them. แหล่งเงิน then
+        // falls back to its neutral system default in onWillStart (source code "2"),
+        // not the document's source. ประเภทงบ (root category) is kept as the
+        // browsing scope: clearing it would force a full expense-chart load before
+        // onWillStart re-picks a category.
+        this.state.filters = {};
+        this.state.filterLabels = {};
+        this.state.sourceId = false;
+    }
+
+    onAccountSearchInput(ev) {
+        this.state.accountSearch = ev.target.value;
+    }
+
+    // Client-side filter on the budget-account code. Keeps each matching account
+    // row plus its ancestor (dimension) rows so the full hierarchy still shows,
+    // and ignores collapse/hide-zero so a match is never hidden. Matches the code
+    // only (feedback), case-insensitively.
+    get visibleRows() {
+        const query = (this.state.accountSearch || "").trim().toLowerCase();
+        if (!query) {
+            return super.visibleRows;
+        }
+        const byKey = this.rowsByKey;
+        const keep = new Set();
+        for (const row of this.state.rows) {
+            if (
+                row.row_type === "account" &&
+                (row.code || "").toLowerCase().includes(query)
+            ) {
+                keep.add(row.key);
+                let pk = row.parent_key;
+                while (pk && !keep.has(pk)) {
+                    keep.add(pk);
+                    pk = byKey[pk] ? byKey[pk].parent_key : false;
+                }
+            }
+        }
+        return this.state.rows.filter((row) => keep.has(row.key));
     }
 
     // The picker's breakdown is fixed (always on, no toggles) — the table always

--- a/budget/static/src/reservation_picker/budget_reservation_picker.js
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.js
@@ -52,10 +52,10 @@ export class BudgetReservationPicker extends BudgetDashboard {
         this.state.accountSearch = ev.target.value;
     }
 
-    // Client-side filter on the budget-account code. Keeps each matching account
-    // row plus its ancestor (dimension) rows so the full hierarchy still shows,
-    // and ignores collapse/hide-zero so a match is never hidden. Matches the code
-    // only (feedback), case-insensitively.
+    // Client-side filter on the budget-account code or name. Keeps each matching
+    // account row plus its ancestor (dimension) rows so the full hierarchy still
+    // shows, and ignores collapse/hide-zero so a match is never hidden. Matches
+    // code or name (feedback), case-insensitively.
     get visibleRows() {
         const query = (this.state.accountSearch || "").trim().toLowerCase();
         if (!query) {
@@ -66,7 +66,8 @@ export class BudgetReservationPicker extends BudgetDashboard {
         for (const row of this.state.rows) {
             if (
                 row.row_type === "account" &&
-                (row.code || "").toLowerCase().includes(query)
+                ((row.code || "").toLowerCase().includes(query) ||
+                    (row.name || "").toLowerCase().includes(query))
             ) {
                 keep.add(row.key);
                 let pk = row.parent_key;

--- a/budget/static/src/reservation_picker/budget_reservation_picker.scss
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.scss
@@ -37,4 +37,10 @@
         width: 120px;
         display: inline-block;
     }
+
+    // Budget-account code search sits in the filter bar next to the dimension
+    // filters; match their width so the controls line up.
+    .o_brp_search input {
+        min-width: 200px;
+    }
 }

--- a/budget/static/src/reservation_picker/budget_reservation_picker.xml
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.xml
@@ -51,6 +51,13 @@
                         />
                     </div>
                 </t>
+                <div class="o_bd_filter o_brp_search">
+                    <label>ค้นหารหัสงบประมาณ</label>
+                    <input type="text" class="form-control form-control-sm"
+                           placeholder="รหัสงบประมาณ"
+                           t-att-value="state.accountSearch"
+                           t-on-input="onAccountSearchInput"/>
+                </div>
                 <div class="o_bd_filter o_bd_check">
                     <label>
                         <input type="checkbox" t-att-checked="state.hideZero" t-on-change="toggleHideZero"/>

--- a/budget/static/src/reservation_picker/budget_reservation_picker.xml
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.xml
@@ -52,9 +52,9 @@
                     </div>
                 </t>
                 <div class="o_bd_filter o_brp_search">
-                    <label>ค้นหารหัสงบประมาณ</label>
+                    <label>ค้นหารหัส/ชื่องบประมาณ</label>
                     <input type="text" class="form-control form-control-sm"
-                           placeholder="รหัสงบประมาณ"
+                           placeholder="รหัสหรือชื่องบประมาณ"
                            t-att-value="state.accountSearch"
                            t-on-input="onAccountSearchInput"/>
                 </div>


### PR DESCRIPTION
Addresses two pieces of feedback on the budget reservation picker. The picker now opens with a blank dimension filter bar (ส่วนงาน/กองทุน/กิจกรรม and แหล่งเงิน) instead of pre-seeding it from the host document's current selection; the ประเภทงบ category is kept as the browsing scope to avoid a full expense-chart load. It also adds a free-text budget-account code search (a plain text input, not an autocomplete) that live-filters the grid on the code while preserving the full hierarchy display, bypassing collapse/hide-zero so a match is never hidden. Manifest bumped to 16.0.1.5.1.