### PR TITLE
[16.0][IMP] purchase_request: unlock form until sarabun submission with over-budget guardrail

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,15 +4,19 @@ How responsible procurement officers (เจ้าหน้าที่พัส
 
 ## Language
 
-**PR (Purchase Request)**:
-The `purchase.request` document — a request to buy/hire (ใบขอซื้อ/ขอจ้าง).
+**PR (Purchase Request, พ.1)**:
+The `purchase.request` document — ใบขอให้จัดหา, a unit's request to procure, approved by the หัวหน้าส่วนงาน (department head). It is the *ask*; it does not itself authorise buying.
 
-**PA (Purchase Approval)**:
-The `purchase.request.approval` document — the approval step between a PR and a PO. The procurement flow is PR → PA → PO.
-_Avoid_: Purchase Agreement, Work Acceptance (WA is a separate document, ตรวจรับ).
+**PA (Purchase Approval, พจ.1)**:
+The `purchase.request.approval` document — ขออนุมัติจัดซื้อจัดจ้าง, the separate step that authorises actually buying, raised after the PR is approved. Its data is *copied* from the PR but may legitimately diverge (vendor, tax, procurement type can be re-edited on the PA) and it has its own approver — so PA is a **separate model, deliberately never merged into PR**. It carries its **own copied columns + line model** (ADR-0004) so those edits never mutate the PR. The procurement flow is PR → PA → PO.
+_Avoid_: Purchase Agreement; Work Acceptance (WA is a separate document, ตรวจรับ); treating PA as a mere view/report of the PR.
 
 **PO (Purchase Order)**:
 The `purchase.order` document — an order to buy/hire (ใบสั่งซื้อ/สั่งจ้าง).
+
+**Procurement Mode (โหมดจัดหา)**:
+A flag chosen on the PR for who sources vendor and price: *ให้พัสดุจัดหา* (the procurement officer sources them — the requester leaves vendor/VAT blank, and they are filled later on the PA) or *ผู้ขอระบุเอง* (the requester specifies vendor + VAT up front). It replaces the old amount-based vendor-required rule; budget is never mandatory at PR creation regardless of mode.
+_Avoid_: deriving "must specify a vendor" from an amount threshold.
 
 **Assigned Officer**:
 The procurement officer (เจ้าหน้าที่พัสดุ) responsible for handling a document's work. Stored in the `assigned_to` field. A PA has no officer of its own — it derives from its parent PR's officer.

--- a/docs/adr/0002-pa-separate-model.md
+++ b/docs/adr/0002-pa-separate-model.md
@@ -1,0 +1,25 @@
+# พจ.1 (PA) stays a separate model from พ.1 (PR) — not collapsed
+
+พ.1 (`purchase.request`, ใบขอให้จัดหา, approved by the หัวหน้าส่วนงาน) and พจ.1
+(`purchase.request.approval`, ขออนุมัติจัดซื้อจัดจ้าง, approved to actually buy) are two distinct
+approval processes with different approvers. พจ.1 copies its data from พ.1 but may legitimately
+diverge — vendor, tax, procurement type, and (God-Mode) the amount within the reserved budget can
+all be re-edited on the พจ.1. We therefore keep `purchase.request.approval` as a **separate model**
+(`_inherits purchase.request` via `request_id`), with **1 พ.1 → 1 พจ.1** enforced as a policy while
+the schema stays one-to-many, rather than folding พจ.1 into a phase/report of the PR.
+
+## Considered options
+
+- **Collapse PA into the PR** as a lifecycle phase plus a generated PDF report — rejected: the two
+  are genuinely separate documents whose data diverges and which carry separate approvers; collapsing
+  would force divergent-data hacks and lose the distinct approval identity.
+
+## Consequences
+
+- The two approvals — พ.1 "อนุมัติให้จัดหา" (dept head) and พจ.1 "อนุมัติจัดซื้อ" — are a
+  **legitimate double approval, not duplication**. The messiness today comes from cramming both onto
+  overlapping PR states, not from the two documents existing.
+- The PA-family modules keep their raison d'être. This **reinforces ADR-0001** (which already treats
+  PA as its own document deriving the officer from its PR); nothing there is superseded.
+- If split procurement (many พจ.1 per พ.1) is ever needed, only the 1:1 policy guard is relaxed — no
+  schema migration.

--- a/docs/adr/0003-sarabun-sole-approval-driver.md
+++ b/docs/adr/0003-sarabun-sole-approval-driver.md
@@ -1,0 +1,26 @@
+# Sarabun is the sole approval driver for พ.1 and พจ.1 — drop manual buttons and tier validation
+
+All approvals in the phase-1 procurement flow — พ.1 "อนุมัติให้จัดหา" (หัวหน้าส่วนงาน) and พจ.1
+"อนุมัติจัดซื้อ" — route **exclusively through Sarabun** document routing. Pressing "send to Sarabun"
+moves the document to its *await-approval* state; Sarabun completion advances it. The three
+competing approval drivers that currently mutate the same `state` — manual buttons
+(`button_approved`/`button_validate`), `base_tier_validation` reviews, and Sarabun callbacks (which
+already disable tier validation) — collapse to **one owner: Sarabun**.
+
+A manual status button, limited to the "return for minor, non-material edits" case, is **deferred to
+a later phase** and deliberately out of scope here.
+
+## Considered options
+
+- **Keep `base_tier_validation` for multi-tier in-system approval** — rejected: the organisation uses
+  Sarabun as its real document-routing/approval system; running two mechanisms produces
+  install-order (MRO) dependent behaviour and tangles the PA-family dependency graph.
+
+## Consequences
+
+- `base_tier_validation*` dependencies come off the พ.1/พจ.1 approval path (e.g. the
+  `purchase_request_egp` → `purchase_request_tier_validation` edge). Work-Acceptance tier validation
+  is a phase-2 concern, evaluated separately.
+- The state machine gains a single, load-order-independent transition owner, removing the
+  `super()`-chain fragility across `purchase_request_approval*`, `purchase_request_verify_state`, and
+  `purchase_request_sarabun`.

--- a/docs/adr/0004-pa-owns-copied-data.md
+++ b/docs/adr/0004-pa-owns-copied-data.md
@@ -1,0 +1,32 @@
+# พจ.1 (PA) carries its own copied, divergeable data — own columns + own line model, not pure delegation
+
+D1/D8/D9 require the พจ.1 to be **copied** from the พ.1 and then edited independently (vendor, VAT,
+line prices, amount), without mutating the พ.1. Today `purchase.request.approval` uses
+`_inherits = {"purchase.request": "request_id"}` — pure delegation — so every field (partner, taxes,
+`line_ids`, `estimated_cost`) resolves to the shared PR; editing them on the PA writes straight back to
+the พ.1. That cannot satisfy "copied but divergeable".
+
+**Decision.** Give the PA its **own stored columns** for the divergeable header fields (vendor/partner,
+VAT/tax, amount) and its **own line model** `purchase.request.approval.line` (product + quantity locked,
+price editable). Both are populated by a **snapshot copy from the PR at PA creation** — identical at
+first, then free to diverge. `_inherits` is **kept only** to carry the shared, non-divergeable
+descriptive metadata (requester, department, financial dimensions, title, fiscal year) as read-only
+single-source context on the PA.
+
+## Considered options
+
+- **Pure delegation (status quo)** — rejected: PA data physically cannot diverge from the PR.
+- **Drop `_inherits` entirely and copy every field** — rejected: large churn and loses the shared-metadata
+  single source of truth for descriptive fields that must *not* diverge.
+
+## Consequences
+
+- **`_inherits` field shadowing:** a PA-own field cannot share a name with a delegated one — either declare
+  the PA-own field so it takes precedence over the delegated related, or use distinct names. Verify Odoo 16
+  `_inherits` shadowing behaviour at implementation.
+- **Blast radius:** any PA code / report / compute that currently reads delegated `line_ids` /
+  `estimated_cost` / `partner_id` must repoint to the PA-own line model and columns. The พจ.1 PDF renders
+  **PA-own** data; the God-Mode amount edit and vendor/VAT edits live on PA columns; the budget check
+  (total ≤ reserved) reads the **PA-own** total.
+- The 1 พ.1 → 1 พจ.1 policy (D3) is re-enforced by re-enabling the commented-out `request_id_uniq`
+  constraint. Reinforces [ADR-0002](0002-pa-separate-model.md).

--- a/docs/adr/purchase-workflow-bpmn.drawio
+++ b/docs/adr/purchase-workflow-bpmn.drawio
@@ -1,0 +1,193 @@
+<mxfile host="Electron">
+  <diagram id="purchase-workflow-bpmn" name="Purchase Workflow (BPMN)">
+    <mxGraphModel dx="1983" dy="960" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="2000" pageHeight="1120" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="title" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=18;fontStyle=1;" value="กระบวนการจัดซื้อจัดจ้าง KMITL — มุมมอง BPMN (Collaboration Diagram) · เฟส 1: ร่าง พ.1 → สร้างสัญญา/PO" vertex="1">
+          <mxGeometry height="30" width="1500" x="40" y="12" as="geometry" />
+        </mxCell>
+        <mxCell id="ph1" parent="1" style="rounded=1;html=1;fillColor=#f5f5f5;strokeColor=#cccccc;fontSize=11;fontStyle=1;" value="① เตรียมเรื่อง — แก้ไขได้ทุกฟิลด์ก่อนส่ง Sarabun" vertex="1">
+          <mxGeometry height="26" width="720" x="100" y="55" as="geometry" />
+        </mxCell>
+        <mxCell id="ph2" parent="1" style="rounded=1;html=1;fillColor=#f5f5f5;strokeColor=#cccccc;fontSize=11;fontStyle=1;" value="② อนุมัติให้จัดหา (Sarabun)" vertex="1">
+          <mxGeometry height="26" width="330" x="830" y="55" as="geometry" />
+        </mxCell>
+        <mxCell id="ph3" parent="1" style="rounded=1;html=1;fillColor=#f5f5f5;strokeColor=#cccccc;fontSize=11;fontStyle=1;" value="③ จัดทำ พจ.1 / e-GP" vertex="1">
+          <mxGeometry height="26" width="360" x="1170" y="55" as="geometry" />
+        </mxCell>
+        <mxCell id="ph4" parent="1" style="rounded=1;html=1;fillColor=#f5f5f5;strokeColor=#cccccc;fontSize=11;fontStyle=1;" value="④ สร้างสัญญา (จบเฟส 1)" vertex="1">
+          <mxGeometry height="26" width="400" x="1540" y="55" as="geometry" />
+        </mxCell>
+        <mxCell id="pool_pr" parent="1" style="swimlane;horizontal=0;html=1;startSize=25;fillColor=none;strokeColor=#6c8ebf;fontStyle=1;fontSize=12;" value="พ.1 (PR) — เอกสารหลัก (master) · purchase.request" vertex="1">
+          <mxGeometry height="450" width="1900" x="40" y="95" as="geometry" />
+        </mxCell>
+        <mxCell id="lane_req" parent="pool_pr" style="swimlane;horizontal=0;html=1;startSize=25;fillColor=#eef5fd;strokeColor=#6c8ebf;fontSize=11;" value="ผู้ขอ" vertex="1">
+          <mxGeometry height="130" width="1875" x="25" as="geometry" />
+        </mxCell>
+        <mxCell id="start_ev" parent="lane_req" style="shape=mxgraph.bpmn.shape;perimeter=ellipsePerimeter;html=1;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;outlineConnect=0;symbol=general;outline=standard;fillColor=#d5e8d4;strokeColor=#82b366;" value="เริ่ม" vertex="1">
+          <mxGeometry height="50" width="50" x="30" y="40" as="geometry" />
+        </mxCell>
+        <mxCell id="t_create" parent="lane_req" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=11;align=left;spacingLeft=26;" value="สร้าง พ.1&#xa;• เลือกโหมดจัดหา&#xa;• กรอกประเภท/วิธีจัดซื้อ&#xa;• (+คู่ค้า/VAT ถ้าระบุเอง)" vertex="1">
+          <mxGeometry height="84" width="210" x="110" y="24" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_create" parent="lane_req" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="116" y="30" as="geometry" />
+        </mxCell>
+        <mxCell id="t_confirm" parent="lane_req" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;fontSize=11;align=left;spacingLeft=26;" value="ยืนยันข้อมูล" vertex="1">
+          <mxGeometry height="60" width="160" x="600" y="35" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_confirm" parent="lane_req" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="606" y="41" as="geometry" />
+        </mxCell>
+        <mxCell id="lane_fin" parent="pool_pr" style="swimlane;horizontal=0;html=1;startSize=25;fillColor=#eafaf1;strokeColor=#82b366;fontSize=11;" value="การเงิน / ธุรการที่มอบหมาย" vertex="1">
+          <mxGeometry height="130" width="1875" x="25" y="130" as="geometry" />
+        </mxCell>
+        <mxCell id="t_reserve" parent="lane_fin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;fontSize=11;align=left;spacingLeft=26;" value="จองงบประมาณ&#xa;(ตรวจ ยอดรวม ≤ งบ)" vertex="1">
+          <mxGeometry height="60" width="185" x="365" y="30" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_reserve" parent="lane_fin" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="371" y="36" as="geometry" />
+        </mxCell>
+        <mxCell id="lane_off" parent="pool_pr" style="swimlane;horizontal=0;html=1;startSize=25;fillColor=#fff9e9;strokeColor=#d6b656;fontSize=11;" value="เจ้าหน้าที่พัสดุ" vertex="1">
+          <mxGeometry height="190" width="1875" x="25" y="260" as="geometry" />
+        </mxCell>
+        <mxCell id="t_send" parent="lane_off" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d6b656;fontSize=11;align=left;spacingLeft=26;" value="ตรวจ/แก้ข้อมูล&#xa;ส่งเข้า Sarabun" vertex="1">
+          <mxGeometry height="60" width="170" x="810" y="65" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_send" parent="lane_off" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="816" y="71" as="geometry" />
+        </mxCell>
+        <mxCell id="gw_egp" parent="lane_off" style="shape=mxgraph.bpmn.shape;perimeter=rhombusPerimeter;html=1;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;outlineConnect=0;background=gateway;outline=standard;symbol=exclusiveGw;fillColor=#fff2cc;strokeColor=#d6b656;" value="e-GP ?" vertex="1">
+          <mxGeometry height="64" width="64" x="1040" y="61" as="geometry" />
+        </mxCell>
+        <mxCell id="t_egp" parent="lane_off" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d6b656;fontSize=11;align=left;spacingLeft=26;" value="กรอกเลขที่โครงการ e-GP" vertex="1">
+          <mxGeometry height="55" width="190" x="1165" y="15" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_egp" parent="lane_off" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="1171" y="21" as="geometry" />
+        </mxCell>
+        <mxCell id="t_makepa" parent="lane_off" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;fontSize=11;align=left;spacingLeft=26;" value="สร้าง พจ.1&#xa;(คัดลอกจาก พ.1)" vertex="1">
+          <mxGeometry height="55" width="190" x="1165" y="120" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_makepa" parent="lane_off" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="1171" y="126" as="geometry" />
+        </mxCell>
+        <mxCell id="t_po" parent="lane_off" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d6b656;fontSize=11;align=left;spacingLeft=26;" value="สร้างสัญญา/PO&#xa;→ เสร็จสิ้น" vertex="1">
+          <mxGeometry height="62" width="190" x="1495" y="63" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_po" parent="lane_off" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="1501" y="69" as="geometry" />
+        </mxCell>
+        <mxCell id="end_ev" parent="lane_off" style="shape=mxgraph.bpmn.shape;perimeter=ellipsePerimeter;html=1;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;outlineConnect=0;symbol=general;outline=end;fillColor=#d5e8d4;strokeColor=#82b366;" value="จบเฟส 1" vertex="1">
+          <mxGeometry height="54" width="54" x="1755" y="68" as="geometry" />
+        </mxCell>
+        <mxCell id="pool_sarabun" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f4eefb;strokeColor=#9673a6;fontStyle=1;fontSize=12;verticalAlign=middle;" value="ระบบสารบรรณ (Sarabun) · ผู้อนุมัติ&#xa;— อนุมัติทุกขั้นผ่าน Sarabun เท่านั้น (เลิก manual + tier.validation) —" vertex="1">
+          <mxGeometry height="66" width="390" x="815" y="575" as="geometry" />
+        </mxCell>
+        <mxCell id="pool_pa" parent="1" style="swimlane;horizontal=0;html=1;startSize=25;fillColor=#faf6fd;strokeColor=#9673a6;fontStyle=1;fontSize=12;" value="พจ.1 (PA) — โมเดลแยก · purchase.request.approval" vertex="1">
+          <mxGeometry height="185" width="1900" x="40" y="675" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_lane" parent="pool_pa" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=top;fontSize=10;fontColor=#9673a6;" value="เจ้าหน้าที่พัสดุ (ดำเนินการ พจ.1)" vertex="1">
+          <mxGeometry height="18" width="300" x="35" y="4" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_start" parent="pool_pa" style="shape=mxgraph.bpmn.shape;perimeter=ellipsePerimeter;html=1;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;outlineConnect=0;symbol=message;outline=standard;fillColor=#e1d5e7;strokeColor=#9673a6;" value="ร่าง พจ.1&#xa;(รับจาก พ.1)" vertex="1">
+          <mxGeometry height="54" width="54" x="900" y="62" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_make" parent="pool_pa" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;fontSize=11;align=left;spacingLeft=26;" value="จัดทำ พจ.1&#xa;(แก้คู่ค้า/VAT/ราคาได้)&#xa;ส่ง Sarabun" vertex="1">
+          <mxGeometry height="60" width="175" x="1010" y="60" as="geometry" />
+        </mxCell>
+        <mxCell id="ic_pamake" parent="pool_pa" style="shape=mxgraph.bpmn.user_task;html=1;" value="" vertex="1">
+          <mxGeometry height="20" width="20" x="1016" y="66" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_appr" parent="pool_pa" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" value="อนุมัติแล้ว" vertex="1">
+          <mxGeometry height="52" width="150" x="1235" y="63" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_end" parent="pool_pa" style="shape=mxgraph.bpmn.shape;perimeter=ellipsePerimeter;html=1;verticalLabelPosition=bottom;labelBackgroundColor=default;verticalAlign=top;outlineConnect=0;symbol=general;outline=end;fillColor=#d5e8d4;strokeColor=#82b366;" value="พจ.1 อนุมัติ" vertex="1">
+          <mxGeometry height="54" width="54" x="1435" y="62" as="geometry" />
+        </mxCell>
+        <mxCell id="e0" edge="1" parent="1" source="start_ev" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_create">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e1" edge="1" parent="1" source="t_create" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_reserve" value="ส่งข้อมูลไปการเงิน [พัสดุ]">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e2" edge="1" parent="1" source="t_reserve" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_confirm" value="จองงบแล้ว → รอผู้ขอยืนยัน">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e3" edge="1" parent="1" source="t_confirm" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_send" value="ยืนยัน → ส่งต่อพัสดุ [ผู้ขอ]">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e4" edge="1" parent="1" source="gw_egp" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_egp" value="ใช่ (เข้า e-GP)">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e5" edge="1" parent="1" source="gw_egp" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_makepa" value="ไม่ใช่">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e6" edge="1" parent="1" source="t_egp" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="t_po" value="ยืนยันข้อมูล">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e7" edge="1" parent="1" source="t_po" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="end_ev">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="bk1" edge="1" parent="1" source="t_confirm" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;strokeColor=#b85450;fontColor=#b85450;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="t_create" value="ดึงกลับ / ตีกลับ (แก้ไขก่อนส่ง)">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="745" y="112" />
+              <mxPoint x="280" y="112" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="pe1" edge="1" parent="1" source="pa_start" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="pa_make">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="pe2" edge="1" parent="1" source="pa_make" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="pa_appr" value="Sarabun อนุมัติ">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="pe3" edge="1" parent="1" source="pa_appr" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="pa_end">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="m1" edge="1" parent="1" source="t_send" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;startArrow=oval;startFill=0;endArrow=open;endFill=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.35;entryY=0;entryDx=0;entryDy=0;" target="pool_sarabun" value="ขออนุมัติให้จัดหา">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="m2" edge="1" parent="1" source="pool_sarabun" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;startArrow=oval;startFill=0;endArrow=open;endFill=0;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" target="gw_egp" value="อนุมัติ (หัวหน้าส่วนงาน)">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="m3" edge="1" parent="1" source="t_makepa" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;startArrow=oval;startFill=0;endArrow=open;endFill=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="pa_start" value="สร้าง พจ.1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1325" y="658" />
+              <mxPoint x="992" y="658" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="m4" edge="1" parent="1" source="pa_make" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;startArrow=oval;startFill=0;endArrow=open;endFill=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.55;entryY=1;entryDx=0;entryDy=0;" target="pool_sarabun" value="ขออนุมัติจัดซื้อ">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="m5" edge="1" parent="1" source="pool_sarabun" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;startArrow=oval;startFill=0;endArrow=open;endFill=0;exitX=0.9;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" target="pa_appr" value="อนุมัติ">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="1166" y="660" />
+              <mxPoint x="1310" y="660" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="m6" edge="1" parent="1" source="pa_end" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;startArrow=oval;startFill=0;endArrow=open;endFill=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" target="t_po" value="พจ.1 อนุมัติ → อยู่ระหว่างจัดซื้อจัดจ้าง">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="legend" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#ffffff;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;คำอธิบายสัญลักษณ์ (BPMN)&lt;/b&gt;&lt;br&gt;● วงกลมบาง = จุดเริ่ม · ◎ วงกลมหนา = จุดจบ · ✉ = เริ่มด้วยข้อความ&lt;br&gt;◇ ข้าวหลามตัด (X) = เกตเวย์ตัดสินใจทางเลือกเดียว (XOR)&lt;br&gt;▢ + ไอคอนคน = งานที่คนทำ (User Task)&lt;br&gt;⎯⎯ เส้นทึบ = ลำดับงาน (Sequence Flow) ภายใน pool เดียว&lt;br&gt;- - ◦ เส้นประ = ข้อความข้าม pool (Message Flow) = คนละเอกสาร/ระบบ&lt;br&gt;กล่อง Pool = เอกสาร/ผู้มีส่วนร่วมที่แยกกัน (พ.1 · Sarabun · พจ.1)" vertex="1">
+          <mxGeometry height="175" width="560" x="60" y="900" as="geometry" />
+        </mxCell>
+        <mxCell id="note_mode" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;โหมดจัดหา (ตั้งบน พ.1) — แทนกฎ ฿100k เดิม&lt;/b&gt;&lt;br&gt;• &quot;ให้พัสดุจัดหา&quot; → คู่ค้า+VAT ไม่บังคับ (พัสดุกรอกที่ พจ.1)&lt;br&gt;• &quot;ผู้ขอระบุเอง&quot; → คู่ค้า+VAT บังคับตั้งแต่ พ.1&lt;br&gt;• ประเภท/วิธีจัดซื้อ: ผู้ขอกรอกก่อนทั้ง 2 โหมด&lt;br&gt;• งบประมาณไม่บังคับ · e-GP เลือกโหมดเองได้" vertex="1">
+          <mxGeometry height="175" width="430" x="640" y="900" as="geometry" />
+        </mxCell>
+        <mxCell id="note_strict" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;ความ strict = window-based + lock-list&lt;/b&gt;&lt;br&gt;• แก้ได้ทุกฟิลด์ (รวม &quot;ประเภทการจ่ายเงิน&quot;) เฉพาะก่อนส่ง Sarabun&lt;br&gt;• ส่ง Sarabun แล้ว → ล็อก&lt;br&gt;• ยอดเงิน: validate &quot;ยอดรวม ≤ งบที่จอง&quot; (เกิน = re-reserve)&lt;br&gt;• พจ.1 God-Mode = group (ไม่ hardcode ชื่อคน)&lt;br&gt;• พจ.1: รายการสินค้าแก้เฉพาะราคา (เพิ่ม/ลดรายการไม่ได้)" vertex="1">
+          <mxGeometry height="175" width="430" x="1090" y="900" as="geometry" />
+        </mxCell>
+        <mxCell id="note_egp" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;dashed=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;เกณฑ์ e-GP + ขอบเขต&lt;/b&gt;&lt;br&gt;• is_egp = computed default (วงเงิน ≥ ฿100,000, config) + พัสดุ override ได้&lt;br&gt;&amp;nbsp;&amp;nbsp;→ เลิก hardcode ฿100,000 (6 จุด/3 โมดูล)&lt;br&gt;• อนุมัติทั้งหมดผ่าน Sarabun เท่านั้น&lt;br&gt;• &lt;b&gt;เฟส 2 (นอกขอบเขต):&lt;/b&gt; ตรวจรับ · เบิกจ่าย · ค้ำประกัน&lt;br&gt;• 1 พ.1 → 1 พจ.1 (policy)" vertex="1">
+          <mxGeometry height="175" width="400" x="1540" y="900" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/adr/purchase-workflow-final.drawio
+++ b/docs/adr/purchase-workflow-final.drawio
@@ -1,0 +1,175 @@
+<mxfile host="Electron">
+  <diagram id="purchase-workflow-final" name="Purchase Workflow (Redesign)">
+    <mxGraphModel dx="1983" dy="960" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1500" pageHeight="1400" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="title" parent="1" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=18;fontStyle=1;" value="กระบวนการจัดซื้อจัดจ้าง KMITL — ออกแบบใหม่ (Target Workflow)&lt;br&gt;&lt;span style=&quot;font-size:11px;font-weight:normal&quot;&gt;master state = พ.1 (PR) · พจ.1 (PA) เป็นเอกสารลูกโมเดลแยก · 1 พ.1 → 1 พจ.1&lt;/span&gt;" vertex="1">
+          <mxGeometry height="50" width="820" x="40" y="10" as="geometry" />
+        </mxCell>
+        <mxCell id="assume" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;สถานะการตัดสินใจ (grill)&lt;/b&gt;&lt;br&gt;✔ พจ.1 แยกโมเดล · พ.1 เป็น master · 1 พ.1 → 1 พจ.1&lt;br&gt;✔ อนุมัติ พจ.1 = Sarabun เท่านั้น (เลิก manual + tier.validation);&lt;br&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;ปุ่ม manual สำหรับตีกลับแก้เล็กน้อย = เฟสถัดไป&lt;br&gt;&lt;br&gt;✔ e-GP = auto-default (≥฿100,000, config) + override; ทุกการอนุมัติผ่าน Sarabun&lt;br&gt;✔ คง 3 แหล่งงบเดิม; จองงบ = การเงิน/ธุรการมอบหมาย; แยกจองงบ↔อนุมัติ&lt;br&gt;&lt;br&gt;✔ ขอบเขตเฟส 1 = ร่าง พ.1 → สร้างสัญญา/PO; WA/เบิกจ่าย/ค้ำประกัน = เฟส 2&lt;br&gt;✔ ความ strict = window-based (แก้ได้ก่อนส่ง Sarabun) + lock-list&lt;br&gt;&lt;br&gt;&lt;b&gt;ถัดไป:&lt;/b&gt; ล้าง dependency → ทำเป็น solution design แยก (ดู docs/)" vertex="1">
+          <mxGeometry height="250" width="410" x="1050" y="20" as="geometry" />
+        </mxCell>
+        <mxCell id="start" parent="1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" value="เริ่ม&lt;br&gt;(ผู้ขอสร้าง พ.1)" vertex="1">
+          <mxGeometry height="50" width="160" x="420" y="70" as="geometry" />
+        </mxCell>
+        <mxCell id="s_draft" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="ร่าง&lt;br&gt;(Draft)" vertex="1">
+          <mxGeometry height="50" width="200" x="400" y="160" as="geometry" />
+        </mxCell>
+        <mxCell id="note_mode" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;โหมดจัดหา (ตั้งบน พ.1)&lt;/b&gt; — แทนกฎ ฿100k เดิม&lt;br&gt;• &quot;ให้พัสดุจัดหา&quot; → คู่ค้า+VAT ไม่บังคับ (พัสดุกรอกที่ พจ.1)&lt;br&gt;• &quot;ผู้ขอระบุเอง&quot; → คู่ค้า+VAT บังคับตั้งแต่ พ.1&lt;br&gt;• ประเภท/วิธีจัดซื้อ: ผู้ขอกรอกก่อนทั้ง 2 โหมด · งบไม่บังคับ&lt;br&gt;• e-GP ก็เลือกโหมดเองได้" vertex="1">
+          <mxGeometry height="120" width="330" x="20" y="420" as="geometry" />
+        </mxCell>
+        <mxCell id="s_reserve" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="รอจองงบประมาณ" vertex="1">
+          <mxGeometry height="50" width="200" x="400" y="260" as="geometry" />
+        </mxCell>
+        <mxCell id="s_confirm" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="รอผู้ขอยืนยัน" vertex="1">
+          <mxGeometry height="50" width="200" x="400" y="360" as="geometry" />
+        </mxCell>
+        <mxCell id="s_submit" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="รอส่งเรื่องอนุมัติให้จัดหา" vertex="1">
+          <mxGeometry height="50" width="200" x="400" y="460" as="geometry" />
+        </mxCell>
+        <mxCell id="s_await" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="รออนุมัติให้จัดหา" vertex="1">
+          <mxGeometry height="50" width="200" x="400" y="560" as="geometry" />
+        </mxCell>
+        <mxCell id="d_egp" parent="1" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" value="e-GP ?" vertex="1">
+          <mxGeometry height="90" width="120" x="440" y="655" as="geometry" />
+        </mxCell>
+        <mxCell id="s_egp" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="รอดำเนินการ e-GP&lt;br&gt;(กรอกเลขที่โครงการ)" vertex="1">
+          <mxGeometry height="60" width="200" x="120" y="675" as="geometry" />
+        </mxCell>
+        <mxCell id="s_wait_pa" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="อนุมัติให้จัดหา&lt;br&gt;(รอทำ พจ.1)" vertex="1">
+          <mxGeometry height="55" width="200" x="400" y="800" as="geometry" />
+        </mxCell>
+        <mxCell id="s_in_proc" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="อยู่ระหว่างจัดหา&lt;br&gt;(พจ.1 กำลังดำเนินการ)" vertex="1">
+          <mxGeometry height="55" width="200" x="400" y="910" as="geometry" />
+        </mxCell>
+        <mxCell id="s_purch" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="อยู่ระหว่างจัดซื้อจัดจ้าง" vertex="1">
+          <mxGeometry height="55" width="200" x="400" y="1030" as="geometry" />
+        </mxCell>
+        <mxCell id="s_done" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" value="จัดซื้อจัดจ้างเสร็จสิ้น&lt;br&gt;(สร้างสัญญา/PO เสร็จ — จบเฟส 1)" vertex="1">
+          <mxGeometry height="55" width="220" x="390" y="1150" as="geometry" />
+        </mxCell>
+        <mxCell id="end" parent="1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" value="จบ" vertex="1">
+          <mxGeometry height="40" width="100" x="450" y="1250" as="geometry" />
+        </mxCell>
+        <mxCell id="s_cancel" parent="1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" value="ยกเลิก" vertex="1">
+          <mxGeometry height="50" width="120" x="140" y="360" as="geometry" />
+        </mxCell>
+        <mxCell id="note_reserve" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;การจองงบ (3 แหล่งเดิมยังใช้ได้)&lt;/b&gt;&lt;br&gt;เดี่ยว = สร้าง commitment ใหม่ · แผน/โครงการ = auto-link commitment เดิม (ไม่จองซ้ำ)&lt;br&gt;• แยก &quot;จองงบ&quot; ออกจาก &quot;อนุมัติ&quot; เด็ดขาด&lt;br&gt;• [รวม 2 บริดจ์เป็น mixin = รอ solution design]" vertex="1">
+          <mxGeometry height="100" width="320" x="20" y="150" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_box" parent="1" style="swimlane;whiteSpace=wrap;html=1;startSize=30;fillColor=#e1d5e7;strokeColor=#9673a6;fontStyle=1;fontSize=11;verticalAlign=top;" value="เอกสาร พจ.1 (PA) — โมเดลแยก · purchase.request.approval" vertex="1">
+          <mxGeometry height="250" width="300" x="700" y="800" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_draft" parent="pa_box" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f0fa;strokeColor=#9673a6;" value="ร่าง พจ.1&lt;br&gt;(คัดลอกจาก พ.1)" vertex="1">
+          <mxGeometry height="45" width="260" x="20" y="45" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_wait" parent="pa_box" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f0fa;strokeColor=#9673a6;" value="รออนุมัติจัดซื้อ" vertex="1">
+          <mxGeometry height="45" width="260" x="20" y="115" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_appr" parent="pa_box" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" value="อนุมัติแล้ว" vertex="1">
+          <mxGeometry height="45" width="260" x="20" y="185" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_e1" edge="1" parent="pa_box" source="pa_draft" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="pa_wait" value="ส่งอนุมัติ">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_e2" edge="1" parent="pa_box" source="pa_wait" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="pa_appr" value="อนุมัติ (Sarabun)">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="pa_e3" edge="1" parent="pa_box" source="pa_wait" style="edgeStyle=orthogonalEdgeStyle;html=1;dashed=1;fontSize=10;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="pa_draft" value="ตีกลับ">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="295" y="137" />
+              <mxPoint x="295" y="67" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e_start" edge="1" parent="1" source="start" style="edgeStyle=orthogonalEdgeStyle;html=1;" target="s_draft">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e1" edge="1" parent="1" source="s_draft" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_reserve" value="ส่งข้อมูลไปการเงิน [พัสดุ]">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e2" edge="1" parent="1" source="s_reserve" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_confirm" value="จองงบประมาณ&lt;br&gt;[การเงิน / ธุรการมอบหมาย]&lt;br&gt;✔ ตรวจงบเพียงพอ">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e3" edge="1" parent="1" source="s_confirm" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_submit" value="ยืนยันข้อมูล [ผู้ขอ]">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_pull" edge="1" parent="1" source="s_confirm" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="s_draft" value="ดึงกลับ [ผู้ขอ]">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="650" y="385" />
+              <mxPoint x="650" y="185" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e_cancel" edge="1" parent="1" source="s_confirm" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_cancel" value="ยกเลิก">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e4" edge="1" parent="1" source="s_submit" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_await" value="ส่งเรื่องเข้า Sarabun [พัสดุ]&lt;br&gt;(Sarabun เริ่มวิ่ง → รออนุมัติ)">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_reject" edge="1" parent="1" source="s_submit" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="s_draft" value="ตีกลับ + ยกเลิกใบจอง">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="485" />
+              <mxPoint x="360" y="185" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e5" edge="1" parent="1" source="s_await" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="d_egp" value="Sarabun อนุมัติ [หัวหน้าส่วนงาน]">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_egp_yes" edge="1" parent="1" source="d_egp" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" target="s_egp" value="ใช่ (เข้า e-GP)">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_egp_no" edge="1" parent="1" source="d_egp" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_wait_pa" value="ไม่ใช่">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_egp_merge" edge="1" parent="1" source="s_egp" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="s_purch" value="ยืนยันข้อมูล">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="350" y="705" />
+              <mxPoint x="350" y="1057" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e_makepa" edge="1" parent="1" source="s_wait_pa" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_in_proc" value="สร้าง พจ.1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_link" edge="1" parent="1" source="s_in_proc" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;dashed=1;endArrow=open;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=0;" target="pa_box" value="ควบคุมโดย พจ.1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_pa_done" edge="1" parent="1" source="pa_appr" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" target="s_purch" value="พจ.1 อนุมัติ">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="660" y="1057" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="e_po" edge="1" parent="1" source="s_purch" style="edgeStyle=orthogonalEdgeStyle;html=1;fontSize=10;" target="s_done" value="สร้างใบสั่งซื้อ/สัญญา (PO)">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e_end" edge="1" parent="1" source="s_done" style="edgeStyle=orthogonalEdgeStyle;html=1;" target="end">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="note_pr" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;พ.1 — ลดความ strict (window-based)&lt;/b&gt;&lt;br&gt;• แก้ได้ทุกฟิลด์ (รวม &quot;ประเภทการจ่ายเงิน&quot;) เฉพาะสถานะ &lt;u&gt;ก่อนส่งสารบรรณ&lt;/u&gt;&lt;br&gt;• ส่ง Sarabun แล้ว → ล็อก&lt;br&gt;• ยอดเงิน: validate &quot;ยอดรวม ≤ งบที่จอง&quot; (เกิน = re-reserve)&lt;br&gt;• แทน is_editable freeze ด้วย lock-list ตามสถานะ" vertex="1">
+          <mxGeometry height="125" width="410" x="1050" y="285" as="geometry" />
+        </mxCell>
+        <mxCell id="note_egp" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;เกณฑ์เข้า e-GP&lt;/b&gt;&lt;br&gt;is_egp = computed default (วงเงิน ≥ ฿100,000) + เจ้าหน้าที่ override ได้&lt;br&gt;เกณฑ์เก็บใน config เดียว — เลิก hardcode ฿100,000 (6 จุด/3 โมดูล)" vertex="1">
+          <mxGeometry height="95" width="270" x="40" y="770" as="geometry" />
+        </mxCell>
+        <mxCell id="note_pa" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#f5f5f5;strokeColor=#9673a6;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;พจ.1 (new version)&lt;/b&gt;&lt;br&gt;• draft (ก่อนส่ง Sarabun) แก้ได้ทุกอย่าง ยกเว้น &quot;ชื่อผู้ขอ&quot;&lt;br&gt;• รายการสินค้า: แก้เฉพาะราคา — เพิ่ม/ลดรายการไม่ได้&lt;br&gt;• คู่ค้า + ภาษีมูลค่าเพิ่ม: &lt;b&gt;แก้ไขได้&lt;/b&gt; (default ดึงจาก พ.1; พัสดุปรับได้)&lt;br&gt;• God Mode = &lt;u&gt;group&lt;/u&gt; (ไม่ hardcode ชื่อคน): แก้ยอด ≤ งบจอง&lt;br&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;แล้วสะท้อนในเอกสาร PDF พจ.1" vertex="1">
+          <mxGeometry height="140" width="410" x="1050" y="800" as="geometry" />
+        </mxCell>
+        <mxCell id="note_seam" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;dashed=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;เฟส 2 — นอกขอบเขต redesign นี้&lt;/b&gt;&lt;br&gt;PO → ตรวจรับ (Work Acceptance) → เบิกจ่าย (Disbursement)&lt;br&gt;คงไว้ตามเดิม; นิยาม &quot;สัญญา contract&quot; ที่ส่งต่อให้ WA/เบิกจ่ายอ่าน" vertex="1">
+          <mxGeometry height="90" width="400" x="700" y="1130" as="geometry" />
+        </mxCell>
+        <mxCell id="legend" parent="1" style="rounded=1;whiteSpace=wrap;html=1;align=left;fillColor=#ffffff;strokeColor=#666666;fontSize=11;verticalAlign=top;spacing=6;" value="&lt;b&gt;คำอธิบาย&lt;/b&gt;&lt;br&gt;น้ำเงิน = สถานะของ พ.1 (master)&lt;br&gt;ม่วง = สถานะของ พจ.1 (เอกสารลูก โมเดลแยก)&lt;br&gt;เหลือง = จุดตัดสินใจ · เขียว = เริ่ม/จบ · แดง = ยกเลิก&lt;br&gt;เทา = หมายเหตุ · [ ] = actor ที่ทำ transition (รอยืนยัน)&lt;br&gt;เส้นประ = ย้อนกลับ / ความสัมพันธ์" vertex="1">
+          <mxGeometry height="130" width="360" x="20" y="1112.5" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/purchase_request_approval_kmitl/models/purchase_request.py
+++ b/purchase_request_approval_kmitl/models/purchase_request.py
@@ -33,13 +33,6 @@ class PurchaseRequest(models.Model):
             return self._popup_exceptions()
         self.write({"state": "to_verify"})
 
-    @api.depends("state")
-    def _compute_is_editable(self):
-        res = super()._compute_is_editable()
-        for record in self:
-            if record.state in ("to_verify"):
-                record.is_editable = False
-
     @api.depends("requested_by")
     def _compute_can_request(self):
         current_user = self.env.user

--- a/purchase_request_budget/models/purchase_request.py
+++ b/purchase_request_budget/models/purchase_request.py
@@ -3,6 +3,7 @@ import logging
 
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_compare
 
 _logger = logging.getLogger(__name__)
 
@@ -101,6 +102,27 @@ class PurchaseRequest(models.Model):
         compute="_compute_hide_reserve_budget_button"
     )
 
+    budget_reserved_amount = fields.Monetary(
+        string="ยอดจองงบ",
+        related="budget_commitment_id.total_reserved",
+        currency_field="currency_id",
+        readonly=True,
+    )
+
+    line_estimated_cost_total = fields.Monetary(
+        string="ยอดรวมรายการ",
+        compute="_compute_line_estimated_cost_total",
+        currency_field="currency_id",
+    )
+
+    is_over_reserved_budget = fields.Boolean(
+        compute="_compute_over_reserved_budget",
+    )
+
+    budget_shortage_message = fields.Text(
+        compute="_compute_over_reserved_budget",
+    )
+
     product_id = fields.Many2one(related=False, readonly=False)
 
     @api.depends("state", "budget_commitment_id", "budget_commitment_id.state")
@@ -125,6 +147,41 @@ class PurchaseRequest(models.Model):
                 rec.hide_reserve_budget_button = False
             else:
                 rec.hide_reserve_budget_button = True
+
+    @api.depends("line_ids.estimated_cost")
+    def _compute_line_estimated_cost_total(self):
+        for rec in self:
+            rec.line_estimated_cost_total = sum(rec.line_ids.mapped("estimated_cost"))
+
+    @api.depends(
+        "line_ids.estimated_cost",
+        "budget_commitment_id",
+        "budget_commitment_id.total_reserved",
+        "budget_commitment_id.state",
+    )
+    def _compute_over_reserved_budget(self):
+        for rec in self:
+            commitment = rec.budget_commitment_id
+            if not commitment or commitment.state == "cancel":
+                rec.is_over_reserved_budget = False
+                rec.budget_shortage_message = False
+                continue
+            line_total = sum(rec.line_ids.mapped("estimated_cost"))
+            reserved = commitment.total_reserved
+            rounding = rec.currency_id.rounding or 0.01
+            if float_compare(line_total, reserved, precision_rounding=rounding) > 0:
+                shortage = line_total - reserved
+                rec.is_over_reserved_budget = True
+                rec.budget_shortage_message = _(
+                    "ยอดรวมรายการ %s บาท เกินยอดจองงบ %s บาท (เกินอยู่ %s บาท)"
+                ) % (
+                    "{:,.2f}".format(line_total),
+                    "{:,.2f}".format(reserved),
+                    "{:,.2f}".format(shortage),
+                )
+            else:
+                rec.is_over_reserved_budget = False
+                rec.budget_shortage_message = False
 
     def _inverse_activity_analytic(self):
         """Update distribution when activity changes"""

--- a/purchase_request_budget/views/purchase_request_views.xml
+++ b/purchase_request_budget/views/purchase_request_views.xml
@@ -52,6 +52,14 @@
             </xpath>
 
             <xpath expr="//notebook" position="before">
+                <field name="is_over_reserved_budget" invisible="1"/>
+                <div class="alert alert-warning" role="alert"
+                     attrs="{'invisible': [('is_over_reserved_budget', '=', False)]}"
+                     style="margin: 10px 0;">
+                    <strong>ยอดรายการเกินยอดจองงบ: </strong>
+                    <field name="budget_shortage_message" nolabel="1" readonly="1"
+                           class="oe_inline"/>
+                </div>
                 <button name="action_open_reservation_picker" type="object"
                     string="เลือกงบประมาณจากผังงบ (ดูยอดคงเหลือ)"
                     class="btn btn-primary mb-2" icon="fa-sitemap"

--- a/purchase_request_sarabun/models/purchase_request.py
+++ b/purchase_request_sarabun/models/purchase_request.py
@@ -2,6 +2,7 @@
 import logging
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -20,6 +21,33 @@ class PurchaseRequest(models.Model):
         string="Main Sarabun Document",
         copy=False,
     )
+
+    @api.depends("state", "main_sarabun_document_id")
+    def _compute_is_editable(self):
+        super()._compute_is_editable()
+        for rec in self:
+            if rec.state == "to_approve" and not rec.main_sarabun_document_id:
+                rec.is_editable = True
+            if rec.main_sarabun_document_id:
+                rec.is_editable = False
+
+    @api.depends(
+        "state",
+        "budget_commitment_id",
+        "budget_commitment_id.state",
+        "main_sarabun_document_id",
+    )
+    def _compute_is_budget_editable(self):
+        super()._compute_is_budget_editable()
+        for rec in self:
+            if rec.main_sarabun_document_id:
+                rec.is_budget_editable = False
+                continue
+            if (
+                rec.budget_commitment_id
+                and rec.budget_commitment_id.state != "cancel"
+            ):
+                rec.is_budget_editable = False
 
     def _compute_access_url(self):
         """Compute the access URL for portal access."""
@@ -70,6 +98,8 @@ class PurchaseRequest(models.Model):
     def action_submit_to_sarabun(self):
         """Submit PR to Sarabun for approval routing."""
         self.ensure_one()
+        if self.is_over_reserved_budget:
+            raise UserError(self.budget_shortage_message)
         result = self.action_create_sarabun_document()
         document = self.env["sarabun.document"].browse(result.get("res_id"))
         self.main_sarabun_document_id = document
@@ -88,3 +118,21 @@ class PurchaseRequest(models.Model):
     def _get_sarabun_report_action(self):
         """Delegate Sarabun report to Purchase Request report."""
         return self.env.ref("purchase_request.action_report_purchase_requests")
+
+
+class PurchaseRequestLine(models.Model):
+    _inherit = "purchase.request.line"
+
+    @api.depends("request_id.state", "request_id.main_sarabun_document_id")
+    def _compute_is_editable(self):
+        super()._compute_is_editable()
+        for rec in self:
+            if rec.purchase_lines:
+                continue
+            if (
+                rec.request_id.state == "to_approve"
+                and not rec.request_id.main_sarabun_document_id
+            ):
+                rec.is_editable = True
+            if rec.request_id.main_sarabun_document_id:
+                rec.is_editable = False

--- a/purchase_request_sarabun/views/purchase_request_views.xml
+++ b/purchase_request_sarabun/views/purchase_request_views.xml
@@ -28,6 +28,12 @@
                     string="Sarabun Document"
                 />
             </xpath>
+
+            <!-- Key line_ids readonly off is_editable instead of the OCA base's
+                 hardcoded state check, so lines stay editable until sarabun submission -->
+            <xpath expr="//field[@name='line_ids']" position="attributes">
+                <attribute name="attrs">{'readonly': [('is_editable', '=', False)]}</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## Summary of changes for PR

**Branch:** `madara1150/purchase-request-form-lock`
**PR Title suggestion:** `[16.0][IMP] purchase_request: unlock form until sarabun submission with over-budget guardrail`

---

### What changed

**`purchase_request_approval_kmitl/models/purchase_request.py`**
- ลบ `_compute_is_editable` override ที่ force `is_editable = False` ตอน `state == "to_verify"` ออก — ก่อนหน้านี้ form จะ lock ตั้งแต่กด "ส่งตรวจ" ซึ่งเร็วเกินไป

**`purchase_request_budget/models/purchase_request.py`**
- เพิ่ม field `budget_reserved_amount` (related → `budget_commitment_id.total_reserved`)
- เพิ่ม field `line_estimated_cost_total` (computed จาก `sum(line_ids.estimated_cost)`)
- เพิ่ม field `is_over_reserved_budget` (Boolean — True เมื่อ line total เกิน reserved และ commitment ยัง active)
- เพิ่ม field `budget_shortage_message` (Text — ข้อความ Thai แจ้งยอดที่เกิน)
- ทั้งหมดใช้ `float_compare` กับ `currency_id.rounding` เพื่อความแม่นยำทางการเงิน

**`purchase_request_budget/views/purchase_request_views.xml`**
- เพิ่ม banner `alert-warning` ก่อน notebook แสดงเมื่อ `is_over_reserved_budget = True`

**`purchase_request_sarabun/models/purchase_request.py`**
- override `_compute_is_editable` บน `PurchaseRequest`: เปิด editing ที่ `to_approve` (จนกว่าจะมี sarabun doc), lock เมื่อ `main_sarabun_document_id` ถูก set
- override `_compute_is_budget_editable` บน `PurchaseRequest`: lock budget dimensions เมื่อ sarabun ส่งแล้ว และเมื่อ commitment active (ป้องกัน ADR-0006 — plan-driven PR budget fields ยัง readonly)
- guard `action_submit_to_sarabun`: check `is_over_reserved_budget` ก่อน raise `UserError` ถ้าเกิน
- เพิ่ม `PurchaseRequestLine._compute_is_editable` override: mirror logic เดียวกับ header เพราะ OCA base ก็ lock lines ที่ `to_approve` เช่นกัน

---

### Behavior

| สถานะ | Non-budget fields | Budget dimensions |
|---|---|---|
| `draft` | แก้ได้ | แก้ได้ (ถ้าไม่มี commitment) |
| `to_verify` | แก้ได้ | แก้ได้ (budget group, ถ้าไม่มี commitment) |
| `to_approve` (ก่อน sarabun) | แก้ได้ | readonly (commitment active) |
| หลัง `action_submit_to_sarabun` | readonly | readonly |

- Banner โผล่เมื่อ `sum(line_ids.estimated_cost) > budget_commitment_id.total_reserved`
- กดส่ง sarabun ตอน over-budget → `UserError` block ไม่ให้ผ่าน