### PR TITLE
[IMP]purchase_request_kmitl: refactor code

### DIFF
--- a/purchase_request_kmitl/models/__init__.py
+++ b/purchase_request_kmitl/models/__init__.py
@@ -3,8 +3,8 @@ from . import (
     procurement_committee,
     procurement_method,
     procurement_type,
+    purchase_order,
     purchase_request,
     purchase_request_line,
     purchase_type,
-    purchase_order,
 )

--- a/purchase_request_kmitl/models/ir_attachment.py
+++ b/purchase_request_kmitl/models/ir_attachment.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
 from odoo import fields, models
 
 

--- a/purchase_request_kmitl/models/procurement_committee.py
+++ b/purchase_request_kmitl/models/procurement_committee.py
@@ -23,7 +23,7 @@ class ProcurementCommittee(models.Model):
     )
     name = fields.Char(
         string="Committee Name",
-        compute="_compute_default_name",
+        compute="_compute_name",
         store=True,
         readonly=False,
         required=True,
@@ -62,11 +62,6 @@ class ProcurementCommittee(models.Model):
         ],
         string="Role",
         required=True,
-        ondelete={
-            "chairman": "set default",
-            "committee": "set default",
-            "secretary": "set default",
-        },
         default="committee",
     )
     note = fields.Text()
@@ -80,13 +75,14 @@ class ProcurementCommittee(models.Model):
     ]
 
     @api.depends("employee_id")
-    def _compute_default_name(self):
+    def _compute_name(self):
         for rec in self:
-            rec.name = rec.employee_id.display_name if rec.employee_id else ""
+            rec.name = rec.employee_id.display_name or ""
 
     @api.constrains("employee_id", "request_id", "committee_type")
     def _check_committee_cross_type_unique(self):
-        allowed_overlap = {"tor_committee", "evaluation" , "work_supervisor"}
+        # TOR, Evaluation and Work Supervisor committees may share members
+        allowed_overlap = {"tor_committee", "evaluation", "work_supervisor"}
         for rec in self:
             if not rec.employee_id or not rec.request_id:
                 continue
@@ -101,7 +97,7 @@ class ProcurementCommittee(models.Model):
                 raise ValidationError(
                     _(
                         "Employee %s cannot appear in multiple committees "
-                        "except TOR and Evaluation committees.",
+                        "except TOR, Evaluation, and Work Supervisor committees.",
                         rec.employee_id.name,
                     )
                 )

--- a/purchase_request_kmitl/models/procurement_type.py
+++ b/purchase_request_kmitl/models/procurement_type.py
@@ -6,7 +6,7 @@ from odoo import fields, models
 
 class ProcurementType(models.Model):
     _name = "procurement.type"
-    _description = "Procurement Method"
+    _description = "Procurement Type"
     _order = "sequence"
 
     name = fields.Char(

--- a/purchase_request_kmitl/models/purchase_order.py
+++ b/purchase_request_kmitl/models/purchase_order.py
@@ -1,14 +1,11 @@
-# -*- coding: utf-8 -*-
-import logging
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
-from odoo.exceptions import UserError, ValidationError
-
-_logger = logging.getLogger(__name__)
+from odoo import fields, models
 
 
 class PurchaseOrder(models.Model):
-    _inherit = 'purchase.order'
+    _inherit = "purchase.order"
 
     procurement_method_id = fields.Many2one(
         comodel_name="procurement.method",

--- a/purchase_request_kmitl/models/purchase_request.py
+++ b/purchase_request_kmitl/models/purchase_request.py
@@ -1,17 +1,13 @@
 # Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import logging
-
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
-
-_logger = logging.getLogger(__name__)
 
 
 class PurchaseRequest(models.Model):
     _inherit = "purchase.request"
 
+    # -- Classification --
     procurement_type_id = fields.Many2one(
         comodel_name="procurement.type",
         string="Procurement Type",
@@ -40,9 +36,58 @@ class PurchaseRequest(models.Model):
     procurement_method_ids = fields.Many2many(
         related="purchase_type_id.procurement_method_ids",
     )
+
+    # -- Header info --
+    title = fields.Char(string="Title", tracking=True)
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Responsible",
+        copy=False,
+        default=lambda self: self.env.user,
+        index=True,
+    )
+    assigned_to = fields.Many2one(
+        string="Purchase Representative",
+        copy=False,
+    )
+    account_fiscal_year_id = fields.Many2one(
+        comodel_name="account.fiscal.year",
+        string="Fiscal Year",
+        tracking=True,
+    )
+    payment_type = fields.Selection(
+        [("direct", "Direct paid"), ("advance", "Advance"), ("prepaid", "Prepaid")],
+        tracking=True,
+    )
     expense_reason = fields.Text(
         string="Reason",
     )
+    is_construction = fields.Boolean(string="Construction", readonly=True)
+
+    # -- Workflow --
+    verified_by = fields.Many2one(
+        comodel_name="res.users",
+        index=True,
+        copy=False,
+        tracking=True,
+    )
+    date_verified = fields.Date(
+        string="Verified Date",
+        copy=False,
+    )
+    approved_by = fields.Many2one(
+        comodel_name="res.users",
+        index=True,
+        copy=False,
+        tracking=True,
+    )
+    date_approved = fields.Date(
+        string="Approved Date",
+        copy=False,
+    )
+    hide_create_po_button = fields.Boolean(compute="_compute_hide_create_po_button")
+
+    # -- Committees --
     procurement_committee_ids = fields.One2many(
         comodel_name="procurement.committee",
         inverse_name="request_id",
@@ -57,63 +102,6 @@ class PurchaseRequest(models.Model):
         domain=[("committee_type", "=", "work_acceptance")],
         copy=True,
     )
-    payment_type = fields.Selection(
-        [("direct", "Direct paid"), ("advance", "Advance"), ("prepaid", "Prepaid")],
-        tracking=True,
-    )
-    assigned_to = fields.Many2one(
-        string="Purchase Representative",
-        copy=False,
-    )
-    verified_by = fields.Many2one(
-        comodel_name="res.users",
-        index=True,
-        copy=False,
-        tracking=True,
-    )
-    approved_by = fields.Many2one(
-        comodel_name="res.users",
-        index=True,
-        copy=False,
-        tracking=True,
-    )
-    date_verified = fields.Date(
-        string="Verified Date",
-        copy=False,
-    )
-    date_approved = fields.Date(
-        string="Approved Date",
-        copy=False,
-    )
-
-    # construction
-    is_construction = fields.Boolean(string="Construction", readonly=True)
-
-    # -- purchase_request_kmitl fields --
-    title = fields.Char(string="title", tracking=True)
-
-    account_fiscal_year_id = fields.Many2one(
-        comodel_name="account.fiscal.year",
-        string="Fiscal Year",
-        tracking=True,
-        readonly=False,
-    )
-
-    attachment_ids = fields.One2many(
-        "ir.attachment",
-        "res_id",
-        string="Document Attachments",
-        tracking=True,
-    )
-
-    user_id = fields.Many2one(
-        comodel_name="res.users",
-        string="Responsible",
-        copy=False,
-        default=lambda self: self.env.user,
-        index=True,
-    )
-
     tor_committee_ids = fields.One2many(
         comodel_name="procurement.committee",
         inverse_name="request_id",
@@ -121,7 +109,6 @@ class PurchaseRequest(models.Model):
         domain=[("committee_type", "=", "tor_committee")],
         copy=True,
     )
-
     price_determine_committee_ids = fields.One2many(
         comodel_name="procurement.committee",
         inverse_name="request_id",
@@ -129,7 +116,6 @@ class PurchaseRequest(models.Model):
         domain=[("committee_type", "=", "price_determine")],
         copy=True,
     )
-
     evaluation_committee_ids = fields.One2many(
         comodel_name="procurement.committee",
         inverse_name="request_id",
@@ -137,7 +123,6 @@ class PurchaseRequest(models.Model):
         domain=[("committee_type", "=", "evaluation")],
         copy=True,
     )
-
     work_supervisor_ids = fields.One2many(
         comodel_name="procurement.committee",
         inverse_name="request_id",
@@ -145,27 +130,36 @@ class PurchaseRequest(models.Model):
         domain=[("committee_type", "=", "work_supervisor")],
         copy=True,
     )
-    hide_create_po_button = fields.Boolean(compute="_hide_create_po_button")
 
-    @api.depends('state')
-    def _hide_create_po_button(self):
+    # -- Attachments --
+    attachment_ids = fields.One2many(
+        "ir.attachment",
+        "res_id",
+        string="Document Attachments",
+        tracking=True,
+    )
+
+    @api.depends("state", "purchase_count")
+    def _compute_hide_create_po_button(self):
         for rec in self:
-            rec.hide_create_po_button = True
-            if rec.state in ('approved', 'in_progress') and rec.purchase_count == 0:
-                rec.hide_create_po_button = False
+            rec.hide_create_po_button = not (
+                rec.state in ("approved", "in_progress") and rec.purchase_count == 0
+            )
 
-    # -- l10n_th_gov_purchase_request methods --
     def _get_domain_purchase_type(self):
         return [("visible_on_purchase_request", "=", True)]
 
     def get_estimated_cost_currency(self, date=False):
-        """Get estimated cost with currency"""
+        """Return estimated cost converted to company currency.
+
+        If the optional module `purchase_request_manual_currency` is installed
+        and a custom rate is set on the request, that rate is used instead of
+        the standard currency conversion.
+        """
         self.ensure_one()
         date = date or fields.Date.context_today(self)
         estimated_cost = sum(self.line_ids.mapped("estimated_cost"))
         if self.currency_id != self.company_id.currency_id:
-            # check installing module `purchase_request_manual_currency`
-            # it should convert following custom rate
             if hasattr(self, "manual_currency") and self.manual_currency:
                 rate = (
                     self.custom_rate
@@ -181,14 +175,8 @@ class PurchaseRequest(models.Model):
 
     @api.onchange("purchase_type_id")
     def _onchange_purchase_type_id(self):
-        procurement_methods = self.purchase_type_id.procurement_method_ids
-        self.update(
-            {
-                "procurement_method_id": len(procurement_methods) == 1
-                and procurement_methods.id
-                or False,
-            }
-        )
+        methods = self.purchase_type_id.procurement_method_ids
+        self.procurement_method_id = methods if len(methods) == 1 else False
 
     def button_approved(self):
         self.write(

--- a/purchase_request_kmitl/models/purchase_request_line.py
+++ b/purchase_request_kmitl/models/purchase_request_line.py
@@ -11,16 +11,15 @@ class PurchaseRequestLine(models.Model):
 
     product_uom_id = fields.Many2one(
         comodel_name="uom.uom",
-        domain=[],
     )
 
     product_id = fields.Many2one(
-        compute="_compute_default_product_id",
+        compute="_compute_product_id",
         store=True,
         readonly=False,
     )
 
     @api.depends("request_id")
-    def _compute_default_product_id(self):
+    def _compute_product_id(self):
         for rec in self:
             rec.product_id = rec.request_id.procurement_type_id.product_id

--- a/purchase_request_kmitl/models/purchase_type.py
+++ b/purchase_request_kmitl/models/purchase_type.py
@@ -48,6 +48,5 @@ class PurchaseType(models.Model):
 
     @api.constrains("active", "is_default")
     def _check_is_default(self):
-        purchase_types = self.env["purchase.type"].search([("is_default", "=", True)])
-        if len(purchase_types) > 1:
+        if self.env["purchase.type"].search_count([("is_default", "=", True)]) > 1:
             raise UserError(_("Purchase type must have only one default."))

--- a/purchase_request_kmitl/wizards/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_kmitl/wizards/purchase_request_line_make_purchase_order.py
@@ -1,14 +1,12 @@
-# -*- coding: utf-8 -*-
-import logging
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
-
-_logger = logging.getLogger(__name__)
+from odoo.exceptions import UserError
 
 
 class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
-    _inherit = 'purchase.request.line.make.purchase.order'
+    _inherit = "purchase.request.line.make.purchase.order"
 
     @api.model
     def _prepare_purchase_order(self, picking_type, group_id, company, origin):
@@ -26,16 +24,14 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         for item in self.item_ids:
             line = item.line_id
             if line.purchase_lines:
-                raise UserError(_(
-                    "The purchase request '%s' already has a Purchase Order."
-                ) % line.display_name)
-
-        res = super().make_purchase_order()
-        return res
+                raise UserError(
+                    _("The purchase request '%s' already has a Purchase Order.", line.display_name)
+                )
+        return super().make_purchase_order()
 
 
 class PurchaseRequestLineMakePurchaseOrderItem(models.TransientModel):
-    _inherit = 'purchase.request.line.make.purchase.order.item'
+    _inherit = "purchase.request.line.make.purchase.order.item"
 
     keep_description = fields.Boolean(
         default=True,


### PR DESCRIPTION
Clean — only the new names remain. All 10 items from the plan are done:

| File | Changes |
|---|---|
| `purchase_request.py` | Removed unused imports, fixed `"title"` → `"Title"`, regrouped all 6 committee fields, reorganized into 5 sections, added `purchase_count` to `@api.depends`, simplified `_onchange_purchase_type_id`, added docstring to `get_estimated_cost_currency`, dropped no-op `readonly=False` |
| `purchase_request_line.py` | Renamed compute to `_compute_product_id`, dropped empty `domain=[]` |
| `procurement_committee.py` | Fixed whitespace in `allowed_overlap`, updated error message to include Work Supervisor, renamed `_compute_default_name` → `_compute_name`, moved `_sql_constraints` above methods, removed `ondelete` from `approve_role` |
| `purchase_type.py` | `search()` + `len()` → `search_count()` |
| `procurement_type.py` | Fixed `_description = "Procurement Method"` → `"Procurement Type"` |
| `purchase_order.py` | Removed coding header, unused imports, standardized string quotes |
| `ir_attachment.py` | Added license header, removed coding header |
| `models/__init__.py` | Alphabetized (`purchase_order` moved into correct position) |
| `wizards/...make_purchase_order.py` | Removed coding header + unused imports, fixed `%` → `_()` positional form, simplified `make_purchase_order` return |