### PR TITLE
[16.0][IMP] accounting_kmitl: show positive totals in Account Entries and Approver lists

### DIFF
--- a/accounting_kmitl/i18n/th.po
+++ b/accounting_kmitl/i18n/th.po
@@ -132,8 +132,19 @@ msgstr "รายการบันทึกบัญชี"
 
 #. module: accounting_kmitl
 #: model:ir.ui.menu,name:accounting_kmitl.menu_account_entries
+#: model:ir.actions.act_window,name:accounting_kmitl.action_account_entries
 msgid "Account Entries"
 msgstr "รายการเดินบัญชี"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_tree_positive_total
+msgid "Total"
+msgstr "รวม"
+
+#. module: accounting_kmitl
+#: model_terms:ir.ui.view,arch_db:accounting_kmitl.view_move_tree_positive_total
+msgid "Total Amount"
+msgstr "ยอดรวม"
 
 #. module: accounting_kmitl
 #: model:ir.ui.menu,name:accounting_kmitl.menu_journal_items_all

--- a/accounting_kmitl/views/account_move_views.xml
+++ b/accounting_kmitl/views/account_move_views.xml
@@ -194,4 +194,30 @@
         </field>
     </record>
 
+    <!-- Account Entries list: show the total as a positive amount (amount_total)
+         instead of the signed total (amount_total_signed). primary view so the
+         change is scoped to this action only, not the shared Journal Entries list. -->
+    <record id="view_move_tree_positive_total" model="ir.ui.view">
+        <field name="name">account.move.tree.positive.total.kmitl</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_tree"/>
+        <field name="mode">primary</field>
+        <field name="priority">99</field>
+        <field name="arch" type="xml">
+            <field name="amount_total_signed" position="replace">
+                <field name="amount_total" string="Total" sum="Total Amount" decoration-bf="1"/>
+            </field>
+        </field>
+    </record>
+
+    <!-- Account Entries action pinned to the positive-total tree -->
+    <record id="action_account_entries" model="ir.actions.act_window">
+        <field name="name">Account Entries</field>
+        <field name="res_model">account.move</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_id" ref="view_move_tree_positive_total"/>
+        <field name="search_view_id" ref="account.view_account_move_filter"/>
+        <field name="context">{'default_move_type': 'entry', 'search_default_posted': 1, 'view_no_maturity': True}</field>
+    </record>
+
 </odoo>

--- a/accounting_kmitl/views/menuitem.xml
+++ b/accounting_kmitl/views/menuitem.xml
@@ -79,7 +79,7 @@
         id="menu_account_entries"
         name="Account Entries"
         parent="menu_journal_entries"
-        action="account.action_move_journal_line"
+        action="action_account_entries"
         sequence="5"
     />
 

--- a/accounting_kmitl_workflow/static/src/approval_queue/approval_queue.js
+++ b/accounting_kmitl_workflow/static/src/approval_queue/approval_queue.js
@@ -13,7 +13,7 @@ const MOVE_FIELDS = [
     "journal_id",
     "submitted_by",
     "submitted_date",
-    "amount_total_signed",
+    "amount_total",
     "narration",
     "activity_analytic_id",
     "department_analytic_id",

--- a/accounting_kmitl_workflow/static/src/approval_queue/approval_queue.xml
+++ b/accounting_kmitl_workflow/static/src/approval_queue/approval_queue.xml
@@ -155,7 +155,7 @@
                                 <td t-esc="displayName(move.partner_id)"/>
                                 <td t-esc="displayName(move.journal_id)"/>
                                 <td t-esc="displayName(move.submitted_by)"/>
-                                <td class="text-end" t-esc="formatCurrency(move.amount_total_signed)"/>
+                                <td class="text-end" t-esc="formatCurrency(move.amount_total)"/>
                                 <td class="text-end text-nowrap">
                                     <button class="btn btn-sm btn-outline-secondary me-1"
                                             t-on-click.stop="() => this.openMove(move)">

--- a/accounting_kmitl_workflow/views/account_move_queue_views.xml
+++ b/accounting_kmitl_workflow/views/account_move_queue_views.xml
@@ -38,10 +38,10 @@
                 <field name="submitted_by"/>
                 <field name="approved_by"/>
                 <field name="approved_date"/>
-                <field name="amount_total_signed" sum="Total" string="Total"/>
+                <field name="amount_total" sum="Total" string="Total"/>
                 <field name="display_state" widget="badge"
                        decoration-success="display_state == 'posted'"/>
-                <field name="company_currency_id" invisible="1"/>
+                <field name="currency_id" invisible="1"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
## สรุป
ทำให้คอลัมน์ยอดรวมแสดงเป็นค่า **บวกเสมอ** ในหน้าจอที่ผู้ใช้ระบุ โดยเดิมใช้ core field `amount_total_signed` ที่มีเครื่องหมาย +/- ตามทิศทางเอกสาร (ใบตั้งหนี้ผู้ขาย / ใบลดหนี้ จึงติดลบ) เปลี่ยนไปใช้ `amount_total` (ยอดรวมสัมบูรณ์ บวกเสมอ) ไม่ต้องเพิ่ม field ใหม่

ครอบคลุม 2 โมดูล:

### 1. `accounting_kmitl` — เมนู รายการบัญชี > รายการเดินบัญชี (Account Entries)
- `views/account_move_views.xml`: เพิ่ม primary inherited view `view_move_tree_positive_total` (สลับ `amount_total_signed` → `amount_total`) + action `action_account_entries` ที่ pin view นี้ (context/search view เดิมจาก core)
- `views/menuitem.xml`: ชี้ `menu_account_entries` ไป action ใหม่
- `i18n/th.po`: คำแปล action + view term (`Total`→`รวม`, `Total Amount`→`ยอดรวม`)
- ใช้ `mode="primary"` เพื่อไม่กระทบเมนูแม่ **รายการบันทึกบัญชี** (Journal Entries) และ list อื่นที่ใช้ `account.view_move_tree` ร่วมกัน

### 2. `accounting_kmitl_workflow` — เมนู ผู้อนุมัติ (Approver)
- **รายการรออนุมัติ** (Approval List, OWL): `static/src/approval_queue/approval_queue.js` (MOVE_FIELDS) + `approval_queue.xml` (template) เปลี่ยนจาก `amount_total_signed` → `amount_total`
- **อนุมัติแล้ว** (Approved, tree): `views/account_move_queue_views.xml` เปลี่ยน field เป็น `amount_total` และสลับ currency companion เป็น `currency_id`

> เมนูอนุมัติในโมดูลอื่น (agx_approval, disbursement, budget transfer, purchase_request_approval, advance_payment) ใช้ field ที่เป็นบวกโดยธรรมชาติ (ไม่ใช่ `_signed`) จึงไม่อยู่ในขอบเขต

## ขอบเขต
- reuse core field `amount_total` — ไม่แตะ Python และไม่เพิ่ม field ใหม่
- แก้เฉพาะ list/tree + OWL queue; ไม่แตะ kanban/form

## การทดสอบ
1. อัปเกรดโมดูล `-u accounting_kmitl,accounting_kmitl_workflow`
2. **รายการเดินบัญชี** → คอลัมน์ "รวม" + ผลรวมท้ายตาราง เป็นบวกทุกแถว
3. **ผู้อนุมัติ > รายการรออนุมัติ** และ **ผู้อนุมัติ > อนุมัติแล้ว** → คอลัมน์ยอดรวม เป็นบวกทุกแถว
4. เมนูแม่ **รายการบันทึกบัญชี** (Journal Entries) → ยอดยัง signed เหมือนเดิม (ยืนยัน scope แคบ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)