### PR TITLE
[16.0][IMP] purchase_request_sarabun: restrict Create Sarabun button to purchase_request_user_all group

### DIFF
--- a/purchase_request_sarabun/views/purchase_request_views.xml
+++ b/purchase_request_sarabun/views/purchase_request_views.xml
@@ -13,6 +13,7 @@
                     type="object"
                     class="oe_highlight"
                     attrs="{'invisible': ['|', ('state', '!=', 'to_approve'), ('sarabun_document_count', '>', 0)]}"
+                    groups="purchase_request_kmitl.group_purchase_request_user_all"
                 />
             </xpath>
 


### PR DESCRIPTION
## Summary
- Add `groups="purchase_request_kmitl.group_purchase_request_user_all"` to the `action_submit_to_sarabun` ("Create Sarabun") button in the inherited purchase request form so only members of that group can see/click it.

## Test plan
- [ ] Upgrade `purchase_request_sarabun` and confirm the button is visible for users in `purchase_request_kmitl.group_purchase_request_user_all` and hidden for others (in state `to_approve`, `sarabun_document_count = 0`).