### PR TITLE
[16.0][FIX] disbursement_accounting_kmitl: create bill in draft state

### DIFF
--- a/disbursement_accounting_kmitl/models/disbursement_request.py
+++ b/disbursement_accounting_kmitl/models/disbursement_request.py
@@ -167,9 +167,7 @@ class DisbursementRequest(models.Model):
                 for line in lines
             ]
             partner_bank = lines[0].partner_bank_id
-            bill = self.env["account.move"].with_context(
-                auto_submit_on_create=True
-            ).create(
+            bill = self.env["account.move"].create(
                 self._prepare_bill_vals(partner, partner_bank, invoice_lines)
             )
             self._apply_wht_to_bill(bill, lines)


### PR DESCRIPTION
## What

Bills created from a disbursement request (DR) no longer auto-submit. Dropping the `auto_submit_on_create` context flag in `_create_bills` makes the vendor bill land in **draft** instead of `submitted`, so the maker can review and edit it before submitting for approval.

## Why

Users want the ใบตั้งหนี้ generated from a DR to open in Draft, not already Submitted.

## Notes

Single-point change; the auto-submit hook in `accounting_kmitl` is kept as an extension point. No i18n or test changes needed — the existing draft → submitted → approve workflow and bill-count/pipeline computes already treat draft bills correctly.