### PR TITLE
[16.0][IMP] budget: hide redundant "โอเค" button in reservation picker

### DIFF
--- a/budget/__manifest__.py
+++ b/budget/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "KMITL Budgeting",
-    "version": "16.0.1.5.2",
+    "version": "16.0.1.5.3",
     "summary": """ KMITL Budgeting""",
     "category": "KMITL/Budgeting",
     "author": "Aginix Technologies",

--- a/budget/static/src/reservation_picker/budget_reservation_picker.scss
+++ b/budget/static/src/reservation_picker/budget_reservation_picker.scss
@@ -6,6 +6,16 @@
         max-width: 100%;
         width: 95vw;
     }
+
+    // The picker draws its own ยกเลิก / ยืนยัน bar inside the body (.o_brp_footer).
+    // The action dialog also renders a default "โอเค" button in .modal-footer that
+    // only closes the dialog without applying the selection — users mistook it for
+    // the confirm. It auto-hides only when buttons are injected into .modal-footer
+    // (see action_dialog.js), which this body-level footer never does, so hide the
+    // redundant default footer here. This also frees vertical space on short screens.
+    .modal-footer {
+        display: none;
+    }
 }
 
 .o_budget_reservation_picker {


### PR DESCRIPTION
The reservation picker (จองงบประมาณ) is a client action opened as a dialog, so Odoo renders a default primary "โอเค" button in `.modal-footer` that merely closes the dialog **without applying the selection**. The picker already draws its own ยกเลิก / ยืนยัน bar in the body, so the two stacked primary buttons led users to click "โอเค" and lose their selection — especially on short laptop screens. This hides the redundant default footer via the picker-scoped SCSS (leaving only ยกเลิก / ยืนยัน) and reclaims vertical space. Version bumped to `16.0.1.5.3`.