### PR TITLE
[16.0][IMP] purchase_request: pr1 state

### DIFF
--- a/purchase_request_approval_kmitl/i18n/th.po
+++ b/purchase_request_approval_kmitl/i18n/th.po
@@ -94,7 +94,7 @@ msgstr "สถานะ"
 #: model:ir.model.fields.selection,name:purchase_request_approval_kmitl.selection__purchase_request__state__to_verify
 #: model:target.state.value,name:purchase_request_approval_kmitl.target_state_value_approved
 msgid "To be verified"
-msgstr "จองงบประมาณ"
+msgstr "รอจองงบประมาณ"
 
 #. module: purchase_request_approval_kmitl
 #: model:tier.definition,name:purchase_request_approval_kmitl.tier_definition_purchase_request_kmitl_manager

--- a/purchase_request_approval_kmitl/i18n/th.po
+++ b/purchase_request_approval_kmitl/i18n/th.po
@@ -78,7 +78,7 @@ msgstr "ส่งคำขออนุมัติ"
 #. module: purchase_request_approval_kmitl
 #: model_terms:ir.ui.view,arch_db:purchase_request_approval_kmitl.view_purchase_request_form
 msgid "Request approval"
-msgstr "ขอการอนุมัติ"
+msgstr "ส่งข้อมูล"
 
 #. module: purchase_request_approval_kmitl
 #: model_terms:ir.ui.view,arch_db:purchase_request_approval_kmitl.view_purchase_request_form

--- a/purchase_request_approval_kmitl/models/purchase_request.py
+++ b/purchase_request_approval_kmitl/models/purchase_request.py
@@ -5,7 +5,6 @@ from odoo.exceptions import UserError, ValidationError
 
 class PurchaseRequest(models.Model):
     _inherit = "purchase.request"
-    _state_from = ["to_verify", "to_submit"]
 
     _STATES = [("to_verify", "To be verified"), ("to_submit",)]
 

--- a/purchase_request_approval_kmitl/models/purchase_request.py
+++ b/purchase_request_approval_kmitl/models/purchase_request.py
@@ -5,9 +5,9 @@ from odoo.exceptions import UserError, ValidationError
 
 class PurchaseRequest(models.Model):
     _inherit = "purchase.request"
-    _state_from = ["to_verify", "to_approve"]
+    _state_from = ["to_verify", "to_submit"]
 
-    _STATES = [("to_verify", "To be verified"), ("to_approve",)]
+    _STATES = [("to_verify", "To be verified"), ("to_submit",)]
 
     is_purchase_request = fields.Boolean(compute="_compute_is_purchase_request")
     state = fields.Selection(

--- a/purchase_request_budget/models/purchase_request.py
+++ b/purchase_request_budget/models/purchase_request.py
@@ -259,7 +259,7 @@ class PurchaseRequest(models.Model):
     def _compute_to_approve_allowed(self):
         super()._compute_to_approve_allowed()
         for rec in self:
-            rec.to_approve_allowed = rec.state == "to_verify" and any(
+            rec.to_approve_allowed = rec.state == "to_submit" and any(
                 not line.cancelled and line.product_qty for line in rec.line_ids
             )
 

--- a/purchase_request_budget/models/purchase_request.py
+++ b/purchase_request_budget/models/purchase_request.py
@@ -243,7 +243,7 @@ class PurchaseRequest(models.Model):
             self.message_post(
                 body=_("Budget reserved: %s for amount %s") % (commitment.name, amount)
             )
-            self.button_to_approve()
+            self.button_to_submit()
             return {
                 "type": "ir.actions.act_window",
                 "res_model": "purchase.request",

--- a/purchase_request_kmitl/__manifest__.py
+++ b/purchase_request_kmitl/__manifest__.py
@@ -27,6 +27,7 @@
         "views/procurement_method_views.xml",
         "views/procurement_type_views.xml",
         "views/procurement_committee_views.xml",
+        "wizards/purchase_request_return_wizard_views.xml",
         "views/purchase_request_views.xml",
         "views/purchase_order_line_views.xml",
         "views/purchase_order_views.xml",

--- a/purchase_request_kmitl/i18n/th.po
+++ b/purchase_request_kmitl/i18n/th.po
@@ -316,9 +316,10 @@ msgstr "ประเภทเอกสารแนบ"
 msgid "Can verify purchase request"
 msgstr ""
 
-#. module: purchase_request
+#. module: purchase_request, purchase_request_kmitl
 #: model:ir.model.fields.selection,name:purchase_request_kmitl.selection__purchase_request__state__cancel
-#: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_line_make_purchase_order
+#: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_form
+#: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_return_wizard_form
 msgid "Cancel"
 msgstr "ยกเลิก"
 
@@ -962,7 +963,7 @@ msgstr ""
 #. module: purchase_request_kmitl
 #: model:ir.ui.menu,name:purchase_request_kmitl.purchase_request_kmitl_root_menu
 msgid "PR1"
-msgstr "คำขอซื้อขอจ้าง"
+msgstr "แบบขอให้จัดหา (พ.1)"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line__pending_qty_to_receive
@@ -1154,7 +1155,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_form
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
 msgid "Purchase Request"
-msgstr "คำขอซื้อขอจ้าง"
+msgstr "แบบขอให้จัดหา (พ.1)"
 
 #. module: purchase_request
 #. odoo-python
@@ -1190,7 +1191,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line_make_purchase_order_item__line_id
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_form
 msgid "Purchase Request Line"
-msgstr "คำขอซื้อขอจ้างไลน์"
+msgstr "แบบขอให้จัดหาไลน์"
 
 #. module: purchase_request_kmitl
 #: model:ir.model,name:purchase_request_kmitl.model_purchase_request_line_make_purchase_order
@@ -1217,7 +1218,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_order_line_form2_sub
 #, python-format
 msgid "Purchase Request Lines"
-msgstr "รายการคำขอซื้อขอจ้าง"
+msgstr "รายการแบบขอให้จัดหา"
 
 #. module: purchase_request
 #: model:res.groups,name:purchase_request.group_purchase_request_manager
@@ -1270,7 +1271,7 @@ msgstr ""
 #: model:ir.ui.menu,name:purchase_request.menu_purchase_request_pro_mgt
 #: model:ir.ui.menu,name:purchase_request.parent_menu_purchase_request
 msgid "Purchase Requests"
-msgstr "คำขอซื้อขอจ้าง (พ.1)"
+msgstr "แบบขอให้จัดหา (พ.1)"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request_line__purchase_state
@@ -1997,12 +1998,12 @@ msgstr ""
 #. module: purchase_request
 #: model:ir.ui.menu,name:purchase_request.menu_purchase_request_act
 msgid "purchase_request.menu_purchase_request_act"
-msgstr "คำขอซื้อขอจ้าง (พ.1)"
+msgstr "แบบขอให้จัดหา (พ.1)"
 
 #. module: purchase_request
 #: model:ir.ui.menu,name:purchase_request.menu_purchase_request_line_act
 msgid "purchase_request.menu_purchase_request_line_act"
-msgstr "รายการคำขอซื้อขอจ้าง"
+msgstr "รายการแบบขอให้จัดหา"
 
 #. module: purchase_request_kmitl
 #: model:ir.model.fields,field_description:purchase_request_kmitl.field_purchase_request__title
@@ -2042,7 +2043,7 @@ msgstr ""
 #. module: purchase_request_kmitl
 #: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_form
 msgid "Purchase Request"
-msgstr "คำขอซื้อขอจ้าง"
+msgstr "แบบขอให้จัดหา"
 
 #. module: purchase_request_kmitl
 #: model:product.template,name:purchase_request_kmitl.product_type_002_product_template
@@ -2196,7 +2197,7 @@ msgstr "ราคาต่อหน่วยต้องมากกว่า 0"
 #. module: purchase_request_kmitl
 #: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_form
 msgid "Purchase Request Details"
-msgstr "รายละเอียดคำขอซื้อขอจ้าง"
+msgstr "รายละเอียดแบบขอให้จัดหา"
 
 #. module: purchase_request_kmitl
 #: model:ir.model.fields.selection,name:purchase_request_kmitl.selection__purchase_request__payment_type__advance
@@ -2221,7 +2222,7 @@ msgstr "สำรองจ่าย"
 #. module: purchase_request_kmitl
 #: model:ir.model,name:purchase_request_kmitl.model_purchase_request
 msgid "Purchase Request"
-msgstr "คำขอซื้อขอจ้าง"
+msgstr "แบบขอให้จัดหา (พ.1)"
 
 #. module: purchase_request_kmitl
 #: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_form
@@ -2261,3 +2262,10 @@ msgstr "สำหรับงานก่อสร้าง"
 #: model:ir.model.fields.selection,name:purchase_request_kmitl.selection__purchase_request__state__to_submit
 msgid "To Submit"
 msgstr "รอส่งขอความเห็นชอบให้จัดหา"
+
+#. module: purchase_request_kmitl
+#. odoo-python
+#: code:addons/purchase_request_kmitl/wizards/purchase_request_return_wizard.py:0
+#, python-format
+msgid "Purchase request returned. Reason: %s"
+msgstr "แบบขอให้จัดหา (พ.1) ถูกตีกลับ. เหตุผล: %s"

--- a/purchase_request_kmitl/i18n/th.po
+++ b/purchase_request_kmitl/i18n/th.po
@@ -1752,7 +1752,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
 msgid "To Approve"
-msgstr "รอการอนุมัติ"
+msgstr "รออนุมัติให้จัดหา"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__to_approve_allowed
@@ -1768,7 +1768,7 @@ msgstr ""
 #. module: purchase_request
 #: model:ir.model.fields.selection,name:purchase_request.selection__purchase_request__state__to_approve
 msgid "To be approved"
-msgstr "รอการอนุมัติ"
+msgstr "รออนุมัติให้จัดหา"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__estimated_cost
@@ -2238,3 +2238,8 @@ msgstr "สำหรับ พ.1 ทั้วไป"
 #: model:ir.model.fields,field_description:purchase_request_kmitl.field_procurement_type__is_construction
 msgid "Is Construction"
 msgstr "สำหรับงานก่อสร้าง"
+
+#. module: purchase_request_verify_state
+#: model:ir.model.fields.selection,name:purchase_request_verify_state.selection__purchase_request__state__to_submit
+msgid "To Submit"
+msgstr "รอส่งเรื่องอนุมัติให้จัดหา"

--- a/purchase_request_kmitl/i18n/th.po
+++ b/purchase_request_kmitl/i18n/th.po
@@ -1752,7 +1752,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
 msgid "To Approve"
-msgstr "รออนุมัติให้จัดหา"
+msgstr "รอพิจารณาให้จัดหา"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__to_approve_allowed
@@ -1768,7 +1768,7 @@ msgstr ""
 #. module: purchase_request
 #: model:ir.model.fields.selection,name:purchase_request.selection__purchase_request__state__to_approve
 msgid "To be approved"
-msgstr "รออนุมัติให้จัดหา"
+msgstr "รอพิจารณาให้จัดหา"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__estimated_cost
@@ -2239,7 +2239,7 @@ msgstr "สำหรับ พ.1 ทั้วไป"
 msgid "Is Construction"
 msgstr "สำหรับงานก่อสร้าง"
 
-#. module: purchase_request_verify_state
-#: model:ir.model.fields.selection,name:purchase_request_verify_state.selection__purchase_request__state__to_submit
+#. module: purchase_request_kmitl
+#: model:ir.model.fields.selection,name:purchase_request_kmitl.selection__purchase_request__state__to_submit
 msgid "To Submit"
-msgstr "รอส่งเรื่องอนุมัติให้จัดหา"
+msgstr "รอส่งข้อความเห็นชอบให้จัดหา"

--- a/purchase_request_kmitl/i18n/th.po
+++ b/purchase_request_kmitl/i18n/th.po
@@ -2242,4 +2242,4 @@ msgstr "สำหรับงานก่อสร้าง"
 #. module: purchase_request_kmitl
 #: model:ir.model.fields.selection,name:purchase_request_kmitl.selection__purchase_request__state__to_submit
 msgid "To Submit"
-msgstr "รอส่งข้อความเห็นชอบให้จัดหา"
+msgstr "รอส่งขอความเห็นชอบให้จัดหา"

--- a/purchase_request_kmitl/i18n/th.po
+++ b/purchase_request_kmitl/i18n/th.po
@@ -317,6 +317,7 @@ msgid "Can verify purchase request"
 msgstr ""
 
 #. module: purchase_request
+#: model:ir.model.fields.selection,name:purchase_request_kmitl.selection__purchase_request__state__cancel
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_line_make_purchase_order
 msgid "Cancel"
 msgstr "ยกเลิก"
@@ -1418,7 +1419,7 @@ msgstr "ตีกลับ"
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
 #: model_terms:ir.ui.view,arch_db:purchase_request.view_purchase_request_search
 msgid "Rejected"
-msgstr "ถูกตีกลับ"
+msgstr "ปฏิเสธ"
 
 #. module: purchase_request
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
@@ -1484,6 +1485,23 @@ msgstr "สถานะคำขอ"
 #: model_terms:ir.ui.view,arch_db:purchase_request.purchase_request_line_search
 msgid "Request status"
 msgstr ""
+
+#. module: purchase_request_kmitl
+#: model:ir.actions.act_window,name:purchase_request_kmitl.action_purchase_request_return_wizard
+#: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_return_wizard_form
+msgid "Return Purchase Request"
+msgstr "ตีกลับคำขอซื้อ"
+
+#. module: purchase_request_kmitl
+#: model:ir.model.fields,field_description:purchase_request_kmitl.field_purchase_request_return_wizard__reason
+msgid "Return Reason"
+msgstr "เหตุผลในการตีกลับ"
+
+#. module: purchase_request_kmitl
+#: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_form
+#: model_terms:ir.ui.view,arch_db:purchase_request_kmitl.view_purchase_request_return_wizard_form
+msgid "Return"
+msgstr "ตีกลับ"
 
 #. module: purchase_request
 #: model:ir.model.fields,field_description:purchase_request.field_purchase_request__requested_by

--- a/purchase_request_kmitl/models/purchase_request.py
+++ b/purchase_request_kmitl/models/purchase_request.py
@@ -4,6 +4,11 @@ from odoo import api, fields, models
 class PurchaseRequest(models.Model):
     _inherit = "purchase.request"
 
+    state = fields.Selection(
+        selection_add = [('to_submit', 'To Submit'), ('to_approve',)],
+        ondelete={'to_submit': 'set default'},
+    )
+
     procurement_type_id = fields.Many2one(
         comodel_name="procurement.type",
         string="Procurement Type",
@@ -128,3 +133,6 @@ class PurchaseRequest(models.Model):
             }
         )
         return super().button_approved()
+
+    def button_to_submit(self):
+        return self.write(({"state": "to_submit"}))

--- a/purchase_request_kmitl/models/purchase_request.py
+++ b/purchase_request_kmitl/models/purchase_request.py
@@ -5,8 +5,12 @@ class PurchaseRequest(models.Model):
     _inherit = "purchase.request"
 
     state = fields.Selection(
-        selection_add = [('to_submit', 'To Submit'), ('to_approve',)],
-        ondelete={'to_submit': 'set default'},
+        selection_add=[
+            ("to_submit", "To Submit"),
+            ("to_approve",),
+            ("cancel", "Cancel"),
+        ],
+        ondelete={"to_submit": "set default", "cancel": "set default"},
     )
 
     procurement_type_id = fields.Many2one(
@@ -136,3 +140,6 @@ class PurchaseRequest(models.Model):
 
     def button_to_submit(self):
         return self.write(({"state": "to_submit"}))
+
+    def button_cancel(self):
+        return self.write({"state": "cancel"})

--- a/purchase_request_kmitl/security/ir.model.access.csv
+++ b/purchase_request_kmitl/security/ir.model.access.csv
@@ -8,3 +8,4 @@ access_procurement_method_pr_user,procurement.method pr user,model_procurement_m
 access_procurement_committee,procurement.committee,model_procurement_committee,purchase_request.group_purchase_request_user,1,1,1,1
 access_procurement_method_all_user,procurement_method_all_user,model_procurement_method,base.group_user,1,0,0,0
 access_procurement_type_all_user,procurement_type_all_user,model_procurement_type,base.group_user,1,0,0,0
+access_purchase_request_return_wizard,purchase.request.return.wizard,model_purchase_request_return_wizard,purchase_request.group_purchase_request_user,1,1,1,1

--- a/purchase_request_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_kmitl/views/purchase_request_views.xml
@@ -122,7 +122,7 @@
             <xpath expr="//form/header/field[@name='state']" position="attributes">
                 <attribute
                     name="statusbar_visible"
-                >draft,to_approve,approved,in_progress,done</attribute>
+                >draft,to_verify,to_submit,to_approve,approved,in_progress,done</attribute>
             </xpath>
 
             <xpath expr="//h1/field[@name='name']" position="attributes">

--- a/purchase_request_kmitl/views/purchase_request_views.xml
+++ b/purchase_request_kmitl/views/purchase_request_views.xml
@@ -115,8 +115,25 @@
             </button>
 
             <xpath expr="//button[@name='button_draft']" position="attributes">
-                <attribute name="states">to_verify,rejected</attribute>
-                <attribute name="groups"></attribute>
+                <attribute name="states">to_verify,to_submit,to_approve</attribute>
+                <attribute
+                    name="groups"
+                >purchase_request.group_purchase_request_manager</attribute>
+            </xpath>
+
+            <xpath expr="//button[@name='button_draft']" position="after">
+                <button
+                    name="%(action_purchase_request_return_wizard)d"
+                    states="to_submit"
+                    string="Return"
+                    type="action"
+                />
+                <button
+                    name="button_cancel"
+                    states="draft,to_verify,to_submit,to_approve"
+                    string="Cancel"
+                    type="object"
+                />
             </xpath>
 
             <xpath expr="//form/header/field[@name='state']" position="attributes">

--- a/purchase_request_kmitl/wizards/__init__.py
+++ b/purchase_request_kmitl/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import purchase_request_line_make_purchase_order
+from . import purchase_request_return_wizard

--- a/purchase_request_kmitl/wizards/purchase_request_return_wizard.py
+++ b/purchase_request_kmitl/wizards/purchase_request_return_wizard.py
@@ -1,0 +1,22 @@
+from odoo import _, fields, models
+
+
+class PurchaseRequestReturnWizard(models.TransientModel):
+    _name = "purchase.request.return.wizard"
+    _description = "Purchase Request Return Wizard"
+
+    request_id = fields.Many2one(
+        comodel_name="purchase.request",
+        string="Purchase Request",
+        required=True,
+        default=lambda self: self.env.context.get("active_id"),
+    )
+    reason = fields.Text(string="Return Reason", required=True)
+
+    def action_confirm_return(self):
+        self.ensure_one()
+        self.request_id.message_post(
+            body=_("Purchase request returned. Reason: %s") % self.reason
+        )
+        self.request_id.button_draft()
+        return {"type": "ir.actions.act_window_close"}

--- a/purchase_request_kmitl/wizards/purchase_request_return_wizard_views.xml
+++ b/purchase_request_kmitl/wizards/purchase_request_return_wizard_views.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_purchase_request_return_wizard_form" model="ir.ui.view">
+        <field name="name">purchase.request.return.wizard.form</field>
+        <field name="model">purchase.request.return.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Return Purchase Request">
+                <field name="request_id" invisible="1" />
+                <group>
+                    <field
+                        name="reason"
+                        placeholder="Enter the reason for returning this purchase request..."
+                    />
+                </group>
+                <footer>
+                    <button
+                        name="action_confirm_return"
+                        string="Return"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_purchase_request_return_wizard" model="ir.actions.act_window">
+        <field name="name">Return Purchase Request</field>
+        <field name="res_model">purchase.request.return.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/purchase_request_sarabun/models/purchase_request.py
+++ b/purchase_request_sarabun/models/purchase_request.py
@@ -76,6 +76,7 @@ class PurchaseRequest(models.Model):
         self.message_post(
             body=_("Submitted to Sarabun for approval: %s") % document.name,
         )
+        self.button_to_approve()
         # return document.action_select_route()
         return {
             "type": "ir.actions.act_window",

--- a/purchase_request_sarabun/views/purchase_request_views.xml
+++ b/purchase_request_sarabun/views/purchase_request_views.xml
@@ -12,7 +12,7 @@
                     string="Create Sarabun"
                     type="object"
                     class="oe_highlight"
-                    attrs="{'invisible': ['|', ('state', '!=', 'to_approve'), ('sarabun_document_count', '>', 0)]}"
+                    attrs="{'invisible': ['|', ('state', '!=', 'to_submit'), ('sarabun_document_count', '>', 0)]}"
                 />
             </xpath>
 


### PR DESCRIPTION
## สรุป
ปรับปรุง flow และ state ของใบขอซื้อ (Purchase Request / PR1) โดยเพิ่ม state ใหม่
2 สถานะ พร้อมปุ่มควบคุม และแก้บั๊กที่ทำให้ส่งเข้าสารบรรณไม่ได้

## Flow ใหม่
draft → to_verify → **to_submit** → to_approve → approved

- `action_reserve_budget` (จองงบ) เดิมพา PR ไป `to_approve` ทันที → เปลี่ยนเป็นไป `to_submit`
- ปุ่ม "Create Sarabun" ย้ายมาแสดงที่ state `to_submit`
- เมื่อสร้างเอกสารสารบรรณ (`action_submit_to_sarabun`) จะพา PR ไป `to_approve`

## รายการที่แก้

### purchase_request_kmitl
- เพิ่ม state `to_submit` (รอส่งข้อความเห็นชอบให้จัดหา) และ `cancel` (ยกเลิก)
- เพิ่มปุ่ม **Cancel** — แสดงตั้งแต่ state `draft` ถึง `to_approve`
- เพิ่มปุ่ม **ตีกลับ (Return)** ที่ state `to_submit` → เปิด wizard บังคับกรอกเหตุผล
  แล้วบันทึกเหตุผลลง chatter และรีเซ็ตกลับเป็น draft (ไม่จำกัดสิทธิ์ group)
- ปุ่ม **Reset (button_draft)** ปรับให้แสดงที่ state `to_verify → to_approve`
  และจำกัดสิทธิ์เป็น purchase_request_manager
- แก้คำแปล state `rejected`: "ถูกตีกลับ" → "ปฏิเสธ"
- ปรับ th.po: คำแปล state `to_submit`, `cancel`, ปุ่ม `Return`

### purchase_request_budget
- **แก้บั๊ก:** `_compute_to_approve_allowed` ยัง gate อยู่ที่ state `to_verify`
  ทำให้ตอนกดส่งเข้าสารบรรณ (เรียก `button_to_approve` จาก state `to_submit`)
  เจอ error หลอกว่า "PR ว่างเปล่า" ทั้งที่มีรายการอยู่ → แก้ gate เป็น `to_submit`
- `action_reserve_budget` เรียก `button_to_submit()` แทน `button_to_approve()`

### purchase_request_sarabun
- `action_submit_to_sarabun` เรียก `button_to_approve()` ต่อท้าย เพื่อพา PR ไป to_approve
- ปุ่ม "Create Sarabun" เปลี่ยนเงื่อนไขการแสดงจาก `to_approve` → `to_submit`

### purchase_request_approval_kmitl
- ปรับ `_STATES` ให้ใช้ `to_submit` และลบ `_state_from` ที่ไม่ใช้แล้ว