### PR TITLE
[16.0][IMP] mail_activity_todo: show all activities in inbox, 2 categories

### DIFF
--- a/accounting_kmitl_workflow/data/mail_activity_type.xml
+++ b/accounting_kmitl_workflow/data/mail_activity_type.xml
@@ -13,12 +13,12 @@
     </record>
 
     <!-- Pushed to the approvers when a maker submits an entry, so it surfaces
-         in their Todo inbox. 'approval' = clears by acting on the source
+         in their Todo inbox. 'execution' = clears by acting on the source
          (approving / rejecting), not by "Mark as Read". -->
     <record id="mail_activity_move_to_approve" model="mail.activity.type">
         <field name="name">Entry to approve</field>
         <field name="summary">An entry was submitted and is waiting for your approval</field>
-        <field name="todo_category">approval</field>
+        <field name="todo_category">execution</field>
         <field name="res_model">account.move</field>
         <field name="icon">fa-check-circle</field>
         <field name="delay_count">0</field>

--- a/mail_activity_todo/CONTEXT.md
+++ b/mail_activity_todo/CONTEXT.md
@@ -16,26 +16,22 @@ _Avoid_: using "activity" and "Todo" interchangeably in user-facing text
 The originating business document a Todo points back to (a procurement plan, a พ.1, a budget transfer …). Every Todo carries a button that opens its source record — the load-bearing feature of the whole context.
 _Avoid_: parent, origin
 
-**Approval Todo**:
-A Todo cleared only by a real decision on the source record (approve / reject). Reading it does not clear it.
-_Avoid_: marking an Approval Todo as "read"
+There are exactly **two** behavioural categories (`todo_category`), splitting Todos by how they clear:
 
 **Execution Todo**:
-A Todo asking its owner to do the next step of work on the source record (e.g. a เจ้าหน้าที่แผน filling the operating plan before a พ.1 can be created). Cleared when the step is done.
+A Todo that clears **only by acting on the source record** — doing the next step of work, approving, or rejecting (e.g. a เจ้าหน้าที่แผน filling the operating plan before a พ.1 can be created; an approver approving/rejecting an entry). Reading it never clears it. Absorbs what was previously split into "Approval" and "Execution".
+_Avoid_: marking an Execution Todo as "read"; treating approval as its own category
 
 **Acknowledgement Todo**:
-A Todo asking the user to read / sign / acknowledge a document. Cleared by the user marking it done ("Mark as Read").
-
-**FYI Todo**:
-A Todo that only informs (e.g. "your พ.1 changed state"); no required action. Cleared by the user marking it read.
-_Avoid_: putting FYI and Approval Todos on the same footing
+A Todo cleared by the user **marking it read** ("Mark as Read" — per-person and reversible), whether it asks the user to read/sign a document or only informs them (e.g. "your พ.1 changed state"). Absorbs what was previously split into "Acknowledgement" and "FYI".
+_Avoid_: FYI (folded into Acknowledgement); treating Mark as Read as completing the work
 
 **Inbox (กล่องขาเข้า)**:
-The unified page — every open Todo addressed to the current user (personal + role-in-unit), the one place to find incoming work. Modelled as an incoming queue, not an email client.
+The unified page — every open activity assigned to the current user (and, with the role-in-unit layer, to their role-in-unit groups), gathered from every module into one place. Membership is "assigned to me and still open", **not** "carries a category": built-in, OCA, and hand-scheduled activities all belong here too. The category only refines how a Todo is flagged and cleared, it does not decide whether it is in the inbox. The one place to find incoming work, modelled as an incoming queue, not an email client.
 _Avoid_: dashboard (the inbox lists actionable items, not analytics)
 
 **Mark as Read (อ่านแล้ว)**:
-A *per-user* dismissal of an FYI or Acknowledgement Todo — removes it from *your* inbox only, leaving it for everyone else in the group. Recorded in `todo.read`; never deletes the shared activity. Not offered on Approval/Execution Todos, which clear by acting on the source.
+A *per-user* dismissal of any Todo that is **not** an Execution Todo — an Acknowledgement Todo *or* an uncategorised built-in / hand-scheduled activity — removes it from *your* inbox only, leaving it for everyone else in the group. Recorded in `todo.read`; never deletes the shared activity. It is the single user-driven clear gesture (there is no "Mark Done" button); only Execution Todos are excluded, because they clear by acting on the source.
 _Avoid_: treating Mark as Read as completing the work
 
 **Claim (รับเรื่อง)**:
@@ -48,7 +44,7 @@ _Avoid_: archived activity (the activity is gone, not archived)
 
 **Next actor**:
 Who a Todo is for at a given state. Either a single `res.users` (personal Todo), or a *role-in-unit* group — everyone holding a Responsible Role who belongs to the source record's Operating Unit, resolved live (never a stored list). The whole inbox depends on this being determinable from the source record's data.
-_Avoid_: approver (the next actor is not always an approver — see the four Todo types)
+_Avoid_: approver (the next actor is not always an approver — see the two Todo types)
 
 **Responsible Role (เจ้าหน้าที่…)**:
 A `base_user_role` role naming *who does a job* (deliberately assigned, date-bounded) — e.g. เจ้าหน้าที่แผน. Distinct from a `res.groups`, which says only who *may* do it. Group Todos route on the Responsible Role so they reach the people accountable, not everyone with the rights.

--- a/mail_activity_todo/README.rst
+++ b/mail_activity_todo/README.rst
@@ -36,20 +36,24 @@ Module layout
     plan's operating unit.
 
 ``purchase_request_todo`` (bridge, depends **core only**)
-    UC2/UC3: tags the PR approval/creation activities as Execution, and FYIs the
-    requester on approve/reject. Personal (``user_id``) — proof the core stands
-    alone without the role-in-unit layer.
+    UC2/UC3: tags the PR approval/creation activities as Execution, and sends
+    the requester an Acknowledgement on approve/reject. Personal (``user_id``) —
+    proof the core stands alone without the role-in-unit layer.
 
 Concepts
 ========
 
-A **Todo** is a ``mail.activity``. Four behavioural categories
-(``todo_category`` on the activity type):
+A **Todo** is a ``mail.activity``. The inbox shows **every open activity
+assigned to you** — built-in, OCA, hand-scheduled, or workflow-emitted; the
+category is not a gate (ADR-0006). ``todo_category`` (set on the activity type)
+only refines how a Todo clears, in **two** behavioural values:
 
-* **Approval / Execution** — cleared by acting on the source record
-  (``activity_feedback`` on a state transition). No "Mark as Read".
-* **Acknowledgement / FYI** — dismissed per-user with **Mark as Read**
-  (recorded in ``todo.read``); never removed for other recipients.
+* **Execution** — cleared by acting on the source record (``activity_feedback``
+  on a state transition). No "Mark as Read".
+* **Acknowledgement** — dismissed per-user with **Mark as Read** (recorded in
+  ``todo.read``); never removed for other recipients. **Uncategorised**
+  activities (a plain Call, etc.) behave the same way — Mark as Read is the one
+  user-driven clear gesture; there is no "Mark Done" button.
 
 Assignment has two modes (ADR-0002, provided by the role-in-unit layer):
 
@@ -68,9 +72,9 @@ KMITL use cases (bridges)
   (``procurement_plan_todo``)
 * **UC2 Execution** — the existing purchase-request "create PA/PO" activities
   are tagged ``execution`` so they show in the inbox. (``purchase_request_todo``)
-* **UC3 FYI** — when a พ.1 (``purchase.request.approval``) is approved or
-  rejected (manual *or* Sarabun-auto path), the requester gets an FYI.
-  (``purchase_request_todo``)
+* **UC3 Acknowledgement** — when a พ.1 (``purchase.request.approval``) is
+  approved or rejected (manual *or* Sarabun-auto path), the requester gets an
+  Acknowledgement Todo. (``purchase_request_todo``)
 
 The core app has two menus: **Inbox** (open Todos) and **Completed** (history).
 A done activity is unlinked by core, so completed Todos are snapshotted into
@@ -82,7 +86,8 @@ The systray bell groups open Todos by source model (native Activities-menu
 style) with per-model icons and counts. It **replaces** Odoo's native
 Activities menu (removed via a small service), because that menu is
 ``user_id``-only and cannot surface role-in-unit group Todos — the unified bell
-covers personal *and* group Todos in one place.
+lists **every** activity assigned to you (personal, group, and plain built-in
+ones alike) in one place, so nothing the native menu showed is lost.
 
 Configuration
 =============
@@ -93,9 +98,9 @@ Configuration
    (``res.users.role``) to the staff actually responsible for plan work.
 #. Make sure those users belong to the right **Operating Unit(s)**
    (``operating.unit.user_ids``) — group routing = role ∩ OU.
-#. Retention window for read FYI/Acknowledgement Todos is the system parameter
-   ``mail_activity_todo.fyi_retention_days`` (default **180**); a daily cron
-   deletes read FYI/Ack Todos older than that.
+#. Retention window for read dismissable Todos (Acknowledgement + uncategorised)
+   is the system parameter ``mail_activity_todo.dismissed_retention_days``
+   (default **180**); a daily cron deletes read dismissable Todos older than that.
 
 Known limitations (v1)
 ======================

--- a/mail_activity_todo/data/ir_cron.xml
+++ b/mail_activity_todo/data/ir_cron.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <record id="ir_cron_gc_read_fyi_todos" model="ir.cron">
-        <field name="name">Todos: garbage-collect read FYI activities past retention</field>
+    <record id="ir_cron_gc_read_dismissed_todos" model="ir.cron">
+        <field name="name">Todos: garbage-collect read dismissed activities past retention</field>
         <field name="model_id" ref="mail.model_mail_activity" />
         <field name="state">code</field>
-        <field name="code">model._gc_read_fyi_todos()</field>
+        <field name="code">model._gc_read_dismissed_todos()</field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
         <field name="numbercall">-1</field>
         <field name="active" eval="True" />
     </record>
 
-    <!-- Tunable retention window (days) for read FYI/Acknowledgement Todos. -->
-    <record id="config_fyi_retention_days" model="ir.config_parameter">
-        <field name="key">mail_activity_todo.fyi_retention_days</field>
+    <!-- Tunable retention window (days) for read dismissable Todos
+         (Acknowledgement + uncategorised). -->
+    <record id="config_dismissed_retention_days" model="ir.config_parameter">
+        <field name="key">mail_activity_todo.dismissed_retention_days</field>
         <field name="value">180</field>
     </record>
 </odoo>

--- a/mail_activity_todo/docs/ROADMAP.md
+++ b/mail_activity_todo/docs/ROADMAP.md
@@ -88,12 +88,21 @@ PoC + review hardening + quick wins are merged on
   `res.users`, fed into `_my_todo_domain`. M. Pairs with Claim.
 - **Auditor group for the Completed log** — a dedicated group with a broader
   `ir.rule` so compliance can read all history (today everyone, incl. admins,
-  sees only their own scope). S.
+  sees only their own scope, via `todo_log_own_rule`). **This is the real
+  enabler of accountability review** — without it a supervisor cannot read
+  another user's completion record. S.
+- **Log every completed activity, not only categorised Todos** — drop the
+  `filtered("todo_category")` gate on `_log_completed` so built-in / personal
+  activity completions are captured too. Deferred: adds write amplification and
+  is only useful once the auditor group above exists. S.
 
 ## Remaining — Tech debt / polish
 
-- **Backfill `todo_category`** on already-shipped activity types and any future
-  ones (the inbox now *hides* uncategorised, but tagging them surfaces them). S.
+- **Tag `todo_category` = `execution`** on activity types that must clear at the
+  source. Since [ADR-0006](./adr/0006-inbox-shows-all-assigned-activities.md) the
+  inbox shows uncategorised activities too (cleared via Mark as Read, like
+  Acknowledgement), so tagging is now about *clear-behaviour + grouping*, not
+  visibility. S.
 - **i18n** — export `i18n/kmitl_todo.pot` + `th.po` (Thai source via the agreed
   i18n route; ensure JS systray strings use `_t`). S.
 - **Document the security model** in CONTEXT.md/ADR-0001: Todo visibility ==

--- a/mail_activity_todo/docs/adr/0003-per-user-read-state-in-side-table.md
+++ b/mail_activity_todo/docs/adr/0003-per-user-read-state-in-side-table.md
@@ -1,5 +1,7 @@
 # Per-user read state lives in a side table, not on the activity
 
+> Note (since [ADR-0006](./0006-inbox-shows-all-assigned-activities.md)): the two readable categories collapsed to one, and uncategorised activities are cleared the same way. Read "FYI / Acknowledgement" below as **Acknowledgement**, and "the readable categories" as **everything that is not an Execution Todo**.
+
 "Mark as Read" must dismiss a Todo **for the reader only**. A group Todo (a `role ∩ OU` activity with no `user_id`) is seen by many people on one shared `mail.activity`; marking it read on the activity itself would clear it for the whole group and confuse everyone else. So read/dismissal is tracked in a thin side model `todo.read` (`activity_id × user_id × read_date`), and the inbox hides the activities the current user has read. The `mail.activity` stays the single source of truth for content, routing and deadline; the side table only records who has dismissed it.
 
 ## Why
@@ -12,6 +14,7 @@
 
 - **`is_read` boolean on `mail.activity`**: global — one reader clears it for the whole group. **Rejected** (the exact confusion this ADR exists to prevent).
 - **Route FYI through `mail.message` / `mail.notification`** (native per-user read + Discuss Inbox): splits the inbox across two object types and two surfaces. **Rejected** for the single-page goal.
+- **Drop per-user read entirely; clear readable Todos with the native "Mark Done"** (`_action_done`, which unlinks the activity + snapshots it to history): considered because it collapses the inbox to a single clear gesture. **Rejected** — native done is *global* (one member clears the shared group activity for everyone) and *irreversible* (the activity is gone, only a history row remains), whereas Mark-as-Read is *per-user* and *reversible* (Mark as Unread). A mis-click on an informational Todo must not destroy it for the whole group, so the gentler dismissal is kept and there is **no Mark-Done button in the inbox at all** ([ADR-0006](./0006-inbox-shows-all-assigned-activities.md)).
 
 ## Consequences
 

--- a/mail_activity_todo/docs/adr/0004-completed-todos-logged-to-history-table.md
+++ b/mail_activity_todo/docs/adr/0004-completed-todos-logged-to-history-table.md
@@ -16,6 +16,6 @@ To let users review Todos they have finished — which the inbox cannot show, be
 ## Consequences
 
 - New model `todo.log` (read-only to users; written via `sudo()` from the `_action_done` hook). The `mail_activity_todo` core defines the personal columns; the role-in-unit layer extends it with `responsible_role_id` / `operating_unit_id` via the `_todo_log_vals` hook.
-- Only activities with a `todo_category` are logged, so non-Todo activities (a plain "Call", etc.) are not captured.
+- Only activities with a `todo_category` are logged, so uncategorised activities (a plain "Call", etc.) are not captured — even though [ADR-0006](./0006-inbox-shows-all-assigned-activities.md) now shows them in the inbox. This scoping is deliberate; expanding it to log *every* completed activity is deferred (see ROADMAP) and only becomes useful paired with an auditor group that can read history beyond its own scope.
 - An activity cleared via `activity_feedback` on a *cancelling* transition (e.g. a plan put on hold) is logged like any completion; distinguishing "done" from "cancelled" is a later refinement, not v1.
 - A "Completed" view + menu live under the Todos app alongside the inbox; the default filter is "Completed by me".

--- a/mail_activity_todo/docs/adr/0006-inbox-shows-all-assigned-activities.md
+++ b/mail_activity_todo/docs/adr/0006-inbox-shows-all-assigned-activities.md
@@ -1,0 +1,16 @@
+# The inbox shows every activity assigned to the user; `todo_category` is metadata, not a gate
+
+The unified Todo inbox (full page + systray) lists **every open `mail.activity` assigned to the current user** — built-in, OCA, hand-scheduled, and workflow-emitted alike — not only those carrying a `todo_category`. Membership is "assigned to me and still open"; `todo_category` no longer decides what *is* a Todo, it only refines behaviour (how a Todo clears, its urgency colour, its grouping). This is what lets the module hide Odoo's native activity bell without hiding work: nothing a user is responsible for can fall outside the one inbox.
+
+## Considered options
+
+- **Curated inbox — only activities with a `todo_category`** (the original discriminator): keeps the inbox to system-emitted workflow steps, but because the native activity bell is hidden ([`hide_native_activity_systray`](../../static/src/js/hide_native_activity_systray.esm.js)), any built-in / OCA / hand-scheduled activity then has *no* systray surface at all — invisible work. **Rejected.**
+- **Keep the curated inbox and un-hide the native bell** (two bells side by side): restores visibility of uncategorised activities but re-introduces the "check each surface separately" fragmentation this module exists to kill. **Rejected.**
+
+## Consequences
+
+- The inbox action domain, the systray count (`res.users._my_todo_count_domain`), and the systray drill-down drop the `("todo_category", "!=", False)` filter.
+- Two clear paths only: `execution` clears by acting on the source (the workflow calls `activity_feedback`); **everything else** — `acknowledgement` *and* uncategorised activities alike — clears by per-user **Mark as Read** (the read-clearable test is `todo_category != 'execution'`). There is deliberately **no native Mark-Done button** in the inbox (mis-click safety — [ADR-0003](./0003-per-user-read-state-in-side-table.md)).
+- `todo_category` collapses to **two** behavioural values — `execution` (clears only at the source; absorbs the former "approval") and `acknowledgement` (dismissable by Mark as Read; absorbs the former "fyi") — since the four original values only ever expressed these two behaviours. It is set once on the `mail.activity.type` (auto-filling onto each activity of that type); the per-activity picker in the Schedule-Activity dialog is removed.
+- Live-badge notification (`_todo_notify`) and completed-history logging (`_log_completed`, [ADR-0004](./0004-completed-todos-logged-to-history-table.md)) stay scoped to categorised workflow Todos — the inbox showing *everything* does **not** mean every activity completion is broadcast or audited.
+- Uncategorised activities keep `todo_category = False` — the compute does **not** default them to `acknowledgement`. They behave *as if* Acknowledgement for clearing (Mark as Read), but staying technically uncategorised is exactly what keeps notification and history scoped to real workflow Todos. Defaulting the stored value would silently turn "log workflow Todos" into "log every activity" (the deferred 6B).

--- a/mail_activity_todo/i18n/th.po
+++ b/mail_activity_todo/i18n/th.po
@@ -48,21 +48,6 @@ msgid "App"
 msgstr "แอป"
 
 #. module: mail_activity_todo
-#: model:ir.model.fields.selection,name:mail_activity_todo.selection__mail_activity__todo_category__approval
-#: model:ir.model.fields.selection,name:mail_activity_todo.selection__mail_activity_type__todo_category__approval
-#: model:ir.model.fields.selection,name:mail_activity_todo.selection__todo_log__todo_category__approval
-msgid "Approval"
-msgstr "การอนุมัติ"
-
-#. module: mail_activity_todo
-#: model:ir.model.fields,help:mail_activity_todo.field_mail_activity_type__todo_category
-msgid ""
-"Behavioural category of Todos created from this activity type. "
-"Approval/Execution clear by acting on the source; Acknowledgement/FYI can be"
-" dismissed with 'Mark as Read'."
-msgstr ""
-
-#. module: mail_activity_todo
 #: model:ir.model.fields,field_description:mail_activity_todo.field_todo_log__todo_category
 #: model_terms:ir.ui.view,arch_db:mail_activity_todo.view_my_todo_search
 #: model_terms:ir.ui.view,arch_db:mail_activity_todo.view_todo_log_search
@@ -123,13 +108,6 @@ msgid "Deadline"
 msgstr "วันครบกำหนด"
 
 #. module: mail_activity_todo
-#: model:ir.model.fields,help:mail_activity_todo.field_mail_activity__todo_category
-msgid ""
-"Defaults from the activity type. Set it on a manually scheduled activity to "
-"turn it into a Todo that lands in your inbox."
-msgstr ""
-
-#. module: mail_activity_todo
 #: model:ir.model.fields,field_description:mail_activity_todo.field_todo_log__display_name
 #: model:ir.model.fields,field_description:mail_activity_todo.field_todo_read__display_name
 msgid "Display Name"
@@ -141,13 +119,6 @@ msgstr "แสดงชื่อ"
 #: model:ir.model.fields.selection,name:mail_activity_todo.selection__todo_log__todo_category__execution
 msgid "Execution"
 msgstr "การดำเนินการ"
-
-#. module: mail_activity_todo
-#: model:ir.model.fields.selection,name:mail_activity_todo.selection__mail_activity__todo_category__fyi
-#: model:ir.model.fields.selection,name:mail_activity_todo.selection__mail_activity_type__todo_category__fyi
-#: model:ir.model.fields.selection,name:mail_activity_todo.selection__todo_log__todo_category__fyi
-msgid "FYI"
-msgstr "เพื่อทราบ"
 
 #. module: mail_activity_todo
 #: model_terms:ir.ui.view,arch_db:mail_activity_todo.view_my_todo_search
@@ -373,12 +344,12 @@ msgid "Todos you finish are archived here for reference."
 msgstr "งานที่คุณทำเสร็จจะถูกเก็บไว้ที่นี่เพื่อเป็นการอ้างอิง"
 
 #. module: mail_activity_todo
-#: model:ir.actions.server,name:mail_activity_todo.ir_cron_gc_read_fyi_todos_ir_actions_server
-#: model:ir.cron,cron_name:mail_activity_todo.ir_cron_gc_read_fyi_todos
-msgid "Todos: garbage-collect read FYI activities past retention"
+#: model:ir.actions.server,name:mail_activity_todo.ir_cron_gc_read_dismissed_todos_ir_actions_server
+#: model:ir.cron,cron_name:mail_activity_todo.ir_cron_gc_read_dismissed_todos
+msgid "Todos: garbage-collect read dismissed activities past retention"
 msgstr ""
-"งานที่ต้องทำ: เคลียร์ข้อมูลหมวดหมู่ 'เพื่อทราบ' "
-"ที่อ่านแล้วเกินระยะเวลาที่กำหนดไว้"
+"งานที่ต้องทำ: เคลียร์งานที่ปัดทิ้งได้ที่อ่านแล้ว "
+"เกินระยะเวลาที่กำหนดไว้"
 
 #. module: mail_activity_todo
 #: model_terms:ir.ui.view,arch_db:mail_activity_todo.view_my_todo_search

--- a/mail_activity_todo/models/mail_activity.py
+++ b/mail_activity_todo/models/mail_activity.py
@@ -3,15 +3,15 @@ from datetime import timedelta
 from odoo import api, fields, models
 
 TODO_CATEGORIES = [
-    ("approval", "Approval"),
     ("execution", "Execution"),
     ("acknowledgement", "Acknowledgement"),
-    ("fyi", "FYI"),
 ]
 
-# Categories the user may dismiss with "Mark as Read" (ADR-0003). The others
-# (approval/execution) clear only by acting on the source record.
-READABLE_CATEGORIES = ("acknowledgement", "fyi")
+# The one category that clears only by acting on the source document. Every
+# other Todo — Acknowledgement and uncategorised built-in / hand-scheduled
+# activities alike — is dismissable per-user with "Mark as Read" (ADR-0003,
+# ADR-0006). Kept as a constant so the "readable?" test lives in one place.
+SOURCE_CLEARED_CATEGORY = "execution"
 
 
 class MailActivityType(models.Model):
@@ -21,8 +21,8 @@ class MailActivityType(models.Model):
         TODO_CATEGORIES,
         string="Todo Category",
         help="Behavioural category of Todos created from this activity type. "
-        "Approval/Execution clear by acting on the source; "
-        "Acknowledgement/FYI can be dismissed with 'Mark as Read'.",
+        "Execution clears by acting on the source; Acknowledgement (and any "
+        "uncategorised activity) can be dismissed with 'Mark as Read'.",
     )
 
 
@@ -36,14 +36,18 @@ class MailActivity(models.Model):
         store=True,
         index=True,
         readonly=False,
-        help="Defaults from the activity type. Set it on a manually scheduled "
-        "activity to turn it into a Todo that lands in your inbox.",
+        help="Set on the activity type and auto-filled here. It only refines "
+        "behaviour — Execution Todos clear at the source, everything else is "
+        "dismissable with 'Mark as Read' — it does not decide whether the "
+        "activity appears in the inbox (every assigned activity does; ADR-0006).",
     )
 
     @api.depends("activity_type_id")
     def _compute_todo_category(self):
-        """Default the category from the type, but leave it user-overridable so a
-        manually scheduled activity can be categorised into the Todo inbox."""
+        """Mirror the type's category. Left blank (not defaulted) for types that
+        set none: an uncategorised activity still shows in the inbox and clears
+        like an Acknowledgement, but keeping it False is what scopes history and
+        notifications to real workflow Todos (ADR-0006)."""
         for activity in self:
             activity.todo_category = activity.activity_type_id.todo_category
 
@@ -139,19 +143,19 @@ class MailActivity(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         activities = super().create(vals_list)
-        # Only Todo-categorised activities drive the inbox; skip the rest.
-        activities.filtered("todo_category")._todo_notify()
+        # Every assigned activity is in someone's inbox now (ADR-0006), so the
+        # badge must react to all of them, not only categorised Todos.
+        activities._todo_notify()
         return activities
 
     def write(self, vals):
-        # A write can move a Todo between inboxes (reassigning user_id), turn an
-        # activity into/out of a Todo (todo_category), or re-route a group Todo
-        # (role/unit, in the role-in-unit layer). Ping both the recipients before
-        # the change and after it, so the old and new owners' badges refresh live
-        # — not only on reload.
-        before = self.filtered("todo_category")._todo_recipient_partners()
+        # A write can move an activity between inboxes (reassigning user_id) or
+        # re-route a group Todo (role/unit, in the role-in-unit layer). Ping the
+        # recipients before the change and after it, so the old and new owners'
+        # badges refresh live — not only on reload.
+        before = self._todo_recipient_partners()
         res = super().write(vals)
-        after = self.filtered("todo_category")._todo_recipient_partners()
+        after = self._todo_recipient_partners()
         partners = before | after
         if partners:
             self._todo_notify(partners)
@@ -159,7 +163,7 @@ class MailActivity(models.Model):
 
     def unlink(self):
         # Capture recipients before the records vanish (badge goes down).
-        partners = self.filtered("todo_category")._todo_recipient_partners()
+        partners = self._todo_recipient_partners()
         res = super().unlink()
         self._todo_notify(partners)
         return res
@@ -168,20 +172,22 @@ class MailActivity(models.Model):
     # Actions
     # ------------------------------------------------------------------
     def action_mark_read(self):
-        """Dismiss FYI/Acknowledgement Todos for the current user only (ADR-0003).
+        """Dismiss a Todo for the current user only (ADR-0003): anything that is
+        not an Execution Todo — Acknowledgement or uncategorised alike.
 
         Category-gated server-side so the rule holds beyond the view's attrs.
         """
         self.env["todo.read"]._mark_read(
-            self.filtered(lambda a: a.todo_category in READABLE_CATEGORIES)
+            self.filtered(lambda a: a.todo_category != SOURCE_CLEARED_CATEGORY)
         )
         self._todo_notify(self.env.user.partner_id)
         return True
 
     def action_mark_unread(self):
-        """Undo a dismissal — bring FYI/Acknowledgement Todos back for me."""
+        """Undo a dismissal — bring a read Todo back for me (anything that is not
+        an Execution Todo)."""
         self.env["todo.read"]._mark_unread(
-            self.filtered(lambda a: a.todo_category in READABLE_CATEGORIES)
+            self.filtered(lambda a: a.todo_category != SOURCE_CLEARED_CATEGORY)
         )
         self._todo_notify(self.env.user.partner_id)
         return True
@@ -194,23 +200,25 @@ class MailActivity(models.Model):
         )
 
     # ------------------------------------------------------------------
-    # Retention (ADR-0003): read FYI/Acknowledgement Todos are garbage
-    # collected once older than a configurable threshold (default 180 days).
+    # Retention (ADR-0003): read dismissable Todos (Acknowledgement +
+    # uncategorised) are garbage collected once older than a configurable
+    # threshold (default 180 days).
     # ------------------------------------------------------------------
     @api.model
-    def _gc_read_fyi_todos(self):
+    def _gc_read_dismissed_todos(self):
         days = int(
             self.env["ir.config_parameter"]
             .sudo()
-            .get_param("mail_activity_todo.fyi_retention_days", 180)
+            .get_param("mail_activity_todo.dismissed_retention_days", 180)
         )
         threshold = fields.Datetime.now() - timedelta(days=days)
         # Personal Todos only: a group Todo is one shared record, so one member's
         # read receipt must not delete it for the whole group (ADR-0003). Group
-        # FYI/Ack are not auto-GC'd on first-reader-read.
+        # dismissable Todos are not auto-GC'd on first-reader-read.
+        # "!= execution" also matches uncategorised (NULL) read Todos in Odoo.
         stale = self.search(
             [
-                ("todo_category", "in", list(READABLE_CATEGORIES)),
+                ("todo_category", "!=", SOURCE_CLEARED_CATEGORY),
                 ("user_id", "!=", False),
                 ("create_date", "<", threshold),
                 ("read_ids", "!=", False),

--- a/mail_activity_todo/models/res_users.py
+++ b/mail_activity_todo/models/res_users.py
@@ -5,10 +5,11 @@ class ResUsers(models.Model):
     _inherit = "res.users"
 
     def _my_todo_count_domain(self):
+        # Fork A (ADR-0006): the inbox is every open activity assigned to me,
+        # minus the ones I've dismissed with Mark as Read. Category is not a gate.
         return [
             ("is_my_todo", "=", True),
             ("is_read_by_me", "=", False),
-            ("todo_category", "!=", False),
         ]
 
     @api.model

--- a/mail_activity_todo/models/res_users.py
+++ b/mail_activity_todo/models/res_users.py
@@ -12,6 +12,14 @@ class ResUsers(models.Model):
             ("is_read_by_me", "=", False),
         ]
 
+    def _my_read_todo_domain(self):
+        # History (ADR-0003): the inbox's read complement — my Todos that I have
+        # dismissed with Mark as Read. Same recipient base, flipped read flag.
+        return [
+            ("is_my_todo", "=", True),
+            ("is_read_by_me", "=", True),
+        ]
+
     @api.model
     def get_my_todo_count(self):
         """Systray payload: open Todos grouped by source model with per-model

--- a/mail_activity_todo/static/src/js/todo_systray.esm.js
+++ b/mail_activity_todo/static/src/js/todo_systray.esm.js
@@ -51,7 +51,6 @@ export class TodoSystray extends Component {
             domain: [
                 ["is_my_todo", "=", true],
                 ["is_read_by_me", "=", false],
-                ["todo_category", "!=", false],
                 ["res_model_id", "=", group.model_id],
             ],
             views: [

--- a/mail_activity_todo/tests/test_mail_activity_todo.py
+++ b/mail_activity_todo/tests/test_mail_activity_todo.py
@@ -28,10 +28,10 @@ class TestMailActivityTodo(TransactionCase):
         cls.Read = cls.env["todo.read"]
         cls.Log = cls.env["todo.log"]
 
-        cls.type_fyi = cls.env["mail.activity.type"].create(
+        cls.type_ack = cls.env["mail.activity.type"].create(
             {
-                "name": "Test FYI",
-                "todo_category": "fyi",
+                "name": "Test Acknowledgement",
+                "todo_category": "acknowledgement",
                 "res_model": "test.todo.host",
             }
         )
@@ -72,18 +72,18 @@ class TestMailActivityTodo(TransactionCase):
 
     def test_action_done_logs_one_history_row(self):
         act = self.rec.activity_schedule(
-            summary="p", activity_type_id=self.type_fyi.id, user_id=self.user.id
+            summary="p", activity_type_id=self.type_ack.id, user_id=self.user.id
         )
         before = self.Log.search_count([])
         act.action_feedback()
         self.assertEqual(self.Log.search_count([]) - before, 1)
         log = self.Log.search([], order="id desc", limit=1)
-        self.assertEqual(log.todo_category, "fyi")
+        self.assertEqual(log.todo_category, "acknowledgement")
         self.assertEqual(log.user_id, self.user)
 
     def test_mark_read_idempotent_and_per_user(self):
         act = self.rec.activity_schedule(
-            summary="fyi", activity_type_id=self.type_fyi.id, user_id=self.user.id
+            summary="ack", activity_type_id=self.type_ack.id, user_id=self.user.id
         )
         act.with_user(self.user).action_mark_read()
         act.with_user(self.user).action_mark_read()
@@ -100,8 +100,8 @@ class TestMailActivityTodo(TransactionCase):
             "read state is per-user",
         )
 
-    def test_mark_read_ignores_non_readable_category(self):
-        """Execution/Approval Todos cannot be dismissed (ADR-0003)."""
+    def test_mark_read_ignores_execution_category(self):
+        """Execution Todos cannot be dismissed with Mark as Read (ADR-0003)."""
         act = self.rec.activity_schedule(
             summary="exec", activity_type_id=self.type_exec.id, user_id=self.user.id
         )
@@ -112,23 +112,50 @@ class TestMailActivityTodo(TransactionCase):
             "execution Todos must not get a read receipt",
         )
 
+    def test_uncategorised_activity_readable_but_not_logged(self):
+        """Fork A + ADR-0006: an activity whose type carries no category still
+        shows in the inbox and clears via Mark as Read like an Acknowledgement,
+        yet completing it is NOT snapshotted to history (logging stays scoped to
+        categorised workflow Todos)."""
+        type_plain = self.env["mail.activity.type"].create(
+            {"name": "Plain", "res_model": "test.todo.host"}
+        )
+        act = self.rec.activity_schedule(
+            summary="plain", activity_type_id=type_plain.id, user_id=self.user.id
+        )
+        self.assertFalse(act.todo_category, "uncategorised stays False")
+        self.assertTrue(act.with_user(self.user).is_my_todo)
+        # Readable: Mark as Read records a receipt (not gated out like execution).
+        act.with_user(self.user).action_mark_read()
+        self.assertTrue(act.with_user(self.user).is_read_by_me)
+        # But completion must not write a history row (6A).
+        before = self.Log.search_count([])
+        act.action_feedback()
+        self.assertEqual(
+            self.Log.search_count([]) - before,
+            0,
+            "uncategorised completion must not be logged",
+        )
+
     def test_recipient_partners_personal(self):
         """Bus recipients for a personal Todo = its assignee."""
         personal = self.rec.activity_schedule(
-            summary="p", activity_type_id=self.type_fyi.id, user_id=self.user.id
+            summary="p", activity_type_id=self.type_ack.id, user_id=self.user.id
         )
         self.assertEqual(
             personal._todo_recipient_partners(), self.user.partner_id
         )
 
-    def test_gc_personal_read_fyi(self):
-        """Retention GC removes read personal FYI past the threshold."""
+    def test_gc_personal_read_dismissed(self):
+        """Retention GC removes read personal dismissable Todos past the threshold."""
         self.env["ir.config_parameter"].sudo().set_param(
-            "mail_activity_todo.fyi_retention_days", "-1"
+            "mail_activity_todo.dismissed_retention_days", "-1"
         )
         personal = self.rec.activity_schedule(
-            summary="p", activity_type_id=self.type_fyi.id, user_id=self.user.id
+            summary="p", activity_type_id=self.type_ack.id, user_id=self.user.id
         )
         self.Read.create({"activity_id": personal.id, "user_id": self.user.id})
-        self.Activity._gc_read_fyi_todos()
-        self.assertFalse(personal.exists(), "read personal FYI should be GC'd")
+        self.Activity._gc_read_dismissed_todos()
+        self.assertFalse(
+            personal.exists(), "read personal dismissable Todo should be GC'd"
+        )

--- a/mail_activity_todo/views/mail_activity_views.xml
+++ b/mail_activity_todo/views/mail_activity_views.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-    <!-- Let users categorise a manually-scheduled activity from the native
-         "Schedule Activity" dialog, so it lands in their Todo inbox (the inbox
-         shows only categorised activities). -->
-    <record id="mail_activity_view_form_popup_todo" model="ir.ui.view">
-        <field name="name">mail.activity.view.form.popup.todo</field>
-        <field name="model">mail.activity</field>
-        <field name="inherit_id" ref="mail.mail_activity_view_form_popup" />
+    <!-- Expose the Todo category on the activity type: an admin sets it once
+         per type, and it auto-fills onto every activity of that type
+         (mail_activity.py::_compute_todo_category). This is the single place
+         the category is configured now that the per-activity picker is gone. -->
+    <record id="mail_activity_type_view_form_todo" model="ir.ui.view">
+        <field name="name">mail.activity.type.form.todo</field>
+        <field name="model">mail.activity.type</field>
+        <field name="inherit_id" ref="mail.mail_activity_type_view_form" />
         <field name="arch" type="xml">
-            <field name="activity_type_id" position="after">
+            <field name="category" position="after">
                 <field name="todo_category" />
             </field>
         </field>
@@ -26,8 +27,8 @@
                 edit="false"
                 decoration-bf="is_read_by_me == False"
                 decoration-muted="is_read_by_me == True"
-                decoration-danger="state == 'overdue' and todo_category in ['approval', 'execution']"
-                decoration-warning="state == 'today' and todo_category in ['approval', 'execution']"
+                decoration-danger="state == 'overdue' and todo_category == 'execution'"
+                decoration-warning="state == 'today' and todo_category == 'execution'"
             >
                 <field
                     name="state"
@@ -56,14 +57,14 @@
                     type="object"
                     string="Mark as Read"
                     icon="fa-check"
-                    attrs="{'invisible': ['|', ('todo_category', 'not in', ['fyi', 'acknowledgement']), ('is_read_by_me', '=', True)]}"
+                    attrs="{'invisible': ['|', ('todo_category', '=', 'execution'), ('is_read_by_me', '=', True)]}"
                 />
                 <button
                     name="action_mark_unread"
                     type="object"
                     string="Mark as Unread"
                     icon="fa-undo"
-                    attrs="{'invisible': ['|', ('todo_category', 'not in', ['fyi', 'acknowledgement']), ('is_read_by_me', '=', False)]}"
+                    attrs="{'invisible': ['|', ('todo_category', '=', 'execution'), ('is_read_by_me', '=', False)]}"
                 />
             </tree>
         </field>
@@ -88,14 +89,14 @@
                         type="object"
                         string="Mark as Read"
                         icon="fa-check"
-                        attrs="{'invisible': ['|', ('todo_category', 'not in', ['fyi', 'acknowledgement']), ('is_read_by_me', '=', True)]}"
+                        attrs="{'invisible': ['|', ('todo_category', '=', 'execution'), ('is_read_by_me', '=', True)]}"
                     />
                     <button
                         name="action_mark_unread"
                         type="object"
                         string="Mark as Unread"
                         icon="fa-undo"
-                        attrs="{'invisible': ['|', ('todo_category', 'not in', ['fyi', 'acknowledgement']), ('is_read_by_me', '=', False)]}"
+                        attrs="{'invisible': ['|', ('todo_category', '=', 'execution'), ('is_read_by_me', '=', False)]}"
                     />
                 </header>
                 <sheet>
@@ -197,7 +198,7 @@
         <field name="view_mode">tree,form</field>
         <field
             name="domain"
-        >[('is_my_todo', '=', True), ('todo_category', '!=', False)]</field>
+        >[('is_my_todo', '=', True)]</field>
         <field name="context">{'search_default_unread': 1}</field>
         <field name="search_view_id" ref="view_my_todo_search" />
         <field
@@ -212,8 +213,9 @@
         </field>
     </record>
 
-    <!-- Bulk actions in the list "Action" menu (FYI/Acknowledgement only,
-         enforced server-side in action_mark_read/unread). -->
+    <!-- Bulk actions in the list "Action" menu (dismissable Todos only —
+         everything except Execution — enforced server-side in
+         action_mark_read/unread). -->
     <record id="action_server_mark_read" model="ir.actions.server">
         <field name="name">Mark as Read</field>
         <field name="model_id" ref="mail.model_mail_activity" />

--- a/mail_activity_todo_discuss/README.rst
+++ b/mail_activity_todo_discuss/README.rst
@@ -17,6 +17,8 @@ Features
 * Clicking the header opens the Todo inbox in the Discuss **main content pane**
   (not a cramped sidebar list); clicking an app group opens it **filtered to
   that app**.
+* A **History** entry below the app groups opens the read/dismissed Todos (all
+  apps, newest first) in the same pane — the inbox's read complement.
 * The page lists the user's open Todos (up to 100, earliest deadline first),
   each with its source-app icon, subject, **app, source record, activity type,
   category, assignee, note** and a colour-coded deadline (overdue / today /
@@ -36,11 +38,13 @@ How it works
 * ``res.users.get_my_todos`` (added here) provides the list payload (optionally
   filtered to one ``res_model``), reusing ``mail_activity_todo``'s
   ``_my_todo_count_domain`` so the page, the sidebar group counts and the Todo
-  app all select the same Todos.
+  app all select the same Todos. Pass ``read=True`` for the History view, which
+  selects the read complement via ``_my_read_todo_domain``.
 * A ``registerPatch`` on the legacy mail ``Discuss`` model adds ``isTodoActive``
-  / ``todoResModel`` flags and an ``openTodos(resModel)`` method (mirroring
-  ``openThread``); the Discuss content/sidebar templates are extended via
-  ``t-inherit`` to render the Todo view and the grouped sidebar panel.
+  / ``isTodoHistory`` / ``todoResModel`` flags and ``openTodos(resModel)`` /
+  ``openTodoHistory()`` methods (mirroring ``openThread``); the Discuss
+  content/sidebar templates are extended via ``t-inherit`` to render the Todo
+  view and the grouped sidebar panel.
 
 Configuration
 =============

--- a/mail_activity_todo_discuss/README.rst
+++ b/mail_activity_todo_discuss/README.rst
@@ -17,8 +17,10 @@ Features
 * Clicking the header opens the Todo inbox in the Discuss **main content pane**
   (not a cramped sidebar list); clicking an app group opens it **filtered to
   that app**.
-* A **History** entry below the app groups opens the read/dismissed Todos (all
-  apps, newest first) in the same pane — the inbox's read complement.
+* A **History** entry below the app groups opens everything that has left the
+  inbox (all apps, newest handled first) in the same pane: the Todos I dismissed
+  with **Mark as Read** merged with the ones that were **completed** (a green
+  *Done* tag distinguishes them).
 * The page lists the user's open Todos (up to 100, earliest deadline first),
   each with its source-app icon, subject, **app, source record, activity type,
   category, assignee, note** and a colour-coded deadline (overdue / today /
@@ -39,7 +41,9 @@ How it works
   filtered to one ``res_model``), reusing ``mail_activity_todo``'s
   ``_my_todo_count_domain`` so the page, the sidebar group counts and the Todo
   app all select the same Todos. Pass ``read=True`` for the History view, which
-  selects the read complement via ``_my_read_todo_domain``.
+  merges the read complement (``_my_read_todo_domain``) with the completed
+  ``todo.log`` snapshots (scoped to the user by record rules), newest handled
+  first, each row tagged ``kind`` ("read"/"done").
 * A ``registerPatch`` on the legacy mail ``Discuss`` model adds ``isTodoActive``
   / ``isTodoHistory`` / ``todoResModel`` flags and ``openTodos(resModel)`` /
   ``openTodoHistory()`` methods (mirroring ``openThread``); the Discuss

--- a/mail_activity_todo_discuss/__manifest__.py
+++ b/mail_activity_todo_discuss/__manifest__.py
@@ -13,7 +13,8 @@ notifications and actionable Todos — lives in one place.
 A collapsible "Todos" section in the Discuss sidebar (next to
 Inbox/Starred/History) lists pending Todos grouped by source app with live
 counts. Clicking the header opens the full Todo page in the main content pane;
-clicking an app group opens it filtered to that app. The page lists each Todo
+clicking an app group opens it filtered to that app. A "History" entry below the
+groups opens the read/dismissed Todos in the same pane. The page lists each Todo
 with its detail (app, source record, activity type, assignee, note, who created
 it and when — as a relative time — and a colour-coded deadline countdown), each
 clickable straight to its source document, plus a link to the full Todo app. The

--- a/mail_activity_todo_discuss/__manifest__.py
+++ b/mail_activity_todo_discuss/__manifest__.py
@@ -14,7 +14,8 @@ A collapsible "Todos" section in the Discuss sidebar (next to
 Inbox/Starred/History) lists pending Todos grouped by source app with live
 counts. Clicking the header opens the full Todo page in the main content pane;
 clicking an app group opens it filtered to that app. A "History" entry below the
-groups opens the read/dismissed Todos in the same pane. The page lists each Todo
+groups opens the already-handled Todos (dismissed with Mark as Read plus
+completed ones) in the same pane. The page lists each Todo
 with its detail (app, source record, activity type, assignee, note, who created
 it and when — as a relative time — and a colour-coded deadline countdown), each
 clickable straight to its source document, plus a link to the full Todo app. The

--- a/mail_activity_todo_discuss/i18n/th.po
+++ b/mail_activity_todo_discuss/i18n/th.po
@@ -24,6 +24,13 @@ msgstr "(แสดงทั้งหมด)"
 
 #. module: mail_activity_todo_discuss
 #. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
+#, python-format
+msgid "Done"
+msgstr "เสร็จสิ้น"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml:0
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
 #, python-format
@@ -55,8 +62,8 @@ msgstr "ไม่มีงานที่รอดำเนินการ 🎉"
 #. odoo-javascript
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
 #, python-format
-msgid "No read todos yet"
-msgstr "ยังไม่มีงานที่อ่านแล้ว"
+msgid "No history yet"
+msgstr "ยังไม่มีประวัติ"
 
 #. module: mail_activity_todo_discuss
 #. odoo-javascript
@@ -69,8 +76,8 @@ msgstr "เปิดแอป Todo"
 #. odoo-javascript
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml:0
 #, python-format
-msgid "Read todos"
-msgstr "งานที่อ่านแล้ว"
+msgid "Read & completed todos"
+msgstr "งานที่อ่านแล้ว / เสร็จสิ้นแล้ว"
 
 #. module: mail_activity_todo_discuss
 #. odoo-javascript
@@ -120,6 +127,13 @@ msgstr "ผู้ใช้"
 #, python-format
 msgid "by"
 msgstr "โดย"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
+#, python-format
+msgid "completed"
+msgstr "เสร็จเมื่อ"
 
 #. module: mail_activity_todo_discuss
 #. odoo-javascript

--- a/mail_activity_todo_discuss/i18n/th.po
+++ b/mail_activity_todo_discuss/i18n/th.po
@@ -25,6 +25,14 @@ msgstr "(แสดงทั้งหมด)"
 #. module: mail_activity_todo_discuss
 #. odoo-javascript
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml:0
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
+#, python-format
+msgid "History"
+msgstr "ประวัติ"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml:0
 #, python-format
 msgid "Late"
 msgstr "เกินกำหนด"
@@ -47,8 +55,22 @@ msgstr "ไม่มีงานที่รอดำเนินการ 🎉"
 #. odoo-javascript
 #: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
 #, python-format
+msgid "No read todos yet"
+msgstr "ยังไม่มีงานที่อ่านแล้ว"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml:0
+#, python-format
 msgid "Open Todo app"
 msgstr "เปิดแอป Todo"
+
+#. module: mail_activity_todo_discuss
+#. odoo-javascript
+#: code:addons/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml:0
+#, python-format
+msgid "Read todos"
+msgstr "งานที่อ่านแล้ว"
 
 #. module: mail_activity_todo_discuss
 #. odoo-javascript

--- a/mail_activity_todo_discuss/models/res_users.py
+++ b/mail_activity_todo_discuss/models/res_users.py
@@ -6,7 +6,7 @@ class ResUsers(models.Model):
     _inherit = "res.users"
 
     @api.model
-    def get_my_todos(self, res_model=False, limit=100):
+    def get_my_todos(self, res_model=False, limit=100, read=False):
         """List payload for the Discuss Todo page: the current user's open Todos
         as records (capped at ``limit``), earliest deadline first, each carrying
         its source-app icon and the detail fields the list renders.
@@ -16,15 +16,20 @@ class ResUsers(models.Model):
         ``res_model`` to drill into a single source app (matching a sidebar
         group); ``total_count`` then reflects that app, staying consistent with
         the sidebar group badge.
+
+        Pass ``read=True`` for the History view: the same payload for the Todos I
+        have dismissed with Mark as Read (the inbox's read complement), newest
+        first.
         """
         Activity = self.env["mail.activity"]
-        domain = self._my_todo_count_domain()
+        domain = (
+            self._my_read_todo_domain() if read else self._my_todo_count_domain()
+        )
         if res_model:
             domain = domain + [("res_model", "=", res_model)]
         total = Activity.search_count(domain)
-        activities = Activity.search(
-            domain, limit=limit, order="date_deadline asc, id desc"
-        )
+        order = "id desc" if read else "date_deadline asc, id desc"
+        activities = Activity.search(domain, limit=limit, order=order)
 
         # Resolve each source model's app icon once, not per record.
         icons = {}

--- a/mail_activity_todo_discuss/models/res_users.py
+++ b/mail_activity_todo_discuss/models/res_users.py
@@ -7,83 +7,192 @@ class ResUsers(models.Model):
 
     @api.model
     def get_my_todos(self, res_model=False, limit=100, read=False):
-        """List payload for the Discuss Todo page: the current user's open Todos
-        as records (capped at ``limit``), earliest deadline first, each carrying
-        its source-app icon and the detail fields the list renders.
+        """List payload for the Discuss Todo page.
 
-        Reuses ``_my_todo_count_domain`` (from mail_activity_todo) so the page,
-        the systray badge and the Todo app all select the same Todos. Pass
+        Default (``read=False``): the current user's open Todos as records
+        (capped at ``limit``), earliest deadline first, each carrying its
+        source-app icon and the detail fields the list renders. Reuses
+        ``_my_todo_count_domain`` (from mail_activity_todo) so the page, the
+        systray badge and the Todo app all select the same Todos. Pass
         ``res_model`` to drill into a single source app (matching a sidebar
-        group); ``total_count`` then reflects that app, staying consistent with
-        the sidebar group badge.
+        group); ``total_count`` then reflects that app.
 
-        Pass ``read=True`` for the History view: the same payload for the Todos I
-        have dismissed with Mark as Read (the inbox's read complement), newest
-        first.
+        History (``read=True``): the Todos that have left my inbox — the ones I
+        dismissed with Mark as Read (still-live ``mail.activity``) merged with
+        the ones that were completed (``todo.log`` snapshots, ADR-0004), newest
+        handled first. See ``_get_my_todo_history``.
         """
+        if read:
+            return self._get_my_todo_history(res_model=res_model, limit=limit)
         Activity = self.env["mail.activity"]
-        domain = (
-            self._my_read_todo_domain() if read else self._my_todo_count_domain()
-        )
+        domain = self._my_todo_count_domain()
         if res_model:
             domain = domain + [("res_model", "=", res_model)]
         total = Activity.search_count(domain)
-        order = "id desc" if read else "date_deadline asc, id desc"
-        activities = Activity.search(domain, limit=limit, order=order)
+        activities = Activity.search(
+            domain, limit=limit, order="date_deadline asc, id desc"
+        )
+        icons = {}
+        todos = [self._todo_activity_card(act, icons) for act in activities]
+        return {"todos": todos, "total_count": total}
 
-        # Resolve each source model's app icon once, not per record.
+    # ------------------------------------------------------------------
+    # History (read + completed) — the inbox's "already handled" complement
+    # ------------------------------------------------------------------
+    def _get_my_todo_history(self, res_model=False, limit=100):
+        """Merge my read/dismissed Todos (live ``mail.activity``) with my
+        completed Todos (``todo.log`` snapshots) into one list, newest handled
+        first, capped at ``limit``.
+
+        The two live in different tables — Mark as Read keeps the activity (with
+        a per-user read receipt), completion unlinks it after logging to
+        ``todo.log`` — so each row carries a ``kind`` ("read"/"done") and a
+        ``key`` unique across both. ``todo.log`` visibility is already scoped to
+        the user by record rules (own / completed-by-me / role-in-unit), so no
+        extra ownership domain is needed for the completed side.
+        """
+        Activity = self.env["mail.activity"]
+        Log = self.env["todo.log"]
         icons = {}
 
-        def model_icon(model_name):
-            if model_name not in icons:
-                icon = False
-                try:
-                    icon_module = self.env[model_name]._original_module
-                    icon = icon_module and modules.module.get_module_icon(icon_module)
-                except Exception:  # never let an icon edge case blank the panel
-                    icon = False
-                icons[model_name] = icon or False
-            return icons[model_name]
+        read_domain = self._my_read_todo_domain()
+        log_domain = []
+        if res_model:
+            read_domain = read_domain + [("res_model", "=", res_model)]
+            log_domain = log_domain + [("res_model", "=", res_model)]
 
-        todos = [
-            {
-                "id": act.id,
-                "summary": (
-                    act.summary
-                    or act.res_name
-                    or act.activity_type_id.display_name
-                    or ""
-                ),
-                "res_name": act.res_name or "",
-                "res_model": act.res_model,
-                "res_id": act.res_id,
-                # sudo: regular users cannot read ir.model (non-sensitive
-                # metadata); without it the whole payload raises AccessError for
-                # non-admins and the Discuss list shows nothing.
-                "app": act.res_model_id.sudo().display_name or "",
-                "icon": model_icon(act.res_model) if act.res_model else False,
-                "activity_type": act.activity_type_id.display_name or "",
-                "todo_category": act.todo_category,
-                "assigned": act.user_id.display_name or "",
-                "note": html2plaintext(act.note)[:160] if act.note else "",
-                "date_deadline": (
-                    fields.Date.to_string(act.date_deadline)
-                    if act.date_deadline
-                    else False
-                ),
-                "state": act.state,
-                # Serialized UTC datetime; the client renders it as a locale-aware
-                # relative time ("3 hours ago") and formats the tooltip.
-                "create_date": (
-                    fields.Datetime.to_string(act.create_date)
-                    if act.create_date
-                    else False
-                ),
-                "create_uid": act.create_uid.display_name or "",
-            }
-            for act in activities
-        ]
+        read_total = Activity.search_count(read_domain)
+        done_total = Log.search_count(log_domain)
+
+        read_acts = Activity.search(read_domain, limit=limit, order="id desc")
+        # read_date drives the merge order; fetched only for sorting, not display.
+        reads = (
+            self.env["todo.read"]
+            .sudo()
+            .search(
+                [
+                    ("activity_id", "in", read_acts.ids),
+                    ("user_id", "=", self.env.uid),
+                ]
+            )
+        )
+        read_date_by_act = {r.activity_id.id: r.read_date for r in reads}
+
+        done_logs = Log.search(
+            log_domain, limit=limit, order="completed_date desc"
+        )
+
+        # (sort_key, card) pairs so read and done interleave by when they were
+        # handled, regardless of which table they came from.
+        dated = []
+        for act in read_acts:
+            card = self._todo_activity_card(act, icons)
+            card.update({"kind": "read", "key": "read-%s" % act.id})
+            dated.append((read_date_by_act.get(act.id) or act.create_date, card))
+        for log in done_logs:
+            card = self._todo_log_card(log, icons)
+            card.update({"kind": "done", "key": "done-%s" % log.id})
+            dated.append((log.completed_date or log.create_date, card))
+
+        dated.sort(key=lambda pair: pair[0], reverse=True)
         return {
-            "todos": todos,
-            "total_count": total,
+            "todos": [card for _, card in dated[:limit]],
+            "total_count": read_total + done_total,
+        }
+
+    # ------------------------------------------------------------------
+    # Card builders (one dict per list row) + shared icon cache
+    # ------------------------------------------------------------------
+    def _todo_model_icon(self, model_name, cache):
+        """Source model's app icon, resolved once per model and memoised in
+        ``cache``. try-guarded so an icon edge case never blanks the list."""
+        if model_name not in cache:
+            icon = False
+            try:
+                icon_module = self.env[model_name]._original_module
+                icon = icon_module and modules.module.get_module_icon(icon_module)
+            except Exception:  # never let an icon edge case blank the panel
+                icon = False
+            cache[model_name] = icon or False
+        return cache[model_name]
+
+    def _todo_activity_card(self, act, icon_cache):
+        """List row for a live Todo (an open inbox item or a read/dismissed
+        one)."""
+        return {
+            "id": act.id,
+            "summary": (
+                act.summary
+                or act.res_name
+                or act.activity_type_id.display_name
+                or ""
+            ),
+            "res_name": act.res_name or "",
+            "res_model": act.res_model,
+            "res_id": act.res_id,
+            # sudo: regular users cannot read ir.model (non-sensitive metadata);
+            # without it the whole payload raises AccessError for non-admins and
+            # the Discuss list shows nothing.
+            "app": act.res_model_id.sudo().display_name or "",
+            "icon": self._todo_model_icon(act.res_model, icon_cache)
+            if act.res_model
+            else False,
+            "activity_type": act.activity_type_id.display_name or "",
+            "todo_category": act.todo_category,
+            "assigned": act.user_id.display_name or "",
+            "note": html2plaintext(act.note)[:160] if act.note else "",
+            "date_deadline": (
+                fields.Date.to_string(act.date_deadline)
+                if act.date_deadline
+                else False
+            ),
+            "state": act.state,
+            # Serialized UTC datetime; the client renders it as a locale-aware
+            # relative time ("3 hours ago") and formats the tooltip.
+            "create_date": (
+                fields.Datetime.to_string(act.create_date)
+                if act.create_date
+                else False
+            ),
+            "create_uid": act.create_uid.display_name or "",
+        }
+
+    def _todo_log_card(self, log, icon_cache):
+        """List row for a completed Todo snapshot (``todo.log``). The source
+        activity is gone, so there is no note / live deadline / urgency state;
+        the meta line shows completed-when/by instead of created-when/by."""
+        return {
+            "id": log.id,
+            "summary": (
+                log.summary
+                or log.res_name
+                or (
+                    log.activity_type_id.display_name
+                    if log.activity_type_id
+                    else ""
+                )
+                or ""
+            ),
+            "res_name": log.res_name or "",
+            "res_model": log.res_model,
+            "res_id": log.res_id,
+            "app": log.res_model_id.sudo().display_name or "",
+            "icon": self._todo_model_icon(log.res_model, icon_cache)
+            if log.res_model
+            else False,
+            "activity_type": (
+                log.activity_type_id.display_name if log.activity_type_id else ""
+            ),
+            "todo_category": log.todo_category,
+            "assigned": log.user_id.display_name or "",
+            "note": "",
+            "date_deadline": False,
+            "state": False,
+            # Serialized UTC datetime, rendered client-side as relative time.
+            "completed_date": (
+                fields.Datetime.to_string(log.completed_date)
+                if log.completed_date
+                else False
+            ),
+            "completed_by": log.completed_by.display_name or "",
         }

--- a/mail_activity_todo_discuss/static/src/js/discuss_todo_sidebar.esm.js
+++ b/mail_activity_todo_discuss/static/src/js/discuss_todo_sidebar.esm.js
@@ -50,6 +50,10 @@ export class DiscussTodoSidebar extends LegacyComponent {
     onClickGroup(group) {
         this.discuss.openTodos(group.model);
     }
+
+    onClickHistory() {
+        this.discuss.openTodoHistory();
+    }
 }
 
 Object.assign(DiscussTodoSidebar, {

--- a/mail_activity_todo_discuss/static/src/js/discuss_todo_view.esm.js
+++ b/mail_activity_todo_discuss/static/src/js/discuss_todo_view.esm.js
@@ -31,14 +31,15 @@ export class DiscussTodoView extends LegacyComponent {
         this.action = useService("action");
         this.state = useState({ todos: [], totalCount: 0, loaded: false });
 
-        // Fetch on mount and whenever the source-app filter changes (the deps
-        // read discuss.todoResModel, which the template also reads, so useModels
-        // re-renders and this effect re-runs on a sidebar group click).
+        // Fetch on mount and whenever the source-app filter or the inbox/history
+        // mode changes (the deps read discuss.todoResModel / isTodoHistory, which
+        // the template also reads, so useModels re-renders and this effect
+        // re-runs on a sidebar group / History click).
         useEffect(
             () => {
                 this.fetchData();
             },
-            () => [this.discuss.todoResModel]
+            () => [this.discuss.todoResModel, this.discuss.isTodoHistory]
         );
         useBus(this.env.bus, "mail_activity_todo_updated", () => this.fetchData());
     }
@@ -120,9 +121,12 @@ export class DiscussTodoView extends LegacyComponent {
     async fetchData() {
         try {
             const resModel = this.discuss.todoResModel || false;
-            const result = await this.orm.call("res.users", "get_my_todos", [
-                resModel,
-            ]);
+            const result = await this.orm.call(
+                "res.users",
+                "get_my_todos",
+                [resModel],
+                { read: this.discuss.isTodoHistory }
+            );
             this.state.todos = result.todos || [];
             this.state.totalCount = result.total_count || 0;
         } catch (error) {

--- a/mail_activity_todo_discuss/static/src/js/discuss_todo_view.esm.js
+++ b/mail_activity_todo_discuss/static/src/js/discuss_todo_view.esm.js
@@ -81,6 +81,22 @@ export class DiscussTodoView extends LegacyComponent {
         return formatDateTime(deserializeDateTime(todo.create_date));
     }
 
+    /** Locale-aware "completed X ago" for completed (done) history rows. */
+    completedAgo(todo) {
+        if (!todo.completed_date) {
+            return "";
+        }
+        return deserializeDateTime(todo.completed_date).toRelative() || "";
+    }
+
+    /** Exact completed datetime for the meta-line tooltip. */
+    completedTooltip(todo) {
+        if (!todo.completed_date) {
+            return "";
+        }
+        return formatDateTime(deserializeDateTime(todo.completed_date));
+    }
+
     /**
      * Deadline as a human countdown plus its urgency styling. Uses
      * toRelativeCalendar ("today"/"tomorrow"/"in 3 days"/"yesterday") — the

--- a/mail_activity_todo_discuss/static/src/models/discuss.esm.js
+++ b/mail_activity_todo_discuss/static/src/models/discuss.esm.js
@@ -16,29 +16,50 @@ registerPatch({
         // When true, the main content pane shows the Todo inbox instead of a
         // conversation. Mutually exclusive with an active thread.
         isTodoActive: attr({ default: false }),
+        // When true, the Todo pane shows the History (read/dismissed Todos)
+        // instead of the open inbox. Only meaningful while isTodoActive.
+        isTodoHistory: attr({ default: false }),
         // Optional source-model filter (e.g. "purchase.order") set when a
         // sidebar app group is clicked; empty string means "all apps".
         todoResModel: attr({ default: "" }),
     },
     recordMethods: {
         /**
-         * Show the Todo inbox in the Discuss main pane (opening Discuss first if
-         * needed), optionally filtered to one source app. Mirrors openThread():
-         * clear the active thread so the conversation pane hides, then flag the
-         * Todo view on.
+         * Show the Todo inbox in the Discuss main pane, optionally filtered to
+         * one source app. "" = all apps.
+         *
+         * @param {string} [resModel=""] source model to filter to, "" = all
+         */
+        openTodos(resModel = "") {
+            this._showTodoPane({
+                isTodoHistory: false,
+                todoResModel: resModel || "",
+            });
+        },
+        /**
+         * Show the Todo History (my read/dismissed Todos, all apps) in the
+         * Discuss main pane.
+         */
+        openTodoHistory() {
+            this._showTodoPane({ isTodoHistory: true, todoResModel: "" });
+        },
+        /**
+         * Reveal the Todo pane in the Discuss main pane (opening Discuss first
+         * if needed). Mirrors openThread(): clear the active thread so the
+         * conversation pane hides, then flag the Todo view on.
          *
          * Presets isInitThreadHandled so DiscussContainer's one-time
          * "open Inbox on first Discuss open" does not steal focus when the
          * systray routes the user straight to Todos.
          *
-         * @param {string} [resModel=""] source model to filter to, "" = all
+         * @param {Object} extra fields to set (isTodoHistory / todoResModel)
          */
-        openTodos(resModel = "") {
+        _showTodoPane(extra) {
             this.update({
                 thread: clear(),
                 isTodoActive: true,
-                todoResModel: resModel || "",
                 isInitThreadHandled: true,
+                ...extra,
             });
             if (!this.discussView) {
                 this.env.services.action.doAction("mail.action_discuss", {

--- a/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml
+++ b/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml
@@ -11,7 +11,7 @@
                     title="Toggle Todos"
                 />
                 <div class="o_DiscussTodoSidebar_title btn btn-sm p-0 text-start text-uppercase fw-bolder flex-grow-1"
-                    t-att-class="{ 'text-primary': discuss.isTodoActive and !discuss.todoResModel }"
+                    t-att-class="{ 'text-primary': discuss.isTodoActive and !discuss.todoResModel and !discuss.isTodoHistory }"
                     t-on-click="onClickAll"
                 >
                     Todos
@@ -48,6 +48,16 @@
                         </button>
                     </t>
                 </t>
+                <!-- History: the read/dismissed Todos, all apps. Always shown
+                     when the section is open, even with an empty inbox. -->
+                <button class="o_DiscussSidebarMailbox o_DiscussTodoSidebar_group o_DiscussTodoSidebar_history btn d-flex align-items-center w-100 py-1 px-0 border-0 rounded-0 fw-normal text-dark"
+                    t-att-class="{ 'o-active bg-200': discuss.isTodoActive and discuss.isTodoHistory }"
+                    t-on-click="onClickHistory"
+                    title="Read todos"
+                >
+                    <i class="fa fa-fw fa-history ms-4 me-2"/>
+                    <div class="flex-grow-1 min-w-0 text-start">History</div>
+                </button>
             </div>
         </div>
     </t>

--- a/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml
+++ b/mail_activity_todo_discuss/static/src/xml/discuss_todo_sidebar.xml
@@ -53,7 +53,7 @@
                 <button class="o_DiscussSidebarMailbox o_DiscussTodoSidebar_group o_DiscussTodoSidebar_history btn d-flex align-items-center w-100 py-1 px-0 border-0 rounded-0 fw-normal text-dark"
                     t-att-class="{ 'o-active bg-200': discuss.isTodoActive and discuss.isTodoHistory }"
                     t-on-click="onClickHistory"
-                    title="Read todos"
+                    title="Read &amp; completed todos"
                 >
                     <i class="fa fa-fw fa-history ms-4 me-2"/>
                     <div class="flex-grow-1 min-w-0 text-start">History</div>

--- a/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
+++ b/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
@@ -4,7 +4,10 @@
     <t t-name="mail_activity_todo_discuss.DiscussTodoView" owl="1">
         <div class="o_DiscussTodoView d-flex flex-column h-100 w-100 bg-view" t-attf-class="{{ className }}" t-ref="root">
             <div class="o_DiscussTodoView_header d-flex align-items-center px-4 py-3 border-bottom">
-                <h4 class="m-0 fw-bold">Todos</h4>
+                <h4 class="m-0 fw-bold">
+                    <t t-if="discuss.isTodoHistory">History</t>
+                    <t t-else="">Todos</t>
+                </h4>
                 <span class="o_DiscussTodoView_filter ms-2 text-muted" t-if="filterLabel">
                     · <t t-esc="filterLabel"/>
                     <a href="#" class="small ms-2" t-on-click.prevent="onShowAll">(show all)</a>
@@ -22,8 +25,14 @@
             </t>
             <t t-elif="state.todos.length === 0">
                 <div class="o_DiscussTodoView_empty d-flex flex-column flex-grow-1 align-items-center justify-content-center text-muted">
-                    <i class="fa fa-check-circle fa-3x mb-2"/>
-                    <h4>No pending todos 🎉</h4>
+                    <t t-if="discuss.isTodoHistory">
+                        <i class="fa fa-history fa-3x mb-2"/>
+                        <h4>No read todos yet</h4>
+                    </t>
+                    <t t-else="">
+                        <i class="fa fa-check-circle fa-3x mb-2"/>
+                        <h4>No pending todos 🎉</h4>
+                    </t>
                 </div>
             </t>
             <t t-else="">
@@ -67,9 +76,15 @@
                     </t>
                 </div>
                 <div class="o_DiscussTodoView_footer border-top px-4 py-2 text-center" t-if="state.totalCount > state.todos.length">
-                    <a href="#" class="text-primary" t-on-click.prevent="onViewAllClick">
+                    <!-- The Todo app opens on the unread inbox, so the "view all"
+                         link only makes sense for the inbox; History shows a plain
+                         count. -->
+                    <a t-if="!discuss.isTodoHistory" href="#" class="text-primary" t-on-click.prevent="onViewAllClick">
                         Showing <t t-esc="state.todos.length"/> of <t t-esc="state.totalCount"/> — View all in the Todo app
                     </a>
+                    <span t-else="" class="text-muted">
+                        Showing <t t-esc="state.todos.length"/> of <t t-esc="state.totalCount"/>
+                    </span>
                 </div>
             </t>
         </div>

--- a/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
+++ b/mail_activity_todo_discuss/static/src/xml/discuss_todo_view.xml
@@ -27,7 +27,7 @@
                 <div class="o_DiscussTodoView_empty d-flex flex-column flex-grow-1 align-items-center justify-content-center text-muted">
                     <t t-if="discuss.isTodoHistory">
                         <i class="fa fa-history fa-3x mb-2"/>
-                        <h4>No read todos yet</h4>
+                        <h4>No history yet</h4>
                     </t>
                     <t t-else="">
                         <i class="fa fa-check-circle fa-3x mb-2"/>
@@ -37,7 +37,7 @@
             </t>
             <t t-else="">
                 <div class="o_DiscussTodoView_list flex-grow-1 overflow-auto">
-                    <t t-foreach="state.todos" t-as="todo" t-key="todo.id">
+                    <t t-foreach="state.todos" t-as="todo" t-key="todo.key or todo.id">
                         <t t-set="deadline" t-value="deadlineInfo(todo)"/>
                         <button class="o_DiscussTodoView_item btn d-flex align-items-start w-100 text-start px-4 py-2 border-0 border-bottom rounded-0"
                             t-on-click="() => this.onTodoClick(todo)"
@@ -48,6 +48,8 @@
                             <div class="o_DiscussTodoView_text flex-grow-1">
                                 <div class="d-flex align-items-center">
                                     <small class="text-muted text-truncate flex-grow-1" t-if="todo.activity_type" t-esc="todo.activity_type"/>
+                                    <span class="flex-grow-1" t-if="!todo.activity_type"/>
+                                    <small t-if="todo.kind === 'done'" class="badge text-bg-success ms-2">Done</small>
                                     <small t-if="deadline"
                                         class="o_DiscussTodoView_deadline ms-2 text-nowrap"
                                         t-att-class="deadline.className"
@@ -69,6 +71,10 @@
                                     <span t-if="todo.create_date" class="text-truncate" t-att-title="createdTooltip(todo)">
                                         <i class="fa fa-clock-o me-1"/>created <t t-esc="createdAgo(todo)"/>
                                         <t t-if="todo.create_uid"> by <t t-esc="todo.create_uid"/></t>
+                                    </span>
+                                    <span t-if="todo.completed_date" class="text-truncate" t-att-title="completedTooltip(todo)">
+                                        <i class="fa fa-check me-1"/>completed <t t-esc="completedAgo(todo)"/>
+                                        <t t-if="todo.completed_by"> by <t t-esc="todo.completed_by"/></t>
                                     </span>
                                 </small>
                             </div>

--- a/mail_activity_todo_role_unit/tests/test_role_unit.py
+++ b/mail_activity_todo_role_unit/tests/test_role_unit.py
@@ -29,10 +29,10 @@ class TestRoleUnit(TransactionCase):
         cls.Activity = cls.env["mail.activity"]
         cls.Log = cls.env["todo.log"]
 
-        cls.type_fyi = cls.env["mail.activity.type"].create(
+        cls.type_ack = cls.env["mail.activity.type"].create(
             {
-                "name": "Test FYI",
-                "todo_category": "fyi",
+                "name": "Test Acknowledgement",
+                "todo_category": "acknowledgement",
                 "res_model": "test.todo.host.role.unit",
             }
         )
@@ -66,7 +66,7 @@ class TestRoleUnit(TransactionCase):
 
     def _schedule_group(self):
         return self.rec.activity_schedule(
-            activity_type_id=self.type_fyi.id,
+            activity_type_id=self.type_ack.id,
             responsible_role_id=self.role.id,
             operating_unit_id=self.ou.id,
         )
@@ -133,13 +133,13 @@ class TestRoleUnit(TransactionCase):
         """Retention GC must never delete a shared group Todo on one member's
         read (ADR-0003)."""
         self.env["ir.config_parameter"].sudo().set_param(
-            "mail_activity_todo.fyi_retention_days", "-1"
+            "mail_activity_todo.dismissed_retention_days", "-1"
         )
         group = self._schedule_group()
         self.env["todo.read"].create(
             {"activity_id": group.id, "user_id": self.officer.id}
         )
-        self.Activity._gc_read_fyi_todos()
+        self.Activity._gc_read_dismissed_todos()
         self.assertTrue(
             group.exists(), "shared group Todo must survive one member's read"
         )

--- a/purchase_request_todo/data/mail_activity_type.xml
+++ b/purchase_request_todo/data/mail_activity_type.xml
@@ -4,7 +4,7 @@
     <record id="mail_activity_pr_status_fyi" model="mail.activity.type">
         <field name="name">Purchase request status update</field>
         <field name="summary">The purchase request changed status</field>
-        <field name="todo_category">fyi</field>
+        <field name="todo_category">acknowledgement</field>
         <field name="res_model">purchase.request.approval</field>
         <field name="icon">fa-info-circle</field>
         <field name="delay_count">0</field>


### PR DESCRIPTION
The Todo inbox and systray now list every open activity assigned to the user (built-in, OCA, hand-scheduled, or workflow-emitted) instead of only categorised ones, so the replaced native activity bell hides no work and `todo_category` becomes metadata rather than a gate (ADR-0006). It collapses from four values to two — `execution` (clears at the source) and `acknowledgement` (dismissable with Mark as Read) — now set only on the activity type since the per-activity picker is removed. Per-user Mark as Read stays the single user-driven clear for everything that is not Execution, including uncategorised activities, and there is no Mark Done button because native done was judged riskier (global and irreversible). Bridges (`purchase_request_todo`, `accounting_kmitl_workflow`), the retention cron/param, tests, and docs (ADR-0003/0004/0006, CONTEXT, ROADMAP, README, th.po) are updated to match; no migration or version bump since the module is not yet deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)