### PR TITLE
[16.0][IMP] iam_operating_unit: add With/Without Operating Unit user filters

### DIFF
--- a/iam_operating_unit/i18n/th.po
+++ b/iam_operating_unit/i18n/th.po
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* iam_operating_unit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-19 17:54+0000\n"
+"PO-Revision-Date: 2026-07-19 17:54+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: iam_operating_unit
+#: model:ir.model.fields,field_description:iam_operating_unit.field_operating_unit__iam_user_count
+#: model_terms:ir.ui.view,arch_db:iam_operating_unit.view_operating_unit_tree_iam
+msgid "# Users"
+msgstr "จำนวนผู้ใช้"
+
+#. module: iam_operating_unit
+#: model:ir.model.fields,help:iam_operating_unit.field_operating_unit__iam_user_count
+msgid "Number of users assigned to this operating unit."
+msgstr "จำนวนผู้ใช้ที่กำหนดให้กับ OU นี้"
+
+#. module: iam_operating_unit
+#: model:ir.model,name:iam_operating_unit.model_operating_unit
+msgid "Operating Unit"
+msgstr "OU"
+
+#. module: iam_operating_unit
+#: model:ir.ui.menu,name:iam_operating_unit.menu_iam_operating_units
+#: model_terms:ir.ui.view,arch_db:iam_operating_unit.view_users_tree_iam_ou
+msgid "Operating Units"
+msgstr "OU"
+
+#. module: iam_operating_unit
+#: model_terms:ir.ui.view,arch_db:iam_operating_unit.view_operating_unit_form_iam
+msgid "Users"
+msgstr "ผู้ใช้"
+
+#. module: iam_operating_unit
+#: model_terms:ir.ui.view,arch_db:iam_operating_unit.view_users_search_iam_ou
+msgid "With Operating Unit"
+msgstr "มี OU"
+
+#. module: iam_operating_unit
+#: model_terms:ir.ui.view,arch_db:iam_operating_unit.view_users_search_iam_ou
+msgid "Without Operating Unit"
+msgstr "ไม่มี OU"

--- a/iam_operating_unit/views/res_users_views.xml
+++ b/iam_operating_unit/views/res_users_views.xml
@@ -24,4 +24,33 @@
         </field>
     </record>
 
+    <!-- "With / Without Operating Unit" filters on the Users search view.
+         Filters on assigned_operating_unit_ids (the stored Many2many) for the
+         same reason the tree column does: operating_unit_ids is a non-stored
+         compute with no search method and cannot back a filter domain. Gated to
+         the IAM manager to match the OU column and keep the standard Users
+         search (used under Settings) uncluttered for everyone else. -->
+    <record id="view_users_search_iam_ou" model="ir.ui.view">
+        <field name="name">res.users.search.iam-ou</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_search" />
+        <field name="arch" type="xml">
+            <filter name="Inactive" position="after">
+                <separator groups="iam.group_iam_manager" />
+                <filter
+                    name="filter_with_operating_unit"
+                    string="With Operating Unit"
+                    domain="[('assigned_operating_unit_ids', '!=', False)]"
+                    groups="iam.group_iam_manager"
+                />
+                <filter
+                    name="filter_without_operating_unit"
+                    string="Without Operating Unit"
+                    domain="[('assigned_operating_unit_ids', '=', False)]"
+                    groups="iam.group_iam_manager"
+                />
+            </filter>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Adds **"With Operating Unit"** / **"Without Operating Unit"** filters to the `res.users` search view, letting IAM managers quickly find users that do or do not have an operating unit assigned. The filters run on the stored `assigned_operating_unit_ids` Many2many (the `operating_unit_ids` One2many is a non-stored compute with no search method, so it cannot back a filter domain — this is why the existing OU list column uses the same field) and are gated to `iam.group_iam_manager` to match that column and keep the standard Users search under Settings uncluttered for everyone else.