### PR TITLE
[16.0][ADD] iam_hr: employees list with user-link filter, grouped HR menus

### DIFF
--- a/iam_hr/README.rst
+++ b/iam_hr/README.rst
@@ -1,15 +1,21 @@
-==============
+====================
 IAM - HR Departments
-==============
+====================
 
-Bridge between the **iam** app and **hr**. Lets an IAM Manager answer two
+Bridge between the **iam** app and **hr**. Lets an IAM Manager answer three
 questions without leaving the IAM app and without being an HR officer:
 
-* **Which users belong to each department?** — *IAM ▸ Departments* lists every
-  ``hr.department`` with a user count; opening one shows a **Users** smart
-  button that drills into that department's backend users.
+* **Which users belong to each department?** — *IAM ▸ HR Directory ▸
+  Departments* lists every ``hr.department`` with a user count; opening one
+  shows a **Users** smart button that drills into that department's backend
+  users.
 * **Which users are / aren't linked to an employee?** — the *Users* list gains
   a *Linked to Employee* column and two filters.
+* **Which employees don't have a user yet?** — *IAM ▸ HR Directory ▸ Employees
+  without User* lists the employees not linked to any ``res.users`` (default
+  filter),
+  so the manager can find and create the missing users. Toggle the filter to
+  cross-check the employees that already have one.
 
 Access design (the non-obvious bit)
 ====================================
@@ -19,12 +25,17 @@ In core ``hr``, ``hr.department`` is readable by every internal user but
 else reads ``hr.employee.public``). An IAM Manager is ``erp_manager`` /
 ``group_user`` and usually **not** HR staff.
 
-So this module never reads ``hr.employee`` in the manager's own right and never
-displays employee data. The user count, the department→users drill-down, and
-the *Linked to Employee* search all derive their data through ``sudo()`` and
-surface only an integer count and ``res.users`` records (which the manager can
-already read). The IAM Manager is **not** granted ``hr.employee`` read access,
-keeping employee PII off-limits (PDPA-friendly).
+So this module never reads ``hr.employee`` in the manager's own right, and it is
+**not** granted ``hr.employee`` read access, keeping employee PII off-limits
+(PDPA-friendly). Instead:
+
+* The department user count, the department→users drill-down, and the *Linked to
+  Employee* search derive their data through ``sudo()`` and surface only an
+  integer count and ``res.users`` records (which the manager can already read).
+* The *Employees without User* list reads ``hr.employee.public`` — the SQL-view
+  projection Odoo already exposes to every internal user — and shows only its
+  public fields (name, department, job title, work email, linked user). No
+  private employee field is ever touched.
 
 Nothing here adds a model, a stored column, or an ACL row — only computed
-fields, two reused-model views, and one menu.
+helper fields, a handful of reused-model views, and two menus.

--- a/iam_hr/README.rst
+++ b/iam_hr/README.rst
@@ -11,11 +11,10 @@ questions without leaving the IAM app and without being an HR officer:
   users.
 * **Which users are / aren't linked to an employee?** — the *Users* list gains
   a *Linked to Employee* column and two filters.
-* **Which employees don't have a user yet?** — *IAM ▸ HR Directory ▸ Employees
-  without User* lists the employees not linked to any ``res.users`` (default
-  filter),
-  so the manager can find and create the missing users. Toggle the filter to
-  cross-check the employees that already have one.
+* **Which employees don't have a user yet?** — *IAM ▸ HR Directory ▸ Employees*
+  lists all employees with **Without User** / **With User** filters, so the
+  manager can spot the ones not linked to any ``res.users`` and create the
+  missing users.
 
 Access design (the non-obvious bit)
 ====================================
@@ -32,7 +31,7 @@ So this module never reads ``hr.employee`` in the manager's own right, and it is
 * The department user count, the department→users drill-down, and the *Linked to
   Employee* search derive their data through ``sudo()`` and surface only an
   integer count and ``res.users`` records (which the manager can already read).
-* The *Employees without User* list reads ``hr.employee.public`` — the SQL-view
+* The *Employees* list reads ``hr.employee.public`` — the SQL-view
   projection Odoo already exposes to every internal user — and shows only its
   public fields (name, department, job title, work email, linked user). No
   private employee field is ever touched.

--- a/iam_hr/__manifest__.py
+++ b/iam_hr/__manifest__.py
@@ -2,9 +2,9 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     "name": "IAM - HR Departments",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "summary": "Browse backend users by HR department and by employee link, "
-    "from the Identity & Access app",
+    "and spot employees without a user, from the Identity & Access app",
     "author": "Aginix Technologies",
     "website": "https://github.com/Aginix/kmitl",
     "category": "Administration",
@@ -15,7 +15,9 @@
     ],
     "data": [
         "views/iam_hr_department_views.xml",
+        "views/iam_hr_employee_views.xml",
         "views/res_users_views.xml",
+        "views/iam_hr_menus.xml",
     ],
     "installable": True,
 }

--- a/iam_hr/__manifest__.py
+++ b/iam_hr/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "IAM - HR Departments",
     "version": "16.0.1.1.0",
     "summary": "Browse backend users by HR department and by employee link, "
-    "and spot employees without a user, from the Identity & Access app",
+    "and list employees with/without a linked user, from the Identity & Access app",
     "author": "Aginix Technologies",
     "website": "https://github.com/Aginix/kmitl",
     "category": "Administration",

--- a/iam_hr/views/iam_hr_department_views.xml
+++ b/iam_hr/views/iam_hr_department_views.xml
@@ -69,12 +69,4 @@
         <field name="act_window_id" ref="action_iam_department" />
     </record>
 
-    <menuitem
-        id="menu_iam_departments"
-        name="Departments"
-        parent="iam.menu_iam_root"
-        action="action_iam_department"
-        sequence="35"
-    />
-
 </odoo>

--- a/iam_hr/views/iam_hr_employee_views.xml
+++ b/iam_hr/views/iam_hr_employee_views.xml
@@ -86,29 +86,28 @@
         </field>
     </record>
 
-    <record id="action_iam_employee_no_user" model="ir.actions.act_window">
-        <field name="name">Employees without User</field>
+    <record id="action_iam_employee" model="ir.actions.act_window">
+        <field name="name">Employees</field>
         <field name="res_model">hr.employee.public</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="iam_hr_view_employee_search" />
-        <field name="context">{'search_default_iam_no_user': 1}</field>
         <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">Every employee is linked to a user</p>
-            <p>Employees not yet linked to a backend user appear here, so you can
-                create the missing users.</p>
+            <p class="o_view_nocontent_smiling_face">No employees found</p>
+            <p>Use the <b>Without User</b> / <b>With User</b> filters to review
+                which employees are linked to a backend user.</p>
         </field>
     </record>
-    <record id="action_iam_employee_no_user_tree" model="ir.actions.act_window.view">
+    <record id="action_iam_employee_tree" model="ir.actions.act_window.view">
         <field name="sequence" eval="1" />
         <field name="view_mode">tree</field>
         <field name="view_id" ref="iam_hr_view_employee_tree" />
-        <field name="act_window_id" ref="action_iam_employee_no_user" />
+        <field name="act_window_id" ref="action_iam_employee" />
     </record>
-    <record id="action_iam_employee_no_user_form" model="ir.actions.act_window.view">
+    <record id="action_iam_employee_form" model="ir.actions.act_window.view">
         <field name="sequence" eval="2" />
         <field name="view_mode">form</field>
         <field name="view_id" ref="iam_hr_view_employee_form" />
-        <field name="act_window_id" ref="action_iam_employee_no_user" />
+        <field name="act_window_id" ref="action_iam_employee" />
     </record>
 
 </odoo>

--- a/iam_hr/views/iam_hr_employee_views.xml
+++ b/iam_hr/views/iam_hr_employee_views.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Aginix Technologies
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+     IAM-scoped, read-only employee views used to spot employees that are not
+     yet linked to a backend user (res.users). We read hr.employee.public (the
+     SQL-view projection every internal user may read), so the IAM manager
+     never needs hr.employee access (mirrors the department views' philosophy).
+     Only public-projection fields are ever shown. -->
+<odoo>
+
+    <record id="iam_hr_view_employee_search" model="ir.ui.view">
+        <field name="name">hr.employee.public.search.iam</field>
+        <field name="model">hr.employee.public</field>
+        <field name="arch" type="xml">
+            <search string="Employees">
+                <field
+                    name="name"
+                    string="Employee"
+                    filter_domain="['|', ('name', 'ilike', self), ('work_email', 'ilike', self)]"
+                />
+                <field name="department_id" />
+                <separator />
+                <filter
+                    name="iam_no_user"
+                    string="Without User"
+                    domain="[('user_id', '=', False)]"
+                />
+                <filter
+                    name="iam_has_user"
+                    string="With User"
+                    domain="[('user_id', '!=', False)]"
+                />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_department"
+                        string="Department"
+                        context="{'group_by': 'department_id'}"
+                    />
+                    <filter
+                        name="group_company"
+                        string="Company"
+                        context="{'group_by': 'company_id'}"
+                        groups="base.group_multi_company"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="iam_hr_view_employee_tree" model="ir.ui.view">
+        <field name="name">hr.employee.public.tree.iam</field>
+        <field name="model">hr.employee.public</field>
+        <field name="arch" type="xml">
+            <tree string="Employees" create="0">
+                <field name="name" />
+                <field name="department_id" />
+                <field name="job_title" />
+                <field name="work_email" />
+                <field name="user_id" />
+                <field name="company_id" groups="base.group_multi_company" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="iam_hr_view_employee_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form.iam</field>
+        <field name="model">hr.employee.public</field>
+        <field name="arch" type="xml">
+            <form string="Employee" create="0" edit="0">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" />
+                            <field name="department_id" />
+                            <field name="job_title" />
+                        </group>
+                        <group>
+                            <field name="work_email" widget="email" />
+                            <field name="user_id" />
+                            <field name="company_id" groups="base.group_multi_company" />
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_iam_employee_no_user" model="ir.actions.act_window">
+        <field name="name">Employees without User</field>
+        <field name="res_model">hr.employee.public</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="iam_hr_view_employee_search" />
+        <field name="context">{'search_default_iam_no_user': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Every employee is linked to a user</p>
+            <p>Employees not yet linked to a backend user appear here, so you can
+                create the missing users.</p>
+        </field>
+    </record>
+    <record id="action_iam_employee_no_user_tree" model="ir.actions.act_window.view">
+        <field name="sequence" eval="1" />
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="iam_hr_view_employee_tree" />
+        <field name="act_window_id" ref="action_iam_employee_no_user" />
+    </record>
+    <record id="action_iam_employee_no_user_form" model="ir.actions.act_window.view">
+        <field name="sequence" eval="2" />
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="iam_hr_view_employee_form" />
+        <field name="act_window_id" ref="action_iam_employee_no_user" />
+    </record>
+
+</odoo>

--- a/iam_hr/views/iam_hr_menus.xml
+++ b/iam_hr/views/iam_hr_menus.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 Aginix Technologies
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+     HR-sourced menus grouped under one "HR Directory" section, kept apart from
+     the iam app's identity primitives (Users / Roles / Groups / Access
+     Control). Loaded after the view files because these menuitems reference
+     the actions those files define. -->
+<odoo>
+
+    <menuitem
+        id="menu_iam_hr"
+        name="HR Directory"
+        parent="iam.menu_iam_root"
+        sequence="45"
+    />
+
+    <menuitem
+        id="menu_iam_departments"
+        name="Departments"
+        parent="menu_iam_hr"
+        action="action_iam_department"
+        sequence="10"
+    />
+
+    <menuitem
+        id="menu_iam_employees"
+        name="Employees without User"
+        parent="menu_iam_hr"
+        action="action_iam_employee_no_user"
+        sequence="20"
+    />
+
+</odoo>

--- a/iam_hr/views/iam_hr_menus.xml
+++ b/iam_hr/views/iam_hr_menus.xml
@@ -25,9 +25,9 @@
 
     <menuitem
         id="menu_iam_employees"
-        name="Employees without User"
+        name="Employees"
         parent="menu_iam_hr"
-        action="action_iam_employee_no_user"
+        action="action_iam_employee"
         sequence="20"
     />
 


### PR DESCRIPTION
Adds an **Employees** menu to the IAM app that lists all employees (`hr.employee.public`) with **Without User** / **With User** filters, so an IAM manager can review which employees are (not) linked to a `res.users` and create the missing ones. It reads only the public employee projection, so the manager needs no `hr.employee` access and no employee PII is exposed (matching the module's existing design). It also groups *Departments* and the new menu under a new **HR Directory** section, and bumps the module to `16.0.1.1.0` with README updates.
