### PR TITLE
[16.0][FIX] finance_kmitl: fix payment amount reset to 0 on save

### DIFF
--- a/finance_kmitl/views/account_payment_views.xml
+++ b/finance_kmitl/views/account_payment_views.xml
@@ -107,7 +107,7 @@
                        attrs="{'invisible': [('amount_wht', '=', 0)]}">
                     <field name="amount_before_wht"/>
                     <field name="amount_wht"/>
-                    <field name="amount" string="Net Amount Paid" readonly="1"/>
+                    <field name="amount" string="Net Amount Paid" readonly="1" force_save="1"/>
                 </group>
             </xpath>
 


### PR DESCRIPTION
## Problem

สร้าง `account.payment` ด้วยฟอร์มแล้วกด **Save** (หรือ **Submit**) ยอดเงิน (`amount`) จะกลายเป็น `0` เสมอ แม้ผู้ใช้กรอกยอดไว้แล้ว

## Root cause

`finance_kmitl/views/account_payment_views.xml` เพิ่ม `<field name="amount" readonly="1">` ซ้ำในกลุ่ม WHT Summary ทั้งที่ฟอร์ม base มี `amount` อยู่แล้ว

Odoo 16 web client รวม field ชื่อซ้ำแบบ **last-wins** (`form_arch_parser.js`) ทำให้ `activeFields['amount']` ถูกเขียนทับเป็น node ที่ `readonly="1"` (static) → ตอน save `getChanges()` (`relational_model.js`) ตัด field ที่ readonly และไม่มี `force_save` ออกจาก payload → ค่าที่พิมพ์หายไป record บันทึกเป็น `0` (ค่า default ของ Monetary) → กลไก sync `account.payment ↔ account.move` สร้าง liquidity line เป็น 0 ตาม

> base Odoo เตือน gotcha เดียวกันไว้เองที่ `account/views/account_payment_view.xml` (กรณี `partner_bank_id`) — path การสร้างแบบ server-side (register wizard / DR flow) ส่ง `amount` ตรง ๆ จึงไม่โดนบั๊กนี้

## Fix

เพิ่ม `force_save="1"` ที่ field `amount` ที่ซ้ำ → `getChanges()` จะไม่ตัดทิ้ง (เงื่อนไข `!forceSave && isReadonly` เป็น false) บันทึกค่าที่ผู้ใช้พิมพ์จาก node ที่แก้ไขได้ โดย field นี้ยังแสดงแบบ readonly เหมือนเดิม และคง WHT summary ครบ 3 บรรทัด (สอดคล้องกับ pattern `journal_id` ในไฟล์เดียวกัน)

```diff
-<field name="amount" string="Net Amount Paid" readonly="1"/>
+<field name="amount" string="Net Amount Paid" readonly="1" force_save="1"/>
```

## Test

1. อัปเดต module `finance_kmitl`
2. สร้าง payment ใหม่ กรอก amount (เช่น 1000) → กด **Save** → `amount` ยังเป็น 1000 (ไม่กลายเป็น 0)
3. กด **Submit** → `amount` คงเดิม; journal items: liquidity/counterpart line = ±1000
4. เคส WHT (amount_wht > 0): WHT summary แสดงและค่า save ถูกต้อง