### PR TITLE
[16.0][ADD] l10n_th_bank_payment_export_kbank: KBANK bank payment file export

### DIFF
--- a/l10n_th_bank_payment_export_bay/README.rst
+++ b/l10n_th_bank_payment_export_bay/README.rst
@@ -1,0 +1,25 @@
+===================================
+Thai Localization - Bank Payment Export BAY
+===================================
+
+Bank payment file export for **Bank of Ayudhya / Krungsri (BAY / AYUDTHBK)**,
+built on top of ``l10n_th_bank_payment_export_format``.
+
+Adds ``BAY`` as an option on ``bank.payment.export`` and ships a fixed-width
+file layout (``BAY CashLink``) for exporting vendor payments.
+
+.. IMPORTANT::
+
+   **The file layout in** ``data/bank.export.format.line.csv`` **is a DRAFT.**
+
+   Krungsri does not publish the direct-credit upload byte specification openly.
+   The shipped layout reproduces Krungsri's confirmed CashLink conventions
+   (256-byte records, ``^`` field separators, ``H``/``D`` record types,
+   ``DDMM20YY`` dates, ``9(11)V99`` satang amounts, bank code ``025``) but the
+   field order/positions are modelled on the KTB direct-credit layout, **not**
+   on an official CashLink direct-credit spec (the only public Krungsri layout
+   found was an incoming bill-payment statement, not the outgoing upload).
+
+   Before production use you **must** obtain the official *Krungsri CashLink
+   Direct Credit upload file layout* + a sample file from the bank, then
+   validate/adjust this CSV accordingly.

--- a/l10n_th_bank_payment_export_bay/data/bank.export.format.line.csv
+++ b/l10n_th_bank_payment_export_bay/data/bank.export.format.line.csv
@@ -1,1 +1,43 @@
 id,bank_id/id,sequence,name,display_type,lenght,match_group,need_loop,sub_loop,sub_value_loop,end_line,condition_line,value_type,value_alignment,value_blank_space,value
+bay_format_01,l10n_th_bank_payment_export_bay.bay_cashlink,10,HEADER,line_section,,,,,,,,fixed,ljust,,
+bay_format_02,l10n_th_bank_payment_export_bay.bay_cashlink,11,Record Type,,1,,,,,,,fixed,ljust,,H
+bay_format_03,l10n_th_bank_payment_export_bay.bay_cashlink,12,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_04,l10n_th_bank_payment_export_bay.bay_cashlink,13,Sequence,,6,,,,,,,fixed,rjust,0,1
+bay_format_05,l10n_th_bank_payment_export_bay.bay_cashlink,14,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_06,l10n_th_bank_payment_export_bay.bay_cashlink,15,Sending Bank Code,,3,,,,,,,fixed,ljust,,025
+bay_format_07,l10n_th_bank_payment_export_bay.bay_cashlink,16,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_08,l10n_th_bank_payment_export_bay.bay_cashlink,17,Company Account,,10,,,,,,,dynamic,rjust,0,line[0].sanitize_account_number(line[0].payment_journal_id.bank_account_id.acc_number)
+bay_format_09,l10n_th_bank_payment_export_bay.bay_cashlink,18,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_10,l10n_th_bank_payment_export_bay.bay_cashlink,19,Company Name,,40,,,,,,,dynamic,ljust,,rec.bay_sender_name or rec.company_id.name
+bay_format_11,l10n_th_bank_payment_export_bay.bay_cashlink,20,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_12,l10n_th_bank_payment_export_bay.bay_cashlink,21,Effective Date,,8,,,,,,,dynamic,ljust,,"rec.effective_date.strftime(""%d%m20%y"")"
+bay_format_13,l10n_th_bank_payment_export_bay.bay_cashlink,22,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_14,l10n_th_bank_payment_export_bay.bay_cashlink,23,Total Amount,,13,,,,,,,dynamic,rjust,0,"str(int(round(rec.total_amount * 100, 2)))"
+bay_format_15,l10n_th_bank_payment_export_bay.bay_cashlink,24,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_16,l10n_th_bank_payment_export_bay.bay_cashlink,25,Transaction Count,,6,,,,,,,dynamic,rjust,0,str(len(line.ids))
+bay_format_17,l10n_th_bank_payment_export_bay.bay_cashlink,26,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_18,l10n_th_bank_payment_export_bay.bay_cashlink,27,Service Code,,2,,,,,,,dynamic,ljust,,rec.bay_service_type
+bay_format_19,l10n_th_bank_payment_export_bay.bay_cashlink,28,Separator,,1,,,,,,,fixed,ljust,,^
+bay_format_20,l10n_th_bank_payment_export_bay.bay_cashlink,29,Filler,,158,,,,,TRUE,,fixed,ljust,,
+bay_format_21,l10n_th_bank_payment_export_bay.bay_cashlink,40,DETAILS,line_section,,,,,,,,fixed,ljust,,
+bay_format_22,l10n_th_bank_payment_export_bay.bay_cashlink,41,Record Type,,1,line,TRUE,,,,,fixed,ljust,,D
+bay_format_23,l10n_th_bank_payment_export_bay.bay_cashlink,42,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_24,l10n_th_bank_payment_export_bay.bay_cashlink,43,Sequence,,6,line,TRUE,,,,,dynamic,rjust,0,str(idx_line+1)
+bay_format_25,l10n_th_bank_payment_export_bay.bay_cashlink,44,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_26,l10n_th_bank_payment_export_bay.bay_cashlink,45,Receiving Bank Code,,3,line,TRUE,,,,,dynamic,ljust,,line.payment_partner_bank_id.bank_id.bank_code
+bay_format_27,l10n_th_bank_payment_export_bay.bay_cashlink,46,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_28,l10n_th_bank_payment_export_bay.bay_cashlink,47,Receiving Branch Code,,4,line,TRUE,,,,,dynamic,rjust,0,line.payment_partner_bank_id.bank_id.bank_branch_code
+bay_format_29,l10n_th_bank_payment_export_bay.bay_cashlink,48,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_30,l10n_th_bank_payment_export_bay.bay_cashlink,49,Receiving Account,,11,line,TRUE,,,,,dynamic,rjust,0,line.sanitize_account_number(line.payment_partner_bank_id.acc_number)
+bay_format_31,l10n_th_bank_payment_export_bay.bay_cashlink,50,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_32,l10n_th_bank_payment_export_bay.bay_cashlink,51,Receiver Name,,50,line,TRUE,,,,,dynamic,ljust,,line.payment_partner_bank_id.acc_holder_name or line.payment_partner_bank_id.partner_id.display_name
+bay_format_33,l10n_th_bank_payment_export_bay.bay_cashlink,52,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_34,l10n_th_bank_payment_export_bay.bay_cashlink,53,Amount,,13,line,TRUE,,,,,dynamic,rjust,0,"str(int(round(line.payment_amount * 100, 2)))"
+bay_format_35,l10n_th_bank_payment_export_bay.bay_cashlink,54,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_36,l10n_th_bank_payment_export_bay.bay_cashlink,55,Effective Date,,8,line,TRUE,,,,,dynamic,ljust,,"rec.effective_date.strftime(""%d%m20%y"")"
+bay_format_37,l10n_th_bank_payment_export_bay.bay_cashlink,56,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_38,l10n_th_bank_payment_export_bay.bay_cashlink,57,Reference,,20,line,TRUE,,,,,dynamic,ljust,,line.payment_id.name
+bay_format_39,l10n_th_bank_payment_export_bay.bay_cashlink,58,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_40,l10n_th_bank_payment_export_bay.bay_cashlink,59,Debit Credit,,1,line,TRUE,,,,,fixed,ljust,,C
+bay_format_41,l10n_th_bank_payment_export_bay.bay_cashlink,60,Separator,,1,line,TRUE,,,,,fixed,ljust,,^
+bay_format_42,l10n_th_bank_payment_export_bay.bay_cashlink,61,Filler,,129,line,TRUE,,,TRUE,,fixed,ljust,,

--- a/l10n_th_bank_payment_export_kbank/README.rst
+++ b/l10n_th_bank_payment_export_kbank/README.rst
@@ -1,0 +1,39 @@
+=====================================
+Thai Localization - Bank Payment Export KBANK
+=====================================
+
+Bank payment file export for **Kasikornbank (KBANK / KASITHBK)**, built on top
+of ``l10n_th_bank_payment_export_format``.
+
+This module adds ``KBANK`` as an option on ``bank.payment.export`` and ships a
+fixed-width file layout (``KBANK K-Cash Connect Plus``) so that vendor payments
+can be exported as a text file for upload to KBANK.
+
+Usage
+=====
+
+#. Create vendor payments (Manual, bank journal) as usual.
+#. From the Payments list, use *Create Bank Payment Export* (or create a
+   ``bank.payment.export`` and *Get All Payments*).
+#. Select bank **KBANK**, fill the KBANK configuration (Company ID, Sender Name,
+   Service Type) and the Effective Date, then *Confirm* and *Export Text File*.
+
+.. IMPORTANT::
+
+   **The file layout in** ``data/bank.export.format.line.csv`` **is a DRAFT.**
+
+   Kasikornbank does not publish the byte-level file specification openly. The
+   shipped layout (Header ``HDCT``, 178 bytes / Detail ``D``, 487 bytes, amounts
+   in satang, ``YYMMDD`` dates, 10-digit same-bank account numbers) was
+   reconstructed from the public reverse-engineered library
+   `MicroBenz/kbank-payroll.js <https://github.com/MicroBenz/kbank-payroll.js>`_
+   and models KBANK's **same-bank K-Cash Connect Plus direct credit**.
+
+   Before production use you **must**:
+
+   #. obtain the official *K-Cash Connect Plus / K-Direct Credit File Format
+      Specification* from KBANK (relationship manager / K-BIZ Contact Center),
+   #. confirm the product used (same-bank direct credit vs interbank SMART — the
+      latter needs additional bank/branch code fields, like the KTB module),
+   #. validate a generated file against a real sample and a bank test upload,
+      then adjust the layout CSV (and add config fields) accordingly.

--- a/l10n_th_bank_payment_export_kbank/__init__.py
+++ b/l10n_th_bank_payment_export_kbank/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_th_bank_payment_export_kbank/__manifest__.py
+++ b/l10n_th_bank_payment_export_kbank/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Aginix Technologies Co., Ltd. (http://aginix.tech)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Thai Localization - Bank Payment Export KBANK",
+    "version": "16.0.1.0.0",
+    "author": "Aginix Technologies",
+    "website": "https://github.com/aginix/kmitl",
+    "license": "AGPL-3",
+    "category": "Localization / Accounting",
+    "summary": "Bank Payment Export File KBANK (Kasikornbank)",
+    "depends": ["l10n_th_bank_payment_export_format"],
+    "data": [
+        "data/bank.export.format.csv",
+        "data/bank.export.format.line.csv",
+        "views/bank_payment_export_view.xml",
+    ],
+    "installable": True,
+    "development_status": "Alpha",
+}

--- a/l10n_th_bank_payment_export_kbank/data/bank.export.format.csv
+++ b/l10n_th_bank_payment_export_kbank/data/bank.export.format.csv
@@ -1,0 +1,2 @@
+id,name,bank
+kbank_ccp,KBANK K-Cash Connect Plus,KBANK

--- a/l10n_th_bank_payment_export_kbank/data/bank.export.format.line.csv
+++ b/l10n_th_bank_payment_export_kbank/data/bank.export.format.line.csv
@@ -1,0 +1,31 @@
+id,bank_id/id,sequence,name,display_type,lenght,match_group,need_loop,end_line,condition_line,value_type,value_alignment,value_blank_space,value
+kbank_format_01,l10n_th_bank_payment_export_kbank.kbank_ccp,10,HEADER,line_section,,,,,,fixed,ljust,,
+kbank_format_02,l10n_th_bank_payment_export_kbank.kbank_ccp,11,Record Type,,4,,,,,fixed,ljust,,HDCT
+kbank_format_03,l10n_th_bank_payment_export_kbank.kbank_ccp,12,Filler,,16,,,,,fixed,ljust,,
+kbank_format_04,l10n_th_bank_payment_export_kbank.kbank_ccp,13,Company ID,,6,,,,,dynamic,ljust,,rec.kbank_company_id
+kbank_format_05,l10n_th_bank_payment_export_kbank.kbank_ccp,14,Filler,,14,,,,,fixed,ljust,,
+kbank_format_06,l10n_th_bank_payment_export_kbank.kbank_ccp,15,Originator Account,,10,,,,,dynamic,rjust,0,line[0].sanitize_account_number(line[0].payment_journal_id.bank_account_id.acc_number)
+kbank_format_07,l10n_th_bank_payment_export_kbank.kbank_ccp,16,Separator,,1,,,,,fixed,ljust,,
+kbank_format_08,l10n_th_bank_payment_export_kbank.kbank_ccp,17,Total Amount,,15,,,,,dynamic,rjust,0,"str(int(round(rec.total_amount * 100, 2)))"
+kbank_format_09,l10n_th_bank_payment_export_kbank.kbank_ccp,18,Separator,,1,,,,,fixed,ljust,,
+kbank_format_10,l10n_th_bank_payment_export_kbank.kbank_ccp,19,Effective Date,,6,,,,,dynamic,ljust,,"rec.effective_date.strftime(""%y%m%d"")"
+kbank_format_11,l10n_th_bank_payment_export_kbank.kbank_ccp,20,Filler,,25,,,,,fixed,ljust,,
+kbank_format_12,l10n_th_bank_payment_export_kbank.kbank_ccp,21,Company Name,,50,,,,,dynamic,ljust,,rec.kbank_sender_name or rec.company_id.name
+kbank_format_13,l10n_th_bank_payment_export_kbank.kbank_ccp,22,Effective Date,,6,,,,,dynamic,ljust,,"rec.effective_date.strftime(""%y%m%d"")"
+kbank_format_14,l10n_th_bank_payment_export_kbank.kbank_ccp,23,Transaction Count,,18,,,,,dynamic,rjust,0,str(len(line.ids))
+kbank_format_15,l10n_th_bank_payment_export_kbank.kbank_ccp,24,Flag,,1,,,,,fixed,ljust,,N
+kbank_format_16,l10n_th_bank_payment_export_kbank.kbank_ccp,25,Filler,,5,,,TRUE,,fixed,ljust,,
+kbank_format_17,l10n_th_bank_payment_export_kbank.kbank_ccp,30,DETAILS,line_section,,,,,,fixed,ljust,,
+kbank_format_18,l10n_th_bank_payment_export_kbank.kbank_ccp,31,Record Type,,1,line,TRUE,,,fixed,ljust,,D
+kbank_format_19,l10n_th_bank_payment_export_kbank.kbank_ccp,32,Running Number,,6,line,TRUE,,,dynamic,rjust,0,str(idx_line+1)
+kbank_format_20,l10n_th_bank_payment_export_kbank.kbank_ccp,33,Filler,,14,line,TRUE,,,fixed,ljust,,
+kbank_format_21,l10n_th_bank_payment_export_kbank.kbank_ccp,34,Receiving Account,,10,line,TRUE,,,dynamic,rjust,0,line.sanitize_account_number(line.payment_partner_bank_id.acc_number)
+kbank_format_22,l10n_th_bank_payment_export_kbank.kbank_ccp,35,Separator,,1,line,TRUE,,,fixed,ljust,,
+kbank_format_23,l10n_th_bank_payment_export_kbank.kbank_ccp,36,Amount,,15,line,TRUE,,,dynamic,rjust,0,"str(int(round(line.payment_amount * 100, 2)))"
+kbank_format_24,l10n_th_bank_payment_export_kbank.kbank_ccp,37,Separator,,1,line,TRUE,,,fixed,ljust,,
+kbank_format_25,l10n_th_bank_payment_export_kbank.kbank_ccp,38,Effective Date,,6,line,TRUE,,,dynamic,ljust,,"rec.effective_date.strftime(""%y%m%d"")"
+kbank_format_26,l10n_th_bank_payment_export_kbank.kbank_ccp,39,Filler,,25,line,TRUE,,,fixed,ljust,,
+kbank_format_27,l10n_th_bank_payment_export_kbank.kbank_ccp,40,Receiver Name,,50,line,TRUE,,,dynamic,ljust,,line.payment_partner_bank_id.acc_holder_name or line.payment_partner_bank_id.partner_id.display_name
+kbank_format_28,l10n_th_bank_payment_export_kbank.kbank_ccp,41,Effective Date,,6,line,TRUE,,,dynamic,ljust,,"rec.effective_date.strftime(""%y%m%d"")"
+kbank_format_29,l10n_th_bank_payment_export_kbank.kbank_ccp,42,Service Code,,6,line,TRUE,,,fixed,ljust,,000000
+kbank_format_30,l10n_th_bank_payment_export_kbank.kbank_ccp,43,Filler,,346,line,TRUE,TRUE,,fixed,ljust,,

--- a/l10n_th_bank_payment_export_kbank/i18n/th.po
+++ b/l10n_th_bank_payment_export_kbank/i18n/th.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_th_bank_payment_export_kbank
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: code:addons/l10n_th_bank_payment_export_kbank/models/bank_payment_export.py:0
+#, python-format
+msgid "Account Number must only be 10 digits."
+msgstr "เลขที่บัญชีต้องมี 10 หลักเท่านั้น"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: model:ir.model.fields,field_description:l10n_th_bank_payment_export_kbank.field_bank_payment_export__kbank_company_id
+msgid "KBANK Company ID"
+msgstr "รหัสบริษัท KBANK"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: model:ir.model.fields,field_description:l10n_th_bank_payment_export_kbank.field_bank_payment_export__kbank_is_editable
+msgid "KBANK Editable"
+msgstr "แก้ไข KBANK ได้"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: model:ir.model.fields,field_description:l10n_th_bank_payment_export_kbank.field_bank_payment_export__kbank_sender_name
+msgid "Kbank Sender Name"
+msgstr "ชื่อผู้ส่ง KBANK"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: model:ir.model.fields,field_description:l10n_th_bank_payment_export_kbank.field_bank_payment_export__kbank_service_type
+msgid "Kbank Service Type"
+msgstr "ประเภทบริการ KBANK"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: code:addons/l10n_th_bank_payment_export_kbank/models/bank_payment_export.py:0
+#, python-format
+msgid "Recipient Bank with %(payment)s is not selected."
+msgstr "ยังไม่ได้เลือกธนาคารผู้รับสำหรับ %(payment)s"
+
+#. module: l10n_th_bank_payment_export_kbank
+#: model_terms:ir.ui.view,arch_db:l10n_th_bank_payment_export_kbank.bank_payment_export_view_form
+msgid "Service Type"
+msgstr "ประเภทบริการ"

--- a/l10n_th_bank_payment_export_kbank/models/__init__.py
+++ b/l10n_th_bank_payment_export_kbank/models/__init__.py
@@ -1,0 +1,3 @@
+from . import bank_export_format
+from . import bank_payment_export
+from . import bank_payment_template

--- a/l10n_th_bank_payment_export_kbank/models/bank_export_format.py
+++ b/l10n_th_bank_payment_export_kbank/models/bank_export_format.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Aginix Technologies Co., Ltd. (http://aginix.tech)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class BankExportFormat(models.Model):
+    _inherit = "bank.export.format"
+
+    bank = fields.Selection(
+        selection_add=[("KASITHBK", "KBANK")],
+        ondelete={"KASITHBK": "cascade"},
+    )

--- a/l10n_th_bank_payment_export_kbank/models/bank_payment_export.py
+++ b/l10n_th_bank_payment_export_kbank/models/bank_payment_export.py
@@ -1,0 +1,85 @@
+# Copyright 2024 Aginix Technologies Co., Ltd. (http://aginix.tech)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+from odoo.addons.base.models.res_bank import sanitize_account_number
+
+
+class BankPaymentExport(models.Model):
+    _inherit = "bank.payment.export"
+
+    bank = fields.Selection(
+        selection_add=[("KASITHBK", "KBANK")],
+        ondelete={"KASITHBK": "cascade"},
+    )
+    # Configuration
+    kbank_company_id = fields.Char(
+        string="KBANK Company ID",
+        size=6,
+        tracking=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
+    kbank_sender_name = fields.Char(
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
+    kbank_service_type = fields.Selection(
+        selection=[
+            ("01", "01 - เงินเดือน ค่าจ้าง บำเหน็จ บำนาญ"),
+            ("02", "02 - เงินปันผล"),
+            ("03", "03 - ดอกเบี้ย"),
+            ("04", "04 - ค่าสินค้า บริการ"),
+            ("05", "05 - ขายหลักทรัพย์"),
+            ("06", "06 - คืนภาษี"),
+            ("07", "07 - เงินกู้"),
+            ("59", "59 - อื่น ๆ"),
+        ],
+        tracking=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
+    # filter
+    kbank_is_editable = fields.Boolean(
+        compute="_compute_kbank_editable",
+        string="KBANK Editable",
+    )
+
+    @api.depends("bank")
+    def _compute_required_effective_date(self):
+        res = super()._compute_required_effective_date()
+        for rec in self.filtered(lambda l: l.bank == "KASITHBK"):
+            rec.is_required_effective_date = True
+        return res
+
+    @api.depends("bank")
+    def _compute_kbank_editable(self):
+        for export in self:
+            export.kbank_is_editable = export.bank == "KASITHBK"
+
+    def _check_constraint_line(self):
+        res = super()._check_constraint_line()
+        self.ensure_one()
+        if self.bank == "KASITHBK":
+            for line in self.export_line_ids:
+                if not line.payment_partner_bank_id:
+                    raise UserError(
+                        _("Recipient Bank with %(payment)s is not selected.")
+                        % {"payment": line.payment_id.name}
+                    )
+        return res
+
+    def _check_constraint_confirm(self):
+        res = super()._check_constraint_confirm()
+        # KBANK K-Cash Connect Plus (direct credit) requires a 10-digit
+        # beneficiary account number (same-bank transfer).
+        for rec in self.filtered(lambda l: l.bank == "KASITHBK"):
+            if any(
+                len(sanitize_account_number(line.payment_partner_bank_id.acc_number))
+                != 10
+                for line in rec.export_line_ids
+            ):
+                raise UserError(_("Account Number must only be 10 digits."))
+        return res

--- a/l10n_th_bank_payment_export_kbank/models/bank_payment_template.py
+++ b/l10n_th_bank_payment_export_kbank/models/bank_payment_template.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Aginix Technologies Co., Ltd. (http://aginix.tech)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class BankPaymentTemplate(models.Model):
+    _inherit = "bank.payment.template"
+
+    bank = fields.Selection(
+        selection_add=[("KASITHBK", "KBANK")],
+        ondelete={"KASITHBK": "cascade"},
+    )

--- a/l10n_th_bank_payment_export_kbank/tests/__init__.py
+++ b/l10n_th_bank_payment_export_kbank/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_bank_payment_export_kbank

--- a/l10n_th_bank_payment_export_kbank/tests/test_bank_payment_export_kbank.py
+++ b/l10n_th_bank_payment_export_kbank/tests/test_bank_payment_export_kbank.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Aginix Technologies Co., Ltd. (http://aginix.tech)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.exceptions import UserError
+
+from odoo.addons.l10n_th_bank_payment_export.tests.common import CommonBankPaymentExport
+
+
+class TestBankPaymentExportKBANK(CommonBankPaymentExport):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.bank_export_format = cls.bank_export_format_model.search(
+            [("bank", "=", "KASITHBK")], limit=1
+        )
+
+    def _create_kbank_export(self):
+        bank_payment = self.bank_payment_export_model.create(
+            {
+                "name": "/",
+                "bank": "KASITHBK",
+                "bank_export_format_id": self.bank_export_format.id,
+                "kbank_company_id": "000001",
+                "kbank_sender_name": "KMITL",
+                "kbank_service_type": "04",
+                "effective_date": fields.Date.today(),
+            }
+        )
+        bank_payment.action_get_all_payments()
+        for line in bank_payment.export_line_ids:
+            if not line.payment_partner_bank_id:
+                line.payment_partner_bank_id = line.payment_partner_id.bank_ids[:1].id
+            # K-Cash Connect Plus requires a 10-digit account number
+            line.payment_partner_bank_id.acc_number = "1234567890"
+        return bank_payment
+
+    def test_01_account_number_must_be_10_digits(self):
+        bank_payment = self._create_kbank_export()
+        bank_payment.export_line_ids[0].payment_partner_bank_id.acc_number = "12345"
+        with self.assertRaises(UserError):
+            bank_payment.action_confirm()
+
+    def test_02_kbank_export_record_length(self):
+        bank_payment = self._create_kbank_export()
+        self.assertTrue(bank_payment.export_line_ids)
+        bank_payment.action_confirm()
+        text = bank_payment._export_bank_payment_text_file()
+        self.assertNotEqual(
+            text, "Demo Text File. You must config `Bank Export Format` First."
+        )
+        records = [rec for rec in text.split("\r\n") if rec]
+        # First record is the HDCT header (178 chars); the rest are D details (487)
+        self.assertEqual(records[0][:4], "HDCT")
+        self.assertEqual(len(records[0]), 178)
+        for detail in records[1:]:
+            self.assertEqual(detail[0], "D")
+            self.assertEqual(len(detail), 487)
+        # Number of detail records equals the number of exported payment lines
+        self.assertEqual(len(records) - 1, len(bank_payment.export_line_ids))

--- a/l10n_th_bank_payment_export_kbank/views/bank_payment_export_view.xml
+++ b/l10n_th_bank_payment_export_kbank/views/bank_payment_export_view.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Aginix Technologies Co., Ltd. (http://aginix.tech)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html) -->
+<odoo>
+    <record id="bank_payment_export_view_form" model="ir.ui.view">
+        <field name="name">bank.payment.export.view.form.kbank</field>
+        <field name="model">bank.payment.export</field>
+        <field
+            name="inherit_id"
+            ref="l10n_th_bank_payment_export.bank_payment_export_view_form"
+        />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='information']//group[@name='left_information']"
+                position="inside"
+            >
+                <field name="kbank_is_editable" invisible="1" />
+                <field
+                    name="kbank_service_type"
+                    string="Service Type"
+                    attrs="{'invisible': [('kbank_is_editable', '!=', True)], 'required': [('kbank_is_editable', '!=', False)]}"
+                />
+            </xpath>
+            <xpath
+                expr="//page[@name='information']/group[@name='system_config']"
+                position="inside"
+            >
+                <field
+                    name="kbank_company_id"
+                    attrs="{'invisible': [('kbank_is_editable', '!=', True)], 'required': [('kbank_is_editable', '!=', False)]}"
+                />
+                <field
+                    name="kbank_sender_name"
+                    attrs="{'invisible': [('kbank_is_editable', '!=', True)], 'required': [('kbank_is_editable', '!=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## What

Complete the set of Thai bank payment-file exporters. The repo already had **KTB** and **SCB** (complete) and **BAY** (scaffold only). This PR:

- **Adds** a new module `l10n_th_bank_payment_export_kbank` for **KBANK / Kasikornbank (`KASITHBK`)**, mirroring the KTB/SCB pattern on top of `l10n_th_bank_payment_export_format`.
- **Fixes** `l10n_th_bank_payment_export_bay`, whose `bank.export.format.line.csv` was empty (exported a blank file), by adding a **BAY CashLink** layout.

## Why

KBANK had no export module anywhere (OCA `l10n-thailand` ships only the base module on 16.0 and KTB only on 15.0 — no KBANK/SCB/BAY on any branch), and BAY's layout was never filled in.

## Details

**KBANK** — selection on `bank.export.format` / `bank.payment.export` / `bank.payment.template`; config fields (Company ID, Sender Name, Service Type); constraints (recipient bank required, 10-digit account for same-bank K-Cash Connect Plus direct credit); form view; Thai i18n; README; tests. Layout: Header `HDCT` 178 / Detail `D` 487, amounts in satang, `YYMMDD` dates.

**BAY** — CashLink layout: 256-byte records, `^` field separators, `DDMM20YY` dates, satang amounts, bank code `025`; field structure modelled on the KTB layout.

## ⚠️ Both layouts are DRAFTS

The official byte-level specs for KBANK and BAY are not public. The shipped layouts are reconstructed from the best available references (KBANK: reverse-engineered `MicroBenz/kbank-payroll.js`; BAY: confirmed Krungsri conventions + KTB structure) and are flagged in each module's README. **Before production use**, obtain the official file-format spec + a sample file from the bank, confirm the product (same-bank direct credit vs interbank SMART — the latter needs bank/branch code fields), and validate the generated file byte-by-byte.

## Verification

Offline: py/XML/manifest/CSV checks pass; file generation simulated with mock data — all dynamic expressions evaluate and record lengths are exact (KBANK 178/487, BAY 256/256). Odoo tests / pre-commit not run in this PR.
